### PR TITLE
BF: joystick method signature variation; closes #632

### DIFF
--- a/psychopy/hardware/joystick/pyglet_input/directinput.py
+++ b/psychopy/hardware/joystick/pyglet_input/directinput.py
@@ -162,6 +162,10 @@ class DirectInputDevice(base.Device):
             index = event.dwOfs // 4
             self.controls[index]._set_value(event.dwData)
 
+    def dispatch_events(self):
+        # standardize the method signature
+        self._dispatch_events()
+
 _i_dinput = None
 
 def _init_directinput():


### PR DESCRIPTION
- might disappear as an issue with pyglet 1.2
