### PR TITLE
BF: Condition keys should be in ASCII

### DIFF
--- a/psychopy/tests/test_data/test_ExperimentHandler.py
+++ b/psychopy/tests/test_data/test_ExperimentHandler.py
@@ -86,8 +86,8 @@ class TestExperimentHandler():
         )
 
         conds = [
-            {'id': '01', u'näme': u'umlauts-öäü'},
-            {'id': '02', u'näme': u'accents-àáâă'}
+            {'id': '01', 'name': u'umlauts-öäü'},
+            {'id': '02', 'name': u'accents-àáâă'}
         ]
 
         trials = data.TrialHandler(


### PR DESCRIPTION
As Jeremy [pointed out](https://github.com/psychopy/psychopy/commit/6b293561edcd778d6de925662cb3c573b9a59d74#commitcomment-9915433), the keys in experimental condition specifications should consist of ASCII characters only, because at least the Builder creates variable names from the keys, and the test might yield misleading results in the future.