### PR TITLE
Small patch to give warning if SimpleImageStim does not fit the window due to position and size

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -1788,6 +1788,14 @@ class SimpleImageStim:
         #check image size against window size
         if (self.size[0]>self.win.size[0]) or (self.size[1]>self.win.size[1]):
             logging.warning("Image size (%s, %s)  was larger than window size (%s, %s). Will draw black screen." % (self.size[0], self.size[1], self.win.size[0], self.win.size[1]))
+
+        #check position with size, warn if stimuli not fully drawn
+        if ((self.pos[0]+(self.size[0]/2.0) > self.win.size[0]/2.0) or (self.pos[0]-(self.size[0]/2.0) < -self.win.size[0]/2.0)):
+            logging.warning("Image position and width mean the stimuli does not fit the window in the X direction.")
+
+        if ((self.pos[1]+(self.size[1]/2.0) > self.win.size[1]/2.0) or (self.pos[1]-(self.size[1]/2.0) < -self.win.size[1]/2.0)):
+            logging.warning("Image position and height mean the stimuli does not fit the window in the Y direction.")            
+
         #flip if necessary
         self.flipHoriz=False#initially it is false, then so the flip according to arg above
         self.setFlipHoriz(flipHoriz)


### PR DESCRIPTION
This just writes a warning if the SimpleImageStim is such that it will draw outside the window. 

What is strange though, is that PsychoPy only draws a black screen if the position values are negative (i.e. moving left) and it cuts off. If it cuts off to the right, it just draws the stimuli but with part of it cut off. I'll try to investigate the source of this asymmetry if I get the time. In the meantime, at least this provides a warning when this occurs.
