### PR TITLE
BF: Don't overwrite extraInfo variables in TrialHandler.saveAsWideText() (#814)

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1187,7 +1187,9 @@ class TrialHandler(_BaseTrialHandler):
         header.extend(self.data.dataTypes)
         # get the extra 'wide' parameter names into the header line:
         header.insert(0,"TrialNumber")
-        if (self.extraInfo != None):
+        # this is wide format, so we want fixed information
+        # (e.g. subject ID, date, etc) repeated every line if it exists:
+        if self.extraInfo is not None:
             for key in self.extraInfo:
                 header.insert(0, key)
         df = DataFrame(columns = header)
@@ -1210,11 +1212,7 @@ class TrialHandler(_BaseTrialHandler):
                 repThisType=repsPerType[trialTypeIndex]#what repeat are we on for this trial type?
 
                 # create a dictionary representing each trial:
-                # this is wide format, so we want fixed information (e.g. subject ID, date, etc) repeated every line if it exists:
-                if (self.extraInfo != None):
-                    nextEntry = self.extraInfo.copy()
-                else:
-                    nextEntry = {}
+                nextEntry = {}
 
                 # add a trial number so the original order of the data can always be recovered if sorted during analysis:
                 trialCount += 1
@@ -1226,6 +1224,8 @@ class TrialHandler(_BaseTrialHandler):
                         nextEntry[parameterName] = self.trialList[trialTypeIndex][parameterName]
                     elif parameterName in self.data:
                         nextEntry[parameterName] = self.data[parameterName][trialTypeIndex][repThisType]
+                    elif self.extraInfo is not None and parameterName in self.extraInfo:
+                        nextEntry[parameterName] = self.extraInfo[parameterName]
                     else: # allow a null value if this parameter wasn't explicitly stored on this trial:
                         if parameterName == "TrialNumber":
                             nextEntry[parameterName] = trialCount


### PR DESCRIPTION
Fixes #814. I think the fix for this is pretty straightforward, we just fill in the `extraInfo`
values along with the rest while looping through the header. I've changed the tests
against `None` to use `is` rather than `!=` since I was changing those sections
anyway, but if people want to suggest any other improvements I'm happy to
include them.