### PR TITLE
BF: Actually use ‘skip’ setting in launchScan

### DIFF
--- a/psychopy/hardware/emulator.py
+++ b/psychopy/hardware/emulator.py
@@ -260,7 +260,7 @@ def launchScan(win, settings, globalClock=None, simResponses=None,
     timeoutClock = core.Clock() # zeroed now
     allKeys = []
     receivedTRs = 0
-    while not settings['sync'] in allKeys and receivedTRs > settings['skip']:
+    while not (settings['sync'] in allKeys and receivedTRs > settings['skip']):
         allKeys = event.getKeys()
         if esc_key and esc_key in allKeys:  # pragma: no cover
             core.quit()

--- a/psychopy/hardware/emulator.py
+++ b/psychopy/hardware/emulator.py
@@ -259,10 +259,13 @@ def launchScan(win, settings, globalClock=None, simResponses=None,
     # wait for first sync pulse:
     timeoutClock = core.Clock() # zeroed now
     allKeys = []
-    while not settings['sync'] in allKeys:
+    receivedTRs = 0
+    while not settings['sync'] in allKeys and receivedTRs > settings['skip']:
         allKeys = event.getKeys()
         if esc_key and esc_key in allKeys:  # pragma: no cover
             core.quit()
+        if settings['sync'] in allKeys:
+            receivedTRs += 1
         if timeoutClock.getTime() > wait_timeout:
             raise TimeoutError('Waiting for scanner has timed out in %.3f seconds.' % wait_timeout)
     if globalClock:


### PR DESCRIPTION
Previously skip was used for the sync generator keypress thread, but not when waiting to launch.

@jeremygray Would you take a look at this one when you get a chance? I've been testing it with this basic compiled builder script: https://gist.github.com/kastman/fa1adbaf95da1d65c175  Something is bonked with my current install (pyglet 1.2alpha from conda not playing nicely?) so it may not work, but I think the logic is ok.

Although you can pass in a 'skip' and the doc sounds like it should wait, in practice the waiting is ignoring skip and going on the first key received. This will count the number of received TRs to wait to go, in line with the doc's intention.