### PR TITLE
issue #523: keep newlines or set them globally to crlf or lf

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -4,7 +4,7 @@
 
 import sys, time, types, re
 import wx, wx.stc, wx.aui, wx.richtext
-import keyword, os, sys, string, StringIO, glob, platform
+import keyword, os, sys, string, StringIO, glob, platform, io
 import threading, traceback, bdb, cPickle
 import psychoParser
 import introspect, py_compile
@@ -1753,7 +1753,9 @@ class CoderFrame(wx.Frame):
 
             #load text from document
             if os.path.isfile(filename):
-                self.currentDoc.SetText(open(filename).read().decode('utf8'))
+                with open(filename, 'rU') as f:
+                    self.currentDoc.SetText(f.read().decode('utf8'))
+                    self.currentDoc.newlines = f.newlines
                 self.currentDoc.fileModTime = os.path.getmtime(filename)
                 self.fileHistory.AddFileToHistory(filename)
             else:
@@ -1862,9 +1864,25 @@ class CoderFrame(wx.Frame):
             try:
                 if failToSave: raise
                 self.SetStatusText('Saving file')
-                f = open(filename,'w')
-                f.write( doc.GetText().encode('utf-8'))
-                f.close()
+                newlines = None # system default, os.linesep
+                try:
+                    # this will fail when doc.newlines was not set (new file)
+                    if self.prefs['newlineConvention'] == 'keep':
+                        if doc.newlines == '\r\n' and not doc.GetText().lstrip(u'\ufeff').startswith("#!"):
+                            # '\r\n' and document has no shebang (ignore byte-order-marker)
+                            newlines = '\r\n'
+                        else: 
+                            # None, \n, tuple or document has shebang
+                            newlines = '\n'
+                    elif self.prefs['newlineConvention'] == 'dos':
+                        newlines = '\r\n'
+                    elif self.prefs['newlineConvention'] == 'unix':
+                        newlines = '\n'
+                except:
+                    pass
+                    
+                with io.open(filename,'w', encoding='utf-8', newline=newlines) as f:
+                    f.write(doc.GetText())
                 self.setFileModified(False)
                 doc.fileModTime = os.path.getmtime(filename) # JRG
             except:

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -79,6 +79,8 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
+    # newline for python files: unix = \n, dos = \r\n
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -79,6 +79,8 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
+    # newline for python files: unix = \n, dos = \r\n
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -79,6 +79,8 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
+    # newline for python files: unix = \n, dos = \r\n
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -79,6 +79,8 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
+    # newline for python files: unix = \n, dos = \r\n
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -76,6 +76,8 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
+    # newline for python files: unix = \n, dos = \r\n
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]


### PR DESCRIPTION
Newline behaviour is made an option in coder -> preferences. It has three possible values:
- keep (the default), keep the type of newlines that the file had when opening, except when they where mixed or the file starts with #!, then use unix. For new files the system default is used.
- unix, use lf as newline
- dos, use crlf as newline

note that because of the use of universal newlines 'show EOL' will now always show LF since this is the standard newline in python strings.
