### PR TITLE
Update sound.rst: Volume parameter missing

### DIFF
--- a/docs/source/builder/components/sound.rst
+++ b/docs/source/builder/components/sound.rst
@@ -23,6 +23,8 @@ sound :
       * a letter gives a note name (e.g. "C") and sharp or flat can also be added (e.g. "Csh" "Bf")
       * a filename, which can be a relative or absolute path (mid, wav, ogg and mp3 are supported).
 
+volume : float or integer
+    The volume with which the sound should be played. It's a normalized value between 0 (minimum) and 1 (maximum).
 
 .. seealso::
 	


### PR DESCRIPTION
I just saw that the documentation for the "Volume" parameter is missing. I was guessing (and there is a tool tip) what it is supposed to mean. I just wasn't sure whether, e.g., the value can be outside the range and will be clipped etc. Maybe someone can improve on this.

Best,

Axel