### PR TITLE
BF: Tobii calibration window not closing in 1.82

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/tobii/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/eyetracker.py
@@ -191,6 +191,12 @@ class EyeTracker(EyeTrackerDevice):
             genv=TobiiPsychopyCalibrationGraphics(self,screenColor=screenColor)
 
             calibrationOK=genv.runCalibration()
+
+            # On some graphics cards, we have to minimize before closing or the calibration window will stay visible
+            # after close is called.
+            genv.window.winHandle.set_visible(False)
+            genv.window.winHandle.minimize()
+
             genv.window.close()
             
             genv._unregisterEventMonitors() 


### PR DESCRIPTION
For some reason, in 1.82, when iohub calls win.close() on the full
screen window created for tobii calibration graphics, the window does
not actually close.

Work around is to minimize() the full screen window before calling
close, then it closes the window fine and the experiment window is
visible as expected.