### PR TITLE
RF: Add `_eval` and `_inverse` methods to `_baseFunctionFit`

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -3977,8 +3977,18 @@ class _baseFunctionFit:
         self.ssq=0
         self.rms=0
         self.chi=0
-        #do the calculations:
+        # do the calculations:
         self._doFit()
+
+    def _eval(self, *args, **kwargs):
+        raise NotImplementedError(
+                "_eval() method must be defined in child class."
+        )
+
+    def _inverse(self, *args, **kwargs):
+        raise NotImplementedError(
+                "_inverse() method must be defined in child class."
+        )
 
     def _doFit(self):
         """The Fit class that derives this needs to specify its _evalFunction


### PR DESCRIPTION
The base class `data._baseFunctionFit` did refer to `self._eval()` and
`self._inverse()`, but these methods were thus far only implemented in
 the child classes.

This commit adds both methods to `_baseFunctionFit`, raising a
`NotImplementedError` if not properly overridden by a child class.