### PR TITLE
BF: Fix KeyError when starting Builder experiment

### DIFF
--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -104,14 +104,10 @@ class SettingsComponent:
         buff.writeIndentedLines("\n# Setup files for saving\n")
         buff.writeIndented("if not os.path.isdir('%s'):\n" % saveToDir)
         buff.writeIndented("    os.makedirs('%s')  # if this fails (e.g. permissions) we will get error\n" % saveToDir)
-        if 'participant' in expInfoDict:
-            buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s_%s' %(expInfo['participant'], expInfo['date'])\n")
-        elif 'Participant' in expInfoDict:
-            buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s_%s' %(expInfo['Participant'], expInfo['date'])\n")
-        elif 'Subject' in expInfoDict:
-            buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s_%s' %(expInfo['Subject'], expInfo['date'])\n")
-        elif 'Observer' in expInfoDict:
-            buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s_%s' %(expInfo['Observer'], expInfo['date'])\n")
+        for field in ['participant', 'Participant', 'Subject', 'Observer']:
+            if field in expInfoDict:
+                buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s_%s' %(expInfo['" + field + "'], expInfo['date'])\n")
+                break;
         else:
             buff.writeIndented("filename = '" + saveToDir + "' + os.path.sep + '%s' %(expInfo['date'])\n")
 


### PR DESCRIPTION
The experiment crashed when starting from Builder and "Experiment info"
contained no field with name "participant", "Participant", "Subject" or
"Observer" but fields with names containing these names. For example if
a field was named "ParticipantID" this showed the dialog asking for the
value but crashed afterwards because "Participant" was looked up. Fault
was that the settings component checked the keys for experiment info by
looking into the serialized form of the dict and found sub strings this
way. This was fixed by using the eval()ed dict to check the keys there.
