### PR TITLE
BF: more reasonable path to look for components on Linux systems

### DIFF
--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -79,7 +79,7 @@
     # if False will create scripts with an 'easier' but more cluttered namespace
     unclutteredNamespace = boolean(default=False)
     # folder names for custom components; expects a comma-separated list
-    componentsFolders = list(default=list('/Users/Shared/PsychoPy2/components'))
+    componentsFolders = list(default=list('/usr/share/pyshared/psychopy/app/builder/components'))
     # a list of components to hide (eg, because you never use them)
     hiddenComponents = list(default=list())
     # where the Builder demos are located on this computer (after unpacking)


### PR DESCRIPTION
question though:  those "list()" constructs in .spec files are not intended to be correct Python "list" definitions -- they are internal structures for validate.py to handle, right? (just clarifying for myself)
