### PR TITLE
data.py had a bug in originPath

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -615,7 +615,7 @@ class _BaseTrialHandler(object):
         #self.originPath and self.origin (the contents of the origin file)
         if originPath is None or not os.path.isfile(originPath):
             try:
-                originPath = inspect.getouterframes(inspect.currentframe())[1][1]
+                originPath = inspect.getouterframes(inspect.currentframe())[2][1]
                 if self.autoLog:
                     logging.debug("Using %s as origin file" %originPath)
             except:


### PR DESCRIPTION
originPath was not returning the calling script. Instead it was returning the path that includes data.py! I realize that one would expect 

inspect.getouterframes(inspect.currentframe())[1][1]

 to return the file one up, but somehow (eg in demo_trialHandler.py) it was returning data.py. In other words, rather than one's code being saved in the "origin" field, the contents of data.py were being saved. I discovered that the first TWO entries in the inspect object, indices 0 and 1, were both the data.py path. The third entry, [2], contains the calling script. Tested in the stand-alone psychopy only.
