### PR TITLE
ENH: use pyglet 1.2.x for testing on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,13 @@ before_install:
   - travis_retry sudo apt-get update -qq
   - sudo apt-cache policy           # What is actually available?
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
-  - travis_retry sudo apt-get install -qq python-pyglet python-pygame python-opengl
+  - travis_retry sudo apt-get install -qq python-pygame python-opengl
+# pyglet 1.1.4:
+#  - travis_retry sudo apt-get install -qq python-pyglet
+# pyglet 1.2.1 needs a patch (should be fixed in 1.2.2). edit the file in-place until then:
+  - travis_retry sudo pip install -qq pyglet
+  - sudo perl -pi -e 's/popitem\(last=False\)\.dispose/popitem\(last=False\)\[1\]\.dispose/' /usr/local/lib/python2.7/dist-packages/pyglet/font/fontconfig.py
+  - python -c 'import pyglet; print pyglet.version'
   - travis_retry sudo pip install -qq gevent # Don't use apt-get (too old version of gevent)
   - travis_retry sudo apt-get install -qq python-yaml python-xlib
   - travis_retry sudo pip install -qq psutil # Don't use apt-get (too old version of psutil)


### PR DESCRIPTION
idea: test all new code to this standard, even if we don't immediately move to pyglet 1.2 for the app