### PR TITLE
Function to set mouse exclusivity for a window in Pyglet

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -570,10 +570,10 @@ class Mouse:
         elif self.win.units=='cm': return cm2pix(pos, self.win.monitor)
         elif self.win.units=='deg': return deg2pix(pos, self.win.monitor)
         elif self.win.units=='height': return pos*float(self.win.size[1])
-    def setMouseExclusivity(self, exclusivity):
+    def setExclusive(self, exclusivity):
         """Binds the mouse to the experiment window. Only works in Pyglet.
         In multi-monitor settings, or with a window that is not fullscreen, the mouse pointer can drift, and thereby
-        psychopy might not get the events from that window. setMouseExclusivity(True) works with Pyglet to bind the
+        psychopy might not get the events from that window. setExclusive(True) works with Pyglet to bind the
         mouse to the experiment window.
 
         Note that binding the mouse pointer to a window will cause the pointer to vanish, and absolute positions will

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -570,7 +570,23 @@ class Mouse:
         elif self.win.units=='cm': return cm2pix(pos, self.win.monitor)
         elif self.win.units=='deg': return deg2pix(pos, self.win.monitor)
         elif self.win.units=='height': return pos*float(self.win.size[1])
+    def setMouseExclusivity(self, exclusivity):
+        """Binds the mouse to the experiment window. Only works in Pyglet.
+        In multi-monitor settings, or with a window that is not fullscreen, the mouse pointer can drift, and thereby
+        psychopy might not get the events from that window. setMouseExclusivity(True) works with Pyglet to bind the
+        mouse to the experiment window.
 
+        Note that binding the mouse pointer to a window will cause the pointer to vanish, and absolute positions will
+        no longer be meaningful getPos() returns [0, 0] in this case.
+        """
+        if type(exclusivity) is not bool:
+            raise ValueError('Exclusivity must be a boolean!')
+        if not usePygame:
+            psychopy.logging.warning('Setting mouse exclusivity in Pyglet will cause the cursor to disappear, ' +
+                                     'and getPos() will be rendered meaningless, returning [0, 0]')
+            self.win.winHandle.set_exclusive_mouse(exclusivity)
+        else:
+            print 'Mouse exclusivity can only be set for Pyglet!'
 
 class BuilderKeyResponse():
     """Used in scripts created by the builder to keep track of a clock and


### PR DESCRIPTION
This function binds the mouse to a window (and makes the cursor invisible). The use-case would be a multi-monitor setting where the participants need to click to respond. Without using a function like this, the cursor can be moved out of the region of the experiment.