### PR TITLE
nxutils can be present but not work for point-in-polygon stuff

### DIFF
--- a/psychopy/visual.py
+++ b/psychopy/visual.py
@@ -7342,7 +7342,13 @@ def pointInPolygon(x, y, poly):
 
     # faster if have matplotlib.nxutils:
     if haveNxutils:
-        return bool(nxutils.pnpoly(x, y, poly))
+        try:
+            return bool(nxutils.pnpoly(x, y, poly))
+            # has failed with matplotlib 1.2.0-r1
+            #   transform = transform.frozen()
+            # AttributeError: 'numpy.float64' object has no attribute 'frozen'
+        except:
+            pass
 
     # fall through to pure python:
     # as adapted from http://local.wasp.uwa.edu.au/~pbourke/geometry/insidepoly/
@@ -7379,9 +7385,11 @@ def polygonsOverlap(poly1, poly2):
 
     # faster if have matplotlib.nxutils:
     if haveNxutils:
-        if any(nxutils.points_inside_poly(poly1, poly2)):
-            return True
-        return any(nxutils.points_inside_poly(poly2, poly1))
+        try: # has failed with matplotlib 1.2.0-r1
+            if any(nxutils.points_inside_poly(poly1, poly2)):
+                return True
+            return any(nxutils.points_inside_poly(poly2, poly1))
+        except: pass
 
     # fall through to pure python:
     for p1 in poly1:


### PR DESCRIPTION
matplotlib 1.2.0-r1 on gentoo does have nxutils, but raised:
AttributeError: 'numpy.float64' object has no attribute 'frozen'

fix: try-except will now fall through to pure python.
long-term, might be better to figure out what is going on, might be a more
general issue for matplotlib 1.2.0-r1 (I use matplotlib 1.1.0)
