### PR TITLE
BF: rename _ as _junk when not intended as translation function _( )

### DIFF
--- a/psychopy/hardware/joystick/pyglet_input/app/xlib.py
+++ b/psychopy/hardware/joystick/pyglet_input/app/xlib.py
@@ -2,14 +2,14 @@
 # pyglet
 # Copyright (c) 2006-2008 Alex Holkner
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions 
+# modification, are permitted provided that the following conditions
 # are met:
 #
 #  * Redistributions of source code must retain the above copyright
 #    notice, this list of conditions and the following disclaimer.
-#  * Redistributions in binary form must reproduce the above copyright 
+#  * Redistributions in binary form must reproduce the above copyright
 #    notice, this list of conditions and the following disclaimer in
 #    the documentation and/or other materials provided with the
 #    distribution.
@@ -112,7 +112,7 @@ class XlibEventLoop(PlatformEventLoop):
         # on a device.
         if not pending_devices and (timeout is None or not timeout):
             iwtd = self._select_devices
-            pending_devices, _, _ = select.select(iwtd, (), (), timeout)
+            pending_devices, _junk, _junk = select.select(iwtd, (), (), timeout)
 
         if not pending_devices:
             return False
@@ -125,7 +125,7 @@ class XlibEventLoop(PlatformEventLoop):
         for window in app.windows:
             if window._needs_resize:
                 window.switch_to()
-                window.dispatch_event('on_resize', 
+                window.dispatch_event('on_resize',
                                       window._width, window._height)
                 window.dispatch_event('on_expose')
                 window._needs_resize = False

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -196,7 +196,7 @@ class RunTimeInfo(dict):
 
         # platform name, etc
         if sys.platform in ['darwin']:
-            OSXver, _, architecture = platform.mac_ver()
+            OSXver, _junk, architecture = platform.mac_ver()
             platInfo = 'darwin ' + OSXver + ' ' + architecture
             # powerSource = ...
         elif sys.platform.startswith('linux'):

--- a/psychopy/iohub/devices/eventfilters.py
+++ b/psychopy/iohub/devices/eventfilters.py
@@ -469,10 +469,10 @@ if __name__ == '__main__':
         filtered_x=None
         filtered_y=None
         if r:
-            _, filtered_x=r
+            _junk, filtered_x=r
 
         r = my_filter.add(e['y_position'])
         if r:
-            _, filtered_y=r
+            _junk, filtered_y=r
 
         print "filtered values: ", filtered_x, filtered_y

--- a/psychopy/iohub/devices/eyetracker/filters/parser.py
+++ b/psychopy/iohub/devices/eyetracker/filters/parser.py
@@ -255,7 +255,7 @@ class EyeTrackerEventParser(eventfilters.DeviceEventFilter):
                 # is returned, add it to the to be processed sample list.
                 filtered_event = self.addToFieldFilters(current_mono_evt)
                 if filtered_event:
-                    filtered_event, _ = filtered_event
+                    filtered_event, _junk = filtered_event
                     x_vel_thresh, y_vel_thresh = self.addVelocityToAdaptiveThreshold(filtered_event)
                     filtered_event[self.io_event_ix('raw_x')] = x_vel_thresh
                     filtered_event[self.io_event_ix('raw_y')] = y_vel_thresh
@@ -468,7 +468,7 @@ class EyeTrackerEventParser(eventfilters.DeviceEventFilter):
             self._addVelocity(prev_samp, curr_samp)
             filtered_event = self.addToFieldFilters(curr_samp)
             if filtered_event:
-                filtered_event, _ = filtered_event
+                filtered_event, _junk = filtered_event
                 samples_for_processing.append(filtered_event)
             prev_samp = curr_samp
         return samples_for_processing
@@ -793,4 +793,3 @@ class EyeTrackerEventParser(eventfilters.DeviceEventFilter):
                 sample[self.io_event_ix('time')]-existing_start_event[self.io_event_ix('time')],
                 sample[self.io_event_ix('status')]
                 ]
