### PR TITLE
NF: Apertures can be defined using image files with transparency

### DIFF
--- a/psychopy/visual/aperture.py
+++ b/psychopy/visual/aperture.py
@@ -6,6 +6,8 @@
 # Copyright (C) 2015 Jonathan Peirce
 # Distributed under the terms of the GNU General Public License (GPL).
 
+import os
+
 # Ensure setting pyglet.options['debug_gl'] to False is done prior to any
 # other calls to pyglet or pyglet submodules, otherwise it may not get picked
 # up by the pyglet GL engine and have no effect.
@@ -23,6 +25,7 @@ import psychopy.event
 from psychopy.tools.monitorunittools import cm2pix, deg2pix, convertToPix
 from psychopy.tools.attributetools import attributeSetter, setAttribute
 from psychopy.visual.shape import ShapeStim
+from psychopy.visual.image import ImageStim
 from psychopy.visual.basevisual import MinimalStim, ContainerMixin
 
 import numpy
@@ -41,6 +44,8 @@ class Aperture(MinimalStim, ContainerMixin):
     If shape is 'square' or 'triangle' then that is what will be used (obviously)
     If shape is 'circle' or `None` then a polygon with nVerts will be used (120 for a rough circle)
     If shape is a list or numpy array (Nx2) then it will be used directly as the vertices to a :class:`~psychopy.visual.ShapeStim`
+    If shape is a filename then it will be used to load and image as a :class:`~psychopy.visual.ImageStim`.
+        Note that transparent parts in the image (e.g. in a PNG file) will not be included in the mask shape. The color of the image will be ignored.
 
     See demos/stimuli/aperture.py for example usage
 
@@ -48,6 +53,7 @@ class Aperture(MinimalStim, ContainerMixin):
         2011, Yuri Spitsyn
         2011, Jon Peirce added units options, Jeremy Gray added shape & orientation
         2014, Jeremy Gray added .contains() option
+        2015, Thomas Emmerling added ImageStim option
     """
     def __init__(self, win, size=1, pos=(0,0), ori=0, nVert=120, shape='circle', units=None,
             name=None, autoLog=None):
@@ -65,7 +71,8 @@ class Aperture(MinimalStim, ContainerMixin):
         self.__dict__['size'] = size
         self.__dict__['pos'] = pos
         self.__dict__['ori'] = ori
-        
+        self.__dict__['filename'] = False
+
         #unit conversions
         if units!=None and len(units):
             self.units = units
@@ -85,15 +92,25 @@ class Aperture(MinimalStim, ContainerMixin):
             vertices = [[0.5,-0.5],[0,0.5],[-0.5,-0.5]]
         elif type(shape) in [tuple, list, numpy.ndarray] and len(shape) > 2:
             vertices = shape
+        elif type(shape) in [str, unicode]:
+            #is a string - see if it points to a file
+            if os.path.isfile(shape):
+                self.__dict__['filename'] = shape
+            else:
+                logging.error("Unrecognized shape for aperture. Expected 'circle', 'square', 'triangle', vertices, filename, or None; got %s" %(repr(shape)))
+
+        if self.__dict__['filename']:
+            self._shape = ImageStim(win=self.win, image=self.__dict__['filename'],
+                                pos=pos, size=size,
+                                autoLog=False)
         else:
-            logging.error("Unrecognized shape for aperture. Expected 'circle', 'square', 'triangle', vertices, or None; got %s" %(repr(shape)))
-        self._shape = ShapeStim(win=self.win, vertices=vertices,
+            self._shape = ShapeStim(win=self.win, vertices=vertices,
                                 fillColor=1, lineColor=None,
                                 interpolate=False, pos=pos, size=size,
                                 autoLog=False)
+            self.vertices = self._shape.vertices
+            self._needVertexUpdate = True
 
-        self.vertices = self._shape.vertices
-        self._needVertexUpdate = True
         self._needReset = True  # Default when setting attributes
         self._reset()  #implicitly runs a self.enabled = True. Also sets self._needReset = True on every call
         
@@ -119,7 +136,13 @@ class Aperture(MinimalStim, ContainerMixin):
             GL.glDepthMask(GL.GL_FALSE)
             GL.glStencilFunc(GL.GL_NEVER, 0, 0)
             GL.glStencilOp(GL.GL_INCR, GL.GL_INCR, GL.GL_INCR)
-            self._shape.draw(keepMatrix=True) #draw without push/pop matrix
+
+            if self.__dict__['filename']:
+                GL.glEnable(GL.GL_ALPHA_TEST)
+                GL.glAlphaFunc(GL.GL_GREATER,0)
+                self._shape.draw()
+            else:
+                self._shape.draw(keepMatrix=True) #draw without push/pop matrix
             GL.glStencilFunc(GL.GL_EQUAL, 1, 1)
             GL.glStencilOp(GL.GL_KEEP, GL.GL_KEEP, GL.GL_KEEP)
     


### PR DESCRIPTION
Hello again!

When trying to define more complicated apertures to use with (e.g.) ElementArrayStims I ran into frustrations. Here, I added a feature to Aperture allowing to use an image with transparency (I tested with a PNG file) as the basis for the aperture shape.

I tried to change the parameters as little as possible so that I reused the shape parameter. I hope that this does not break anything (I check whether the filename string leads to a real file on disk like in SimpleImage).

One open question would be whether these calls during the _reset need to be disabled again after the draw():
```python
GL.glEnable(GL.GL_ALPHA_TEST)
GL.glAlphaFunc(GL.GL_GREATER,0)
```
Any comments on that?

Also I hope that was not too bold to include my name in the author list of the file... :)

This is a very slightly modified demo code to test the new feature, including an image with transparency:

```python
#!/usr/bin/env python2

"""Demo for the class psychopy.visual.Aperture().
Draw two gabor circles, one with an irregular aperture and one with no aperture.
"""

from psychopy import visual, event

win = visual.Window([400,400], allowStencil=True, units='norm')
instr = visual.TextStim(win, text="Any key to quit", pos=(0,-.7))
gabor1 = visual.GratingStim(win, mask='circle', sf=4, size=1.2, color=[0.5,-0.5,1])
gabor2 = visual.GratingStim(win, mask='circle', sf=4, size=1.2, color=[-0.5,-0.5,-1])
vertices=[(-0.02, -0.0), (-.8,.2), (0,.6), (.1,0.06), (.8, .3), (.6,-.4)]

# NOTE: size in Aperture refers to the diameter when shape='circle';
# vertices or other shapes are scaled accordingly
aperture = visual.Aperture(win, size=200, shape='wedges.png')  # or try shape='square'

aperture.enabled = False  # enabled by default when created
gabor1.draw()
instr.draw()
aperture.enabled = True  # drawing is now restricted to be within the aperture shape
gabor2.draw()

win.flip()
event.waitKeys()
```

![wedges](https://cloud.githubusercontent.com/assets/2376790/8211857/fe0b1aea-1518-11e5-9b82-edf10c0b2bfd.png)
