### PR TITLE
NF: autosave by default at end of loops

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2841,7 +2841,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         panelSizer = wx.GridBagSizer(5,5)
         panel.SetSizer(panelSizer)
         row=0
-        for fieldName in ['name','loopType','isTrials']:
+        for fieldName in ['name','loopType','isTrials','autosave']:
             try:
                 label = self.currentHandler.params[fieldName].label
             except:

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -35,7 +35,9 @@ _localized = {
         'N up': _translate('N up'), 'max value': _translate('max value'), 'N down': _translate('N down'),
         'step type': _translate('step type'), 'step sizes': _translate('step sizes'),
     # strings for interleaved Staircases
-        'stairType': _translate('stairType'), 'switchMethod': _translate('switchMethod')
+        'stairType': _translate('stairType'), 'switchMethod': _translate('switchMethod'),
+    # other
+        'Auto-save': _translate('Auto-save')
     }
 
 """
@@ -623,7 +625,7 @@ class TrialHandler(object):
             """
     def __init__(self, exp, name, loopType='random', nReps=5,
         conditions=[], conditionsFile='',endPoints=[0,1],randomSeed='', selectedRows='',
-        isTrials = True):
+        isTrials=True, autosave=True):
         """
         @param name: name of the loop e.g. trials
         @type name: string
@@ -662,6 +664,9 @@ class TrialHandler(object):
         self.params['isTrials']=Param(isTrials, valType='bool', updates=None, allowedUpdates=None,
             hint=_translate("Indicates that this loop generates TRIALS, rather than BLOCKS of trials or stimuli within a trial. It alters how data files are output"),
             label=_localized["Is trials"])
+        self.params['autosave']=Param(autosave, valType='bool', updates=None, allowedUpdates=None,
+            hint=_translate("Auto-save all data to the data file(s) when the loop finishes"),
+            label=_localized["Auto-save"])
     def writeInitCode(self,buff):
         #no longer needed - initialise the trial handler just before it runs
         pass
@@ -718,6 +723,8 @@ class TrialHandler(object):
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndented("# completed %s repeats of '%s'\n" \
             %(self.params['nReps'], self.params['name']))
+        if self.params['autosave'].val:
+            buff.writeIndented("thisExp.saveData()  # auto-save\n")
         buff.writeIndented("\n")
         #save data
         if self.params['isTrials'].val == True:
@@ -1230,6 +1237,7 @@ class Routine(list):
         if self.exp.settings.params['Enable Escape'].val:
             buff.writeIndentedLines('\n# check for quit (the Esc key)')
             buff.writeIndentedLines('if endExpNow or event.getKeys(keyList=["escape"]):\n')
+            buff.writeIndentedLines('    thisExp.saveData()\n')
             buff.writeIndentedLines('    core.quit()\n')
         #update screen
         buff.writeIndentedLines('\n# refresh the screen\n')

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1237,7 +1237,7 @@ class Routine(list):
         if self.exp.settings.params['Enable Escape'].val:
             buff.writeIndentedLines('\n# check for quit (the Esc key)')
             buff.writeIndentedLines('if endExpNow or event.getKeys(keyList=["escape"]):\n')
-            buff.writeIndentedLines('    thisExp.saveData()\n')
+            buff.writeIndentedLines('    thisExp.saveData(force=True)\n')
             buff.writeIndentedLines('    core.quit()\n')
         #update screen
         buff.writeIndentedLines('\n# refresh the screen\n')

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -112,9 +112,11 @@ class ExperimentHandler(object):
         else:
             checkValidFilePath(dataFileName, makeValid=True) #fail now if we fail at all!
     def __del__(self):
-        self.saveData()
-    def saveData(self):
-        if self.dataFileName and self.unsavedData:
+        self.saveData(force=True)
+    def saveData(self, force=False):
+        """Saves .pkl or .csv (wide text) data,
+        """
+        if self.dataFileName and (self.unsavedData or force):
             if self.autoLog:
                 logging.debug('Saving data for %s ExperimentHandler' %self.name)
             if self.savePickle==True:

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -285,10 +285,9 @@ class TestExpt():
         script = self.exp.writeScript(expPath=expfile)
         py_file = os.path.join(self.tmp_dir, 'testLoopBlocks.py')
         # save it
-        f = codecs.open(py_file, 'w', 'utf-8')
-        f.write(script.getvalue().replace("core.quit()", "pass"))
-        f.write("del thisExp\n") #garbage collect the experiment so files are auto-saved
-        f.close()
+        with codecs.open(py_file, 'w', 'utf-8') as f:
+            f.write(script.getvalue().replace("core.quit()", "pass"))
+            f.write("thisExp.saveData(force=True)\n")
         #run the file (and make sure we return to this location afterwards)
         wd = os.getcwd()
         execfile(py_file)

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -21,7 +21,7 @@ def handleFileCollision(fileName, fileCollisionMethod):
             If a file with the requested name already exists, specify how to deal with it. 'overwrite' will overwite existing files in place, 'rename' will append an integer to create a new file ('trials1.psydat', 'trials2.pysdat' etc) and 'error' will raise an IOError.
     """
     if fileCollisionMethod == 'overwrite':
-        logging.warning('Data file, %s, will be overwritten' % fileName)
+        logging.data('Data file, %s, will be overwritten' % fileName)
     elif fileCollisionMethod == 'fail':
         raise IOError("Data file %s already exists. Set argument fileCollisionMethod to overwrite." % fileName)
     elif fileCollisionMethod == 'rename':

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -136,7 +136,7 @@ def openOutputFile(fileName, append=False, delim=None,
         encoding = None
 
     if os.path.exists(fileName) and writeFormat in ['w', 'wb']:
-        logging.warning('Data file, %s will be overwritten!' % fileName)
+        logging.data('Data file, %s will be overwritten!' % fileName)
 
     f = codecs.open(fileName, writeFormat, encoding=encoding)
     return f


### PR DESCRIPTION
- intended to mitigate data loss in case of abnormal program exit
- easy to disable (uncheck the box in the loop dialog)
- saves all data (not just the loop's data like the `IsTrials` option will do)
- using `<esc>` to quit experiment will now try to save data first
- changed file-overwrite to use level logging.data instead of logging.warning
  (if you explicitly request overwrite, that's what you want, don't want a warning)