### PR TITLE
BF: Fix closed stdout after ExperimentHandler save

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -299,7 +299,8 @@ class ExperimentHandler(object):
                 else:
                     f.write(delim)
             f.write('\n')
-        f.close()
+        if f != sys.stdout:
+            f.close()
         print "saved data to %r" %f.name
 
     def saveAsPickle(self,fileName, fileCollisionMethod='rename'):

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -301,7 +301,7 @@ class ExperimentHandler(object):
             f.write('\n')
         if f != sys.stdout:
             f.close()
-        print "saved data to %r" %f.name
+        logging.info('saved data to %r' %f.name)
 
     def saveAsPickle(self,fileName, fileCollisionMethod='rename'):
         """Basically just saves a copy of self (with data) to a pickle file.


### PR DESCRIPTION
If ExperimentHandler's saveAsWideText() function was called with the file name "stdout" (to write to sys.stdout instead of a real file), the standard output was closed afterwards. This was fixed by only closing the used file object if it is not the standard output object.

Also replaced a print statement with call to logging function for consistency.
