### PR TITLE
DOC: Deleted mp3 support for sound

### DIFF
--- a/docs/source/builder/components/sound.rst
+++ b/docs/source/builder/components/sound.rst
@@ -21,7 +21,7 @@ sound :
       
       * a number can specify the frequency in Hz (e.g. 440)
       * a letter gives a note name (e.g. "C") and sharp or flat can also be added (e.g. "Csh" "Bf")
-      * a filename, which can be a relative or absolute path (mid, wav, ogg and mp3 are supported).
+      * a filename, which can be a relative or absolute path (mid, wav, and ogg are supported).
 
 volume : float or integer
     The volume with which the sound should be played. It's a normalized value between 0 (minimum) and 1 (maximum).


### PR DESCRIPTION

For now, I just deleted the "mp3" support for sound, since it doesn't seem to work and most people found out the hard that they have to use "wav" or other. If there is a more detailed story about this issue (mp3 use possible under conditions 1-x, for example), which should also be part of the documentation, let me know and I can take care of it.

Cheers,

Axel