### PR TITLE
ENH: Fix ImportError if old wxpython is installed

### DIFF
--- a/docs/source/builder/settings.rst
+++ b/docs/source/builder/settings.rst
@@ -38,7 +38,7 @@ Data filename: (new in version 1.80.00):
         'data/%s/%s-%s' %(expInfo['participant'], expName, expInfo['date'])
         
         # put into dropbox: ~/dropbox/data/memoryTask/JWP-2014_Feb_15_1648
-        # on windows you may need to replace ~ with your hom directory
+        # on Windows you may need to replace ~ with your home directory
         '~/dropbox/data/%s/%s-%s' %(expName, expInfo['participant'], expInfo['date'])
 
 Save Excel file:

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -152,9 +152,9 @@ class PsychoPyApp(wx.App):
         #then override the prev files by command options and passed files
         if len(sys.argv)>1:
             if sys.argv[1]==__name__:
-                args = sys.argv[2:] # program was excecuted as "python.exe PsychoPyIDE.py %1'
+                args = sys.argv[2:] # program was executed as "python.exe PsychoPyIDE.py %1'
             else:
-                args = sys.argv[1:] # program was excecuted as "PsychoPyIDE.py %1'
+                args = sys.argv[1:] # program was executed as "PsychoPyIDE.py %1'
             #choose which frame to start with
             if args[0] in ['builder', '--builder', '-b']:
                     mainFrame='builder'


### PR DESCRIPTION
Builder imports modules from wxpython 2.8 which are not available for
older versions. If the system had older versions installed and one of
these versions was set as the default than starting Builder raised an
ImportError. This was fixed by just using wxversion to ensure that at
least wxpython 2.8 is available which provides the needed agw module.
