### PR TITLE
RF: add file name extension to localization/mappings.txt

### DIFF
--- a/psychopy/app/localization/__init__.py
+++ b/psychopy/app/localization/__init__.py
@@ -42,7 +42,8 @@ for i in range(230):
         wxIdFromCode[info.CanonicalName] = i
         codeFromWxId[i] = info.CanonicalName
 
-for line in codecs.open(os.path.join(os.path.dirname(__file__), 'mappings'), 'rU', 'utf8').readlines():
+mappings = os.path.join(os.path.dirname(__file__), 'mappings.txt')
+for line in codecs.open(mappings, 'rU', 'utf8').readlines():
     try:
         can, win, name = line.strip().split(' ', 2)  # canonical, windows, name-with-spaces
     except ValueError:
@@ -73,7 +74,7 @@ def getID(lang=None):
         if not val:
             val = codeFromWxId[wx.LANGUAGE_DEFAULT]
     try:
-        # can't set wx.Locale here because no app yet
+        # out-dated: [can't set wx.Locale here because no app yet] now there is an app
         # here just determine the value to be used when it can be set
         language = wxIdFromCode[val]
     except KeyError:

--- a/psychopy/app/localization/mappings.txt
+++ b/psychopy/app/localization/mappings.txt
@@ -2,7 +2,7 @@ af_ZA AFK
 am_ET AMH
 ar_SA ARA
 ar_LB ARB
-ar_EG ARE العربية
+ar_EG ARE العربية  (Arabic)
 ar_DZ ARG
 ar_BH ARH
 ar_IQ ARI
@@ -25,18 +25,18 @@ bn_IN BNG
 bo_CN BOB
 br_FR BRE
 ca_ES CAT
-zh_CN CHS 中文
-zh_TW CHT 台語
+zh_CN CHS 中文  (Chinese, simplified)
+zh_TW CHT 台語  (Chinese, traditional)
 co_FR COS
-cs_CZ CSY čeština
+cs_CZ CSY čeština  (Czech)
 cy_GB CYM
-da_DK DAN dansk
+da_DK DAN dansk  (Danish)
 de_AT DEA
 de_LI DEC
 de_LU DEL
 de_CH DES
-de_DE DEU Deutsch
-el_GR ELL ελληνικά
+de_DE DEU Deutsch  (German)
+el_GR ELL ελληνικά  (Greek)
 en_AU ENA
 en_CB ENB
 en_CA ENC
@@ -64,7 +64,7 @@ es_HN ESH
 es_NI ESI
 es_CL ESL
 es_MX ESM
-es_ES ESN español
+es_ES ESN español  (Spanish)
 es_CO ESO
 es_PE ESR
 es_AR ESS
@@ -76,9 +76,9 @@ es_PY ESZ
 et_EE ETI
 eu_ES EUQ
 fa_IR FAR
-fi_FI FIN suomi
+fi_FI FIN suomi  (Finnish)
 fo_FO FOS
-fr_FR FRA français
+fr_FR FRA français  (French)
 fr_BE FRB
 fr_CA FRC
 fr_LU FRL
@@ -88,27 +88,27 @@ fy_NL FYN
 gd_GB GLA
 gl_ES GLC
 gu_IN GUJ
-he_IL HEB עברית
-hi_IN HIN हिन्दी
+he_IL HEB עברית  (Hebrew)
+hi_IN HIN हिन्दी  (Hindi)
 hr_BA HRB
 hr_HR HRV
-hu_HU HUN magyar
+hu_HU HUN magyar  (Hungarian)
 hy_AM HYE
 ig_NG IBO
 ii_CN III
 id_ID IND
 ga_IE IRE
 is_IS ISL
-it_IT ITA italiano
+it_IT ITA italiano  (Italian)
 it_CH ITS
-ja_JP JPN 日本語
+ja_JP JPN 日本語  (Japanese)
 kl_GL KAL
 ka_GE KAT
 kn_IN KDI
 km_KH KHM
 rw_RW KIN
 kk_KZ KKZ
-ko_KR KOR 한국어
+ko_KR KOR 한국어  (Korean)
 ky_KG KYR
 lo_LA LAO
 lb_LU LBX
@@ -120,24 +120,24 @@ mt_MT MLT
 mn_MN MON
 mi_NZ MRI
 ms_BN MSB
-ms_MY MSL Bahasa melayu
+ms_MY MSL Bahasa melayu  (Malay)
 ml_IN MYM
 ne_NP NEP
 nl_BE NLB
-nl_NL NLD Nederlands
-nn_NO NON Norsk
+nl_NL NLD Nederlands  (Dutch)
+nn_NO NON Norsk  (Norwegian)
 nb_NO NOR
 ns_ZA NSO
 oc_FR OCI
 or_IN ORI
 pa_IN PAN
 ps_AF PAS
-pl_PL PLK polski
+pl_PL PLK polski  (Polish)
 pt_BR PTB
-pt_PT PTG português
+pt_PT PTG português  (Portugese)
 rm_CH RMC
-ro_RO ROM limba română
-ru_RU RUS Русский язык
+ro_RO ROM limba română  (Romanian)
+ru_RU RUS Русский язык  (Russian)
 sa_IN SAN
 si_LK SIN
 sk_SK SKY
@@ -146,18 +146,18 @@ se_NO SME
 se_SE SMF
 se_FI SMG
 sq_AL SQI
-sv_SE SVE Svenska
+sv_SE SVE Svenska  (Swedish)
 sv_FI SVF
 sw_KE SWK
 ta_IN TAM
 te_IN TEL
 th_TH THA
-tr_TR TRK Türkçe
+tr_TR TRK Türkçe  (Turkish)
 tn_ZA TSN
 tt_RU TTT
 tk_TM TUK
 ug_CN UIG
-uk_UA UKR Українська
+uk_UA UKR Українська  (Ukranian)
 ur_PK URD
 vi_VN VIT
 wo_SN WOL


### PR DESCRIPTION
- might help auto-add to the manifest?
- also add English names of languages (in case people switch to Japanese out of curiosity and then get lost trying to switch back) -- the locale pref is a lot more evident this way (to non-Japanese readers)
