### PR TITLE
BF: Cast the gamma-grid to be an array.

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -282,7 +282,8 @@ class Monitor:
     def getGammaGrid(self):
         """Gets the min,max,gamma values for the each gun"""
         if self.currentCalib.has_key('gammaGrid'):
-            grid = self.currentCalib['gammaGrid']
+            # Make sure it's an array, so you can look at the shape
+            grid = numpy.asarray(self.currentCalib['gammaGrid'])
             if grid.shape!=[4,6]:
                 newGrid = numpy.zeros([4,6],'f')*numpy.nan#start as NaN
                 newGrid[:grid.shape[0],:grid.shape[1]]=grid


### PR DESCRIPTION
This fixes an error being thrown in some cases (maybe old calibration files?), where the gammagrid is a list: 

File "/Users/arokem/usr/local/lib/python2.7/site-packages/psychopy/monitors/calibTools.py", line 286, in getGammaGrid
    if grid.shape!=[4,6]:
AttributeError: 'list' object has no attribute 'shape' 
