### PR TITLE
psychopy.visual.MovieStim.seek() fails when log=True

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -3995,7 +3995,7 @@ class MovieStim(_BaseVisualStim):
         """
         self._player.seek(float(timestamp))
         if log and self.autoLog:
-            self.win.logOnFlip("Set %s seek=" %(self.name,timestamp),
+            self.win.logOnFlip("Set %s seek=%f" %(self.name,timestamp),
                 level=logging.EXP,obj=self)
     def draw(self, win=None):
         """Draw the current frame to a particular visual.Window (or to the


### PR DESCRIPTION
Hi,

I found that psychopy.visual.MovieStim.seek() fails with following message when log=True.

```
Traceback (most recent call last):
  File "D:\work\test.py", line 94,
in <module>
    mov.seek(0)
  File "C:\Python27\lib\site-packages\psychopy-1.75.02-py2.7.egg\psychopy\visual
.py", line 3997, in seek
    self.win.logOnFlip("Set %s seek=" %(self.name,timestamp),
TypeError: not all arguments converted during string formatting
```

I think that %f is missing at the end of the string.
