### PR TITLE
BF: Fix not opening files after drop on Builder and related log messages

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -95,7 +95,7 @@ class FileDropTarget(wx.FileDropTarget):
             if filename.endswith('.psyexp') or filename.lower().endswith('.py'):
                 self.builder.fileOpen(filename=filename)
             else:
-                logging.warning('dropped file ignored: did not end in .psyexp')
+                logging.warning('dropped file ignored: did not end in .psyexp or .py')
 
 class WindowFrozen(object):
     """

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -92,10 +92,8 @@ class FileDropTarget(wx.FileDropTarget):
     def OnDropFiles(self, x, y, filenames):
         logging.debug('PsychoPyBuilder: received dropped files: %s' % filenames)
         for filename in filenames:
-            if filename.endswith('.psyexp'):
+            if filename.endswith('.psyexp') or filename.lower().endswith('.py'):
                 self.builder.fileOpen(filename=filename)
-            elif filename.lower().endswith('.py'):
-                self.app.fileOpen(filename=filename)
             else:
                 logging.warning('dropped file ignored: did not end in .psyexp')
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -90,7 +90,7 @@ class FileDropTarget(wx.FileDropTarget):
         wx.FileDropTarget.__init__(self)
         self.builder = builder
     def OnDropFiles(self, x, y, filenames):
-        logging.debug('PsychoPyBuilder: received dropped files: filenames')
+        logging.debug('PsychoPyBuilder: received dropped files: %s' % filenames)
         for filename in filenames:
             if filename.endswith('.psyexp'):
                 self.builder.fileOpen(filename=filename)


### PR DESCRIPTION
For the debug log message the variable name was logged instead of its contents.

Dropping ".py" files on Builder raised an AttributeError instead of opening them in Coder (found by pylint).

The warning log message was incomplete because ".py" files are also accepted.
