### PR TITLE
Fixed bug: fieldPos of Builder dot stim couldn't change per frame

### DIFF
--- a/psychopy/app/builder/components/__init__.py
+++ b/psychopy/app/builder/components/__init__.py
@@ -101,12 +101,12 @@ def getInitVals(params):
             inits[name].val='None'
             inits[name].valType='code'
 
-        #is constant to don't touch the parameter value
+        #is constant so don't touch the parameter value
         elif inits[name].updates in ['constant',None,'None']:
             continue #things that are constant don't need handling
 
         #is changing so work out a reasonable default
-        elif name == 'pos':
+        elif name in ['pos', 'fieldPos']:
             inits[name].val='[0,0]'
             inits[name].valType='code'
         elif name in ['ori','sf','size','height','color','phase','opacity',

--- a/psychopy/app/builder/components/_visual.py
+++ b/psychopy/app/builder/components/_visual.py
@@ -102,6 +102,8 @@ class VisualComponent(_base.BaseComponent):
                 paramCaps='SF' #setSF, not SetSf
             elif thisParamName=='coherence':
                 paramCaps='FieldCoherence' #setSF, not SetSf
+            elif thisParamName=='fieldPos':
+                paramCaps='FieldPos'
             else:
                 paramCaps = thisParamName.capitalize()
             #color is slightly special

--- a/psychopy/app/builder/components/patch.py
+++ b/psychopy/app/builder/components/patch.py
@@ -48,7 +48,7 @@ class PatchComponent(VisualComponent):
             label="Phase")
         self.params['texture resolution']=Param(texRes, valType='code', allowedVals=['32','64','128','256','512'],
             updates='constant', allowedUpdates=[],
-            hint="Spatial positioning of the image on the patch (in range 0-1.0)",
+            hint="Resolution of the texture for standard ones such as sin, sqr etc. For most cases a value of 256 pixels will suffice",
             label="Texture resolution")
         self.params['interpolate']=Param(mask, valType='str', allowedVals=['linear','nearest'],
             updates='constant', allowedUpdates=[],


### PR DESCRIPTION
fieldPos attribute of Builder dot stimulus component couldn't be
changed each frame. Due to differences between handling of this
attribute called fieldPos as opposed to simply pos in the patch
stimulus.
Also fixed some typos in a tool tip for the patch stimulus hints and in
one code comment.
