### PR TITLE
get current time in unix-time

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -178,3 +178,17 @@ def wait(secs, hogCPUperiod=0.2):
         except:
             pass #presumably not pyglet
 
+def getAbsTime():
+    """Return unix time (i.e., whole seconds elapsed since Jan 1, 1970).
+
+    This uses the same clock-base as the other timing features, like `getTime()`.
+    The time (in seconds) ignores the time-zone (like `time.time()` on linux).
+    To take the timezone into account, use `int(time.mktime(time.gmtime()))`.
+
+    Absolute times in seconds are especially useful to add to generated file
+    names for being unique, informative (= a meaningful time stamp), and because
+    the resulting files will always sort as expected when sorted in chronological,
+    alphabetical, or numerical order, regardless of locale and so on.
+    """
+    return int(time.mktime(time.localtime()))
+

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -5,7 +5,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import sys, threading
-from clock import MonotonicClock, Clock, CountdownTimer, wait, monotonicClock
+from clock import MonotonicClock, Clock, CountdownTimer, wait, monotonicClock, getAbsTime
 # always safe to call rush, even if its not going to do anything for a particular OS
 from psychopy.platform_specific import rush
 from psychopy import logging
@@ -23,6 +23,7 @@ runningThreads=[] # just for backwards compatibility?
 # descripancy between OS's when win32 was using time.clock).
 global getTime
 getTime=monotonicClock.getTime
+#getAbsTime=clock.getAbsTime  # imported
 
 try:
     import pyglet

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -178,7 +178,7 @@ class RunTimeInfo(dict):
             pass
         
         # when was this run?
-        self['experimentRunTime.epoch'] = core.getTime() # basis for default random.seed()
+        self['experimentRunTime.epoch'] = core.getAbsTime()  # basis for default random.seed()
         self['experimentRunTime'] = data.getDateStr(format="%Y_%m_%d %H:%M (Year_Month_Day Hour:Min)")
         
         # random.seed -- record the value, and initialize random.seed() if 'set:'

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -169,11 +169,12 @@ class AudioCapture(object):
         while self.recorder.running:
             pass
         self.duration = float(sec)
-        self.onset = core.getTime() # note: report onset time in log, and use in filename
-        logging.data('%s: Record: onset %.3f, capture %.3fs' %
-                     (self.loggingId, self.onset, self.duration) )
+        self.onset = core.getTime()  # for duration estimation, high precision
+        self.fileOnset = core.getAbsTime()  # for log and filename, 1 sec precision
+        logging.data('%s: Record: onset %d, capture %.3fs' %
+                     (self.loggingId, self.fileOnset, self.duration) )
         if not file:
-            onsettime = '-%.3f' % self.onset
+            onsettime = '-%d' % self.fileOnset
             self.savedFile = onsettime.join(os.path.splitext(self.wavOutFilename))
         else:
             self.savedFile = os.path.abspath(file).strip('.wav') + '.wav'


### PR DESCRIPTION
motivations:
- useful in filenames (to be unique, meaningful, and safely sortable)
- want it to be in the same clock-base as other time features, and be documented as such
