### PR TITLE
Fixed Mouse constructor ignoring mouse cursor visibility

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -337,6 +337,7 @@ class Mouse:
         if not usePygame:
             global mouseButtons
             mouseButtons = [0,0,0]
+        self.setVisible(visible)
         if newPos is not None: self.setPos(newPos)
 
     def setPos(self,newPos=(0,0)):


### PR DESCRIPTION
The constructor for event.Mouse only uses the visibility argument to set self.visibility. The expected behaviour is that setting visibility=True in the contructor does the same as calling setVisible(False) just after the constructor. That is the case after this change.
