### PR TITLE
BF: loadFromXML ignores 'componentsFolders' option.

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -337,7 +337,7 @@ class Experiment:
             for componentNode in routineNode:
                 componentType=componentNode.tag
                 #create an actual component of that type
-                component=getAllComponents()[componentType](\
+                component=getAllComponents(self.prefsBuilder['componentsFolders'])[componentType](\
                     name=componentNode.get('name'),
                     parentName=routineNode.get('name'), exp=self)
                 # check for components that were absent in older versions of the builder and change the default behavior (currently only the new behavior of choices for RatingScale, HS, November 2012)


### PR DESCRIPTION
I placed a custom Builder component named 'MyComponent' in D:\work\customComponents and registered this directory to 'componentsFolders' option.
Then, I made a Builder experiment using this component and saved it as D:\work\test.psyexp. When I restarted Builder and try to load test.psyexp, I got following messages.

---

Failed to load D:\work\test.psyexp. Please send the following to the PsychoPy user list
Traceback (most recent call last):
  File "C:\Python27\lib\site-packages\psychopy-1.76.00-py2.7.egg\psychopy\app\builder\builder.py", line 3674, in fileOpen
    self.exp.loadFromXML(filename)
  File "C:\Python27\lib\site-packages\psychopy-1.76.00-py2.7.egg\psychopy\app\builder\experiment.py", line 340, in loadFromXML
    component=getAllComponents()[componentType](\
## KeyError: 'MyComponent'

I think that getAllComponents() in line 340 should receive the value of 'componentsFolders' as an argument to fix this problem.
