### PR TITLE
SaveAsText Datatype Numpy Instance Error

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -426,9 +426,9 @@ class _BaseTrialHandler(object):
         #loop through lines in the data matrix
         for line in dataArray:
             for cellN, entry in enumerate(line):
-                if type(entry) in [float]:
+                if type(entry) in [float, numpy.float]:
                     f.write('%.4f' %(entry))
-                elif type(entry) in [int]:
+                elif type(entry) in [int, numpy.int32, numpy.int64]:
                     f.write('%i' %(entry))
                 elif entry==None:
                     f.write('')


### PR DESCRIPTION
SaveAsText attempts to check datatype and write an appropriately formatted string (int, float, str). However, it's not grouping numpy dt's, which fall to the 'else' of a string. This causes a write error that breaks saving output when numpy datatypes are included.

This fix just checks that datatype is int or numpy int. 