-

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -79,7 +79,7 @@ class Keyboard(ioHubKeyboardDevice):
 
             report_system_wide_events = self.getConfiguration().get(
                 'report_system_wide_events', True)
-                
+
             pyglet_window_hnds = self._iohub_server._pyglet_window_hnds
             if event.Window in pyglet_window_hnds:
                 pass
@@ -87,7 +87,7 @@ class Keyboard(ioHubKeyboardDevice):
                     pyglet_window_hnds) > 0 and report_system_wide_events is False:
                 # For keyboard, when report_system_wide_events is false
                 # do not record kb events that are not targeted for
-                # a PsychoPy window, still allow them to pass to the desktop 
+                # a PsychoPy window, still allow them to pass to the desktop
                 # apps.
                 return True
 
@@ -201,7 +201,7 @@ class Keyboard(ioHubKeyboardDevice):
             # time of the second message.
             device_time = event.Time / 1000.0  # convert to sec
             time = notifiedTime
-            
+
             # since this is a keyboard device using a callback method,
             # confidence_interval is not applicable
             confidence_interval = 0.0
@@ -212,13 +212,13 @@ class Keyboard(ioHubKeyboardDevice):
             delay = 0.0
 
             #
-            ## check for unicode char        
+            ## check for unicode char
             #
 
             result = self._user32.ToUnicode(event.KeyID, event.ScanCode,
                                             ctypes.byref(self._keyboard_state),
                                             ctypes.byref(self._unichar), 8, 0)
-                                                        
+
             uchar = 0
             char = None
             ucat = None
@@ -240,12 +240,12 @@ class Keyboard(ioHubKeyboardDevice):
                 ucat = ucategory(self._unichar[0])
 
             if result == 0 or ucat and ucat[0] == 'C':
-                lukey, _ = KeyboardConstants._getKeyNameAndModsForEvent(event)
+                lukey, _junk = KeyboardConstants._getKeyNameAndModsForEvent(event)
                 if lukey and len(lukey) > 0:
                     char = lukey.lower()
 
             # Get evt.key field >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-                                            
+
             prev_shift =  self._keyboard_state[win32_vk.VK_SHIFT]
             temp_unichar =  (ctypes.c_wchar * 8)()
             self._keyboard_state[win32_vk.VK_SHIFT] = 0
@@ -254,7 +254,7 @@ class Keyboard(ioHubKeyboardDevice):
                                             ctypes.byref(temp_unichar), 8, 0)
 
             self._keyboard_state[win32_vk.VK_SHIFT] = prev_shift
-            
+
             key = None
             ucat2 = None
             if result2 > 0:
@@ -263,10 +263,10 @@ class Keyboard(ioHubKeyboardDevice):
                     ucat2 = ucategory(temp_unichar[0])
                 else:
                     for c in range(result2):
-                        ucat2 = ucategory(temp_unichar[c])                    
+                        ucat2 = ucategory(temp_unichar[c])
                     key = temp_unichar[0:result2]
                     key = key.encode('utf-8')
-            
+
             if event.Key.lower().startswith('numpad'):
                 key = 'num_%s'%(event.Key[6:])
             elif ucat2 == 'Cc':
@@ -274,11 +274,11 @@ class Keyboard(ioHubKeyboardDevice):
 
             if key is None and char:
                 key = char
-            
+
             #print2err('>>KEY: {0} {1} {2} {3}  {4} {5}'.format(
             #event.flags, event.Ascii, event.Key, key.lower(), uchar2, ucat2))
             #<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
