### PR TITLE
BF: Fix MultiStairHandler addReponse() and next(). 

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2356,7 +2356,14 @@ class MultiStairHandler(_BaseTrialHandler):
                 raise StopIteration
         #fetch next staircase/value
         self.currentStaircase = self.thisPassRemaining.pop(0)#take the first and remove it
-        self._nextIntensity = self.currentStaircase._nextIntensity#gets updated by self.addData()
+        #if staircase.next() not called, staircaseHandler would not save the first intensity,
+        #Error: miss align intensities and responses
+        try:
+            self._nextIntensity =self.currentStaircase.next()#gets updated by self.addData()
+        except:
+            self.runningStaircases.remove(self.currentStaircase)
+            if len(self.runningStaircases)==0: #If finished,set finished flag 
+                self.finished=True
         #return value
         if not self.finished:
             #inform experiment of the condition (but not intensity, that might be overridden by user)
@@ -2390,10 +2397,6 @@ class MultiStairHandler(_BaseTrialHandler):
         This is essential to advance the staircase to a new intensity level!
         """
         self.currentStaircase.addResponse(result, intensity)
-        try:
-            self.currentStaircase.next()
-        except:
-            self.runningStaircases.remove(self.currentStaircase)
         #add the current data to experiment if poss
         if self.getExp() != None:#update the experiment handler too
             self.getExp().addData(self.name+".response", result)


### PR DESCRIPTION
Every multi handler would lose first intensity in every staircase, which caused misalignment of intensities and
responses in the result.
e.g. 
====code start=====
from psychopy import data

startVal=0.5
stepSizes=[8,4,4]
conditions=[   {"label":"2.0","startVal":startVal,"stepType":"db","stepSizes":stepSizes,"nUp":1,"nDown":2,"minVal":0,"maxVal":1,"nTrials":12},
{"label":"4.0","startVal":startVal,"stepType":"db","stepSizes":stepSizes,"nUp":1,"nDown":2,"minVal":0,"maxVal":1,"nTrials":12}
]

stairHandler=data.MultiStairHandler(conditions=conditions,method='random')
currentStair=stair.next()
while True:
    print "cur stair:",currentStair[1]["label"],"cur contrast:",currentStair[0]
    response=raw_input("input a number:")
    stairHandler.addResponse(int(response))
    try:
        currentStair=stair.next()
    except StopIteration:
        break
stairHandler.saveAsExcel("MultiStairTest.xlsx")

=======code end========

The first intensity was 0.5, but it would lose in the excel files in all sheet. All result just misalign the intensities and responses, but reversals were not affected.   

This commit just fix the problems above.
