### PR TITLE
Restore Pillow support

### DIFF
--- a/psychopy/app/builder/components/__init__.py
+++ b/psychopy/app/builder/components/__init__.py
@@ -6,10 +6,7 @@
 
 import os, glob, copy
 import wx
-try:
-    from PIL import Image
-except ImportError:
-    import Image
+from PIL import Image
 from os.path import join, dirname, abspath
 
 excludeComponents = ['VisualComponent', 'BaseComponent', #these are templates, not for use

--- a/psychopy/app/builder/components/__init__.py
+++ b/psychopy/app/builder/components/__init__.py
@@ -13,10 +13,17 @@ excludeComponents = ['VisualComponent', 'BaseComponent', #these are templates, n
                      'EyetrackerComponent', #this one isn't ready yet
                      ]
 
-def pilToBitmap(pil,scaleFactor=1.0):
-    image = wx.EmptyImage(pil.size[0], pil.size[1] )
-    image.SetData( pil.convert( "RGB").tostring() )
-    image.SetAlphaData(pil.convert("RGBA").tostring()[3::4])
+
+def pilToBitmap(pil, scaleFactor=1.0):
+    image = wx.EmptyImage(pil.size[0], pil.size[1])
+
+    try:  # For PIL.
+        image.SetData(pil.convert("RGB").tostring())
+        image.SetAlphaData(pil.convert("RGBA").tostring()[3::4])
+    except Exception:  # For Pillow.
+        image.SetData(pil.convert("RGB").tobytes())
+        image.SetAlphaData(pil.convert("RGBA").tobytes()[3::4])
+
     image.Rescale(image.Width*scaleFactor, image.Height*scaleFactor)
     return image.ConvertToBitmap()#wx.Image and wx.Bitmap are different
 


### PR DESCRIPTION
The Builder would not start if the most recent Pillow version (3.0) was installed in my Python environment. Turned out that the method `Image.tostring()` was removed from Pillow, and `Image.tobytes()` should be used instead.

This PR restores support for recent Pillow versions while maintaining PIL compatibility (e.g. for standalone).