### PR TITLE
setSound should fail when given a bad value instead of defaulting to a tone

### DIFF
--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -105,7 +105,7 @@ class _SoundBase:
     def setSound(self, value, secs=0.5, octave=4):
         """Set the sound to be played.
 
-        Often this is not needed byt the user - it is called implicitly during
+        Often this is not needed by the user - it is called implicitly during
         initialisation.
 
         :parameters:
@@ -123,6 +123,8 @@ class _SoundBase:
                 output sounds in the bottom octave (1) and the top
                 octave (8) is generally painful
         """
+        self._snd = None  # Re-init sound to ensure bad values will raise RuntimeError during setting
+        
         try:#could be '440' meaning 440
             value = float(value)
         except:


### PR DESCRIPTION
Although sound.py is supposed to raise an error if a sound's value cannot be figured out heuristically, it effectively only does that check on initialization. This is because it fails only if the instance var _snd is None, which only occurs directly after initialization.

When a Sound Builder Component is set to "set each repeat", it initializes a sound with a dummy value (so _snd is initialized to a tone) and doesn't do any smart checking to ensure that the files to be presented each repeat exist. Later during repeat, if a sound file doesn't exist, this currently doesn't fail because the previous sound (the dummy tone) is valid.

This has the effect of causing experiments created with Builder to default to a tone instead of raising an error when a bad filepath is given.

By resetting _snd at the beginning of each setSound call, each new sound will either be set correctly or raise an error, as appropriate. This does introduce the possibility of raising an error halfway through an experiment, so we it would be nice to have some smart checking of stimuli at experiment initialization, but at least the error will be more obvious now and easier to fix given this PR.
