### PR TITLE
(Beginning of a) Fix to allow importing of PsychoPy on systems with special characters in the profile name.

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -35,6 +35,14 @@ if sys.platform=='win32':
         os.renames(oldMonitorFolder, monitorFolder)
 else:
     monitorFolder = join(os.environ['HOME'], '.psychopy2' , 'monitors')
+# HACK! On system where `monitorFolder` contains special characters, for
+# example because the Windows profile name does, `monitorFolder` must be
+# decoded to Unicode to prevent errors later on. However, this is not a proper
+# fix, since *everything* should be decoded to Unicode, and not just this
+# specific pathname. Right now, errors will still occur if `monitorFolder` is
+# combined with `str`-type objects that contain non-ASCII characters.
+if isinstance(monitorFolder, str):
+    monitorFolder = monitorFolder.decode(sys.getfilesystemencoding())
 
 if not os.path.isdir(monitorFolder):
     os.makedirs(monitorFolder)


### PR DESCRIPTION
On Windows systems with special characters in the profile name, an error occurred when concatenating `monitorFolder` with `self.name`, here:
- https://github.com/psychopy/psychopy/blob/master/psychopy/monitors/calibTools.py#L384

This prevented PsychoPy from being usable on (I imagine) all Windows systems where the profile name contains special characters. A hack to fix this specific issue is to decode `monitorFolder` into a `Unicode` string. With this patch it now runs fine on my test system.

However, the more general problem is that PsychoPy is not Unicode safe: Internally `str` strings are used seemingly everywhere, which is a recipe for trouble, particularly when it comes to file-system operations. It's probably a pretty major undertaking (I know it was for OpenSesame, where I ran into the same issues!), but ideally _all_ strings are decoded to `unicode` when they enter the program, and encoded back into `str` when they leave the program (if necessary, much of the input out can deal with `unicode`, so there's not always a need for conversion). As explained here:
- http://docs.python.org/2/howto/unicode.html#tips-for-writing-unicode-aware-programs

Cheers!
Sebastiaan
