### PR TITLE
DOC: Added Preferences documentation and related links

### DIFF
--- a/docs/source/api/sound.rst
+++ b/docs/source/api/sound.rst
@@ -6,7 +6,7 @@
 :class:`Sound`
 -------------------
 PsychoPy currently supports a choice of two sound libraries: pyo, or pygame. Select which will be
-used via the `audioLib` preference. `sound.Sound()` will then refer to either
+used via the :ref:`audioLib<generalSettings>` preference. `sound.Sound()` will then refer to either
 `SoundPyo` or `SoundPygame`. This can be set on a per-experiment basis by importing
 preferences, and setting the audioLib preference to use.
 

--- a/docs/source/general/prefs.rst
+++ b/docs/source/general/prefs.rst
@@ -16,8 +16,22 @@ fullscr:
     Should windows be created full screen by default? Can be overridden by individual experiments.
 
 allowGUI:
-    When the window is created, should the frame of the window and the mouse pointer be visible.
-    If set to False then both will be hidden.
+	    When the window is created, should the frame of the window and the mouse pointer be visible. If set to False then both will be hidden.
+
+paths:
+    Paths for additional Python packages can be specified. See more information :ref:`here<addModules>`.
+
+audioLib:
+    As explained in the :doc:`Sound</api/sound>` documentation, currently two sound libraries are available, pygame and pyo.
+
+audioDriver:
+    Also, different audio drivers are available.
+
+audioFlac:
+    Set flac audio compression.
+
+parallelPorts:
+    This list determines the addresses available in the drop-down menu for the :doc:`/builder/components/parallelout`.
 
 .. _applicationSettings:
 

--- a/docs/source/recipes/addCustomModules.rst
+++ b/docs/source/recipes/addCustomModules.rst
@@ -14,7 +14,7 @@ Avoid adding the entire path (e.g. the site-packages folder) of separate install
 Using preferences
 --------------------------
 
-As of version 1.70.00 you can do this using the PsychoPy preferences/general. There you will find preference for `paths` which can be set to a list of strings e.g. `['/Users/jwp/code', '~/code/thirdParty']`
+As of version 1.70.00 you can do this using the PsychoPy preferences/general. There you will find a preference for :ref:`paths<generalSettings>` which can be set to a list of strings e.g. `['/Users/jwp/code', '~/code/thirdParty']`
 
 These only get added to the Python path when you import psychopy (or one of the psychopy packages) in your script.
 


### PR DESCRIPTION

Hello,

I added documentation for some options in the "General Settings" that were missing. I had a couple of questions related to that:

* sound.rst: In the first paragraph, it says: "This can be set on a per-experiment basis by importing preferences, and setting the audioLib preference to use." I couldn't find any current documentation that could be linked. It would be good to know how exactly this can be done on a per-experiment basis (and not just the general settings).
* prefs.rst: I would restructure the document to reflect the sequence of tabs in the "General Settings" dialog, but I still feel uneasy about this without an OK from the core team.
* prefs.rst: Documentation for options in most other tabs are missing, but, again, I wanted to ask for an OK before I proceed with this. The only drawback will be that I might not really know what's going on with some of the options. Should I check first on the developer's mailing list and then proceed or rather just make the changes with stubs if necessary and then improve later on?
* prefs.rst: I didn't have to say much about  __audio driver__ and __flac audio compression__. Maybe somebody can improve on that.
* prefs.rst: Often lists are used in the preferences settings. Ideally, one would specify how the list is handled in each case. For example, the parallel-port setting defines a list of options that is displayed as a drop-down menu in the corresponding component. But I guess for many other settings the first option is checked and if it fails, the next options are tried (e.g., for __audio library__ or __audio driver__). Maybe somebody can confirm this behavior.

I hope that the links work as expected. As always, I am happy to extend the documentation accordingly after some feedback.

Cheers,

Axel