### PR TITLE
ENH: improvement of contains() and overlaps()

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -1419,7 +1419,15 @@ class _BaseVisualStim:
         """
         if self.needVertexUpdate:
             self._calcVerticesRendered()
-        return polygonsOverlap(self, polygon)
+        if self.ori:
+            oriRadians = numpy.radians(self.ori)
+            sinOri = numpy.sin(-oriRadians)
+            cosOri = numpy.cos(-oriRadians)
+            x = self._verticesRendered[:,0] * cosOri - self._verticesRendered[:,1] * sinOri
+            y = self._verticesRendered[:,0] * sinOri + self._verticesRendered[:,1] * cosOri
+            return polygonsOverlap(numpy.column_stack((x,y)) + self._posRendered, polygon)
+        else:
+            return polygonsOverlap(self, polygon)
 
 class DotStim(_BaseVisualStim):
     """


### PR DESCRIPTION
- contains() returns correct value when 'units' is 'deg' or 'cm'
- contains() and overlaps() return correct value when 'ori' is non-zero.
