### PR TITLE
FIX: an extension *.mo is added to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ recursive-include psychopy/app/Resources *.icns
 recursive-include psychopy/app/Resources *.ico
 recursive-include psychopy/app/Resources *.ttf
 recursive-include psychopy/app/Resources *.desktop
+recursive-include psychopy/app/locale *.mo
 recursive-include psychopy/app *.spec *.xsd
 
 recursive-include psychopy/monitors *.ico


### PR DESCRIPTION
*.mo files are necessary for translating Builder strings.
