### PR TITLE
mouse.setPos() works on pyglet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,3 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then xvfb-run -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" coverage run --rcfile=.travis_coveragerc psychopy/tests/runPytest.py -v -s -m "not needs_sound"; else { echo "TODO while avoiding duplication"; exit 1; } fi
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
- then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ before_install:
   - sudo apt-cache policy           # What is actually available?
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
   - travis_retry sudo apt-get install -qq python-pyglet python-pygame python-opengl
-  - travis_retry sudo pip install gevent # Don't use apt-get (too old version of gevent)
+  - travis_retry sudo pip install -qq gevent # Don't use apt-get (too old version of gevent)
   - travis_retry sudo apt-get install -qq python-yaml python-xlib
   - travis_retry sudo pip install -qq psutil # Don't use apt-get (too old version of psutil)
-  - travis_retry sudo pip install msgpack-python #not apt-get (no permissions for universe)
+  - travis_retry sudo pip install -qq msgpack-python #not apt-get (no permissions for universe)
   - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-lxml
   - travis_retry sudo apt-get install -qq python-configobj python-imaging python-openpyxl python-mock python-wxgtk2.8 libavbin0 python-pyo
-  - travis_retry sudo pip install pandas #not apt-get (no permissions for universe)
+  - travis_retry sudo apt-get install -qq python-pandas
 install:
   - travis_retry sudo apt-get install -qq flac
   - flac -version
@@ -36,3 +36,4 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then xvfb-run -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" coverage run --rcfile=.travis_coveragerc psychopy/tests/runPytest.py -v -s -m "not needs_sound"; else { echo "TODO while avoiding duplication"; exit 1; } fi
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
+ then coveralls; fi

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -347,9 +347,10 @@ class Mouse:
         (will match the current units for the Window it lives in)
         """
         return self.win.units
+
     def setPos(self,newPos=(0,0)):
-        """Sets the current position of the mouse (pygame only),
-        in the same units as the :class:`~visual.Window` (0,0) is at centre
+        """Sets the current position of the mouse,
+        in the same units as the :class:`~visual.Window`. (0,0) is the center.
 
         :Parameters:
             newPos : (x,y) or [x,y]
@@ -357,10 +358,15 @@ class Mouse:
         """
         newPosPix = self._windowUnits2pix(numpy.array(newPos))
         if usePygame:
-            newPosPix[1] = self.win.size[1]/2-newPosPix[1]
-            newPosPix[0] = self.win.size[0]/2+newPosPix[0]
+            newPosPix[1] = self.win.size[1] / 2 - newPosPix[1]
+            newPosPix[0] = self.win.size[0] / 2 + newPosPix[0]
             mouse.set_pos(newPosPix)
-        else: print "pyglet does not support setting the mouse position yet"
+        else:
+            if hasattr(self.win.winHandle, 'set_mouse_position'):
+                newPosPix = self.win.size / 2 + newPosPix
+                self.win.winHandle.set_mouse_position(*newPosPix)
+            else:
+                print 'cannot set mouse position with XlibWindows (maybe others)'
 
     def getPos(self):
         """Returns the current position of the mouse,


### PR DESCRIPTION
Used Sol's idea to set the mouse under pyglet. Worked fine on Mac with pyglet1.2alpha1, but not on travis (= linux, and maybe pyglet 1.1).

travis tweaks for less verbose installation of software