### PR TITLE
saveAsWideText now also returns dataframe

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -8,6 +8,7 @@ from psychopy import logging
 from psychopy.tools.arraytools import extendArr, shuffleArray
 from psychopy.tools.fileerrortools import handleFileCollision
 import psychopy
+from pandas import DataFrame
 import cPickle, string, sys, os, time, copy
 import numpy
 from scipy import optimize, special
@@ -1101,7 +1102,6 @@ class TrialHandler(_BaseTrialHandler):
             dataOut.remove(invalidAnal)
         return dataOut, dataAnal, dataHead
 
-
     def saveAsWideText(self,fileName,
                    delim='\t',
                    matrixOnly=False,
@@ -1109,40 +1109,41 @@ class TrialHandler(_BaseTrialHandler):
                   ):
         """
         Write a text file with the session, stimulus, and data values from each trial in chronological order.
-
+        Also, return a pandas DataFrame containing same information as the file.
+    
         That is, unlike 'saveAsText' and 'saveAsExcel':
          - each row comprises information from only a single trial.
          - no summarising is done (such as collapsing to produce mean and standard deviation values across trials).
-
+    
         This 'wide' format, as expected by R for creating dataframes, and various other analysis programs, means that some
         information must be repeated on every row.
-
+    
         In particular, if the trialHandler's 'extraInfo' exists, then each entry in there occurs in every row.
         In builder, this will include any entries in the 'Experiment info' field of the 'Experiment settings' dialog.
         In Coder, this information can be set using something like::
-
+    
             myTrialHandler.extraInfo = {'SubjID':'Joan Smith', 'DOB':1970 Nov 16, 'Group':'Control'}
-
+    
         :Parameters:
-
+    
             fileName:
                 if extension is not specified, '.csv' will be appended if the delimiter is ',', else '.txt' will be appended.
                 Can include path info.
-
+    
             delim:
                 allows the user to use a delimiter other than the default tab ("," is popular with file extension ".csv")
-
+    
             matrixOnly:
                 outputs the data with no header row.
-
+    
             appendFile:
                 will add this output to the end of the specified file if it already exists.
-
+    
         """
         if self.thisTrialN<1 and self.thisRepN<1:#if both are <1 we haven't started
             logging.info('TrialHandler.saveAsWideText called but no trials completed. Nothing saved')
             return -1
-
+    
         #create the file or print to stdout
         if appendFile:
             writeFormat = 'a'
@@ -1157,7 +1158,7 @@ class TrialHandler(_BaseTrialHandler):
                 f = codecs.open(fileName+'.csv', writeFormat, encoding="utf-8")
             else:
                 f = codecs.open(fileName+'.txt', writeFormat, encoding="utf-8")
-
+    
         # collect parameter names related to the stimuli:
         if self.trialList[0]:
             header = self.trialList[0].keys()
@@ -1165,12 +1166,18 @@ class TrialHandler(_BaseTrialHandler):
             header = []
         # and then add parameter names related to data (e.g. RT)
         header.extend(self.data.dataTypes)
-
+        # get the extra 'wide' parameter names into the header line:
+        header.insert(0,"TrialNumber")
+        if (self.extraInfo != None):
+            for key in self.extraInfo:
+                header.insert(0, key)
+        df = DataFrame(columns = header)
+        
         # loop through each trial, gathering the actual values:
         dataOut = []
         trialCount = 0
         # total number of trials = number of trialtypes * number of repetitions:
-
+    
         repsPerType={}
         for rep in range(self.nReps):
             for trialN in range(len(self.trialList)):
@@ -1182,18 +1189,17 @@ class TrialHandler(_BaseTrialHandler):
                 else:
                     repsPerType[trialTypeIndex]+=1
                 repThisType=repsPerType[trialTypeIndex]#what repeat are we on for this trial type?
-
+    
                 # create a dictionary representing each trial:
                 # this is wide format, so we want fixed information (e.g. subject ID, date, etc) repeated every line if it exists:
                 if (self.extraInfo != None):
                     nextEntry = self.extraInfo.copy()
                 else:
                     nextEntry = {}
-
+    
                 # add a trial number so the original order of the data can always be recovered if sorted during analysis:
                 trialCount += 1
-                nextEntry["TrialNumber"] = trialCount
-
+    
                 # now collect the value from each trial of the variables named in the header:
                 for parameterName in header:
                     # the header includes both trial and data variables, so need to check before accessing:
@@ -1202,24 +1208,22 @@ class TrialHandler(_BaseTrialHandler):
                     elif parameterName in self.data:
                         nextEntry[parameterName] = self.data[parameterName][trialTypeIndex][repThisType]
                     else: # allow a null value if this parameter wasn't explicitly stored on this trial:
-                        nextEntry[parameterName] = ''
-
+                        if parameterName == "TrialNumber":
+                            nextEntry[parameterName] = trialCount
+                        else:
+                            nextEntry[parameterName] = ''
+    
                 #store this trial's data
                 dataOut.append(nextEntry)
-
-        # get the extra 'wide' parameter names into the header line:
-        header.insert(0,"TrialNumber")
-        if (self.extraInfo != None):
-            for key in self.extraInfo:
-                header.insert(0, key)
-
+                df = df.append(nextEntry, ignore_index=True)
+        
         if not matrixOnly:
         # write the header row:
             nextLine = ''
             for parameterName in header:
                 nextLine = nextLine + parameterName + delim
             f.write(nextLine[:-1] + '\n') # remove the final orphaned tab character
-
+    
         # write the data matrix:
         for trial in dataOut:
             nextLine = ''
@@ -1227,11 +1231,12 @@ class TrialHandler(_BaseTrialHandler):
                 nextLine = nextLine + unicode(trial[parameterName]) + delim
             nextLine = nextLine[:-1] # remove the final orphaned tab character
             f.write(nextLine + '\n')
-
+    
         if f != sys.stdout:
             f.close()
             logging.info('saved wide-format data to %s' %f.name)
-
+        return df
+        
     def addData(self, thisType, value, position=None):
         """Add data for the current trial
         """


### PR DESCRIPTION
Only about two lines of code had to be added, simple DataFrame commands. and about 4 lines of code moved up in the function. Sorry the github preview shows a bunch of deleted spaces added back in, I think that's an artifact of copy/paste (I still don't have my local repository working). Tested with stand-alone Psychopy v1.81.02, but of course none of this should be heavily version-dependent. 

This is the minimal solution, just adding return of a dataframe to saveAsWideText. I suspect it violates psychopy convention and expectation. I should write a function whose only role is to return a dataframe. Also the code should be vectorised. I can add all this to a github issue that I can post. I don't have time to do much more this year, but if you really want a stand-alone function, I could inelegantly duplicate saveAsWideText, delete the file-writing lines and replace them with the DataFrame lines.

Let me know, the other thing that possibly has to be done is do it for ExperimentHandler.
