### PR TITLE
BF: WindowsError fix that should work on other OS

### DIFF
--- a/psychopy/visual/_pygletLibOverload.py
+++ b/psychopy/visual/_pygletLibOverload.py
@@ -108,34 +108,50 @@ class LibraryLoader(object):
                 platform_names.append(libname or 'lib%s.so' % name)
 
         platform_names.extend(names)
-        for name in platform_names:
-            try:
-                lib = ctypes.cdll.LoadLibrary(name)
-                if _debug_lib:
-                    print name
-                if _debug_trace:
-                    lib = _TraceLibrary(lib)
-                return lib
-            except OSError, o:
-                if ((self.platform == "win32" and o.winerror != 126) or
-                    (self.platform.startswith("linux") and
-                     self.linux_not_found_error not in o.args[0]) or
-                    (self.platform == "darwin" and
-                     self.darwin_not_found_error not in o.args[0])):
-                    print "Unexpected error loading library %s: %s" % (name, str(o))
-                    raise
-                path = self.find_library(name)
-                if path:
-                    try:
-                        lib = ctypes.cdll.LoadLibrary(path)
-                        if _debug_lib:
-                            print path
-                        if _debug_trace:
-                            lib = _TraceLibrary(lib)
-                        return lib
-                    except OSError:
-                        pass
-        raise ImportError('Library "%s" not found.' % names[0])
+
+        if self.platform == "win32":
+            for name in platform_names:
+                try:
+                    lib = ctypes.cdll.LoadLibrary(name)
+                    if _debug_lib:
+                        print name
+                    if _debug_trace:
+                        lib = _TraceLibrary(lib)
+                    return lib             
+                except WindowsError:
+                    pass
+                except:
+                    pass
+            raise ImportError('Library "%s" not found.' % names[0])
+        else:            
+            for name in platform_names:
+                try:
+                    lib = ctypes.cdll.LoadLibrary(name)
+                    if _debug_lib:
+                        print name
+                    if _debug_trace:
+                        lib = _TraceLibrary(lib)
+                    return lib
+                except OSError, o:
+                    if ((self.platform == "win32" and o.winerror != 126) or
+                        (self.platform.startswith("linux") and
+                         self.linux_not_found_error not in o.args[0]) or
+                        (self.platform == "darwin" and
+                         self.darwin_not_found_error not in o.args[0])):
+                        print "Unexpected error loading library %s: %s" % (name, str(o))
+                        raise
+                    path = self.find_library(name)
+                    if path:
+                        try:
+                            lib = ctypes.cdll.LoadLibrary(path)
+                            if _debug_lib:
+                                print path
+                            if _debug_trace:
+                                lib = _TraceLibrary(lib)
+                            return lib
+                        except OSError:
+                            pass
+            raise ImportError('Library "%s" not found.' % names[0])
 
     find_library = lambda self, name: ctypes.util.find_library(name)
 


### PR DESCRIPTION
This fix for the memory access failed exception should not give issues
on Linux or OS X.

BTW, while debugging I printed the lib that was causing the WindowsError
originally, and I got:

Unexpected error loading library gdk-x11-2.0: [Error 126] The specified
module could not be found.

No idea why it was trying to load  gdk-x11-2.0, but is fails because it
does not exist from what I can tell.
