### PR TITLE
BF #157 - Gracefully fall back to primary display 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -37,6 +37,7 @@ The compatibility changes in this release below are likely to affect very few us
 * ADDED: a first-run wizard to check the system, report as html (somewhat experimental) (Jeremy Gray)
 * ADDED: a benchmark wizard (Tools menu) to test hardware & software, option to share on psychopy.org (Jeremy Gray)
 * ADDED: info.getRAM() (Jeremy Gray)
+* FIXED: Fall back to primary display if a secondary one is specified but unavailable. (Erik Kastman)
 
 PsychoPy 1.75.01
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -137,7 +137,14 @@ class SettingsComponent:
                if thisComp.type=='Aperture': allowStencil = True
                if thisComp.type=='RatingScale': allowGUI = True # to have a mouse; BUT might not want it shown in other routines
 
-        screenNumber = int(self.params['Screen'].val)-1 #computer has 1 as first screen
+        
+        requestedScreenNumber = int(self.params['Screen'].val)
+        if requestedScreenNumber > wx.Display.GetCount():
+            logging.warn("Requested screen can't be found. Writing script using first available screen.")
+            screenNumber = 0
+        else:
+            screenNumber = requestedScreenNumber-1 #computer has 1 as first screen
+        
         if fullScr:
             size = wx.Display(screenNumber).GetGeometry()[2:4]
         else:

--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -906,11 +906,12 @@ class Window:
         config = GL.Config(depth_size=8, double_buffer=True,
             stencil_size=stencil_size, stereo=self.stereo) #options that the user might want
         allScrs = pyglet.window.get_platform().get_default_display().get_screens()
-        if len(allScrs)>self.screen:
+        if len(allScrs)<int(self.screen)+1:  # Screen (from Exp Settings) is 1-indexed, so the second screen is Screen 1
+            logging.warn("Requested an unavailable screen number - using first available.")
+            thisScreen = allScrs[0]
+        else:
             thisScreen = allScrs[self.screen]
             logging.info('configured pyglet screen %i' %self.screen)
-        else:
-            logging.error("Requested an unavailable screen number")
         #if fullscreen check screen size
         if self._isFullScr:
             self._checkMatchingSizes(self.size,[thisScreen.width, thisScreen.height])


### PR DESCRIPTION
If a second screen was requested, but only one was available, both the Builder script writer and visual.Window would crash when trying to run. 

This fix allows both the Builder and Window to warn about the screen and then graciously step down to the available screen, instead of throwing an error. Builder will temporarily write the screen as 0 if the requested one can't be found, and Window itself which will run on any available screen.

It's probably alright for this to be an Error that halts, but I think warning and running on the available screen is probably a better choice for most people. If we really want the script to fail to build when a screen's not available, perhaps we could add some check to see if Debug mode has been enabled, but I think it's probably better this way.
