### PR TITLE
small changes to Timer related ENH.

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -46,11 +46,12 @@ if sys.platform == 'win32':
     _fcounter = c_int64()
     _qpfreq = c_int64()
     windll.Kernel32.QueryPerformanceFrequency(byref(_qpfreq))
+    _qpfreq=float(_qpfreq.value)
     _winQPC=windll.Kernel32.QueryPerformanceCounter
 
     def getTime():
         _winQPC(byref(_fcounter))
-        return  _fcounter.value/_qpfreq.value
+        return  _fcounter.value/_qpfreq
 else:
     cur_pyver = sys.version_info
     if cur_pyver[0]==2 and cur_pyver[1]<=6: 
@@ -65,8 +66,12 @@ class MonotonicClock:
     When a MonotonicClock is created, it stores the current time
     from getTime and uses this as an offset for psychopy times returned.
     """
-    def __init__(self):
-        self._timeAtLastReset=getTime()#this is sub-millisec timer in python
+    def __init__(self,start_time=None):
+        if start_time is None:
+            self._timeAtLastReset=getTime()#this is sub-millisec timer in python
+        else:
+            self._timeAtLastReset=start_time
+
     def getTime(self):
         """Returns the current time on this clock in secs (sub-ms precision)
         """

--- a/psychopy/tests/test_misc/test_CoreGetTime.py
+++ b/psychopy/tests/test_misc/test_CoreGetTime.py
@@ -5,15 +5,12 @@ Created on Tue Apr 23 11:18:47 2013
 Tests the psychopy.core.getTime Function:
 
   On Windows:
-    1) Checks that the QPC time implementation gives duration results
-       consistent with the Python high resolution timer implementation
-    2) Checks that the time between calls is never negative and never jumps
-       more than 3 sdev from the avaerge.
-       
-  On all platforms:
-    1) Tests the overhead in the getTime function call
-    2) Assesses the resolution of the underlying time base.
-    3) Tests MonotonicClock, Clock, CountdownTimer, wait
+    1) Checks that the currently used core.getTime() implementation gives duration results
+       consistent with directly using the Python high resolution timer.
+    2) Checks that the time between core.getTime calls is never negative.
+    3) Tests the overhead in the core.getTime function call
+    4) Tries to assess the resolution of the underlying core.getTime() time base and the Python high resolution timer.
+    5) Tests MonotonicClock, Clock, CountdownTimer, wait
 @author: Sol
 """
 import time


### PR DESCRIPTION
- Made a small change to the ctypes Win QPC timer implementation that
  saves ~100 usec per call.
- Changed MonotonicTimer class so that the initial start time value can
  be passed in as a param to the class **init**. (This is needed by the
  ioHub process, as it gets told by the experiment process what the global
  timer initial offset should be).
- Clarified timer test file comments at start of file, correctly what
  tests were actually implemented.
