### PR TITLE
BF: correction to fit cumulative normal function 

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2800,11 +2800,11 @@ class FitCumNormal(_baseFunctionFit):
     """Fit a Cumulative Normal function (aka error function or erf)
     of the form::
 
-        y = chance + (1-chance)*(special.erf(xx*xScale - xShift)/2.0+0.5)
+        y = chance + (1-chance)*((special.erf((xx-xShift)/(sqrt(2)*sd))+1)*0.5)
 
     and with inverse::
 
-        x = (erfinv((yy-chance)/(1-chance)*2.0-1)+xShift)/xScale
+        x = xShift+sqrt(2)*sd*(erfinv(((yy-chance)/(1-chance)-.5)*2))
 
     After fitting the function you can evaluate an array of x-values
     with fit.eval(x), retrieve the inverse of the function with


### PR DESCRIPTION
Fitting a cumulative normal function gave incorrect results on recovering parameters from simulated data. I looked up the function on http://en.wikipedia.org/wiki/Normal_distribution and there seemed to be some differences. I updated to code according to this definition and did so for the inverse function and recovering the parameters from simulated data worked fine. 
