### PR TITLE
BF: microphone.stop() at end of every trial; fixes #763

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -20,6 +20,11 @@ Changelog
 PsychoPy 1.81
 ------------------------------
 
+PsychoPy 1.81.04
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* FIXED: builder: microphone recordings are explicitly stopped at the end of every trial
+
 PsychoPy 1.81.03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -10,6 +10,12 @@ Changelog
 PsychoPy 1.81
 ------------------------------
 
+
+PsychoPy 1.81.04
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* FIXED: builder: microphone recordings are explicitly stopped at the end of every trial
+
 PsychoPy 1.81.03
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/psychopy/app/builder/components/microphone.py
+++ b/psychopy/app/builder/components/microphone.py
@@ -70,7 +70,8 @@ class MicrophoneComponent(BaseComponent):
             currLoop = self.exp._expHandler
 
         #write the actual code
-        buff.writeIndented("# check responses\n" %self.params)
+        buff.writeIndented("# %(name)s stop & responses\n" %self.params)
+        buff.writeIndented("%s.stop()  # sometimes helpful\n" % self.params['name'])
         buff.writeIndented("if not %(name)s.savedFile:\n"%self.params)
         buff.writeIndented("    %(name)s.savedFile = None\n" %(self.params))
         buff.writeIndented("# store data for %s (%s)\n" %(currLoop.params['name'], currLoop.type))


### PR DESCRIPTION
- sometimes useful to avoid conflicts across trials when recording in a loop (see #763)
- should be harmless if the recording is already stopped
