### PR TITLE
NF: sort display order of routines in routine panel; closes #430

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1421,7 +1421,8 @@ class RoutinesNotebook(wx.aui.AuiNotebook):
         """
         currPage = self.GetSelection()
         self.removePages()
-        for routineName in self.frame.exp.routines:
+        displayOrder = sorted(self.frame.exp.routines.keys())  # alphabetical
+        for routineName in displayOrder:
             self.addRoutinePage(routineName, self.frame.exp.routines[routineName])
         if currPage>-1:
             self.SetSelection(currPage)


### PR DESCRIPTION
- ordering done when redrawing routines, alphabetical order
- previously was no defined order at all (dict keys)
- user can still move routines around, but any such ordering is not saved
- new routines are added to the end (rightmost), sorted when re-draw
