### PR TITLE
One more Unicode Logfile Bugfix

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1141,7 +1141,7 @@ class TrialHandler(_BaseTrialHandler):
         for trial in dataOut:
             nextLine = ''
             for parameterName in header:
-                nextLine = nextLine + str(trial[parameterName]) + delim
+                nextLine = nextLine + unicode(trial[parameterName]) + delim
             nextLine = nextLine[:-1] # remove the final orphaned tab character
             f.write(nextLine + '\n')
 


### PR DESCRIPTION
If there is unicode data in the TrialList, it's cast to an ascii string and errors when when exporting to WideText. This fixes the one particular cast that was breaking.

If you want, you can reject this pull request and we can go through all of the psychopy codebase to make it unicode compatible in a principled way, so that we don't keep sending single line bug fixes like this. But, this fix would be useful for my tasks at least, and I'll bet you'll be seeing people ask about it when wide text becomes the default in 1.74.

Is there any reason not to just do a global find-and-replace of str() with unicode()?
