### PR TITLE
minor change to visual.Rect.setHeight

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -4758,8 +4758,8 @@ class Rect(ShapeStim):
         self._calcVertices()
         self.setVertices(self.vertices)
 
-    def setHeight(self, width):
-        """Changes the width of the Rectangle """
+    def setHeight(self, height):
+        """Changes the height of the Rectangle """
         self.height = height
         self._calcVertices()
         self.setVertices(self.vertices)


### PR DESCRIPTION
setHeight had `width` as an argument rather than `height` - causing it to crash when this function was called
