### PR TITLE
ENH: Restore compatibility with wxPython 2.8

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -255,8 +255,12 @@ class CodeComponentDialog(wx.Dialog):
             self.params['name'].val = self.frame.exp.namespace.makeValid(params['name'].val)
 
 
+        agwStyle = flatnotebook.FNB_NO_X_BUTTON
+        if hasattr(flatnotebook, "FNB_NAV_BUTTONS_WHEN_NEEDED"):
+            # this style is not yet available in wxPython 2.8
+            agwStyle |= flatnotebook.FNB_NAV_BUTTONS_WHEN_NEEDED
         self.code_sections = flatnotebook.FlatNotebook(self, wx.ID_ANY,
-            agwStyle=flatnotebook.FNB_NO_X_BUTTON | flatnotebook.FNB_NAV_BUTTONS_WHEN_NEEDED)
+            agwStyle = agwStyle)
 
         for pkey in self.order:
             param=self.params.get(pkey)


### PR DESCRIPTION
The recent switch from using wxPython's Notebook widget to FlatNotebook
for code dialog broke the compatibility with wxPython 2.8 because style
FNB_NAV_BUTTONS_WHEN_NEEDED is not available there. This prevented code
dialog from showing because an AttributeError was raised. The attribute
is not needed to make code dialog work so this was fixed by checking if
it is available and only using it if this is the case (newer wxPython).
