### PR TITLE
Fix errors in addUnitTypeConversion() and useVersion()

### DIFF
--- a/psychopy/tools/monitorunittools.py
+++ b/psychopy/tools/monitorunittools.py
@@ -84,9 +84,9 @@ def addUnitTypeConversion(unit_label, mapping_func):
 
         return pix
     """
-    if unit_label in unit2PixMappings:
+    if unit_label in _unit2PixMappings:
         raise ValueError("The unit type label [{0}] is already registered with PsychoPy".format(unit_label))
-    unit2PixMappings[unit_label]=mapping_func
+    _unit2PixMappings[unit_label] = mapping_func
 
 #
 # Built in conversion functions follow ...

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -20,7 +20,7 @@ def useVersion(requestedVersion):
     """Manage paths and checkout psychopy libraries for requested versions of psychopy.
 
     Inputs:
-        * requestedVersion : A string with the requested version of Psychopy to use
+        * requestedVersion : A string with the requested version of PsychoPy to use
           (NB Must be an exact version to checkout; ">=1.80.04" is NOT allowable yet.)
 
     Outputs:
@@ -32,7 +32,7 @@ def useVersion(requestedVersion):
 
     Usage (at the top of an experiment script):
 
-        from psychopy.versionchooser import useVersion
+        from psychopy.tools.versionchooser import useVersion
         useVersion('1.80.04')
         from psychopy import visual, event, ...
 

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -25,7 +25,7 @@ def useVersion(requestedVersion):
 
     Outputs:
         * Returns True if requested version was successfully loaded.
-          Raises a ScriptError if git is needed and not present, or if other psychopy modules
+          Raises a RuntimeError if git is needed and not present, or if other psychopy modules
           have already been loaded. Raises a subprocess CalledProcessError if an invalid
           git tag/version was checked out.
 
@@ -40,13 +40,13 @@ def useVersion(requestedVersion):
     # Sanity Checks
     imported = _psychopyComponentsImported()
     if len(imported):
-        raise ScriptError(
+        raise RuntimeError(
             "Please request a version before importing any psychopy modules. "
             "Found: %s" % imported)
     if _versionOk(psychopy.__version__, requestedVersion):
         return  # No switching needed
     if not _gitPresent():  # Switching required, so make sure `git` is available.
-        raise ScriptError("Please install git to specify a version with useVersion()")
+        raise RuntimeError("Please install git to specify a version with useVersion()")
 
     # Setup Requested Version
     requestedPath = _setupRequested(requestedVersion)


### PR DESCRIPTION
Using addUnitTypeConversion() raised a NameError because there were typos in two variable names.

useVersion() raised ScriptError with message but there is no ScriptError in Python and NameError was raised with a default message instead. This made the raise only useful to exit the function but not to message back what was wrong. This was fixed by replacing ScriptError with RuntimeError.

Both were found by pylint.
