### PR TITLE
Add Filename Collision Handling

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -590,7 +590,7 @@ class TrialHandler:
         if saveExcel or savePsydat or saveCSV:
             buff.writeIndented("#save data for this loop\n")
         if savePsydat:
-            buff.writeIndented("%(name)s.saveAsPickle(filename+'%(name)s')\n" %self.params)
+            buff.writeIndented("%(name)s.saveAsPickle(filename+'%(name)s', fileCollisionMethod='rename')\n" %self.params)
         if saveExcel:
             buff.writeIndented("%(name)s.saveAsExcel(filename+'.xlsx', sheetName='%(name)s',\n" %self.params)
             buff.writeIndented("    stimOut=params,\n")

--- a/psychopy/misc.py
+++ b/psychopy/misc.py
@@ -9,7 +9,7 @@ import numpy, random #this is imported by psychopy.core
 from psychopy import logging
 import monitors
 
-import os, shutil
+import os, shutil, glob
 import Image, cPickle
 #from random import shuffle #this is core python dist
 
@@ -556,3 +556,30 @@ def plotFrameIntervals(intervals):
     #    hist(intervals, int(len(intervals)/10))
     plot(intervals)
     show()
+
+def _handleFileCollision(fileName, fileCollisionMethod):
+    """ Handle filename collisions by overwriting, renaming, or failing hard. 
+    
+    :Parameters:
+
+        fileCollisionMethod: 'overwrite', 'rename', 'fail'
+            If a file with the requested name already exists, specify how to deal with it. 'overwrite' will overwite existing files in place, 'rename' will append an integer to create a new file ('trials1.psydat', 'trials2.pysdat' etc) and 'error' will raise an IOError.
+    """
+    if fileCollisionMethod == 'overwrite':
+        logging.warning('Data file, %s, will be overwritten' % fileName)
+    elif fileCollisionMethod == 'fail':
+        raise IOError("Data file %s already exists. Set argument fileCollisionMethod to overwrite." % fileName)
+    elif fileCollisionMethod == 'rename':
+        rootName, extension = os.path.splitext(fileName)
+        matchingFiles = glob.glob("%s*%s" % (rootName, extension))
+        count = len(matchingFiles)
+        
+        fileName = "%s_%d%s" % (rootName, count, extension) # Build the renamed string.
+        
+        if os.path.exists(fileName): # Check to make sure the new fileName hasn't been taken too.
+            raise IOError("New fileName %s has already been taken. Something is wrong with the append counter." % fileName)
+        
+    else:
+        raise ValueError("Argument fileCollisionMethod was invalid: %s" % str(fileCollisionMethod))
+
+    return fileName


### PR DESCRIPTION
Here are some proposed changes to prevent overwriting of .psydat files without warning. Sorry that it didn't make it into the 1.73.05 bug fix. I think having this capability is still worthwhile, even if we're switching the App to use Experiment handler as we speak. 

I didn't update testExperimentHandler since it looks like there aren't any tests yet, just setup, but TrialHandler should have sufficient coverage.

Adds the bug fix support from Issue #76

As an aside, testRandomDataOutput and testFullRandomDataOutput are failing for me - I think the fixtures are outdated. I'll look at them later this week.
