### PR TITLE
BF: allow MonitorCenter to be run without psychopyapp; closes #742

### DIFF
--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -6,6 +6,7 @@
 
 import wx
 from wx import grid
+from psychopy.app import localization
 from psychopy import monitors, hardware, logging
 from psychopy.app import dialogs
 import time, os


### PR DESCRIPTION
- can now run from the command line (i.e., without PsychoPy app)
