### PR TITLE
ENH: supporting Portable VLC Media Player

### DIFF
--- a/psychopy/visual/vlc.py
+++ b/psychopy/visual/vlc.py
@@ -136,8 +136,16 @@ def find_lib():
                 dll = ctypes.CDLL('libvlc.dll')
                  # restore cwd after dll has been loaded
                 os.chdir(p)
-            else:  # may fail
-                dll = ctypes.CDLL('libvlc.dll')
+            else:
+                try: # try PortableVLC
+                    drive, path = os.path.splitdrive(os.path.abspath(os.path.dirname(__file__)))
+                    plugin_path = drive+'\\VLCPortable\\App\\vlc'
+                    # libvlccore.dll must be loaded before loading libvlc.dll
+                    coredll = ctypes.CDLL(drive+'\\VLCPortable\\App\\vlc\\libvlccore.dll')
+                    # loading libvlc.dll
+                    dll = ctypes.CDLL(drive+'\\VLCPortable\\App\\vlc\\libvlc.dll')
+                except: # may fail
+                    dll = ctypes.CDLL('libvlc.dll')
         else:
             plugin_path = os.path.dirname(p)
             dll = ctypes.CDLL(p)


### PR DESCRIPTION
I am trying to install PsychoPy on PortablePython (http://portablepython.com/) for my student who want to learn PsychoPy using a Windows PC in a University computer room. My student doesn't have privileges to install software on them.  Most of demos in psychopy/demos/coder/stimuli work fine simply copying site-packages directory of the StandAlone PsychoPy to Portable Python, but MovieStim2.py doesn't work because VLC Media Player is not installed on the PC.

In order to run MovieStim2.py without installing VLC Media Player to the PC, I installed Porable VLC Media Player (http://portableapps.com/apps/music_video/vlc_portable) and Portable Python together on an USB memory. Then I modified lines 139-140 of psychopy/visual/vlc.py to search for Porable VLC Media Player if VLC Media Player is not found in the PC. I tested this code on several Windows PCs. It worked fine.

Because these lines are executed only when platform is Windows and VLC Media Player is not found in "Program Files" directory, I don't think that this code affect normal behavior of vlc.py.  Please consider to merge this code.