### PR TITLE
ioSync enhancements

### DIFF
--- a/psychopy/demos/coder/iohub_extended/mcu/TODO.py
+++ b/psychopy/demos/coder/iohub_extended/mcu/TODO.py
@@ -1,0 +1,89 @@
+"""
+ioSync MCU Program
+===================
+
+Analog Inputs
+~~~~~~~~~~~~~~
+
+- Add support for specifying a threshold level for each analog input; 
+  effectively allowing an AI to be turned into a user adjustable DI. When
+  the analog input value crosses threshold (up or down), generate a 
+  DigitalInputEvent.
+  
+- Add support to specify which of the 8 analog inputs should actually be read
+  during recording.
+
+- User adjustable analog input settings:
+    - resolution
+    - HW level averaging count
+    - AREF source
+    - sampling rate ??
+        
+Digital Inputs
+~~~~~~~~~~~~~~~
+
+- Add support to specify which of the 8 digital inputs should actually be read
+  during recording. The others can effectively be masked off.
+
+- User adjustable digital input settings:
+    - sampling rate ??
+
+- Change DI reads to use interupts.
+
+Misc.
+~~~~~
+
+- Add request type that resets the T3 to values like the chip was reset.
+    - reset usec clock
+    - ??
+
+ioSync Python API
+==================
+
+- Document
+   - API
+   - examples
+   
+
+ioSync Hardware
+===============
+
+Base Teensy 3 Breakout
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Create a diagram showing what Teensy 3 pins map to ioSync lines.
+
+- Create a schematic and associated text about the suggested way to mount the
+  Teensy 3 and bring out the different ioSync pins.
+
+ioSync HW Accessories
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Create a list of hardware plug-ins that can be built and used with ioSync.
+  For each accessory:
+      - Document:
+          - purpose
+          - parts list
+          - suggestions on build process.
+          - How to connect to ioSync
+          - How to access via ioSync Python API
+          - Picture.
+
+LED Control
+------------
+
+TBC
+
+Light Meter
+------------
+
+TBC
+
+Button Box
+-----------
+
+TBC
+
+
+EOF
+"""

--- a/psychopy/demos/coder/iohub_extended/mcu/digitalInTest.py
+++ b/psychopy/demos/coder/iohub_extended/mcu/digitalInTest.py
@@ -1,0 +1,76 @@
+ # -*- coding: utf-8 -*-
+"""
+Simple example of how to enable ioSync digital input events. The demo starts
+the iosync with digital input events enabled. An ioSync DigitalInputEvent is 
+created each time one of the eight digital input lines changes state. The
+event returns a 'state' byte, giving the value of all input lines when 
+the event occurred. 
+
+ioSync supports 8 digital inputs. Digital inputs are sampled at 1000 Hz.
+ 
+A state of 0 indicates no input lines are high. If DI_0
+is high, state will equal 1, DI_1 = 2,  DI_2 = 4 etc. 
+
+So digital input state = sum(2**di), where di is the index of an input that
+is high, bound by 0 <= di <= 7.
+
+Digital inputs which have a open ended wire connected to it (i.e. the input 
+wire is not also connected to a stable digital input source) will 'float'; 
+which will cause rapid random toggling of the digital input state. Only connect
+a lead to a digital input if it is also connected to a stable digital input 
+source.
+
+IMPORTANT: Input voltage to a digital input pin must be between 0.0 V and 3.3 V 
+or you may damage the Teensy 3. The Teensy 3.1 supports digital inputs up to
+5 V. 
+
+"""
+
+import numpy as np    
+import time
+from psychopy import core
+from psychopy.iohub import launchHubServer,Computer
+getTime=core.getTime
+
+io=None
+mcu=None
+
+try:
+    psychopy_mon_name='testMonitor'
+    exp_code='events'
+    sess_code='S_{0}'.format(long(time.mktime(time.localtime())))
+    
+    iohub_config={
+    "psychopy_monitor_name":psychopy_mon_name,
+    "mcu.iosync.MCU":dict(serial_port='COM8',monitor_event_types=['DigitalInputEvent',]),
+    "experiment_code":exp_code, 
+    "session_code":sess_code
+    }
+    
+    io=launchHubServer(**iohub_config)
+    
+    display=io.devices.display
+    mcu=io.devices.mcu
+    kb=io.devices.keyboard
+    experiment=io.devices.experiment
+        
+    mcu.enableEventReporting(True)
+    
+    io.clearEvents("all")   
+    i=0
+    while not kb.getEvents():   
+        mcu_events=  mcu.getEvents()  
+        for mcu_evt in mcu_events:
+            print'{0}\t{1}\t{2}'.format(mcu_evt.time,mcu_evt.device_time,
+                                                                 mcu_evt.state
+                                                                 )
+            
+    io.clearEvents('all')
+except:
+    import traceback
+    traceback.print_exc()    
+finally:
+    if mcu:    
+        mcu.enableEventReporting(False)   
+    if io:
+        io.quit() 

