### PR TITLE
BF : ImportError cannot import name types while using Joystick on Windows

### DIFF
--- a/psychopy/hardware/joystick/pyglet_input/app/win32.py
+++ b/psychopy/hardware/joystick/pyglet_input/app/win32.py
@@ -41,9 +41,9 @@ import ctypes
 from pyglet import app
 from base import PlatformEventLoop
 
-from pyglet.window.win32 import _kernel32, _user32, types, constants
-from pyglet.window.win32.constants import *
-from pyglet.window.win32.types import *
+from pyglet.libs.win32 import _kernel32, _user32, types, constants
+from pyglet.libs.win32.constants import *
+from pyglet.libs.win32.types import *
 
 class Win32EventLoop(PlatformEventLoop):
     def __init__(self):


### PR DESCRIPTION
An Incorrect pyglet package name was causing the below issue which using Joystick on windows.

from psychopy.hardware import joystick

Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "C:\Program Files\PsychoPy2\lib\site-packages\psychopy-1.81.02-py2.7.egg\psychopy\hardware\joystick\__init__.py", line 36, in <module>
    import pyglet_input
  File "C:\Program Files\PsychoPy2\lib\site-packages\psychopy-1.81.02-py2.7.egg\psychopy\hardware\joystick\pyglet_input\__init__.py", line 163, in <module>
    from directinput import get_devices, get_joysticks
  File "C:\Program Files\PsychoPy2\lib\site-packages\psychopy-1.81.02-py2.7.egg\psychopy\hardware\joystick\pyglet_input\directinput.py", line 6, in <module>
    import app
  File "C:\Program Files\PsychoPy2\lib\site-packages\psychopy-1.81.02-py2.7.egg\psychopy\hardware\joystick\pyglet_input\app\__init__.py", line 150, in <module>
    from win32 import Win32EventLoop as PlatformEventLoop
  File "C:\Program Files\PsychoPy2\lib\site-packages\psychopy-1.81.02-py2.7.egg\psychopy\hardware\joystick\pyglet_input\app\win32.py", line 44, in <module>
    from pyglet.window.win32 import _kernel32, _user32, types, constants
ImportError: cannot import name types
