### PR TITLE
Beginning to allow conditions via file or list

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -607,7 +607,7 @@ class TrialHandler:
             hint="Number of repeats (for each condition)")
         self.params['conditions']=Param(conditions, valType='str', updates=None, allowedUpdates=None,
             hint="A list of dictionaries describing the parameters in each condition")
-        self.params['conditionsFile']=Param(conditionsFile, valType='str', updates=None, allowedUpdates=None,
+        self.params['conditionsFile']=Param(conditionsFile, valType='str', updates=None, allowedUpdates=None, label='Conditions',
             hint="Name of a file specifying the parameters for each condition (.csv, .xlsx, or .pkl). Browse to select a file. Right-click to preview file contents, or create a new file.")
         self.params['endPoints']=Param(endPoints, valType='num', updates=None, allowedUpdates=None,
             hint="The start and end of the loop (see flow timeline)")

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -720,6 +720,8 @@ class TrialHandler(_BaseTrialHandler):
 
         if trialList in [None, []]:#user wants an empty trialList
             self.trialList = [None]#which corresponds to a list with a single empty entry
+        elif isinstance(trialList, basestring) and os.path.isfile(trialList): #user has hopefully specified a filename
+            self.trialList = data.importConditions(trialList) #import conditions from that file
         else:
             self.trialList =trialList
         #convert any entry in the TrialList into a TrialType object (with obj.key or obj[key] access)


### PR DESCRIPTION
Allow Builder users to specify the conditions for a loop as either a
file (as previously) or as a variable containing a list of conditions.
