### PR TITLE
Psychopy OSX 64-bit compatibility added

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -19,7 +19,7 @@ GL = pyglet.gl
 import ctypes
 
 #try to find avbin (we'll overload pyglet's load_library tool and then add some paths)
-if pyglet.version < "1.2" or sys.platform != "darwin":
+if pyglet.version < "1.2":
     import pyglet.lib
 
     # This piece of code does no longer work with pyglet 1.2alpha and results in the pyglet.gl
@@ -1381,7 +1381,7 @@ class Window:
         #identify gfx card vendor
         self.glVendor = GL.gl_info.get_vendor().lower()
 
-        if pyglet.version < "1.2" or sys.platform != "darwin":
+        if pyglet.version < "1.2" and sys.platform == 'darwin':
             platform_specific.syncSwapBuffers(1)
 
         if self.useFBO:


### PR DESCRIPTION
Got psychopy to work on 64-bit OSX systems, with the latest snapshot of pyglet 1.2 alpha 1 from code.google.com (190c95ab345e)
I mainly omitted some code blocks that prevented psychopy from finding pyglet or which caused segmentation faults. I don't know how crucial these blocks are for correct functioning of psychopy, but after disabling them all demos ran fine for me.

The three main changes were:
- Disabled overloading of pyglet.lib. This caused pyglet.gl (specifically gl_info) to not be found anymore afterwards. To my understanding this is only to aid in finding avbin, but if you do not use this, one can skip this step.
- Changed
  self._hw_handle=self.winHandle._window.value
  to
  self._hw_handle=self.winHandle._nswindow  
  though I have the feeling this is not entirely correct here. _window.value pointed to the window ID of the pyglet window, but ._nswindow points to the complete objc reference of this window. I couldn't find the window id value in this structure. Nevertheless, this change did the trick and I have no idea if the window ID value will ever be used somewhere else by psychopy?
- Disabled platform_specific.syncSwapBuffers(1)
  somehow this caused a segmentation fault and crashed everything...