-         
+
             kb_event = [0,
                         0,
                         0,  #device id (not currently used)

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -459,7 +459,7 @@ def getMarkerOnset(filename, chunk=128, secs=0.5, marker_hz=19000, marker_durati
     start = onsetChunks - 4
     stop = int(onsetChunks + marker_duration*sampleRate/chunk) + 4
     backwards = dftProfile[max(start, 0):min(stop, len(dftProfile))]
-    offChunks, _ = thresh2SD(backwards[::-1], thr=thr)
+    offChunks, _junk = thresh2SD(backwards[::-1], thr=thr)
     offSecs = (start + len(backwards) - offChunks) * chunk / sampleRate  # in secs
 
     return onsetSecs, offSecs
@@ -497,7 +497,7 @@ def getDftBins(data=None, sampleRate=None, low=100, high=8000, chunk=64):
     bins = []
     i = chunk
     if sampleRate:
-        _, freq = getDft(data[:chunk], sampleRate)  # just to get freq vector
+        _junk, freq = getDft(data[:chunk], sampleRate)  # just to get freq vector
         band = (freq > low) & (freq < high)  # band (frequency range)
     while i <= len(data):
         magn = getDft(data[i-chunk:i])
@@ -568,7 +568,7 @@ def getRMS(data):
     if isinstance(data, basestring):
         if not os.path.isfile(data):
             raise ValueError('getRMS: could not find file %s' % data)
-        _, data = wavfile.read(data)
+        _junk, data = wavfile.read(data)
         data_tr = np.transpose(data)
         data = data_tr / 32768.
     elif not isinstance(data, np.ndarray):
@@ -773,7 +773,7 @@ class Speech2Text(object):
         if ext not in ['.flac', '.wav']:
             raise SoundFormatNotSupported("Unsupported filetype: %s\n" % ext)
         if ext == '.wav':
-            _, samplingrate = readWavFile(filename)
+            _junk, samplingrate = readWavFile(filename)
         if samplingrate not in [16000, 8000]:
             raise SoundFormatNotSupported('Speech2Text sample rate must be 16000 or 8000 Hz')
         self.filename = filename
@@ -935,7 +935,7 @@ def flac2wav(path, keep=True):
     for flacfile in flac_files:
         wavname = flacfile.strip('.flac') + '.wav'
         flac_cmd = [flac_path, "-d", "--totally-silent", "-f", "-o", wavname, flacfile]
-        _, se = core.shellCall(flac_cmd, stderr=True)
+        _junk, se = core.shellCall(flac_cmd, stderr=True)
         if se:
             logging.error(se)
         if not keep:
@@ -968,12 +968,12 @@ def wav2flac(path, keep=True, level=5):
     for wavname in wav_files:
         flacfile = wavname.replace('.wav', '.flac')
         flac_cmd = [flac_path, "-%d" % level, "-f", "--totally-silent", "-o", flacfile, wavname]
-        _, se = core.shellCall(flac_cmd, stderr=True)
+        _junk, se = core.shellCall(flac_cmd, stderr=True)
         if se or not os.path.isfile(flacfile): # just try again
             # ~2% incidence when recording for 1s, 650+ trials
             # never got two in a row; core.wait() does not help
             logging.warn('Failed to convert to .flac; trying again')
-            _, se = core.shellCall(flac_cmd, stderr=True)
+            _junk, se = core.shellCall(flac_cmd, stderr=True)
             if se:
                 logging.error(se)
         if not keep:

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -163,7 +163,7 @@ class Preferences:
         if resultOfValidate == True:
             return
         vtor = validate.Validator()
-        for (section_list, key, _) in configobj.flatten_errors(cfg, resultOfValidate):
+        for (section_list, key, _junk) in configobj.flatten_errors(cfg, resultOfValidate):
             if key is not None:
                 cfg[', '.join(section_list)][key] = vtor.get_default_value(cfg.configspec[', '.join(section_list)][key])
             else:

--- a/psychopy/visual/vlc.py
+++ b/psychopy/visual/vlc.py
@@ -114,7 +114,7 @@ def find_lib():
                 for r in w.HKEY_LOCAL_MACHINE, w.HKEY_CURRENT_USER:
                     try:
                         r = w.OpenKey(r, 'Software\\VideoLAN\\VLC')
-                        plugin_path, _ = w.QueryValueEx(r, 'InstallDir')
+                        plugin_path, _junk = w.QueryValueEx(r, 'InstallDir')
                         w.CloseKey(r)
                         break
                     except w.error:
@@ -228,7 +228,7 @@ class _Cstruct(ctypes.Structure):
     _fields_ = []  # list of 2-tuples ('name', ctyptes.<type>)
 
     def __str__(self):
-        l = [' %s:\t%s' % (n, getattr(self, n)) for n, _ in self._fields_]
+        l = [' %s:\t%s' % (n, getattr(self, n)) for n, _junk in self._fields_]
         return '\n'.join([self.__class__.__name__] + l)
 
     def __repr__(self):
@@ -823,7 +823,7 @@ class CallbackDecorators(object):
     Callback = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     Callback.__doc__ = '''Callback function notification
 \param p_event the event triggering the callback
-    ''' 
+    '''
     LogCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, Log_ptr, ctypes.c_char_p, ctypes.c_void_p)
     LogCb.__doc__ = '''Callback prototype for LibVLC log message handler.
 \param data data pointer as given to L{libvlc_log_set}()
@@ -834,7 +834,7 @@ class CallbackDecorators(object):
 \note Log message handlers <b>must</b> be thread-safe.
 \warning The message context pointer, the format string parameters and the
          variable arguments are only valid until the callback returns.
-    ''' 
+    '''
     VideoLockCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ListPOINTER(ctypes.c_void_p))
     VideoLockCb.__doc__ = '''Callback prototype to allocate and lock a picture buffer.
 Whenever a new video frame needs to be decoded, the lock callback is
@@ -846,7 +846,7 @@ planes must be aligned on 32-bytes boundaries.
             of void pointers, this callback must initialize the array) [OUT]
 \return a private pointer for the display and unlock callbacks to identify
         the picture buffers
-    ''' 
+    '''
     VideoUnlockCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ListPOINTER(ctypes.c_void_p))
     VideoUnlockCb.__doc__ = '''Callback prototype to unlock a picture buffer.
 When the video frame decoding is complete, the unlock callback is invoked.
@@ -859,7 +859,7 @@ but before the picture is displayed.
                callback [IN]
 \param planes pixel planes as defined by the @ref libvlc_video_lock_cb
               callback (this parameter is only for convenience) [IN]
-    ''' 
+    '''
     VideoDisplayCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     VideoDisplayCb.__doc__ = '''Callback prototype to display a picture.
 When the video frame needs to be shown, as determined by the media playback
@@ -867,7 +867,7 @@ clock, the display callback is invoked.
 \param opaque private pointer as passed to L{libvlc_video_set_callbacks}() [IN]
 \param picture private pointer returned from the @ref libvlc_video_lock_cb
                callback [IN]
-    ''' 
+    '''
     VideoFormatCb = ctypes.CFUNCTYPE(ctypes.POINTER(ctypes.c_uint), ListPOINTER(ctypes.c_void_p), ctypes.c_char_p, ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_uint))
     VideoFormatCb.__doc__ = '''Callback prototype to configure picture buffers format.
 This callback gets the format of the video as output by the video decoder
@@ -891,47 +891,47 @@ the pixel height.
 Furthermore, we recommend that pitches and lines be multiple of 32
 to not break assumption that might be made by various optimizations
 in the video decoders, video filters and/or video converters.
-    ''' 
+    '''
     VideoCleanupCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)
     VideoCleanupCb.__doc__ = '''Callback prototype to configure picture buffers format.
 \param opaque private pointer as passed to L{libvlc_video_set_callbacks}()
               (and possibly modified by @ref libvlc_video_format_cb) [IN]
-    ''' 
+    '''
     AudioPlayCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint, ctypes.c_int64)
     AudioPlayCb.__doc__ = '''Callback prototype for audio playback.
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
 \param samples pointer to the first audio sample to play back [IN]
 \param count number of audio samples to play back
 \param pts expected play time stamp (see libvlc_delay())
