### PR TITLE
ENH: expose PyGame sound looping feature

### DIFF
--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -265,17 +265,29 @@ class SoundPygame(_SoundBase):
         self._snd=None
         self.setSound(value=value, secs=secs, octave=octave)
 
-    def play(self, fromStart=True, log=True):
+    def play(self, fromStart=True, log=True, loops=0):
         """Starts playing the sound on an available channel.
-        If no sound channels are available, it will not play and return None.
 
+        Parameters
+        ----------
+        fromStart : bool
+            Not yet implemented.
+        log : bool
+            Whether or not to log the playback event.
+        loops : int
+            How many times to repeat the sound after it plays once. If 
+            `loops` == -1, the sound will repeat indefinitely until stopped.
+
+        Notes
+        -----
+        If no sound channels are available, it will not play and return None.
         This runs off a separate thread i.e. your code won't wait for the
         sound to finish before continuing. You need to use a
         psychopy.core.wait() command if you want things to pause.
         If you call play() whiles something is already playing the sounds will
         be played over each other.
         """
-        self._snd.play()
+        self._snd.play(loops=loops)
         self.status=STARTED
         if log and self.autoLog:
             logging.exp("Sound %s started" %(self.name), obj=self)


### PR DESCRIPTION
This is useful for psychoacoustics studies where you have a continuous masker sound that you want to play continuously throughout an entire block of trials; you can just create say 20 seconds of gaussian noise using numpy and create a sound with `loops=-1` (which means "loop forever until `stop()` is called).  Defaults to `loops=0` (PyGame's internal default) which means "play once and don't repeat."
