### PR TITLE
Small bugfix in MovieStim.__init__

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -3346,7 +3346,8 @@ class MovieStim(_BaseVisualStim):
             opacity :
                 the movie can be made transparent by reducing this
         """
-        self.win = win 
+        self.win = win
+        self._useShaders=False #Should False be the default?
         if win._haveShaders: self._useShaders=True
 
         self._movie=None # the actual pyglet media object


### PR DESCRIPTION
There was no default behavior for setting self._useShaders. Added setting it to False. Is that really the appropriate default behavior? 