-    ''' 
+    '''
     AudioPauseCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64)
     AudioPauseCb.__doc__ = '''Callback prototype for audio pause.
 \note The pause callback is never called if the audio is already paused.
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
 \param pts time stamp of the pause request (should be elapsed already)
-    ''' 
+    '''
     AudioResumeCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64)
     AudioResumeCb.__doc__ = '''Callback prototype for audio resumption (i.e. restart from pause).
 \note The resume callback is never called if the audio is not paused.
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
 \param pts time stamp of the resumption request (should be elapsed already)
-    ''' 
+    '''
     AudioFlushCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int64)
     AudioFlushCb.__doc__ = '''Callback prototype for audio buffer flush
 (i.e. discard all pending buffers and stop playback as soon as possible).
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
-    ''' 
+    '''
     AudioDrainCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)
     AudioDrainCb.__doc__ = '''Callback prototype for audio buffer drain
 (i.e. wait for pending buffers to be played).
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
-    ''' 
+    '''
     AudioSetVolumeCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_float, ctypes.c_bool)
     AudioSetVolumeCb.__doc__ = '''Callback prototype for audio volume change.
 \param data data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
 \param volume software volume (1. = nominal, 0. = mute)
 \param mute muted flag
-    ''' 
+    '''
     AudioSetupCb = ctypes.CFUNCTYPE(ctypes.POINTER(ctypes.c_int), ListPOINTER(ctypes.c_void_p), ctypes.c_char_p, ctypes.POINTER(ctypes.c_uint), ctypes.POINTER(ctypes.c_uint))
     AudioSetupCb.__doc__ = '''Callback prototype to setup the audio playback.
 This is called when the media player needs to create a new audio output.
