### PR TITLE
BF: updated depth calculations in ElementArrayStim to match docstring

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -3493,7 +3493,7 @@ class ElementArrayStim:
         self._visXYZvertices[:,3,1] = self._XYsRendered[:,1] -wy - hy
 
         #depth
-        self._visXYZvertices[:,:,2] = self.depths
+        self._visXYZvertices[:,:,2] = numpy.tile(self.depths,(4,1)).T + self.fieldDepth
 
         self.needVertexUpdate=False
 


### PR DESCRIPTION
- Passing a `depth` value to ElementArrayStim as an (Nx1) vector, as specified in the docstring, crashed with a shape mismatch. I changed it to replicate the depth value for the four coordinates of each vertex.
- I added the `fieldDepth` calculation, which didn't seem to be operating.
