### PR TITLE
Allow non-ASCII characters in .csv condition files

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1973,7 +1973,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
 
     if fileName.endswith('.csv'):
         with open(fileName, 'rU') as fileUniv:
-            trialsArr = read_csv(fileUniv)  # use pandas reader, which can handle commas in fields, etc
+            trialsArr = read_csv(fileUniv, encoding='utf-8')  # use pandas reader, which can handle commas in fields, etc
         trialsArr = trialsArr.to_records(index=False) # convert the resulting dataframe to a numpy recarry
         if trialsArr.shape == ():  # convert 0-D to 1-D with one element:
             trialsArr = trialsArr[numpy.newaxis]


### PR DESCRIPTION
Switching to pandas for reading in .csv conditions files unintentionally broke the ability to deal with non-ASCII character content. By now explicitly setting the default encoding parameter to UTF-8, we restore that ability (.xlsx files unaffected: they already deal with Unicode OK).