### PR TITLE
minor colorspace doc changes, and ugly explanation added of how to make docs

### DIFF
--- a/docs/source/developers/developers.rst
+++ b/docs/source/developers/developers.rst
@@ -15,6 +15,8 @@ Don't *install* PsychoPy. Instead fetch a copy of the git repository and add thi
    
    repository
    *
+x    
+    - Modifying the html documentation (docs). Edit the .rst source files and then in the docs directory type "make html".
 
 Happy Coding Folks!!
 

--- a/docs/source/general/colours.rst
+++ b/docs/source/general/colours.rst
@@ -45,19 +45,21 @@ Examples:
     
 The reason that these colors are expressed ranging between 1 and -1 (rather than 0:1 or 0:255) is that many experiments, particularly in visual science where PsychoPy has its roots, express colors as deviations from a grey screen. Under that scheme a value of -1 is the maximum decrement from grey and +1 is the maximum increment above grey.
 
+Note that Psychopy will use your monitor calibration to linearize this for each gun. E.g., 0 will be halfway between the minimum luminance and maximum luminance for each gun, if your monitor gammaGrid is set correctly.
+
 .. _DKL:
 
 DKL color space
 -------------------
 To use DKL color space the monitor should be calibrated with an appropriate spectrophotometer, such as a PR650.
 
-In the Derrington, Krauskopf and Lennie [#dkl1984]_ color space (based on the Macleod and Boynton [#mb1979]_ chromaticity diagram) colors are represented in a 3-dimensional space using circular coordinates that specify the `elevation` from the isoluminant plane, the `azimuth` (the hue) and the contrast (as a fraction of the maximal modulations along the cardinal axes of the space).
+In the Derrington, Krauskopf and Lennie [#dkl1984]_ color space (based on the Macleod and Boynton [#mb1979]_ chromaticity diagram) colors are represented in a 3-dimensional space using spherical coordinates that specify the `elevation` from the isoluminant plane, the `azimuth` (the hue) and the contrast (as a fraction of the maximal modulations along the cardinal axes of the space).
 
 .. image:: ../images/dklSPace.png
 
 In PsychoPy these values are specified in units of degrees for elevation and azimuth and as a float (ranging -1:1) for the contrast.
 
-Note that not all colours that can be specified in DKL colour space can be reproduced on a monitor. `Alex Holcombe <http://www.psych.usyd.edu.au/staff/alexh/>`_ has produced a movie showing `the gamut of producable DKL colors <http://www.youtube.com/watch?v=GwACmja-U-g>`_ on a typical (CRT) monitor.
+Note that not all colours that can be specified in DKL colour space can be reproduced on a monitor. `Here <http://youtu.be/xwoVrGoBaWg>`_ is a movie plotting in DKL space (showing `cartesian` coordinates, not spherical coordinates) the gamut of colors available on an example CRT monitor.
 
 Examples:
 


### PR DESCRIPTION
Added some clarifying things about color coordinates. It's so tempting to assume RGB coordinates will not be linearized, that I added a note there dispelling that.
Added an explanation of how to build the docs, but doesn't look good because I don't know how to integrate with the automatic hierarchy on that page.
