### PR TITLE
Bubbled some contribution guidelines to root of repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+For simple changes, and for users that aren't so confident with things like version control systems then just send your changes to `the mailing list <http://groups.google.com/group/psychopy-users>`_.
+
+If you want to make more substantial changes then it's often good to discuss them first on the `developers mailing list <http://groups.google.com/group/psychopy-dev>`_. 
+
+The ideal model, is to contribute via the repository on github. There is more information on that in the :ref:`developers` section of the documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-For simple changes, and for users that aren't so confident with things like version control systems then just send your changes to `the mailing list <http://groups.google.com/group/psychopy-users>`_.
+For simple changes, and for users that aren't so confident with things like version control systems then just send your changes to [the mailing list](http://groups.google.com/group/psychopy-users).
 
-If you want to make more substantial changes then it's often good to discuss them first on the `developers mailing list <http://groups.google.com/group/psychopy-dev>`_. 
+If you want to make more substantial changes then it's often good to discuss them first on the [developers mailing list](http://groups.google.com/group/psychopy-dev). 
 
-The ideal model, is to contribute via the repository on github. There is more information on that in the :ref:`developers` section of the documentation.
+The ideal model, is to contribute via the repository on github. There is more information on that in the [developers](https://github.com/psychopy/psychopy/blob/master/docs/source/developers/developers.rst) section of the documentation.


### PR DESCRIPTION
Hi, it's my first time contributing to a repo - I am excited to use PsychoPy and eventual make a "real" contribution to the open source code base.

Happy to start a conversation here regarding more information to add to `CONTRIBUTING.md` (pep8? code style? etc.)

[It's nice to have this file](https://github.com/blog/1184-contributing-guidelines) because anytime you open a PR on github it automatically displays a big yellow bar with "Have you read the contributing guidelines?" and a link to the file.