@@ -941,12 +941,12 @@ This is called when the media player needs to create a new audio output.
 \param rate sample rate [IN/OUT]
 \param channels channels count [IN/OUT]
 \return 0 on success, anything else to skip audio playback
-    ''' 
+    '''
     AudioCleanupCb = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p)
     AudioCleanupCb.__doc__ = '''Callback prototype for audio playback cleanup.
 This is called when the media player no longer needs an audio output.
 \param opaque data pointer as passed to L{libvlc_audio_set_callbacks}() [IN]
-    ''' 
+    '''
 cb = CallbackDecorators
  # End of generated enum types #
 
@@ -1210,7 +1210,7 @@ class EventManager(_Ctype):
 
     @note: Only a single notification can be registered
     for each event type in an EventManager instance.
-    
+
     '''
 
     _callback_handler = None
@@ -1287,7 +1287,7 @@ class Instance(_Ctype):
       - a string
       - a list of strings as first parameters
       - the parameters given as the constructor parameters (must be strings)
-    
+
     '''
 
     def __new__(cls, *args):
@@ -1753,11 +1753,11 @@ class Instance(_Ctype):
 
 class Media(_Ctype):
     '''Create a new Media instance.
-    
+
     Usage: Media(MRL, *options)
 
     See vlc.Instance.media_new documentation for details.
-    
+
     '''
 
     def __new__(cls, *args):
@@ -2053,11 +2053,11 @@ class MediaLibrary(_Ctype):
 
 class MediaList(_Ctype):
     '''Create a new MediaList instance.
-    
+
     Usage: MediaList(list_of_MRLs)
 
     See vlc.Instance.media_list_new documentation for details.
-    
+
     '''
 
     def __new__(cls, *args):
@@ -2073,10 +2073,10 @@ class MediaList(_Ctype):
 
     def get_instance(self):
         return getattr(self, '_instance', None)
-    
+
     def add_media(self, mrl):
         """Add media instance to media list.
-        
+
         The L{lock} should be held upon entering this function.
         @param mrl: a media instance or a MRL.
         @return: 0 on success, -1 if the media list is read-only.
@@ -2193,7 +2193,7 @@ class MediaListPlayer(_Ctype):
     It may take as parameter either:
       - a vlc.Instance
       - nothing
-    
+
     '''
 
     def __new__(cls, arg=None):
@@ -2319,13 +2319,13 @@ class MediaPlayer(_Ctype):
     It may take as parameter either:
       - a string (media URI), options... In this case, a vlc.Instance will be created.
       - a vlc.Instance, a string (media URI), options...
