### PR TITLE
BF: import csv files containing quoted commas

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -8,7 +8,7 @@ from psychopy import logging
 from psychopy.tools.arraytools import extendArr, shuffleArray
 from psychopy.tools.fileerrortools import handleFileCollision
 import psychopy
-from pandas import DataFrame
+from pandas import DataFrame, read_csv
 import cPickle, string, sys, os, time, copy
 import numpy
 from scipy import optimize, special
@@ -1347,14 +1347,12 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         raise ImportError('Conditions file not found: %s' %os.path.abspath(fileName))
 
     if fileName.endswith('.csv'):
-        #use csv import library to fetch the fieldNames
-        f = open(fileName, 'rU')#the U converts line endings to os.linesep (not unicode!)
-        trialsArr = numpy.recfromcsv(f, case_sensitive=True)
+        trialsArr = read_csv(fileName) # use pandas reader, which can handle commas in fields, etc
+        trialsArr = trialsArr.to_records(index=False) # convert the resulting dataframe to a numpy recarry
         if trialsArr.shape == ():  # convert 0-D to 1-D with one element:
             trialsArr = trialsArr[numpy.newaxis]
         fieldNames = trialsArr.dtype.names
         _assertValidVarNames(fieldNames, fileName)
-        f.close()
         #convert the record array into a list of dicts
         trialList = []
         for trialN, trialType in enumerate(trialsArr):


### PR DESCRIPTION
Currently, PsychoPy cannot import conditions files which have fields which contain commas, even when those fields are surrounded by quotes, which is a common CSV convention.
To fix this, the TrialHandler now imports conditions files using the pandas csv_reader rather than numpy's recfromcsv
NB this works for Coder BUT Builder's loop dialog still fails to deal with csv files which contain quoted commas. That GUI aspect needs to be updated in a similar fashion but I'm not sure how.
i.e. at this stage, data.py can deal with these csv files, but Builder users can't select them.