### PR TITLE
DOC: Added information for the 'cross' mask for GratingStim

### DIFF
--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -243,7 +243,7 @@ class GratingStim(BaseVisualStim, TextureMixin, ColorMixin, ContainerMixin):
         """The alpha mask (forming the shape of the image)
 
         This can be one of various options:
-            + 'circle', 'gauss', 'raisedCos', **None** (resets to default)
+            + 'circle', 'gauss', 'raisedCos', 'cross', **None** (resets to default)
             + the name of an image file (most formats supported)
             + a numpy array (1xN or NxN) ranging -1:1
         """


### PR DESCRIPTION
Changed the docstring to include the 'cross' mask in /visual/grating.py
