### PR TITLE
BF: component nonSlip and duration

### DIFF
--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -218,8 +218,7 @@ class BaseComponent(object):
         elif startType=='time (s)' and numericStart:
             startTime=float(self.params['startVal'].val)
         else: startTime=None
-        #if we have an exact
-        if stopType=='time (s)' and numericStop:
+        if stopType=='time (s)' and numericStop and numericStart:
             duration=float(self.params['stopVal'].val)-startTime
         elif stopType=='duration (s)' and numericStop:
             duration=float(self.params['stopVal'].val)
@@ -231,7 +230,7 @@ class BaseComponent(object):
                 duration=FOREVER#infinite duration
             else:
                 duration=None
-        nonSlipSafe = numericStart and numericStop
+        nonSlipSafe = numericStop and (numericStart or stopType == 'time (s)')
         return startTime, duration, nonSlipSafe
     def getPosInRoutine(self):
         """Find the index (position) in the parent Routine (0 for top)

--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -218,7 +218,7 @@ class BaseComponent(object):
         elif startType=='time (s)' and numericStart:
             startTime=float(self.params['startVal'].val)
         else: startTime=None
-        if stopType=='time (s)' and numericStop and numericStart:
+        if stopType=='time (s)' and numericStop and startTime is not None:
             duration=float(self.params['stopVal'].val)-startTime
         elif stopType=='duration (s)' and numericStop:
             duration=float(self.params['stopVal'].val)


### PR DESCRIPTION
- app would crash if trying to calculate duration when startTime==None (== using code for start). app would fail to reopen because trying to reload the offending file.
- allow nonSlip in cases where the end time is known (relative to start of routine)