### PR TITLE
BF: Fix locking out of Builder Experiment Settings

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -3266,11 +3266,15 @@ class DlgExperimentProperties(_BaseParamsDlg):
         if self.paramCtrls['Full-screen window'].valueCtrl.GetValue():
             #get screen size for requested display
             num_displays = wx.Display.GetCount()
-            if int(self.paramCtrls['Screen'].valueCtrl.GetValue())>num_displays:
+            try:
+                screen_value=int(self.paramCtrls['Screen'].valueCtrl.GetValue())
+            except ValueError:
+                screen_value=1#param control currently contains no integer value
+            if screen_value<1 or screen_value>num_displays:
                 logging.error("User requested non-existent screen")
                 screenN=0
             else:
-                screenN=int(self.paramCtrls['Screen'].valueCtrl.GetValue())-1
+                screenN=screen_value-1
             size=list(wx.Display(screenN).GetGeometry()[2:])
             #set vals and disable changes
             self.paramCtrls['Window size (pixels)'].valueCtrl.SetValue(unicode(size))


### PR DESCRIPTION
If the "Screen" setting in the "Experiment Settings" dialog was set to an unsupported text value, the dialog could not be opened again after closing it. Values which could not be converted to integers raised a ValueError in int() and values which could be converted but were smaller 1 raised a ValueError in wx.Display(). Both cases were fixed by adding additional checks and using the default value (first screen) if needed.

The change also fixed not updating the "Window size" field if the window setting was toggled while an unsupported "Screen" value was set above.