### PR TITLE
BF: numpy.asarray was being called without numpy being imported

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -6,6 +6,8 @@
 
 '''Functions and classes related to attribute handling'''
 
+import numpy
+
 from psychopy import logging
 
 class attributeSetter(object):


### PR DESCRIPTION
This was creating a NameError exception, which then wasn't being caught and was manifesting as a UnboundLocalError in the finally branch.
