### PR TITLE
BF: allow lists of key presses to be considered correct in Builder

### DIFF
--- a/psychopy/app/builder/components/keyboard.py
+++ b/psychopy/app/builder/components/keyboard.py
@@ -157,7 +157,7 @@ class KeyboardComponent(BaseComponent):
 
         if storeCorr:
             buff.writeIndented("# was this 'correct'?\n" %self.params)
-            buff.writeIndented("if (%(name)s.keys == str(%(correctAns)s)): %(name)s.corr = 1\n" %(self.params))
+            buff.writeIndented("if (%(name)s.keys == str(%(correctAns)s)) or (%(name)s.keys == %(correctAns)): %(name)s.corr = 1\n" %(self.params))
             buff.writeIndented("else: %(name)s.corr=0\n" %self.params)
 
         if forceEnd==True:


### PR DESCRIPTION
Currently the builder is only set up to use single key presses for answers to single trials rather than lists of key presses. This change would make both possible.

(this is both my first change to the PsychoPy source and my first use of Git, apologies if I've done something entirely stupid)
