### PR TITLE
FIX: added check for pyoSndServer.getIsBooted() to initPyo call

### DIFF
--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -276,7 +276,7 @@ class SoundPygame(_SoundBase):
         log : bool
             Whether or not to log the playback event.
         loops : int
-            How many times to repeat the sound after it plays once. If 
+            How many times to repeat the sound after it plays once. If
             `loops` == -1, the sound will repeat indefinitely until stopped.
 
         Notes
@@ -414,7 +414,7 @@ class SoundPyo(_SoundBase):
             effect on sounds from files.
         """
         global pyoSndServer
-        if pyoSndServer==None:
+        if pyoSndServer==None or pyoSndServer.getIsBooted()==0:
             initPyo(rate=sampleRate)
 
         self.sampleRate=pyoSndServer.getSamplingRate()


### PR DESCRIPTION
This fixes a bug arising when `pyoSndServer` was not `None` because it had been initiated earlier in the python session (by a previous instance of psychopy).  Probably nobody else noticed it because normally `core.quit()` kills the python instance, so this never arises.  In my case, we catch `core.quit()`'s call to `sys.exit(0)` and prevent it from executing, so that we can do other stuff in python after the experiment is run (including, sometimes, running another psychopy instance).
