### PR TITLE
Fix ValueError in keyboard component output code

### DIFF
--- a/psychopy/app/builder/components/keyboard.py
+++ b/psychopy/app/builder/components/keyboard.py
@@ -157,7 +157,7 @@ class KeyboardComponent(BaseComponent):
 
         if storeCorr:
             buff.writeIndented("# was this 'correct'?\n" %self.params)
-            buff.writeIndented("if (%(name)s.keys == str(%(correctAns)s)) or (%(name)s.keys == %(correctAns)): %(name)s.corr = 1\n" %(self.params))
+            buff.writeIndented("if (%(name)s.keys == str(%(correctAns)s)) or (%(name)s.keys == %(correctAns)s): %(name)s.corr = 1\n" %(self.params))
             buff.writeIndented("else: %(name)s.corr=0\n" %self.params)
 
         if forceEnd==True:


### PR DESCRIPTION
Running an experiment from the Builder view using a keyboard component
raised a ValueError because a format string had an error in its syntax.
