### PR TITLE
Cleanup window.py

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1533,7 +1533,11 @@ class Window:
 
 
 def getMsPerFrame(myWin, nFrames=60, showVisual=False, msg='', msDelay=0.):
-    """Assesses the monitor refresh rate (average, median, SD) under current
+    """
+    Deprecated: please use the getMsPerFrame method in the
+    `psychopy.visual.Window` class.
+
+    Assesses the monitor refresh rate (average, median, SD) under current
     conditions, over at least 60 frames.
 
     Records time for each refresh (frame) for n frames (at least 60), while


### PR DESCRIPTION
Large-scale cleanup of visual/window.py.  Includes code formatting cleanup, cleanup of imports, some reorganization of methods, and better type handling (using isinstance or duck-typing where possible).  

It also includes explicit handling of None.  Previously, "if var == None:" or "if var != None:" was being used.  These, however, are equivalent to "if var:" and "if not var", respectively.  

In many cases, however, it was clear that actually testing for a value of None was what was expected.  This is done by "if var is None" or "if var is not None".  Depending on the circumstances I tried to determine whether "if var" or "if var is None" is better.  

However, although this can fix obscure bugs (for instance with "var = []", since "[] == None" is True), it is still a potentially backwards-incompatible change.  For an explicit backward-compatible change, then "if var" should be used everywhere.  But I don't think this is really the correct behavior.

All the other changes should be backwards-compatible.
