### PR TITLE
Fix support for fORP's "Eprime" setting

### DIFF
--- a/psychopy/hardware/forp.py
+++ b/psychopy/hardware/forp.py
@@ -96,7 +96,8 @@ class ButtonBox:
             held down. On the "Bitwise" setting, you will get a set of all
             currently pressed buttons every time a button is pressed or
             released.
-            Really, don't use this option.
+            This option might be useful if you think your participant may be
+            holding the button down before you start checking for presses.
         """
         nToGet = self.port.inWaiting()
         evtStr = self.port.read(nToGet)


### PR DESCRIPTION
When on the "Eprime" setting, the fORP controller sends a continuous stream of characters over the serial port, instead of a character for every press/release of a button. This means that while a button is held down, each call to getEvents() will return the currently pressed set of buttons. Not great if you're calling getEvents() in a loop.

This pull request adds some state to ButtonBox objects, so getEvents() will only return buttons when they're actually pressed. If the original behavior is desired, the allowRepeats option to getEvents() will make it act as it did before.

There's also a little bit of redesign in the code that translates the fORP's bit patterns to the corresponding set of button numbers.
