### PR TITLE
Suppress git warning if not in repository

### DIFF
--- a/createInitFile.py
+++ b/createInitFile.py
@@ -67,7 +67,7 @@ if __git_sha__=='n/a':
     try:
         thisFileLoc = os.path.split(__file__)[0]
         output = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                         cwd=thisFileLoc)
+                                         cwd=thisFileLoc, stderr=subprocess.PIPE)
     except:
         output=False
     if output:

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -29,7 +29,7 @@ if __git_sha__=='n/a':
     try:
         thisFileLoc = os.path.split(__file__)[0]
         output = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                         cwd=thisFileLoc)
+                                         cwd=thisFileLoc, stderr=subprocess.PIPE)
     except:
         output=False
     if output:


### PR DESCRIPTION
Following the lead of other `check_output` calls to git, this redirects `stderr` so that warnings are suppressed.