### PR TITLE
BF: Shape stim interpolate value effect

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -243,10 +243,10 @@ class ShapeStim(BaseVisualStim):
 
         if self.interpolate:
             GL.glEnable(GL.GL_LINE_SMOOTH)
-            GL.glEnable(GL.GL_POLYGON_SMOOTH)
+            GL.glEnable(GL.GL_MULTISAMPLE)
         else:
             GL.glDisable(GL.GL_LINE_SMOOTH)
-            GL.glDisable(GL.GL_POLYGON_SMOOTH)
+            GL.glDisable(GL.GL_MULTISAMPLE)
         GL.glVertexPointer(2, GL.GL_DOUBLE, 0, vertsPix.ctypes)#.data_as(ctypes.POINTER(ctypes.c_float)))
 
         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)


### PR DESCRIPTION
Changed Shape.py to set the state of GL_MULTISAMPLE instead of
GL_POLYGON_SMOOTH based on interpolation value.

Fixes issue of some filled stim having visible line artefacts in the
filled area.
