### PR TITLE
BF: Fix Builder not displaying new name in panel

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -652,7 +652,7 @@ class FlowPanel(wx.ScrolledWindow):
         # deleted.
         dc = wx.BufferedPaintDC(self)
         dc = wx.GCDC(dc)
-        # use PrepateDC to set position correctly
+        # use PrepareDC to set position correctly
         self.PrepareDC(dc)
         # we need to clear the dc BEFORE calling PrepareDC
         bg = wx.Brush(self.GetBackgroundColour())
@@ -1124,7 +1124,7 @@ class RoutineCanvas(wx.ScrolledWindow):
             gcdc = dc
         else:
             gcdc = wx.GCDC(dc)
-        # use PrepateDC to set position correctly
+        # use PrepareDC to set position correctly
         self.PrepareDC(dc)
         # we need to clear the dc BEFORE calling PrepareDC
         bg = wx.Brush(self.GetBackgroundColour())
@@ -2936,7 +2936,7 @@ class DlgExperimentProperties(_BaseParamsDlg):
         self.mainSizer.Add(buttons, flag=wx.ALIGN_RIGHT)
         self.SetSizerAndFit(self.mainSizer)
 
-        #move the psoition to be v near the top of screen and to the right of the left-most edge of builder
+        #move the position to be v near the top of screen and to the right of the left-most edge of builder
         builderPos = self.frame.GetPosition()
         self.SetPosition((builderPos[0]+200,20))
 


### PR DESCRIPTION
Builder did not immediately display new component name in routine panel
if it was renamed in component properties. Displaying new name was only
accidentally possible by moving component, switching tabs or reloading.
This was fixed by conditional redraw of the routine if name was edited.
