### PR TITLE
ENH: set text only if it changed

### DIFF
--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -1023,11 +1023,9 @@ class RatingScale(MinimalStim):
                     else:
                         valTmp = self.markerPlacedAt + self.low
                         val = self.fmtStr % (valTmp * self.autoRescaleFactor)
-                    if self.accept.text != val:  # not just for speed: reduce impact of mem leaks in TextStim
-                        self.accept.setText(val)
+                    self.accept.setText(val)
                 elif self.markerPlacedAt is not False:
-                    if self.accept.text != self.acceptText:
-                        self.accept.setText(self.acceptText)
+                    self.accept.setText(self.acceptText)
 
         # handle key responses:
         if not self.mouseOnly:

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -225,9 +225,14 @@ class TextStim(BaseVisualStim, ColorMixin):
 
     @attributeSetter
     def text(self, text):
-        """String
-        The text to be rendered. Use \\\\n to make new lines. OBS: may be slow.
+        """The text to be rendered. Use \\\\n to make new lines.
+
+        Issues: May be slow, and pyglet has a memory leak when setting text.
+        For these reasons, check and only update the text if it has changed. So
+        scripts can safely set the text on every frame, and not need to check.
         """
+        if text == self.text:
+            return
         if text != None:  #make sure we have unicode object to render
             self.__dict__['text'] = unicode(text)
         if self.useShaders:
@@ -522,18 +527,18 @@ class TextStim(BaseVisualStim, ColorMixin):
         self.__dict__['wrapWidth'] = wrapWidth
         self._wrapWidthPix = convertToPix(pos = numpy.array([0, 0]), vertices=numpy.array([self.wrapWidth, 0]), units=self.units, win=self.win)[0]
         self._needSetText = True
-        
+
     @property
     def boundingBox(self):
-        """(read only) attribute representing the bounding box of the text (w,h). 
+        """(read only) attribute representing the bounding box of the text (w,h).
         This differs from `width` in that the width represents the width of the
         margins, which might differ from the width of the text within them
-        
-        NOTE: currently always returns the size in pixels 
+
+        NOTE: currently always returns the size in pixels
         (this will change to return in stimulus units)
         """
         return (self._pygletTextObj._layout.content_width, self._pygletTextObj._layout.content_height)
-        
+
     @property
     def posPix(self):
         """This determines the coordinates in pixels of the position for the


### PR DESCRIPTION
Reduces the impact of pyglet memory leak for text, and is faster when there's no change. This is quite useful when setting text every frame via Builder.

Such a check seems useful for slow and or leaky things, much less expected benefit for fast and clean things, like setting .pos. Would be good to do such a check in ShapeStim, to avoid redundant tesselation.