### PR TITLE
stopping MovieStim objects before they are finished

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -3725,11 +3725,10 @@ class MovieStim(_BaseVisualStim):
         self.status=PLAYING
 
     def stop(self):
-        """Stop a movie presentation before it has finished.
+        """Stop a movie before it has completely finished.
         """
-        print 'hi, from stop'
-        #self._player.stop()
-        #self.status=FINISHED
+        self._player.stop()
+        self.status=FINISHED
 
     def seek(self,timestamp):
         """ Seek to a particular timestamp in the movie.


### PR DESCRIPTION
this seems to work as desired.  as a use case, i have some 4s clips and just want to play the first 2s of them and then stop the MoviesStim instance -- not pause it or just hide if behind a flipped window buffer, but just kill it all together.
