### PR TITLE
FF: Fix NameError when using keyboard component

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2171,7 +2171,7 @@ class _BaseParamsDlg(wx.Dialog):
         currRow += 1
         #loop through the prescribed order (the most important?)
         for fieldName in self.order:
-            print fieldName
+#            print fieldName
             if fieldName not in paramNames:
                 continue#skip advanced params
             self.addParam(fieldName, parent, sizer, currRow, valType=self.params[fieldName].valType)


### PR DESCRIPTION
After recent changes it was not possible to use the keyboard component
because opening the property dialog raised a NameError. This was fixed
by using an available Sizer.
