### PR TITLE
BF: Fix ignoring stimOut when saving data output

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2241,7 +2241,7 @@ class MultiStairHandler(_BaseTrialHandler):
 
             conditions: a list of dictionaries specifying conditions
                 Can be used to control parameters for the different staicases.
-                Can be imported from an Excel file using `psychopy.data.importTrialTypes`
+                Can be imported from an Excel file using `psychopy.data.importConditions`
                 MUST include keys providing, 'startVal', 'label' and 'startValSd' (QUEST only).
                 The 'label' will be used in data file saving so should be unique.
                 See Example Usage below.


### PR DESCRIPTION
The methods saveAsExcel(), saveAsText() and indirectly printAsText() did
not use the lists from stimOut parameter. This prevented removing single
attributes from data output because by default every attribute is added.

This was an older problem. There may be working programs using the above
methods but actually pass not valid arguments. This did not matter until
now because the argument was ignored. Depending on the argument this may
raise errors (e.g. unrelated types) or cause less attributes written for
output (e.g. a former ignored list with less attributes than available).
