### PR TITLE
ENH: ensure some visible space between log elements

### DIFF
--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -168,7 +168,7 @@ class _Logger:
     self.targets is a list of dicts {'stream':stream, 'level':level}
 
     """
-    def __init__(self, format="%(t).4f\t%(levelname)s\t%(message)s"):
+    def __init__(self, format="%(t).4f \t%(levelname)s \t%(message)s"):
         """The string-formatted elements %(xxxx)f can be used, where
         each xxxx is an attribute of the LogEntry.
         e.g. t, t_ms, level, levelname, message
@@ -304,4 +304,3 @@ def log(msg, level, t=None, obj=None):
     Log the msg, at a  given level on the root logger
     """
     root.log(msg, level=level, t=t, obj=obj)
-


### PR DESCRIPTION
Sometimes (like coder output window) a tab \t has no visible extent
despite there being a tab char. so you can get things running together:
0.1435  INFOencrypt: destroy()ed original file (secure delete)

The change ensures that there is some whitespace, like:
0.1279  INFO encrypt: destroy()ed original file (secure delete)

For me this makes DEBUG and INFO columns line up a lot more read-ably.

Note: maybe some people parse their log files in a way that splits on \t
and the trailing space would now mess them up? probably very few people
