### PR TITLE
ENH: Better handling of Unicode characters in the Preference Dialog

### DIFF
--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -33,7 +33,7 @@ class SettingsComponent(object):
                  saveLogFile=True, showExpInfo=True, expInfo="{'participant':'', 'session':'001'}",units='use prefs',
                  logging='exp', color='$[0,0,0]', colorSpace='rgb', enableEscape=True, blendMode='avg',
                  saveXLSXFile=False, saveCSVFile=False, saveWideCSVFile=True, savePsydatFile=True,
-                 savedDataFolder='', filename="'xxxx/%s_%s_%s' %(expInfo['participant'], expName, expInfo['date'])"):
+                 savedDataFolder='', filename="u'xxxx/%s_%s_%s' %(expInfo['participant'], expName, expInfo['date'])"):
         self.type='Settings'
         self.exp=exp#so we can access the experiment if necess
         self.exp.requirePsychopyLibs(['visual', 'gui'])
@@ -41,10 +41,10 @@ class SettingsComponent(object):
         self.url="http://www.psychopy.org/builder/settings.html"
 
         #if filename is the default value fetch the builder pref for the folder instead
-        if filename.startswith("'xxxx"):
+        if filename.startswith("u'xxxx"):
             filename = filename.replace("xxxx", self.exp.prefsBuilder['savedDataFolder'].strip())
         else:
-            print filename[0:5]
+            print filename[0:6]
         #params
         self.params={}
         self.order=['expName','Show info dlg','Experiment info',


### PR DESCRIPTION
Following problems are fixed.
Please see also https://groups.google.com/forum/#!topic/psychopy-dev/bB_GdHuNjes

* Preference Dialog is not opened when Unicode character is included in userPrefs.cfg (this problem occurs when Unicode character is included in string-type properties).

* Unicode characters are shown as hexadecimal values if they are included in list-type properties.

* It is hard for beginners to notice error message "Output Pane" of the Coder View when ungrammatical string is input to list-type properties in the Preference Dialog.

* Add 'u' to "Data filename $" in the Experiment Settings dialog in case Unicode characters are input to 'set data folder' in the Preference Dialog.
