### PR TITLE
BF: ConfigWizard - Do not try to sort 'systemUserProcFlagged' with None

### DIFF
--- a/psychopy/wizard.py
+++ b/psychopy/wizard.py
@@ -393,6 +393,9 @@ class ConfigWizard(object):
 
         msg = ''
         warn = False
+        # assure that we have a list
+        if items['systemUserProcFlagged'] is None:
+            items['systemUserProcFlagged'] = []
         items['systemUserProcFlagged'].sort()
         self.badBgProc = [p for p,pid in items['systemUserProcFlagged']]
         if len(self.badBgProc):


### PR DESCRIPTION
assure it contains a list

Got into that situation in a pristine chroot sid environment
