### PR TITLE
ENH: Add context manager to visual.Window

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -383,6 +383,13 @@ class Window(object):
         if self._closed!=False:
             self.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self._closed:
+            self.close()
+
     def __str__(self):
         className = 'Window'
         paramStrings = []


### PR DESCRIPTION
Allow for a with statement that implicitly closes a `Window` at the end of the block, e.g.

    with visual.Window(...) as w:
        [Perform experiment]

    [w is now closed]