### PR TITLE
User Components not loaded from Builder Preferences Directory

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1193,7 +1193,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
             self.sizer=wx.FlexGridSizer(cols=2)
         # add a button for each type of event that can be added
         self.componentButtons={}; self.componentFromID={}
-        self.components=experiment.getAllComponents()
+        self.components=experiment.getAllComponents(self.app.prefs.builder['componentsFolders'])
         for hiddenComp in self.frame.prefs['hiddenComponents']:
             del self.components[hiddenComp]
         del self.components['SettingsComponent']#also remove settings - that's in toolbar not components panel

--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -6,7 +6,7 @@ import wx, copy
 from os import path
 from psychopy.app.builder.experiment import Param
 
-class BaseComponent:
+class BaseComponent(object):
     """A template for components, defining the methods to be overridden"""
     def __init__(self, exp, parentName, name=''):
         self.type='Base'


### PR DESCRIPTION
It looks like you meant for users to be able to add their own components (Jeremy even wrote a [recipe](http://www.psychopy.org/developers/buildercomponent.html) in the documentation for how to do it) but somewhere along the way, or perhaps intentionally[?], only the built-in components are being grabbed and the app preference directory is never actually being searched. 

This one-liner should allow user components again.

(I also updated BaseComponent to a new-style class because it seemed like a good idea).
