### PR TITLE
BF: proper sorting of events accessed via device

### DIFF
--- a/psychopy/iohub/devices/__init__.py
+++ b/psychopy/iohub/devices/__init__.py
@@ -926,7 +926,7 @@ class Device(ioObject):
                 self.clearEvents()
 
         if len(currentEvents)>0:
-            sorted(currentEvents, key=itemgetter(DeviceEvent.EVENT_HUB_TIME_INDEX))
+            currentEvents=sorted(currentEvents, key=itemgetter(DeviceEvent.EVENT_HUB_TIME_INDEX))
         return currentEvents
 
 

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -122,6 +122,10 @@ class ioHubKeyboardDevice(Device):
                 charEvent=list(key_release)
                 charEvent[DeviceEvent.EVENT_TYPE_ID_INDEX]=KeyboardCharEvent.EVENT_TYPE_ID
                 charEvent[DeviceEvent.EVENT_ID_INDEX]=Computer._getNextEventID()
+                # Add .1 msec to the Char event time so that, when sorted, Char event follows
+                # the Release Event that generated it.
+                #
+                charEvent[DeviceEvent.EVENT_HUB_TIME_INDEX]=key_release[DeviceEvent.EVENT_HUB_TIME_INDEX]+0.0001
                 charEvent.append(tuple(key_press))
                 charEvent.append(key_release[DeviceEvent.EVENT_HUB_TIME_INDEX]-key_press[DeviceEvent.EVENT_HUB_TIME_INDEX])
                 charEvents.append(charEvent)

--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -127,7 +127,7 @@ class udpServer(DatagramServer):
             self.iohub.eventBuffer.clear()
 
             if len(currentEvents)>0:
-                sorted(currentEvents, key=itemgetter(DeviceEvent.EVENT_HUB_TIME_INDEX))
+                currentEvents=sorted(currentEvents, key=itemgetter(DeviceEvent.EVENT_HUB_TIME_INDEX))
                 self.sendResponse(('GET_EVENTS_RESULT',currentEvents),replyTo)
             else:
                 self.sendResponse(('GET_EVENTS_RESULT', None),replyTo)


### PR DESCRIPTION
- BF: Add 0.1 /msec/ to KeyboardChar Event time so that when it is
  retrieved from a list of events, it just follows the KeyboardRelease
  event that generated it. Previously, the two event types had the same
  time, and the sort alg would always put the KeyboardChar event just
  /prior/ to the KeyboardRelease event that generated it, which is kind of
  incorrect.

**This one is important; please ensure it is in next release!**
