### PR TITLE
enable mouse.setPos under pyglet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ before_install:
   - sudo apt-cache policy           # What is actually available?
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
   - travis_retry sudo apt-get install -qq python-pyglet python-pygame python-opengl
-  - travis_retry sudo pip install gevent # Don't use apt-get (too old version of gevent)
+  - travis_retry sudo pip install -qq gevent # Don't use apt-get (too old version of gevent)
   - travis_retry sudo apt-get install -qq python-yaml python-xlib
   - travis_retry sudo pip install -qq psutil # Don't use apt-get (too old version of psutil)
-  - travis_retry sudo pip install msgpack-python #not apt-get (no permissions for universe)
+  - travis_retry sudo pip install -qq msgpack-python #not apt-get (no permissions for universe)
   - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-lxml
   - travis_retry sudo apt-get install -qq python-configobj python-imaging python-openpyxl python-mock python-wxgtk2.8 libavbin0 python-pyo
-  - travis_retry sudo pip install pandas #not apt-get (no permissions for universe)
+  - travis_retry sudo apt-get install -qq python-pandas
 install:
   - travis_retry sudo apt-get install -qq flac
   - flac -version

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -348,19 +348,20 @@ class Mouse:
         """
         return self.win.units
     def setPos(self,newPos=(0,0)):
-        """Sets the current position of the mouse (pygame only),
-        in the same units as the :class:`~visual.Window` (0,0) is at centre
+        """Sets the current position of the mouse,
+        in the same units as the :class:`~visual.Window`. (0,0) is the center.
 
         :Parameters:
             newPos : (x,y) or [x,y]
                 the new position on the screen
         """
         newPosPix = self._windowUnits2pix(numpy.array(newPos))
+        newPosPix[1] = self.win.size[1] / 2 - newPosPix[1]
+        newPosPix[0] = self.win.size[0] / 2 + newPosPix[0]
         if usePygame:
-            newPosPix[1] = self.win.size[1]/2-newPosPix[1]
-            newPosPix[0] = self.win.size[0]/2+newPosPix[0]
             mouse.set_pos(newPosPix)
-        else: print "pyglet does not support setting the mouse position yet"
+        else:
+            self.win.winHandle.set_mouse_position(*newPosPix)
 
     def getPos(self):
         """Returns the current position of the mouse,

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -361,7 +361,10 @@ class Mouse:
         if usePygame:
             mouse.set_pos(newPosPix)
         else:
-            self.win.winHandle.set_mouse_position(*newPosPix)
+            if hasattr(self.win.winHandle, 'set_mouse_position'):
+                self.win.winHandle.set_mouse_position(*newPosPix)
+            else:
+                print 'cannot set mouse position with XlibWindows (maybe others)'
 
     def getPos(self):
         """Returns the current position of the mouse,


### PR DESCRIPTION
Works for me on Mac with pyglet 1.2alpha1, and for Sol on Windows. Fails on Travis, possibly due to either pyglet or to xlib. So seems safest to build in a check before trying to set it.