### PR TITLE
DOC: Restructured help for preferences dialog and added options

### DIFF
--- a/docs/source/general/prefs.rst
+++ b/docs/source/general/prefs.rst
@@ -1,6 +1,104 @@
 Preferences
 ====================================
 
+.. _applicationSettings:
+
+Application settings
+---------------------------
+These settings are common to all components of the application (Coder and Builder etc)
+
+showTips:
+    Display tips when starting PsychoPy.
+
+largeIcons:
+    Do you want large icons (on some versions of wx on OS X this has no effect)?
+
+defaultView:
+    Determines which view(s) open when the PsychoPy app starts up. Default is ‘last’, which fetches the same views as were open when PsychoPy last closed.
+
+resetPrefs:
+    Reset preferences to defaults on next restart of PsychoPy.
+
+autosavePrefs:
+    Save any unsaved preferences before closing the window.
+
+debugMode:
+    Enable features for debugging PsychoPy itself, including unit-tests.
+
+locale:
+    Language to use in menus etc.; not all translations are available. Select a value, then restart the app. Think about :doc:`adding translations for your language</developers/localization>`.
+
+
+.. _builderSettings:
+
+Builder settings
+---------------------------
+reloadPrevExp (default=False):
+    Select whether to automatically reload a previously opened experiment at start-up.
+
+unclutteredNamespace:
+    If this option is selected, the scripts will use more complex code, but the advantage is that there is less of a chance that name conflicts will arise.
+
+componentsFolders:
+    A list of folder path names that can hold additional custom components for the Builder view; expects a comma-separated list.
+
+hiddenComponents:
+    A list of components to hide (e.g., because you never use them)
+
+unpackedDemosDir:
+    Location of Builder demos on this computer (after unpacking).
+
+savedDataFolder:
+    Name of the folder where subject data should be saved (relative to the script location).
+
+flowAtTop:
+    If selected, the “Flow” section will be shown topmost and the “Components” section will be on the left. Restart PsychoPy to activate this option.
+
+showReadme:
+    If selected, PsychoPy always shows the Readme file if you open an experiment. The Readme file needs to be located in the same folder as the experiment file.
+
+maxFavorites:
+    Upper limit on how many components can be in the Favorites menu of the Components panel.
+
+
+.. _coderSettings:
+
+Coder settings
+---------------------------
+codeFont:
+    A list of font names to be used for code display. The first found on the system will be used.
+
+commentFont:
+    A list of font names to be used for comments sections. The first found on the system will be used
+
+outputFont:
+    A list of font names to be used in the output panel. The first found on the system will be used.
+
+fontSize (in pts):
+    an integer between 6 and 24 that specifies the size of fonts
+
+codeFontSize (in pts, default=12):
+    An integer between 6 and 24 that specifies the font size for code display.
+
+outputFontSize (in pts, default=12):
+    An integer between 6 and 24 that specifies the font size for output display.
+
+showSourceAsst:
+    Do you want to show the source assistant panel (to the right of the Coder view)? On Windows this provides help about the current function if it can be found. On OS X the source assistant is of limited use and is disabled by default.
+
+showOutput:
+    Show the output panel in the Coder view. If shown all python output from the session will be output to this panel. Otherwise it will be directed to the original location (typically the terminal window that called PsychoPy application to open).
+
+reloadPrevFiles:
+    Should PsychoPy fetch the files that you previously had open when it launches?
+
+preferredShell:
+    Specify which shell should be used for the coder shell window.
+
+newlineConvention:
+    Specify which character sequence should be used to encode newlines in code files: unix = \n (line feed only), dos = \r\n (carriage return plus line feed). 
+
+
 .. _generalSettings:
 
 General settings
@@ -33,101 +131,30 @@ audioFlac:
 parallelPorts:
     This list determines the addresses available in the drop-down menu for the :doc:`/builder/components/parallelout`.
 
-.. _applicationSettings:
 
