### PR TITLE
Fix types of the columns of dataframe returned

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1235,6 +1235,8 @@ class TrialHandler(_BaseTrialHandler):
         if f != sys.stdout:
             f.close()
             logging.info('saved wide-format data to %s' %f.name)
+            
+        df= df.convert_objects() # Converts numbers to numeric, such as float64, boolean to bool. Otherwise they all are "object" type, i.e. strings
         return df
         
     def addData(self, thisType, value, position=None):


### PR DESCRIPTION
Converted types, otherwise every column's values are of "object" dtype, i.e. strings, which you can't do arithmetic with. It's because of some pandas quirk I haven't worked out, there may be a more proper way at the encoding stage to ensure the type is float64, bool, etc. rather than object.
