### PR TITLE
Update psychopy/visual.py

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -581,9 +581,9 @@ class Window:
 
         """
         if buffer=='left':
-            GL.glDrawBuffer(GL.GL_LEFT)
+            GL.glDrawBuffer(GL.GL_BACK_LEFT)
         elif buffer=='right':
-            GL.glDrawBuffer(GL.GL_RIGHT)
+            GL.glDrawBuffer(GL.GL_BACK_RIGHT)
         else:
             raise "Unknown buffer '%s' requested in Window.setBuffer" %buffer
         if clear:


### PR DESCRIPTION
Stereo presentation (with Nvidia at least) requries updating the back buffers (GL_BACK_LEFT and GL_BACK_RIGHT)
