### PR TITLE
FF: Fix parameter being in wrong tab in settings

### DIFF
--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -30,7 +30,8 @@ class SettingsComponent:
             hint="Run the experiment full-screen (recommended)",
             categ='Screen')
         self.params['Window size (pixels)']=Param(winSize, valType='code', allowedTypes=[],
-            hint="Size of window (if not fullscreen)")
+            hint="Size of window (if not fullscreen)",
+            categ='Screen')
         self.params['Screen']=Param(screen, valType='num', allowedTypes=[],
             hint="Which physical screen to run on (1 or 2)",
             categ='Screen')


### PR DESCRIPTION
In Builder's experiment settings the optional parameter for window size
was displayed in the "Basic" tab and not the "Screen" tab where related
check box is located. This was fixed by changing category to "Screen".