--- a/psychopy/iohub/devices/mcu/iosync/__init__.py
+++ b/psychopy/iohub/devices/mcu/iosync/__init__.py
@@ -306,11 +306,12 @@ class AnalogInputEvent(DeviceEvent):
         DeviceEvent.__init__(self,*args,**kwargs)
 
 class DigitalInputEvent(DeviceEvent):
-    _newDataTypes = [ ('state',N.uint8),  # the value of the 8 digital input lines as an uint8.
+    _newDataTypes = [ ('state',N.uint8)  # the value of the 8 digital input lines as an uint8.
                     ]
     EVENT_TYPE_ID=EventConstants.DIGITAL_INPUT
     EVENT_TYPE_STRING='DIGITAL_INPUT'
     IOHUB_DATA_TABLE=EVENT_TYPE_STRING
     __slots__=[e[0] for e in _newDataTypes]    
     def __init__(self,*args,**kwargs):        
+        self.state=0
         DeviceEvent.__init__(self,*args,**kwargs)

--- a/psychopy/iohub/devices/mcu/iosync/pysync.py
+++ b/psychopy/iohub/devices/mcu/iosync/pysync.py
@@ -153,7 +153,8 @@ class DigitalInputEvent(T3Event):
         T3Event.__init__(self,event_type,event_time_bytes,din_value)
 
     def _parseRemainingBytes(self,din_value):
-        self._value=din_value
+        print2err('DIN: ',din_value)
+        self._value=din_value[0]
         
     def getDigitalInputByte(self):
         return self._value

--- a/psychopy/iohub/devices/mcu/iosync/t3_sketch/ioSync/ioSync.ino
+++ b/psychopy/iohub/devices/mcu/iosync/t3_sketch/ioSync/ioSync.ino
@@ -469,6 +469,7 @@ void initDigitalInputs(){
   for (int i=0;i<sizeof(DIN_PINS);i++){
     pinMode(DIN_PINS[i], INPUT);
   }
+  pinMode(DIN_8, INPUT);
 }
 
 void initAnalogInputs(){


### PR DESCRIPTION
The ioSync software (teensy 3 program and the computer side python
interface) and base teensy 3 / 3.1 pin out functionality has now been
verified for:
- 8 digital inputs,  currently at 1000 Hz on MCU
- 8 analog inputs, currently at 1000 Hz on MCU, 0 - 3.3 V input range,
  12 - 13 usable bits of resolution.
- 8 digital outputs.
- MCU usec clock to psychopy / iohub time base syncronization has been
  verified to be within +/- 0.5 msec. Can likely get it better with more
  effort.

ioHub interface is working well it seems.

Examples are provided using psychopy.iohub for using each pin type and
testing time syncing.

As usual, doc's are very light at the moment. ;)
