### PR TITLE
making MovieStim3 (moviepy) more visible/accessible and better timing for keyboard.RT

### DIFF
--- a/psychopy/app/builder/components/movie.py
+++ b/psychopy/app/builder/components/movie.py
@@ -11,7 +11,7 @@ iconFile = path.join(thisFolder,'movie.png')
 tooltip = _translate('Movie: play movie files')
 
 # only use _localized values for label values, nothing functional:
-_localized = {'movie': _translate('Movie file'), 'forceEndRoutine': _translate('Force end of Routine'), 
+_localized = {'movie': _translate('Movie file'), 'forceEndRoutine': _translate('Force end of Routine'),
               'backend':_translate('backend')}
 
 class MovieComponent(VisualComponent):
@@ -39,7 +39,7 @@ class MovieComponent(VisualComponent):
             updates='constant', allowedUpdates=['constant','set every repeat'],
             hint=_translate("A filename for the movie (including path)"),
             label=_localized['movie'])
-        self.params['backend']=Param(backend, valType='str', allowedVals=['avbin','opencv'],
+        self.params['backend']=Param(backend, valType='str', allowedVals=['moviepy','avbin','opencv'],
             hint=_translate("What underlying lib to use for loading movies"),
             label=_localized['backend'])
         self.params['forceEndRoutine']=Param(forceEndRoutine, valType='bool', allowedTypes=[],
@@ -62,7 +62,9 @@ class MovieComponent(VisualComponent):
             params = components.getInitVals(self.params)
         else:
             params = self.params
-        if self.params['backend'].val=='avbin':
+        if self.params['backend'].val=='moviepy':
+            buff.writeIndented("%s = visual.MovieStim3(win=win, name='%s',%s\n" %(params['name'],params['name'],unitsStr))
+        elif self.params['backend'].val=='avbin':
             buff.writeIndented("%s = visual.MovieStim(win=win, name='%s',%s\n" %(params['name'],params['name'],unitsStr))
         else:
             buff.writeIndented("%s = visual.MovieStim2(win=win, name='%s',%s\n" %(params['name'],params['name'],unitsStr))

--- a/psychopy/demos/coder/stimuli/MovieStim.py
+++ b/psychopy/demos/coder/stimuli/MovieStim.py
@@ -1,9 +1,9 @@
 from psychopy import visual, core, event
 
 win = visual.Window([800,600])
-mov = visual.MovieStim(win, 'jwpIntro.mov', size=[320,240],
-                       flipVert=False, flipHoriz=False, loop=True)
-print('orig movie size=[%i,%i]' %(mov.format.width, mov.format.height))
+mov = visual.MovieStim3(win, 'jwpIntro.mov', size=[320,240],
+                       flipVert=False, flipHoriz=False, loop=False)
+print('orig movie size=%s' %(mov.size))
 print('duration=%.2fs' %(mov.duration))
 globalClock = core.Clock()
 

--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -280,7 +280,7 @@ class SoundPygame(_SoundBase):
 
     def _setSndFromFile(self, fileName):
         #load the file
-        if not os.path.ispath(filename):
+        if not path.isfile(filename):
             msg = "Sound file %s could not be found." % fileName
             logging.error(msg)
             raise ValueError(msg)

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -1090,6 +1090,18 @@ KeyboardComponent.store.label:Store
 KeyboardComponent.store.readOnly:False
 KeyboardComponent.store.updates:constant
 KeyboardComponent.store.valType:str
+KeyboardComponent.syncScreenRefresh.default:True
+KeyboardComponent.syncScreenRefresh.staticUpdater:None
+KeyboardComponent.syncScreenRefresh.categ:Basic
+KeyboardComponent.syncScreenRefresh.val:True
+KeyboardComponent.syncScreenRefresh.allowedTypes:[]
+KeyboardComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
+KeyboardComponent.syncScreenRefresh.allowedUpdates:[]
+KeyboardComponent.syncScreenRefresh.allowedVals:[]
+KeyboardComponent.syncScreenRefresh.label:sync RT with screen
+KeyboardComponent.syncScreenRefresh.readOnly:False
+KeyboardComponent.syncScreenRefresh.updates:constant
+KeyboardComponent.syncScreenRefresh.valType:bool
 MicrophoneComponent.order:['name']
 MicrophoneComponent.stereo.default:False
 MicrophoneComponent.stereo.staticUpdater:None
@@ -1469,7 +1481,7 @@ MovieComponent.backend.val:avbin
 MovieComponent.backend.allowedTypes:[]
 MovieComponent.backend.hint:What underlying lib to use for loading movies
 MovieComponent.backend.allowedUpdates:None
-MovieComponent.backend.allowedVals:['avbin', 'opencv']
+MovieComponent.backend.allowedVals:['moviepy', 'avbin', 'opencv']
 MovieComponent.backend.label:backend
 MovieComponent.backend.readOnly:False
 MovieComponent.backend.updates:None
@@ -1570,14 +1582,14 @@ ParallelOutComponent.startType.label:start type
 ParallelOutComponent.startType.readOnly:False
 ParallelOutComponent.startType.updates:None
 ParallelOutComponent.startType.valType:str
-ParallelOutComponent.address.default:u'/dev/parport0'
+ParallelOutComponent.address.default:u'0x0378'
 ParallelOutComponent.address.staticUpdater:None
 ParallelOutComponent.address.categ:Basic
-ParallelOutComponent.address.val:/dev/parport0
+ParallelOutComponent.address.val:0x0378
 ParallelOutComponent.address.allowedTypes:[]
 ParallelOutComponent.address.hint:Parallel port to be used (you can change these options in preferences>general)
 ParallelOutComponent.address.allowedUpdates:None
-ParallelOutComponent.address.allowedVals:[u'/dev/parport0', u'/dev/parport1', u'LabJack U3']
+ParallelOutComponent.address.allowedVals:[u'0x0378', u'0x03BC', u'/dev/parport0', u'/dev/parport1', u'LabJack U3']
 ParallelOutComponent.address.label:Port address
 ParallelOutComponent.address.readOnly:False
 ParallelOutComponent.address.updates:None
@@ -3254,6 +3266,18 @@ cedrusButtonBoxComponent.store.label:Store
 cedrusButtonBoxComponent.store.readOnly:False
 cedrusButtonBoxComponent.store.updates:constant
 cedrusButtonBoxComponent.store.valType:str
+cedrusButtonBoxComponent.syncScreenRefresh.default:True
+cedrusButtonBoxComponent.syncScreenRefresh.staticUpdater:None
+cedrusButtonBoxComponent.syncScreenRefresh.categ:Basic
+cedrusButtonBoxComponent.syncScreenRefresh.val:True
+cedrusButtonBoxComponent.syncScreenRefresh.allowedTypes:[]
+cedrusButtonBoxComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
+cedrusButtonBoxComponent.syncScreenRefresh.allowedUpdates:[]
+cedrusButtonBoxComponent.syncScreenRefresh.allowedVals:[]
+cedrusButtonBoxComponent.syncScreenRefresh.label:sync RT with screen
+cedrusButtonBoxComponent.syncScreenRefresh.readOnly:False
+cedrusButtonBoxComponent.syncScreenRefresh.updates:constant
+cedrusButtonBoxComponent.syncScreenRefresh.valType:bool
 ioLabsButtonBoxComponent.order:['forceEndRoutine', 'active', 'lights', 'store', 'storeCorrect', 'correctAns']
 ioLabsButtonBoxComponent.correctAns.default:'0'
 ioLabsButtonBoxComponent.correctAns.staticUpdater:None
@@ -3434,3 +3458,15 @@ ioLabsButtonBoxComponent.store.label:Store
 ioLabsButtonBoxComponent.store.readOnly:False
 ioLabsButtonBoxComponent.store.updates:constant
 ioLabsButtonBoxComponent.store.valType:str
+ioLabsButtonBoxComponent.syncScreenRefresh.default:True
+ioLabsButtonBoxComponent.syncScreenRefresh.staticUpdater:None
+ioLabsButtonBoxComponent.syncScreenRefresh.categ:Basic
+ioLabsButtonBoxComponent.syncScreenRefresh.val:True
+ioLabsButtonBoxComponent.syncScreenRefresh.allowedTypes:[]
+ioLabsButtonBoxComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
+ioLabsButtonBoxComponent.syncScreenRefresh.allowedUpdates:[]
+ioLabsButtonBoxComponent.syncScreenRefresh.allowedVals:[]
+ioLabsButtonBoxComponent.syncScreenRefresh.label:sync RT with screen
+ioLabsButtonBoxComponent.syncScreenRefresh.readOnly:False
+ioLabsButtonBoxComponent.syncScreenRefresh.updates:constant
+ioLabsButtonBoxComponent.syncScreenRefresh.valType:bool

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -380,7 +380,7 @@ class Window(object):
             logging.exp("Created %s = %s" %(self.name, str(self)))
 
     def __del__(self):
-        if self._closed!=False:
+        if self._closed==False:
             self.close()
 
     def __str__(self):
@@ -961,13 +961,17 @@ class Window(object):
     def close(self):
         """Close the window (and reset the Bits++ if necess)."""
         self._closed=True
+
         try:
             openWindows.remove(self)
         except:
             pass
         if (not self.useNativeGamma) and self.origGammaRamp is not None:
             setGammaRamp(self.winHandle, self.origGammaRamp)
-        self.mouseVisible = True
+        try:
+            self.mouseVisible = True
+        except: #can cause unimportant "'NoneType' object is not callable"
+            pass
         if self.winType == 'pyglet':
             _hw_handle = None
             try:

--- a/setupApp.py
+++ b/setupApp.py
@@ -46,6 +46,7 @@ setup(app=['psychopy/app/psychopyApp.py'],
                                   ],
                               packages=['wx','pyglet','pygame','OpenGL','psychopy','pytz',
                                 'scipy','matplotlib','lxml','xml','openpyxl',
+                                'moviepy', 'imageio',
                                 'coverage',#for unit testing
                                 'serial','IPython',
                                 'egi','labjack','pylink',#handy external science interfaces


### PR DESCRIPTION
moviepy is now available (and is the default!) in Builder. Making it default so quickly may seem strange but the other options have been such a pain that I think it's worth it!

Keyboard now has the option to sync with screen refresh, which should be turned on (default) if the stimulus of interest is a visual stimulus. If turned off then the RT clock starts before the screen has refreshed (i.e before the stimulus is visible) so RT's were ~0.5 screen refreshes longer than they should be.