### PR TITLE
BF: TrialHandlerExt - ensure proper masking of data for uncompleted blocks

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1689,7 +1689,7 @@ class TrialHandlerExt(TrialHandler):
                     thisDataChunk = self.data[dataType][idx_data==curTrialIndex,:]
                     padWidth = max(self.trialWeights)*self.nReps - numpy.prod(thisDataChunk.shape)
                     thisDataChunkRowPadded = numpy.pad(thisDataChunk.transpose().flatten().data, (0, padWidth), mode='constant', constant_values=(0,0))
-                    thisDataChunkRowPaddedMask = numpy.pad(thisDataChunk.flatten().mask, (0, padWidth), mode='constant', constant_values=(0,True))
+                    thisDataChunkRowPaddedMask = numpy.pad(thisDataChunk.transpose().flatten().mask, (0, padWidth), mode='constant', constant_values=(0,True))
 
                     thisDataChunkRow = numpy.ma.masked_array(thisDataChunkRowPadded, mask=thisDataChunkRowPaddedMask)
                     resizedData[curTrialIndex,:] = thisDataChunkRow

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -570,7 +570,23 @@ class Mouse:
         elif self.win.units=='cm': return cm2pix(pos, self.win.monitor)
         elif self.win.units=='deg': return deg2pix(pos, self.win.monitor)
         elif self.win.units=='height': return pos*float(self.win.size[1])
+    def setMouseExclusivity(self, exclusivity):
+        """Binds the mouse to the experiment window. Only works in Pyglet.
+        In multi-monitor settings, or with a window that is not fullscreen, the mouse pointer can drift, and thereby
+        psychopy might not get the events from that window. setMouseExclusivity(True) works with Pyglet to bind the
+        mouse to the experiment window.
 
+        Note that binding the mouse pointer to a window will cause the pointer to vanish, and absolute positions will
+        no longer be meaningful getPos() returns [0, 0] in this case.
+        """
+        if type(exclusivity) is not bool:
+            raise ValueError('Exclusivity must be a boolean!')
+        if not usePygame:
+            psychopy.logging.warning('Setting mouse exclusivity in Pyglet will cause the cursor to disappear, ' +
+                                     'and getPos() will be rendered meaningless, returning [0, 0]')
+            self.win.winHandle.set_exclusive_mouse(exclusivity)
+        else:
+            print 'Mouse exclusivity can only be set for Pyglet!'
 
 class BuilderKeyResponse():
     """Used in scripts created by the builder to keep track of a clock and

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -570,23 +570,7 @@ class Mouse:
         elif self.win.units=='cm': return cm2pix(pos, self.win.monitor)
         elif self.win.units=='deg': return deg2pix(pos, self.win.monitor)
         elif self.win.units=='height': return pos*float(self.win.size[1])
-    def setMouseExclusivity(self, exclusivity):
-        """Binds the mouse to the experiment window. Only works in Pyglet.
-        In multi-monitor settings, or with a window that is not fullscreen, the mouse pointer can drift, and thereby
-        psychopy might not get the events from that window. setMouseExclusivity(True) works with Pyglet to bind the
-        mouse to the experiment window.
 
-        Note that binding the mouse pointer to a window will cause the pointer to vanish, and absolute positions will
-        no longer be meaningful getPos() returns [0, 0] in this case.
-        """
-        if type(exclusivity) is not bool:
-            raise ValueError('Exclusivity must be a boolean!')
-        if not usePygame:
-            psychopy.logging.warning('Setting mouse exclusivity in Pyglet will cause the cursor to disappear, ' +
-                                     'and getPos() will be rendered meaningless, returning [0, 0]')
-            self.win.winHandle.set_exclusive_mouse(exclusivity)
-        else:
-            print 'Mouse exclusivity can only be set for Pyglet!'
 
 class BuilderKeyResponse():
     """Used in scripts created by the builder to keep track of a clock and


### PR DESCRIPTION
In the TrialHandlerExt class used for noncounterbalanced designs, the saved data for each of the conditions can be repeated for different numbers of times. This requires us to organize the data for each condition in a single row for saving in excel/csv format. Due to a typo failing to transposing the mask array, the masking was improper for unsaved blocks. This has been fixed now.