### PR TITLE
ENH: Correct comments in builder component source

### DIFF
--- a/psychopy/app/builder/components/eyetracker.py
+++ b/psychopy/app/builder/components/eyetracker.py
@@ -11,7 +11,7 @@ iconFile = path.join(thisFolder,'eyetracker.png')
 tooltip = 'Eyetracker: use one of several eyetrackers to follow gaze'
 
 class EyetrackerComponent(BaseComponent):
-    """An event class for checking the mouse location and buttons at given timepoints"""
+    """A class for using one of several eyetrackers to follow gaze"""
     categories = ['Responses']
     def __init__(self, exp, parentName, name='eyes',
                 startType='time (s)', startVal=0.0,

--- a/psychopy/app/builder/components/movie.py
+++ b/psychopy/app/builder/components/movie.py
@@ -11,7 +11,7 @@ iconFile = path.join(thisFolder,'movie.png')
 tooltip = 'Movie: play movie files'
 
 class MovieComponent(VisualComponent):
-    """An event class for presenting image-based stimuli"""
+    """An event class for presenting movie-based stimuli"""
     def __init__(self, exp, parentName, name='movie', movie='',
                 units='from exp settings',
                 pos=[0,0], size='', ori=0,

--- a/psychopy/app/builder/components/parallelOut.py
+++ b/psychopy/app/builder/components/parallelOut.py
@@ -12,7 +12,7 @@ iconFile = path.join(thisFolder,'parallelOut.png')
 tooltip = 'Parallel out: send signals from the parallel port'
 
 class ParallelOutComponent(BaseComponent):
-    """An event class for checking the mouse location and buttons at given timepoints"""
+    """A class for sending signals from the parallel port"""
     categories = ['I/O']
     def __init__(self, exp, parentName, name='p_port',
                 startType='time (s)', startVal=0.0,
@@ -58,7 +58,7 @@ class ParallelOutComponent(BaseComponent):
         self.params['syncScreen']=Param(syncScreen, valType='bool',
             allowedVals=[True, False],
             updates='constant', allowedUpdates=[],
-            hint="If the parallel port data relates to visual stimuli then sync it's pulse to the screen refresh",
+            hint="If the parallel port data relates to visual stimuli then sync its pulse to the screen refresh",
             label="Sync to screen")
     def writeInitCode(self,buff):
         buff.writeIndented("%(name)s = parallel.ParallelPort(address=%(address)s)\n" %(self.params))


### PR DESCRIPTION
Three source files had comments incorrectly copied from related files.
I fixed this by reproducing the available tool tips or changing words.
