### PR TITLE
BF: Fix display list leaks in stimuli objects

### DIFF
--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -407,6 +407,7 @@ class GratingStim(BaseVisualStim):
 
 
     def __del__(self):
+        GL.glDeleteLists(self._listID, 1)
         self.clearTextures()#remove textures from graphics card to prevent crash
 
     def clearTextures(self):

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -239,6 +239,7 @@ class ImageStim(BaseVisualStim):
 
 
     def __del__(self):
+        GL.glDeleteLists(self._listID, 1)
         self.clearTextures()#remove textures from graphics card to prevent crash
 
     def contains(self, x, y=None):

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -473,6 +473,8 @@ class RadialStim(GratingStim):
                 level=logging.EXP,obj=self)
 
     def __del__(self):
+        if not self.useShaders:
+            GL.glDeleteLists(self._listID, 1)
         self.clearTextures()#remove textures from graphics card to prevent crash
 
     def clearTextures(self):

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -162,6 +162,10 @@ class TextStim(BaseVisualStim):
         self.contrast = float(contrast)
         self.setText(text, log=False) #self.width and self.height get set with text and calcSizeRednered is called
         self._needUpdate = True
+
+    def __del__(self):
+        GL.glDeleteLists(self._listID, 1)
+
     def setHeight(self,height, log=True):
         """Set the height of the letters (including the entire box that surrounds the letters
         in the font). The width of the letters is then defined by the font.


### PR DESCRIPTION
The OpenGL display lists created by four of the stimuli objects were not deleted. In most experiments this may not matter because the stimuli are usually reused instead of being deleted and created again. Still this is an improvement because it allows PsychoPy to scale better in such cases.
