### PR TITLE
ENH: unify fonts in non-code boxes in Builder components dialog (Win32)

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -151,13 +151,17 @@ class PsychoPyApp(wx.App):
         self.dpi = int(wx.GetDisplaySize()[0]/float(wx.GetDisplaySizeMM()[0])*25.4)
         if not (50<self.dpi<120): self.dpi=80#dpi was unreasonable, make one up
 
-        self._mainFont = wx.SystemSettings.GetFont(wx.SYS_SYSTEM_FONT)
+        if sys.platform=='win32': #wx.SYS_DEFAULT_GUI_FONT is default GUI font in Win32
+            self._mainFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
+        else:
+            self._mainFont = wx.SystemSettings.GetFont(wx.SYS_SYSTEM_FONT)
         if hasattr(self._mainFont, 'Larger'):
             # Font.Larger is available since wyPython version 2.9.1
             # PsychoPy still supports 2.8 (see ensureMinimal above)
             self._mainFont = self._mainFont.Larger()
         self._codeFont = wx.SystemSettings.GetFont(wx.SYS_SYSTEM_FIXED_FONT)
         self._codeFont.SetFaceName(self.prefs.coder['codeFont'])
+        self._codeFont.SetPointSize(self._mainFont.GetPointSize()) #unify font size
 
         #create both frame for coder/builder as necess
         if splash:


### PR DESCRIPTION
In Windows, wx.SYS_DEFAULT_GUI_FONT should be used to get default dialog font.
Because font size of wx.SYS_SYSTEM_FIXED_FONT is different from that of wx.SYS_DEFAULT_GUI_FONT in Windows, size of _codeFont must be set to size of _mainFont.
