### PR TITLE
ENH: iohub still runs if  pytables module can not be loaded

### DIFF
--- a/psychopy/demos/coder/iohub_extended/datastore/event2txt.py
+++ b/psychopy/demos/coder/iohub_extended/datastore/event2txt.py
@@ -11,6 +11,11 @@ tab delimited file.
 import sys,os
 import psychopy
 from psychopy.core import getTime
+import psychopy.iohub
+if psychopy.iohub._DATA_STORE_AVAILABLE is False:
+    raise ImportError("DataStore module could not be imported. (Likely that pyTables hdf5dll could not be found). Exiting demo...")
+    sys.exit(1)
+    
 from psychopy.iohub.datastore.util import displayDataFileSelectionDialog,displayEventTableSelectionDialog, ExperimentDataAccessUtility
     
 def writeOutputFileHeader(output_file, session_metadata_columns,log_entry_names):

--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -74,12 +74,19 @@ if sys.platform not in SUPPORTED_SYS_NAMES:
 import constants
 from constants import EventConstants, DeviceConstants, KeyboardConstants, MouseConstants,EyeTrackerConstants
 
-import client
-from client import ioHubConnection, launchHubServer, ioHubExperimentRuntime
-
 import devices
 from devices import Computer, import_device, DeviceEvent, Device
 
-import datastore
+_DATA_STORE_AVAILABLE=False
+try:
+    import datastore
+    _DATA_STORE_AVAILABLE=True
+except Exception, e:
+    print2err("WARNING: ioHub DataStore could not be loaded. DataStore functionality will be disabled. Error: ")
+    printExceptionDetailsToStdErr()
+    
+import client
+from client import ioHubConnection, launchHubServer, ioHubExperimentRuntime
 
+    
 import server

--- a/psychopy/iohub/client.py
+++ b/psychopy/iohub/client.py
@@ -33,6 +33,7 @@ from .devices import Computer, DeviceEvent,import_device
 from .devices.experiment import MessageEvent,LogEvent
 from .constants import DeviceConstants,EventConstants
 from .net import UDPClientConnection
+from . import _DATA_STORE_AVAILABLE
 
 currentSec= Computer.currentSec
 
@@ -1482,12 +1483,14 @@ def launchHubServer(**kwargs):
     psychopy_monitor_name=kwargs.get('psychopy_monitor_name',None)
     if psychopy_monitor_name:
         del kwargs['psychopy_monitor_name']
-
-    datastore_name=kwargs.get('datastore_name',None)
-    if datastore_name is not None:
-        del kwargs['datastore_name']
-    else:
-        datastore_name = None
+        
+    datastore_name=None
+    if _DATA_STORE_AVAILABLE is True:        
+        datastore_name=kwargs.get('datastore_name',None)
+        if datastore_name is not None:
+            del kwargs['datastore_name']
+        else:
+            datastore_name = None
 
 
     device_dict=kwargs
@@ -1533,7 +1536,7 @@ def launchHubServer(**kwargs):
     # Create an ioHub configuration dictionary.
     ioConfig=dict(monitor_devices=device_list)
     
-    if experiment_code and session_code:    
+    if _DATA_STORE_AVAILABLE is True and experiment_code and session_code:    
         # Enable saving of all device events to the 'ioDataStore'
         # datastore name is equal to experiment code given unless the 
         # datastore_name kwarg is provided, inwhich case it is used.


### PR DESCRIPTION
If the datastore / pytables module can not be loaded, a warning is given
on stderr but the program continues to run, with all datastore
functionality disabled. Streaming events are not effected.
