### PR TITLE
BF: fix bug introduced to getKeys/waitKeys

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -66,7 +66,7 @@ def _onPygletText(text, emulated=False):
     global useText
     if not useText: # _onPygletKey has handled the input
         return
-    keyTime=psychopy.core.getTime() #capture when the key was pressed
+    keyTime=psychopy.clock.getTime() #capture when the key was pressed
     if emulated:
         keySource = 'EmulatedKey'
     else:
@@ -91,7 +91,7 @@ def _onPygletKey(symbol, modifiers, emulated=False):
     """
 
     global useText
-    keyTime=psychopy.core.getTime() #capture when the key was pressed
+    keyTime=psychopy.clock.getTime() #capture when the key was pressed
     if emulated:
         thisKey = unicode(symbol)
         keySource = 'EmulatedKey'


### PR DESCRIPTION
CHange made in
https://github.com/psychopy/psychopy/commit/788292b736aa8d357ca5487d69ee02b3995ba79f
was causing issues for these functions when a clock instance was padded
in as the timer arg.

Also changed _onPygletText to use psychopy.clock.getTime()  instead of
psychopy.core.getTime() as it was before.

This fixes this specific (and big) bug I introduced, but does not
address other issues (which I thought the original commit was fixing).
Will look into this more later.
