### PR TITLE
BF: DataHandler.addDataType no longer tries loop over unicode strings

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2445,7 +2445,7 @@ class DataHandler(dict):
         during initialisation and as each xtra type is needed.
         """
         if not shape: shape = self.dataShape
-        if type(names) != str:
+        if not isinstance(names,basestring):
             #recursively call this function until we have a string
             for thisName in names: self.addDataType(thisName)
         else:


### PR DESCRIPTION
another one-line commit :)

There are still a number of issues with using unicode field names, but at least this prevents a potentially confusing stack-overflow error.
