### PR TITLE
BF: Benchmarck wizard could not detect pywin32.

### DIFF
--- a/psychopy/wizard.py
+++ b/psychopy/wizard.py
@@ -437,6 +437,9 @@ class ConfigWizard(object):
                     elif pkg == 'pyserial':
                         exec('import serial')
                         ver = serial.VERSION
+                    elif pkg == 'pywin32':
+                        exec('import win32api')
+                        ver = 'import ok'
                     else:
                         exec('import ' + pkg)
                         try: ver = eval(pkg+'.__version__')


### PR DESCRIPTION
pywin32 cannot be imported by 'import pywin32'.
Therefore, dedicated code is necessary to detect pywin32 installation.
