### PR TITLE
DOC: Broken link from Builder to Coder Sound documentation

### DIFF
--- a/docs/source/builder/components/sound.rst
+++ b/docs/source/builder/components/sound.rst
@@ -28,4 +28,4 @@ volume : float or integer
 
 .. seealso::
 	
-	API reference for :class:`~psychopy.sound.Sound`
+	API reference for :class:`~psychopy.sound.SoundPyo`


### PR DESCRIPTION
Hi Jon and others,

It seems there were some name changes; that's why the links were broken. I changed "~psychopy.sound.Sound" to "~psychopy.sound.SoundPyo". If somebody could confirm that this fixes the problem, I would also fix some other broken links in the same manner: Keyboard --> Event, Microphone --> AudioCapture, Mouse --> mouse.

Cheers,

Axel