### PR TITLE
BF: Handle images that don't have a row stride of 4

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -758,6 +758,7 @@ class TextureMixin(object):
         GL.glEnable(GL.GL_TEXTURE_2D)
         GL.glBindTexture(GL.GL_TEXTURE_2D, id)#bind that name to the target
         GL.glTexParameteri(GL.GL_TEXTURE_2D,GL.GL_TEXTURE_WRAP_S,GL.GL_REPEAT) #makes the texture map wrap (this is actually default anyway)
+        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)  # data from PIL/numpy is packed, but default for GL is 4 bytes
         #important if using bits++ because GL_LINEAR
         #sometimes extrapolates to pixel vals outside range
         if interpolate:


### PR DESCRIPTION
Previously, luminance 8-bit images which don't have a width that's a multiple of 4 would render with a shear effect since GL is assuming a 4-byte alignment between rows, and PIL seems to always return packed data.