-    
+
     '''
 
     def __new__(cls, *args):
         if len(args) == 1 and isinstance(args[0], _Ints):
             return _Constructor(cls, args[0])
-        
+
         if args and isinstance(args[0], Instance):
             instance = args[0]
             args = args[1:]
@@ -2397,13 +2397,13 @@ class MediaPlayer(_Ctype):
         Specify where the media player should render its video
         output. If LibVLC was built without Win32/Win64 API output
         support, then this has no effects.
-           
+
         @param drawable: windows handle of the drawable.
         """
         if not isinstance(drawable, ctypes.c_void_p):
             drawable = ctypes.c_void_p(int(drawable))
         libvlc_media_player_set_hwnd(self, drawable)
-            
+
     def video_get_width(self, num=0):
         """Get the width of a video in pixels.
 
@@ -2562,12 +2562,12 @@ class MediaPlayer(_Ctype):
         If you want to use it along with Qt4 see the QMacCocoaViewContainer. Then
         the following code should work:
         @begincode
-        
+
             NSView *video = [[NSView alloc] init];
             QMacCocoaViewContainer *container = new QMacCocoaViewContainer(video, parent);
             L{set_nsobject}(mp, video);
             [video release];
-        
+
         @endcode
         You can find a live example in VLCVideoView in VLCKit.framework.
         @param drawable: the drawable that is either an NSView or an object following the VLCOpenGLVideoViewEmbedding protocol.
@@ -4388,18 +4388,18 @@ def libvlc_video_set_callbacks(mp, lock, unlock, display, opaque):
     '''
     print 'libvlc_video_set_callbacks 1'
     sys.stdout.flush()
-    
+
     f = _Cfunctions.get('libvlc_video_set_callbacks', None) or \
         _Cfunction('libvlc_video_set_callbacks', ((1,), (1,), (1,), (1,), (1,),), None,
                     None, MediaPlayer, VideoLockCb, VideoUnlockCb, VideoDisplayCb, ctypes.c_void_p)
     print 'libvlc_video_set_callbacks 2'
     sys.stdout.flush()
- 
+
     r= f(mp, lock, unlock, display, opaque)
     print 'libvlc_video_set_callbacks 3'
     sys.stdout.flush()
     return r
-    
+
 def libvlc_video_set_format(mp, chroma, width, height, pitch):
     '''Set decoded video chroma and dimensions.
     This only works in combination with L{libvlc_video_set_callbacks}(),
@@ -4425,7 +4425,7 @@ def libvlc_video_set_format(mp, chroma, width, height, pitch):
     print 'libvlc_video_set_format 3'
     sys.stdout.flush()
     return r
-    
+
 def libvlc_video_set_format_callbacks(mp, setup, cleanup):
     '''Set decoded video chroma and dimensions. This only works in combination with
     L{libvlc_video_set_callbacks}().
@@ -4454,12 +4454,12 @@ def libvlc_media_player_set_nsobject(p_mi, drawable):
     If you want to use it along with Qt4 see the QMacCocoaViewContainer. Then
     the following code should work:
     @begincode
-    
+
         NSView *video = [[NSView alloc] init];
         QMacCocoaViewContainer *container = new QMacCocoaViewContainer(video, parent);
         L{libvlc_media_player_set_nsobject}(mp, video);
         [video release];
-    
+
     @endcode
     You can find a live example in VLCVideoView in VLCKit.framework.
     @param p_mi: the Media Player.

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -721,7 +721,7 @@ class Window(object):
                             "unnecessary because Window.waitBlanking=False")
 
         #Do the flipping with last flip as special case
-        for _ in range(flips-1):
+        for _junk in range(flips-1):
             self.flip(clearBuffer=False)
         self.flip(clearBuffer=clearBuffer)
 


### PR DESCRIPTION
- need to avoid name collision in the app: use of _ to mean junk when unpacking tuple, vs global translation function
- only preferences.py should actually matter, maybe info.py (because the translation function is for the app, not user scripts)
- but change everywhere to be consistent

$ find ../.. -name '*.py' | xargs -n 1 python gg_.py > gg_out.txt

where gg_.py is:

```
import re, sys
exp = re.compile(r'\b_\b[^\(]')
print sys.argv[1], '---------'*4
for i,line in enumerate(open(sys.argv[1]).readlines()):
  if exp.search(line):
    print i+1, ':', line,
```