-Application settings
----------------------------
-These settings are common to all components of the application (Coder and Builder etc)
-
-largeIcons:
-    Do you want large icons (on some versions of wx on OS X this has no effect)
-    
-defaultView:
-    Determines which view(s) open when the PsychoPy app starts up. Default is 'last',
-    which fetches the same views as were open when PsychoPy last closed.
-    
-runScripts:
-    Don't ask. ;-) Just leave this option as 'process' for now!
-    
-allowModuleImports (only used by win32):
-    Allow modules to be imported at startup for analysis by source assistant. This will
-    cause startup to be slightly slower but will speedup the first analysis of a script. 
-  
-.. _coderSettings:
-
-Coder settings
----------------------------
-outputFont:
-    a list of font names to be used in the output panel. The first found on the system will be used
-    
-fontSize (in pts):
-    an integer between 6 and 24 that specifies the size of fonts
-    
-codeFontSize = integer(6,24, default=12)
-
-outputFontSize = integer(6,24, default=12)
-
-showSourceAsst:
-    Do you want to show the `source assistant` panel (to the right of the Coder view)?
-    On Windows this provides help about the current function if it can be found. On
-    OS X the source assistant is of limited use and is disabled by default.
-    
-analysisLevel:
-    If using the source assistant, how much depth should PsychoPy try to analyse the 
-    current script? Lower values may reduce the amount of analysis performed and
-    make the Coder view more responsive (particularly for files that import many modules
-    and sub-modules).
-
-analyseAuto:
-    If using the source assistant, should PsychoPy try to analyse the current script 
-    on every save/load of the file? The code can be analysed manually from the tools menu
-    
-showOutput:
-    Show the output panel in the Coder view. If shown all python output from the session
-    will be output to this panel. Otherwise it will be directed to the original location
-    (typically the terminal window that called PsychoPy application to open).
-
-reloadPrevFiles:
-    Should PsychoPy fetch the files that you previously had open when it launches?
-
-.. _builderSettings:
-
-Builder settings
----------------------------
-reloadPrevExp (default=False):
-    for the user to add custom components (comma-separated list)
-    
-componentsFolders:
-    a list of folder pathnames that can hold additional custom components for the Builder view
-    
-hiddenComponents:
-    a list of components to hide (e.g., because you never use them)
-  
 .. _connectionSettings:
 
 Connection settings
 ---------------------------
+
 proxy:
-    The proxy server used to connect to the internet if needed. Must be of the form `http://111.222.333.444:5555`
-    
+    The proxy server used to connect to the internet if needed. Must be of the form ``http://111.222.333.444:5555``
+
 autoProxy:
-    PsychoPy should try to deduce the proxy automatically (if this is True and autoProxy is successful 
-    then the above field should contain a valid proxy address).
-    
+    PsychoPy should try to deduce the proxy automatically. If this is True and autoProxy is successful, then the above field should contain a valid proxy address.
+
 allowUsageStats:
-    Allow PsychoPy to ping a website at when the application starts up. **Please** leave this
-    set to True. The info sent is simply a string that gives the date, PsychoPy version and platform info.
-    There is no cost to you: no data is sent that could identify you and PsychoPy will not be delayed in starting as a result.
-    The aim is simple: if we can show that lots of people are using PsychoPy there is a greater chance of it being
-    improved faster in the future.
-    
+    Allow PsychoPy to ping a website at when the application starts up. Please leave this set to True. The info sent is simply a string that gives the date, PsychoPy version and platform info. There is no cost to you: no data is sent that could identify you and PsychoPy will not be delayed in starting as a result. The aim is simple: if we can show that lots of people are using PsychoPy there is a greater chance of it being improved faster in the future.
+
 checkForUpdates:
-    PsychoPy can (hopefully) automatically fetch and install updates. This will only work for minor updates
-    and is still in a very experimental state (as of v1.51.00).
-  
+    PsychoPy can (hopefully) automatically fetch and install updates. This will only work for minor updates and is still in a very experimental state (as of v1.51.00).
+
+timeout:
+    Maximum time in seconds to wait for a connection response.
+
+
 .. _keyBindings:
 
 Key bindings
 ------------------
-There are many shortcut keys that you can use in PsychoPy. For instance did you realise that
-you can indent or outdent a block of code with Ctrl-[ and Ctrl-] ?
+There are many shortcut keys that you can use in PsychoPy. For instance did you realise that you can indent or outdent a block of code with Ctrl-[ and Ctrl-] ?


### PR DESCRIPTION
Dear all,

I have restructured the help section on Preferences to reflect the order of tabs and options in the current dialog and also added missing options. There were a few options documented in the prefs.rst file that weren't available anymore in the dialog itself. But I'm not sure if there are some options that would only appear on certain systems. The options I deleted were (with help text):

"App" settings:
runScripts:
    Don't ask. ;-) Just leave this option as 'process' for now!
    
allowModuleImports (only used by win32):
    Allow modules to be imported at startup for analysis by source assistant. This will
    cause startup to be slightly slower but will speedup the first analysis of a script.

"Coder" settings:    
analysisLevel:
    If using the source assistant, how much depth should PsychoPy try to analyse the 
    current script? Lower values may reduce the amount of analysis performed and
    make the Coder view more responsive (particularly for files that import many modules
    and sub-modules).
    
analyseAuto:
    If using the source assistant, should PsychoPy try to analyse the current script 
    on every save/load of the file? The code can be analysed manually from the tools menu

Maybe somebody could confirm that these options can be deleted.

Best,

Axel