### PR TITLE
Support for non-ASCII keyboard input

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -885,6 +885,7 @@ class Window:
         self.winHandle.setGammaRamp = psychopy.gamma.setGammaRamp
         self.winHandle.getGammaRamp = psychopy.gamma.getGammaRamp
         self.winHandle.set_vsync(True)
+        self.winHandle.on_text = psychopy.event._onPygletText
         self.winHandle.on_key_press = psychopy.event._onPygletKey
         self.winHandle.on_mouse_press = psychopy.event._onPygletMousePress
         self.winHandle.on_mouse_release = psychopy.event._onPygletMouseRelease


### PR DESCRIPTION
Hi Jon,

This patch should, at least as a proof of concept, make it possible to properly capture non-ASCII character input. For example, on my testing Ubuntu 12.04 machine, γρεεκ text input is not dealt with properly.

The fix appears to be to use the Pyglet on_key_press event to capture most keyboard responses, but fall back to on_text when Pyglet decides to represent the key as a 'user_key()' string, rather than an actual character.

Does this make sense? Disclaimer: I just whipped it together and haven't tested this patch extensively.

Cheers,
Sebastiaan
