### PR TITLE
new visual.Window method: multiFlip()

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -558,8 +558,8 @@ class Window:
         """
         
         #Sanity checking
-        if flips >= 1 and abs(flips) == flips:
-            logging.error("flips argument for multiFlip was not positive integer")
+        if flips >= 1 and int(flips) == flips:
+            logging.error("flips argument for multiFlip should be a positive integer")
         if flips > 1 and self.waitBlanking: 
             logging.warning("Call to Window.multiFlip() with flips > 1 is unnecessary because Window.waitBlanking=False")
         


### PR DESCRIPTION
I don't know if I should have posted this on dev-list for discussion before submitting pull-request? Anyway, the problem I try to solve here is that I always find myself timing brief presentations of stimuli using:

for frame in range(3):
   stim.draw()
   win.flip()

With the multiFlip() method, this can be done like this:

stim.draw()
win.multiflip(3)

... which is also more efficient, since it does not draw the stimulus to buffer before every flip. Another advantage is that this method is easier to understand for first-time users, who often have difficulties understanding the range()-method and hence revert to core.wait()-based methods for timing.

Best,
Jonas
