### PR TITLE
Docs: start HTML title with current page

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -141,11 +141,11 @@ changed: sidebar, rootrellink, header, footer,
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     {{ metatags }}
     {%- if not embedded %}
-      {%- set titlesuffix = docstitle|e + " &mdash; "|safe%}
+      {%- set titlesuffix = " &mdash; "|safe + docstitle|e%}
     {%- else %}
       {%- set titlesuffix = "" %}
     {%- endif %}
-    <title>{{ titlesuffix }}{{ title|striptags }}</title>
+    <title>{{ title|striptags }}{{ titlesuffix }}</title>
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
     {%- if not embedded %}


### PR DESCRIPTION
As discussed in #824. This was very easy to implement, and as far I can tell from building the docs on my machine everything works fine. I guess we may want to change some page titles for the main landing pages, e.g. the main/root page is now titled 'Home -- PsychoPy vX.X.X', we could change this and other "main" pages so they have PsychoPy at the start, e.g. "Psychopy Home".

If there's anything I should be checking in terms of the docs building correctly, let me know.