### PR TITLE
Don't draw lines when lineWidth is 0.

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -255,7 +255,7 @@ class ShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
                 #then draw
                 GL.glColor4f(fillRGB[0], fillRGB[1], fillRGB[2], self.opacity)
                 GL.glDrawArrays(GL.GL_POLYGON, 0, nVerts)
-        if self.lineRGB!=None:
+        if self.lineRGB!=None and self.lineWidth!=0.0:
             lineRGB = self._getDesiredRGB(self.lineRGB, self.lineColorSpace, self.contrast)
             #then draw
             GL.glLineWidth(self.lineWidth)


### PR DESCRIPTION
The OpenGL function GL.glDrawArrays(GL.GL_LINE_STRIP…) alway draw the line with a width of at least 1. If the line width of a shape stimuli is set to 0 then do not draw the lines.
