### PR TITLE
BF: Fix broken locale conversion in monitor center

### DIFF
--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -535,10 +535,10 @@ class MainFrame(wx.Frame):
         #insert values from new calib into GUI
         self.ctrlCalibDate.SetValue(
             monitors.strFromDate(self.currentMon.getCalibDate()))
-        self.ctrlScrDist.SetValue(str(self.currentMon.getDistance()))
-        self.ctrlScrWidth.SetValue(str(self.currentMon.getWidth()))
-        self.ctrlScrPixHoriz.SetValue(str(self.currentMon.currentCalib['sizePix'][0]))
-        self.ctrlScrPixVert.SetValue(str(self.currentMon.currentCalib['sizePix'][1]))
+        self.ctrlScrDist.SetValue(locale.str(self.currentMon.getDistance()))
+        self.ctrlScrWidth.SetValue(locale.str(self.currentMon.getWidth()))
+        self.ctrlScrPixHoriz.SetValue(locale.str(self.currentMon.currentCalib['sizePix'][0]))
+        self.ctrlScrPixVert.SetValue(locale.str(self.currentMon.currentCalib['sizePix'][1]))
         #self.ctrlScrGamma.SetValue(str(self.currentMon.getGamma()))
         self.ctrlCalibNotes.SetValue(self.currentMon.getNotes() or '')
         self.ctrlUseBits.SetValue(self.currentMon.getUseBits())


### PR DESCRIPTION
Saving and loading monitor configurations in the Monitor Center changed their values in some locales. The entered values are correctly converted from strings into floats using locale.atof() but they were incorrectly converted back into strings by using str() instead of locale.str(). The former does not use the decimal separator of the current locale and always adds a fractional part. locale.atof() then just removed the not valid separator (only) which led to a number having a different value.
