### PR TITLE
ENH: win.flip returns time of flip (time immediately following  GL.glFinish() call)

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -510,6 +510,14 @@ class Window:
             #{'msg':msg,'level':level,'obj':copy.copy(obj)}
             logging.log(msg=logEntry['msg'], level=logEntry['level'], t=now, obj=logEntry['obj'])
         self._toLog = []
+        
+        #    If self.waitBlanking is True, then return the time that
+        # GL.glFinish() returned, set as the 'now' variable. Otherwise
+        # return None as before
+        #
+        if self.waitBlanking is True:
+            return now
+            
 
     def update(self):
         """Deprecated: use Window.flip() instead


### PR DESCRIPTION
If waitBlanking is True during the current call to win.flip(), have flip
return the time that was read immediately following the GL.glFinish() in
the waitBlanking blocking code.

This

a) makes for cleaner user script code when someone wants to get the time
of the flip (for calculating an RT start time for example) and

b) maybe somewhat more accurate than having someone call the get time
function after flip returns, given there is a small amount of extra
logic preformed in flip() between the end of the blocking code and the flip
method return.

One file changed. Only flip method in Window effected(). Unless someone is relying on flip returning None, I can not see any possible negaitive side effect to this change.

Thank you.

Sol
