### PR TITLE
Bug #257: Fix README link

### DIFF
--- a/README
+++ b/README
@@ -2,4 +2,4 @@ PsychoPy is an open-source package for creating psychology stimuli in Python (A 
 
 The goal is to provide, for the busy scientist (including me!), tools to control timing and windowing and a simple set of pre-packaged stimuli and methods. The code is platform independent, using Python and C libraries that are widely available.
 
-To contribute, please fork the repository, hack in a feature branch, and send a pull request.  For more, see http://www.psychopy.org/psychopy1/home.php/Main/Help.
+To contribute, please fork the repository, hack in a feature branch, and send a pull request.  For more, see http://www.psychopy.org/developers/repository.html.


### PR DESCRIPTION
Fixed README link from http://www.psychopy.org/psychopy1/home.php/Main/Help link  to http://www.psychopy.org/developers/repository.html
