### PR TITLE
BF: sounds from a file were looping accidentally sound had been a tone b...

### DIFF
--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -203,7 +203,6 @@ class SoundPygame(_SoundBase):
         """
         self.name=name#only needed for autoLogging
         self.autoLog=autoLog
-        self.loops = 0 #-1 for infinite, or a number of loops
         #check initialisation
         if not mixer.get_init():
             pygame.mixer.init(sampleRate, -16, 2, 3072)
@@ -216,6 +215,9 @@ class SoundPygame(_SoundBase):
 
         #try to create sound
         self._snd=None
+        #distinguish the loops requested from loops actual because of infinite tones
+        # (which have many loops but none requested)
+        self.requestedLoops = self.loops = int(loops) #-1 for infinite or a number of loops
         self.setSound(value=value, secs=secs, octave=octave)
 
     def play(self, fromStart=True, log=True, loops=None):
@@ -278,6 +280,7 @@ class SoundPygame(_SoundBase):
     def _setSndFromFile(self, fileName):
         #load the file
         self.fileName = fileName
+        self.loops = self.requestedLoops #in case a tone with inf loops had been used before
         self._snd = mixer.Sound(self.fileName)
 
     def _setSndFromArray(self, thisArray):
@@ -369,7 +372,9 @@ class SoundPyo(_SoundBase):
         #try to create sound; set volume and loop before setSound (else needsUpdate=True)
         self._snd=None
         self.volume = min(1.0, max(0.0, volume))
-        self.loops = int(loops) #-1 for infinite or a number of loops
+        #distinguish the loops requested from loops actual because of infinite tones
+        # (which have many loops but none requested)
+        self.requestedLoops = self.loops = int(loops) #-1 for infinite or a number of loops
 
         self.setSound(value=value, secs=secs, octave=octave, hamming=hamming)
         self.needsUpdate = False
@@ -460,6 +465,7 @@ class SoundPyo(_SoundBase):
         # want mono sound file played to both speakers, not just left / 0
         self.fileName = fileName
         self._sndTable = pyo.SndTable(initchnls=self.channels)
+        self.loops = self.requestedLoops #in case a tone with inf loops had been used before
         # mono file loaded to all chnls:
         self._sndTable.setSound(self.fileName,
                                 start=self.startTime, stop=self.stopTime)


### PR DESCRIPTION
...efore

Fixes #802

Setting sound to a tone sets loops to infinite under the new scheme to
allow variable-duration tones. We needed to store that this was not done
on request but because of the tone so that if the sound is set to a file
then the loops can be reverted to the requested value