### PR TITLE
FIX: Allow un-overloading Pyglet lib dir

### DIFF
--- a/psychopy/visual/_pygletLibOverload.py
+++ b/psychopy/visual/_pygletLibOverload.py
@@ -34,6 +34,8 @@
 '''Functions for loading dynamic libraries.
 
 These extend and correct ctypes functions.
+
+THIS IS A MODIFIED VERSION OF ``pyglet/lib.py``
 '''
 
 __docformat__ = 'restructuredtext'
@@ -93,7 +95,7 @@ class LibraryLoader(object):
 
         if not names:
             raise ImportError("No library name specified")
-        
+
         platform_names = kwargs.get(self.platform, [])
         if type(platform_names) in (str, unicode):
             platform_names = [platform_names]


### PR DESCRIPTION
On my system, the `ld.so.conf` replacement does not follow the rules of the underlying `ldconfig` routine. `ld.so.conf` just tells `ldconfig` to look in `ld.so.conf.d` and do some parsing. I tried to fix the routines to follow this pattern, but it became too much of a hassle to parse, and I would be concerned about reliability. Hopefully the alternative solution of just (optionally) turning off the overriding acceptable for now.

Basically, on my system (Ubuntu 13.04 w/NVIDIA drivers), if I have the `libgl1-mesa-dev` package installed, the way PsychoPy's `ld` search replacement goes, it finds the software-rendering OpenGL instead of the NVIDIA ones. This causes `pyglet` to be unusable, regardless of whether I use PsychoPy or Pyglet directly subsequently. For this minimum example script:

```
from psychopy import prefs
prefs.general['pygletLibOverload'] = True
from psychopy import visual
import pyglet
w = pyglet.window.Window()
```

I get this error:

```
libGL error: failed to load driver: swrast
libGL error: Try again with LIBGL_DEBUG=verbose for more details.
Traceback (most recent call last):
  File "/home/larsoner/Desktop/untitled1.py", line 5, in <module>
    w = pyglet.window.Window()
  File "/home/larsoner/.local/lib/python2.7/site-packages/pyglet/__init__.py", line 338, in __getattr__
    __import__(import_name)
  File "/home/larsoner/.local/lib/python2.7/site-packages/pyglet/window/__init__.py", line 1815, in <module>
    gl._create_shadow_window()
  File "/home/larsoner/.local/lib/python2.7/site-packages/pyglet/gl/__init__.py", line 205, in _create_shadow_window
    _shadow_window = Window(width=1, height=1, visible=False)
  File "/home/larsoner/.local/lib/python2.7/site-packages/pyglet/window/xlib/__init__.py", line 166, in __init__
    super(XlibWindow, self).__init__(*args, **kwargs)
  File "/home/larsoner/.local/lib/python2.7/site-packages/pyglet/window/__init__.py", line 510, in __init__
    raise NoSuchConfigException('No standard config is available.')
pyglet.window.NoSuchConfigException: No standard config is available.
```

If I then set `prefs.general['pygletLibOverload'] = False` using my PR, it runs without issue.
