### PR TITLE
	ENH: Extending TrialHandler's n-back information options

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -886,14 +886,24 @@ class TrialHandler(_BaseTrialHandler):
         return self.thisTrial
 
     def getFutureTrial(self, n=1):
-        """Returns the condition for n trials into the future without advancing
-        the trials.
+        """Returns the condition for n trials into the future, without advancing
+        the trials. Returns 'None' if attempting to go beyond the last trial.
         """
-        if n>self.nRemaining:
+        # check that we don't go out of bounds for either positive or negative offsets:
+        if n>self.nRemaining or self.thisN+n < 0:
             return None
         seqs = numpy.array(self.sequenceIndices).transpose().flat
         condIndex=seqs[self.thisN+n]
         return self.trialList[condIndex]
+
+    def getEarlierTrial(self, n=-1):
+        """Returns the condition information from n trials previously. Useful 
+        for comparisons in n-back tasks. Returns 'None' if trying to access a trial
+        prior to the first.
+        """
+        # treat positive offset values as equivalent to negative ones:
+        if n > 0: n = n * -1
+        return self.getFutureTrial(n)
 
     def _createOutputArray(self,stimOut,dataOut,delim=None,
                           matrixOnly=False):


### PR DESCRIPTION
In response to user query at
https://groups.google.com/forum/#!topic/psychopy-users/9aeU1AgEJv4.
Sometimes access is needed to information from previous trials (as in
an n-back task). As a kludge, the trialHandler's getFutureTrial()
function could be used for this by passing a negative index value, but
as it wasn't designed for this, it didn't include a bounds check to
handle trying to access a trial before the first one. This has now been
added.
To be explicit, have also added a getEarlierTrial() function, which
simply calls the getFutureTrial function but ensures the index is
negative.
