### PR TITLE
BF: mouse-click event in Win-touch device(Pyglet)

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -35,6 +35,8 @@ else: usePygame=False
 if havePyglet:
     global _keyBuffer
     _keyBuffer = []
+    global mouseButtons
+    mouseButtons = [0,0,0]
     global mousePressed
     mousePressed = [0,0,0]
     global mouseReleased


### PR DESCRIPTION
When using windows touch device, Windows will intercept user's touch
after few milliseconds. This makes psychopy.event with Pyglet Window
unable to define mouse-click event correctly, even it catches both
mouse-press event and mouse-release event perfectly.

This bug-fix mainly seperates mouse-click event(mouseButtons) into two
lists (mousePressed and mouseReleased), which could catch mouse pressing
within few milliseconds.
