### PR TITLE
ENH: allow code execution without editing (2 ways)

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1740,6 +1740,7 @@ class CoderFrame(wx.Frame):
     def setCurrentDoc(self, filename, keepHidden=False):
         #check if this file is already open
         docID=self.findDocID(filename)
+        readonly = 'readonly' in self.app.prefs.coder and self.app.prefs.coder['readonly']
         if docID>=0:
             self.currentDoc = self.notebook.GetPage(docID)
             self.notebook.SetSelection(docID)
@@ -1750,7 +1751,6 @@ class CoderFrame(wx.Frame):
                 self.fileClose(self.currentDoc.filename)
 
             #create an editor window to put the text in
-            readonly = 'readonly' in self.app.prefs.coder and self.app.prefs.coder['readonly']
             p = self.currentDoc = CodeEditor(self.notebook,-1, frame=self,
                                              readonly=readonly)
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -401,7 +401,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
     # this comes mostly from the wxPython demo styledTextCtrl 2
     def __init__(self, parent, ID, frame,
                  pos=wx.DefaultPosition, size=wx.Size(100,100),#set the viewer to be small, then it will increase with wx.aui control
-                 style=0):
+                 style=0, readonly=False):
         wx.stc.StyledTextCtrl.__init__(self, parent, ID, pos, size, style)
         #JWP additions
         self.notebook=parent
@@ -465,7 +465,9 @@ class CodeEditor(wx.stc.StyledTextCtrl):
         self.Bind(wx.stc.EVT_STC_MARGINCLICK, self.OnMarginClick)
         self.Bind(wx.EVT_KEY_DOWN, self.OnKeyPressed)
 
-        self.setFonts()
+        # black-and-white text signals read-only file open in Coder window
+        if not readonly:
+            self.setFonts()
         self.SetDropTarget(FileDropTarget(coder = self.coder))
 
     def setFonts(self):
@@ -1748,7 +1750,9 @@ class CoderFrame(wx.Frame):
                 self.fileClose(self.currentDoc.filename)
 
             #create an editor window to put the text in
-            p = self.currentDoc = CodeEditor(self.notebook,-1, frame=self)
+            readonly = 'readonly' in self.app.prefs.coder and self.app.prefs.coder['readonly']
+            p = self.currentDoc = CodeEditor(self.notebook,-1, frame=self,
+                                             readonly=readonly)
 
             #load text from document
             if os.path.isfile(filename):
@@ -1790,6 +1794,8 @@ class CoderFrame(wx.Frame):
             self.SetStatusText('')
         if not keepHidden:
             self.Show()#if the user had closed the frame it might be hidden
+        if readonly:
+            self.currentDoc.SetReadOnly(True)
     def fileOpen(self, event):
         #get path of current file (empty if current file is '')
         if hasattr(self.currentDoc, 'filename'):

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -25,6 +25,7 @@ _localized = {
             'largeIcons': _translate("large icons"), 'defaultView': _translate("default view"),
             'resetPrefs': _translate('reset preferences'), 'autoSavePrefs': _translate('auto-save prefs'),
             'debugMode': _translate('debug mode'), 'locale': _translate('locale'),
+            'readonly': _translate('read-only'),
             'codeFont': _translate('code font'), 'commentFont': _translate('comment font'),
             'outputFont': _translate('output font'), 'outputFontSize': _translate('output font size'),
             'codeFontSize': _translate('code font size'),

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -11,6 +11,13 @@ from psychopy.app._psychopyApp import *
 #now used solely as a launcher for the app, not as the app itself.
 
 if __name__=='__main__':
+    if '-x' in sys.argv:
+        # enable execution of .py script from command line using StandAlone python
+        targetScript = sys.argv[sys.argv.index('-x') + 1]
+        from psychopy import core
+        import os
+        core.shellCall([sys.executable, os.path.abspath(targetScript)])
+        sys.exit()
     if '-v' in sys.argv or '--version' in sys.argv:
         print 'PsychoPy2, version %s (c)Jonathan Peirce, 2015, GNU GPL license' %psychopy.__version__
         sys.exit()
@@ -30,6 +37,7 @@ depends on the type of the [file]:
 Options:
     -c, --coder, coder       opens coder view only
     -b, --builder, builder   opens builder view only
+    -x script.py             directly execute script.py using StandAlone python
 
     -v, --version    prints version and exits
     -h, --help       prints this help and exit

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -65,6 +65,8 @@
 
 # Settings for the Coder window
 [coder]
+    # open Coder files as read-only (allows running without accidental changes)
+    readonly = boolean(default=False)
     # a list of font names; the first one found on the system will be used
     codeFont = string(default='Monaco')
     # a list of font names; the first one found on the system will be used

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -65,6 +65,8 @@
 
 # Settings for the Coder window
 [coder]
+    # open Coder files as read-only (allows running without accidental changes)
+    readonly = boolean(default=False)
     # a list of font names; the first one found on the system will be used
     codeFont = string(default='Palatino Linotype')
     # a list of font names; the first one found on the system will be used

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -65,6 +65,8 @@
 
 # Settings for the Coder window
 [coder]
+    # open Coder files as read-only (allows running without accidental changes)
+    readonly = boolean(default=False)
     # a list of font names; the first one found on the system will be used
     codeFont = string(default='Ubuntu Mono, DejaVu Sans Mono')
     # a list of font names; the first one found on the system will be used

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -65,6 +65,8 @@
 
 # Settings for the Coder window
 [coder]
+    # open Coder files as read-only (allows running without accidental changes)
+    readonly = boolean(default=False)
     # a list of font names; the first one found on the system will be used
     codeFont = string(default='Lucida Console')
     # a list of font names; the first one found on the system will be used

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -62,6 +62,8 @@
 
 # Settings for the Coder window
 [coder]
+    # open Coder files as read-only (allows running without accidental changes)
+    readonly = boolean(default=False)
     # a list of font names; the first one found on the system will be used
     codeFont = string(default='Helvetica')
     # a list of font names; the first one found on the system will be used


### PR DESCRIPTION
Idea: allow execution of code without the possibility of either the subject or experimenter inadvertently typing something that would end up in the script. See #943 
1) -x option: Use the PsychoPy app to invoke StandAlone python to execute a .py script passed as an argument.
2) User pref: make Coder files read-only

Other use cases for -x option = programmatic invoking of python scripts using StandAlone's python (Craig Stark, users' list)