### PR TITLE
BF: Fixed memory leak in visual.MovieStim

### DIFF
--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -119,7 +119,7 @@ class MovieStim(BaseVisualStim):
         self._movie=None # the actual pyglet media object
         self._player=pyglet.media.ManagedSoundPlayer()
         self._player.volume=volume
-        self._player._on_eos=self._onEos
+        self._player_default_on_eos = self._player._on_eos
         self.filename=filename
         self.duration=None
         self.loop = loop
@@ -210,6 +210,7 @@ class MovieStim(BaseVisualStim):
         will not advance).  If play() is called again both will restart.
         """
         self._player.pause()
+        self._player._on_eos = self._player_default_on_eos
         self.status=PAUSED
         if log and self.autoLog:
             self.win.logOnFlip("Set %s paused" %(self.name),
@@ -220,6 +221,7 @@ class MovieStim(BaseVisualStim):
         be loaded again. Use pause() if you may need to restart the movie.
         """
         self._player.stop()
+        self._player._on_eos = self._player_default_on_eos
         self.status=STOPPED
         if log and self.autoLog:
             self.win.logOnFlip("Set %s stopped" %(self.name),
@@ -228,6 +230,7 @@ class MovieStim(BaseVisualStim):
         """Continue a paused movie from current position
         """
         self._player.play()
+        self._player._on_eos=self._onEos
         self.status=PLAYING
         if log and self.autoLog:
             self.win.logOnFlip("Set %s playing" %(self.name),
@@ -314,6 +317,7 @@ class MovieStim(BaseVisualStim):
             self.status=PLAYING
         else:
             self.status=FINISHED
+            self._player._on_eos = self._player_default_on_eos
         if self.autoLog:
             self.win.logOnFlip("Set %s finished" %(self.name),
                 level=logging.EXP,obj=self)
@@ -332,4 +336,4 @@ class MovieStim(BaseVisualStim):
         #add to drawing list and update status
         BaseVisualStim.autoDraw = val
     def __del__(self):
-        self._clearTextures()
+        self._player.next()


### PR DESCRIPTION
Two problems caused a memory leak when creating multiple MovieStim
instances across the experiment:

1.)
The line "self._player._on_eos=self._onEos" creates a reference to the
MovieStim object that prevents it from being garbage collected, that is
__del__ was never called

Solution:
set _on_eos only on playback and reset it on movie pause, stop and eos

2.)
The **del** function did not release the memory occupied by the movie.py

Solution:
replace self._clearTextures() (which is not defined in MovieStim) by
self._player.next() (which releases the memory)
##### 

Test cases to compare the old and new behavior:

First, add a "print 'del'" line to the MovieStim **del** function to see that it
is not called. Additionally, watch the memory consumption of the psychopy
process

1.)
Realisitc test case (Memory adds up over time, takes a while until python
crashes because of a "MemoryError").. I guess any .avi movie should do.

from psychopy import visual

window = visual.Window()
for i in range(0,500):
    video_stimulus = visual.MovieStim(window, "movie_memory_leak_demo.avi")
    while video_stimulus.status != visual.FINISHED:
        video_stimulus.draw()
        window.flip()
window.close()

2.)
Faster test case which will quickly result in a "MemoryError"

from psychopy import visual

window = visual.Window()
for i in range(0,500):
    video_stimulus = visual.MovieStim(window, "movie_memory_leak_demo.avi")
window.close()
