### PR TITLE
BF: Make StairHandler work with stepSizes other than float, int

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2208,13 +2208,13 @@ class StairHandler(_BaseTrialHandler):
         self.stepType=stepType
 
         self.stepSizes=stepSizes
-        if type(stepSizes) in [int, float]:
-            self.stepSizeCurrent=stepSizes
-            self._variableStep=False
-        else:#list, tuple or array
-            self.stepSizeCurrent=stepSizes[0]
-            self.nReversals= max(len(stepSizes),self.nReversals)
-            self._variableStep=True
+        try:
+            self.stepSizeCurrent = stepSizes[0]
+            self.nReversals = max(len(stepSizes), self.nReversals)
+            self._variableStep = True
+        except (IndexError, TypeError):  # stepSizes is not array-like.
+            self.stepSizeCurrent = stepSizes
+            self._variableStep = False
 
         self.nTrials = nTrials#to terminate the nTrials must be exceeded and either
         self.finished=False


### PR DESCRIPTION
``StairHandler.__init__()`` used to check if the `stepSizes` argument was a
float or an int, and treated it as array-like otherwise. However, this would
fail e.g. for NumPy types like np.float32.

We now try to treat `stepSizes` as array-like without prior checking, and catch
exceptions if that fails.