### PR TITLE
BF: Fix ReadmeFrame not showing again after close

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -4166,7 +4166,11 @@ class BuilderFrame(wx.Frame):
         if not self.readmeFrame.IsShown():
             self.readmeFrame.Show(value)
     def toggleReadme(self, evt=None):
-        self.readmeFrame.toggleVisible()
+        if self.readmeFrame == None:
+           self.updateReadme()
+           self.showReadme()
+        else:
+           self.readmeFrame.toggleVisible()
 
     def OnFileHistory(self, evt=None):
         # get the file based on the menu ID


### PR DESCRIPTION
After closing (and not just hiding) the ReadmeFrame in Builder it was
not possible to show it again using the "toggle" option in the "view"
menu. The ReadmeFrame removes its reference from parent when closing.
Using the menu entry then caused an AttributeError. This was fixed by
checking the attribute (which exists because of **init**) and calling
updateReadme() and showReadme() if it does not contain a ReadmeFrame.
