### PR TITLE
BF: ElementArrayStim initialization

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -31,24 +31,28 @@ def setWithOperation(self, attrib, value, operation, stealth=False):
     # Handle cases where attribute is not defined yet.
     try:
         oldValue = getattr(self, attrib)
-
-        # Calculate new value using operation
-        if operation == '':
-            newValue = oldValue * 0 + value  # Preserves dimensions, if array
-        elif operation == '+':
-            newValue = oldValue + value
-        elif operation == '*':
-            newValue = oldValue * value
-        elif operation == '-':
-            newValue = oldValue - value
-        elif operation == '/':
-            newValue = oldValue / value
-        elif operation == '**':
-            newValue = oldValue ** value
-        elif operation == '%':
-            newValue = oldValue % value
+        if oldValue == None:
+            newValue = value 
         else:
-            raise ValueError('Unsupported value "', operation, '" for operation when setting', attrib, 'in', self.__class__.__name__)
+            oldValue = numpy.asarray(oldValue, float)        
+            
+            # Calculate new value using operation
+            if operation == '':
+                newValue = oldValue * 0 + value  # Preserves dimensions, if array
+            elif operation == '+':
+                newValue = oldValue + value
+            elif operation == '*':
+                newValue = oldValue * value
+            elif operation == '-':
+                newValue = oldValue - value
+            elif operation == '/':
+                newValue = oldValue / value
+            elif operation == '**':
+                newValue = oldValue ** value
+            elif operation == '%':
+                newValue = oldValue % value
+            else:
+                raise ValueError('Unsupported value "', operation, '" for operation when setting', attrib, 'in', self.__class__.__name__)
     except AttributeError:
         # attribute is not set yet. Do it now in a non-updating manner
         newValue = value

--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -169,7 +169,7 @@ class ElementArrayStim(object):
         self.nElements = nElements
         #info for each element
         self.sizes = sizes
-        self.xys= val2array(xys, length=len(xys))
+        self.xys= xys
         self.opacities = opacities
         self.oris = oris
         self.contrs = contrs


### PR DESCRIPTION
the setWithOperation function in attributetools gave an error when initializing a stimulus with either None as one of its arguments or a list or a tuple instead of a numpy array. I changed the function a bit such that it handles None as well as converts the input value to an array. 
