### PR TITLE
BF: code startVal should not be nonSlipSafe; hopefully closes #792

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1381,7 +1381,7 @@ class RoutineCanvas(wx.ScrolledWindow):
         """
         maxTime, nonSlip = self.routine.getMaxTime()
         if self.routine.hasOnlyStaticComp():
-            maxTime = max(maxTime, int(maxTime) + 1.0)
+            maxTime = int(maxTime) + 1.0
         return maxTime
     def drawTimeGrid(self, dc, yPosTop, yPosBottom, labelAbove=True):
         """Draws the grid of lines and labels the time axes

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1068,7 +1068,7 @@ class FlowPanel(wx.ScrolledWindow):
             fontSizeDelta = (8,4,0)[self.appData['flowSize']]
             font.SetPointSize(1000/self.dpi-fontSizeDelta)
 
-        maxTime, nonSlip, onlyStaticComps = routine.getMaxTime()
+        maxTime, nonSlip = routine.getMaxTime()
         if nonSlip:
             rgbFill=nonSlipFill
             rgbEdge=nonSlipEdge
@@ -1379,9 +1379,9 @@ class RoutineCanvas(wx.ScrolledWindow):
     def getMaxTime(self):
         """Return the max time to be drawn in the window
         """
-        maxTime, nonSlip, onlyStaticComps = self.routine.getMaxTime()
-        if onlyStaticComps:
-            maxTime= maxTime+0.5
+        maxTime, nonSlip = self.routine.getMaxTime()
+        if self.routine.hasOnlyStaticComp():
+            maxTime = max(maxTime, int(maxTime) + 1.0)
         return maxTime
     def drawTimeGrid(self, dc, yPosTop, yPosBottom, labelAbove=True):
         """Draws the grid of lines and labels the time axes
@@ -2078,8 +2078,8 @@ class ParamCtrls:
         This function checks them all and returns the value or None.
 
         .. note::
-            Don't use GetStringSelection() here to avoid that translated value 
-            is returned. Instead, use GetSelection() to get index of selection 
+            Don't use GetStringSelection() here to avoid that translated value
+            is returned. Instead, use GetSelection() to get index of selection
             and get untranslated value from _choices attribute.
         """
         if ctrl is None:
@@ -2107,7 +2107,7 @@ class ParamCtrls:
         This function checks them all and returns the value or None.
 
         .. note::
-            Don't use SetStringSelection() here to avoid using tranlated 
+            Don't use SetStringSelection() here to avoid using tranlated
             value.  Instead, get index of the value using _choices attribute
             and use SetSelection() to set the value.
         """

--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -209,22 +209,21 @@ class BaseComponent(object):
             return None, None, True#this component does not have any start/stop
         startType=self.params['startType'].val
         stopType=self.params['stopType'].val
+        numericStart = canBeNumeric(self.params['startVal'].val)
+        numericStop = canBeNumeric(self.params['stopVal'].val)
         #deduce a start time (s) if possible
         #user has given a time estimate
         if canBeNumeric(self.params['startEstim'].val):
             startTime=float(self.params['startEstim'].val)
-        elif startType=='time (s)' and canBeNumeric(self.params['startVal'].val):
+        elif startType=='time (s)' and numericStart:
             startTime=float(self.params['startVal'].val)
         else: startTime=None
         #if we have an exact
-        if stopType=='time (s)' and canBeNumeric(self.params['stopVal'].val):
+        if stopType=='time (s)' and numericStop:
             duration=float(self.params['stopVal'].val)-startTime
-            nonSlipSafe=True
-        elif stopType=='duration (s)' and canBeNumeric(self.params['stopVal'].val):
+        elif stopType=='duration (s)' and numericStop:
             duration=float(self.params['stopVal'].val)
-            nonSlipSafe=True
         else:
-            nonSlipSafe=False
             #deduce duration (s) if possible. Duration used because component time icon needs width
             if canBeNumeric(self.params['durationEstim'].val):
                 duration=float(self.params['durationEstim'].val)
@@ -232,6 +231,7 @@ class BaseComponent(object):
                 duration=FOREVER#infinite duration
             else:
                 duration=None
+        nonSlipSafe = numericStart and numericStop
         return startTime, duration, nonSlipSafe
     def getPosInRoutine(self):
         """Find the index (position) in the parent Routine (0 for top)

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1180,7 +1180,7 @@ class Routine(list):
         buff.writeIndented('%s.reset()  # clock \n' %(self._clockName))
         buff.writeIndented('frameN = -1\n')
         #can we use non-slip timing?
-        maxTime, useNonSlip, onlyStaticComps = self.getMaxTime()
+        maxTime, useNonSlip = self.getMaxTime()
         if useNonSlip:
             buff.writeIndented('routineTimer.add(%f)\n' %(maxTime))
 
@@ -1270,6 +1270,8 @@ class Routine(list):
             if comp.params['name'].val==name:
                 return comp
         return None
+    def hasOnlyStaticComp(self):
+        return all([comp.type == 'Static' for comp in self])
     def getMaxTime(self):
         """What the last (predetermined) stimulus time to be presented. If
         there are no components or they have code-based times then will default
@@ -1277,8 +1279,7 @@ class Routine(list):
         """
         maxTime=0
         nonSlipSafe = True # if possible
-        onlyStaticComps = True
-        for n, component in enumerate(self):
+        for component in self:
             if 'startType' in component.params:
                 start, duration, nonSlip = component.getStartAndDuration()
                 if not nonSlip:
@@ -1292,13 +1293,10 @@ class Routine(list):
                 except:
                     thisT=0
                 maxTime=max(maxTime,thisT)
-                #update onlyStaticComps if needed
-                if component.type != 'Static':
-                    onlyStaticComps = False
         if maxTime==0:#if there are no components
             maxTime=10
             nonSlipSafe=False
-        return maxTime, nonSlipSafe, onlyStaticComps
+        return maxTime, nonSlipSafe
 
 class ExpFile(list):
     """An ExpFile is similar to a Routine except that it generates its code


### PR DESCRIPTION
This change definitely addresses issue #792; it completely fixes both the minimal example, and the original
post to the users list.

I think this change is conceptually right (i.e., code for a start value means that start times are not always known, and hence are not safe to treat as non-slip friendly).

But I'm not certain that *everything* is right. Please review (as always).