### PR TITLE
DOC: Fixed broken links for Keyboard, Microphone, Mouse

### DIFF
--- a/docs/source/builder/components/keyboard.rst
+++ b/docs/source/builder/components/keyboard.rst
@@ -36,5 +36,5 @@ Discard previous
         
 .. seealso::
 
-    API reference for :mod:`~psychopy.event`
+    API reference for :mod:`~psychopy.event.Mouse`
      

--- a/docs/source/builder/components/microphone.rst
+++ b/docs/source/builder/components/microphone.rst
@@ -37,4 +37,4 @@ Parameters
 
 .. seealso::
 	
-	API reference for :class:`~psychopy.microphone.AudioCapture`
+	API reference for :class:`~psychopy.microphone.AdvAudioCapture`

--- a/docs/source/builder/components/mouse.rst
+++ b/docs/source/builder/components/mouse.rst
@@ -46,5 +46,5 @@ Time Relative To
         
 .. seealso::
     
-    API reference for :mod:`~psychopy.event.mouse`
+    API reference for :mod:`~psychopy.event.Mouse`
      


### PR DESCRIPTION

The links from Builder to the Coder API (under "see also") did not show for Keyboard, Microphone, Mouse. It seems some name changes were responsible. I hope everything works now. Keyboard is pointing to Mouse now because both are handled in the API on one page (psychopy.event alone does not work). Maybe somebody can check.

Best,

Axel