### PR TITLE
[RF/TEST] Improved user feedback in `StairHandler`, more tests

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2489,8 +2489,11 @@ class StairHandler(_BaseTrialHandler):
                 The initial value for the staircase.
 
             nReversals:
-                The minimum number of reversals permitted. If stepSizes is a list then there must
-                also be enough reversals to satisfy this list.
+                The minimum number of reversals permitted.
+                If `stepSizes` is a list, but the minimum number of
+                reversals to perform, `nReversals`, is less than the
+                length of this list, PsychoPy will automatically increase
+                the minimum number of reversals and emit a warning.
 
             stepSizes:
                 The size of steps as a single value or a list (or array). For a single value the step
@@ -2544,21 +2547,28 @@ class StairHandler(_BaseTrialHandler):
         """
         self.name=name
         self.startVal=startVal
-        self.nReversals=nReversals
         self.nUp=nUp
         self.nDown=nDown
         self.extraInfo=extraInfo
         self.method=method
         self.stepType=stepType
 
-        self.stepSizes=stepSizes
         try:
-            self.stepSizeCurrent = stepSizes[0]
-            self.nReversals = max(len(stepSizes), self.nReversals)
-            self._variableStep = True
-        except (IndexError, TypeError):  # stepSizes is not array-like.
-            self.stepSizeCurrent = stepSizes
-            self._variableStep = False
+            self.stepSizes = list(stepSizes)
+        except TypeError:  # stepSizes is not array-like, i.e., a scalar.
+            self.stepSizes = [stepSizes]
+
+        self._variableStep = True if len(self.stepSizes) > 1 else False
+        self.stepSizeCurrent = self.stepSizes[0]
+
+        if nReversals is not None and len(self.stepSizes) > nReversals:
+            logging.warn(
+                    "Increasing number of minimum required reversals to "
+                    "the number of step sizes (%i)." % len(self.stepSizes)
+            )
+            self.nReversals = len(self.stepSizes)
+        else:
+            self.nReversals = nReversals
 
         self.nTrials = nTrials#to terminate the nTrials must be exceeded and either
         self.finished=False

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -269,8 +269,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.439, 0.439, 0.44, 0.441, 0.442, 0.443, 0.443, 0.443, 0.442
         ]
 
+        self.reversalPoints = [4, 10, 12, 18]
         self.reversalIntensities = list(
-                itemgetter(4, 8, 12, 16)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -237,6 +237,65 @@ class TestStairHandler(_BaseTestStairHandler):
         self.simulate()
         self.checkSimulationResults()
 
+    def test_StairHandlerLinearReveralsNone(self):
+        nTrials = 20
+        startVal, minVal, maxVal = 0.8, 0, 1
+        stepSizes = [0.1, 0.01, 0.001]
+        nUp, nDown = 1, 3
+        nReversals = None
+        stepType = 'lin'
+
+        self.stairs = data.StairHandler(
+            startVal=startVal, nUp=nUp, nDown=nDown, minVal=minVal,
+            maxVal=maxVal, nReversals=nReversals, stepSizes=stepSizes,
+            nTrials=nTrials, stepType=stepType
+        )
+
+        self.responses = makeBasicResponseCycles(
+            cycles=3, nCorrect=4, nIncorrect=4, length=20
+        )
+
+        self.intensities = [
+            0.8, 0.7, 0.6, 0.5, 0.4, 0.41, 0.42, 0.43, 0.44, 0.44, 0.44,
+            0.439, 0.439, 0.44, 0.441, 0.442, 0.443, 0.443, 0.443, 0.442
+        ]
+
+        self.reversalIntensities = list(
+                itemgetter(4, 8, 12, 16)(self.intensities)
+        )
+
+        self.simulate()
+        self.checkSimulationResults()
+
+    def test_StairHandlerLinearScalarStepSizeReveralsNone(self):
+        nTrials = 10
+        startVal, minVal, maxVal = 0.8, 0, 1
+        stepSizes = 0.1
+        nUp, nDown = 1, 1
+        nReversals = None
+        stepType = 'lin'
+
+        self.stairs = data.StairHandler(
+            startVal=startVal, nUp=nUp, nDown=nDown, minVal=minVal,
+            maxVal=maxVal, nReversals=nReversals, stepSizes=stepSizes,
+            nTrials=nTrials, stepType=stepType
+        )
+
+        self.responses = makeBasicResponseCycles(
+            cycles=4, nCorrect=2, nIncorrect=1, length=10
+        )
+
+        self.intensities = [
+            0.8, 0.7, 0.6, 0.7, 0.6, 0.5, 0.6, 0.5, 0.4, 0.5
+        ]
+
+        self.reversalIntensities = list(
+                itemgetter(2, 3, 5, 6, 8, 9)(self.intensities)
+        )
+
+        self.simulate()
+        self.checkSimulationResults()
+
 
 class TestQuestHandler(_BaseTestStairHandler):
     """

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -4,9 +4,10 @@ from psychopy import data, logging
 import numpy as np
 import shutil
 from tempfile import mkdtemp
+from operator import itemgetter
 
 logging.console.setLevel(logging.DEBUG)
-DEBUG=False
+DEBUG = False
 
 np.random.seed(1000)
 
@@ -15,6 +16,11 @@ class _BaseTestStairHandler(object):
     def setup(self):
         self.tmpFile = mkdtemp(prefix='psychopy-tests-%s' %
                                type(self).__name__)
+
+        self.stairs = None
+        self.responses = None
+        self.intensities = None
+
         self.exp = data.ExperimentHandler(
                 name='testExp',
                 savePickle=True,
@@ -128,7 +134,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.439, 0.439, 0.44, 0.441, 0.442, 0.443, 0.443, 0.443, 0.442
         ]
 
-        self.reversalIntensities = [0.4, 0.44, 0.439, 0.443]
+        self.reversalIntensities = list(
+                itemgetter(4, 8, 12, 16)(self.intensities)
+        )
 
         self.simulate()
         self.checkSimulationResults()
@@ -160,9 +168,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.746603441, 0.746603441, 0.738057142
         ]
 
-        self.reversalIntensities = [
-            0.665411017, 0.729608671, 0.713000751, 0.746603441
-        ]
+        self.reversalIntensities = list(
+                itemgetter(4, 8, 12, 16)(self.intensities)
+        )
 
         self.simulate()
         self.checkSimulationResults()
@@ -193,9 +201,38 @@ class TestStairHandler(_BaseTestStairHandler):
             0.746603441, 0.746603441, 0.738057142
         ]
 
-        self.reversalIntensities = [
-            0.665411017, 0.729608671, 0.713000751, 0.746603441
+        self.reversalIntensities = list(
+                itemgetter(4, 8, 12, 16)(self.intensities)
+        )
+
+        self.simulate()
+        self.checkSimulationResults()
+
+    def test_StairHandlerScalarStepSize(self):
+        nTrials = 10
+        startVal, minVal, maxVal = 0.8, 0, 1
+        stepSizes = 0.1
+        nUp, nDown = 1, 1
+        nReversals = 6
+        stepType = 'lin'
+
+        self.stairs = data.StairHandler(
+            startVal=startVal, nUp=nUp, nDown=nDown, minVal=minVal,
+            maxVal=maxVal, nReversals=nReversals, stepSizes=stepSizes,
+            nTrials=nTrials, stepType=stepType
+        )
+
+        self.responses = makeBasicResponseCycles(
+            cycles=4, nCorrect=2, nIncorrect=1, length=10
+        )
+
+        self.intensities = [
+            0.8, 0.7, 0.6, 0.7, 0.6, 0.5, 0.6, 0.5, 0.4, 0.5
         ]
+
+        self.reversalIntensities = list(
+                itemgetter(2, 3, 5, 6, 8, 9)(self.intensities)
+        )
 
         self.simulate()
         self.checkSimulationResults()

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -18,8 +18,10 @@ class _BaseTestStairHandler(object):
                                type(self).__name__)
 
         self.stairs = None
-        self.responses = None
-        self.intensities = None
+        self.responses = []
+        self.intensities = []
+        self.reversalIntensities = []
+        self.reversalPoints = []
 
         self.exp = data.ExperimentHandler(
                 name='testExp',
@@ -53,14 +55,8 @@ class _BaseTestStairHandler(object):
         stairs = self.stairs
         responses = self.responses
         intensities = self.intensities
-        if hasattr(self, 'reversalPoints'):
-            reversalPoints = self.reversalPoints
-        else:
-            reversalPoints = None
-        if hasattr(self, 'reversalIntensities'):
-            reversalIntensities = self.reversalIntensities
-        else:
-            reversalIntensities = None
+        reversalPoints = self.reversalPoints
+        reversalIntensities = self.reversalIntensities
 
         assert stairs.finished  # Staircase terminated normally.
         assert stairs.data == responses  # Responses were stored correctly.
@@ -81,12 +77,21 @@ class _BaseTestStairHandler(object):
             assert stairs.nReversals == len(stairs.reversalIntensities)
 
         if stairs.reversalPoints:
+            assert stairs.reversalIntensities
+
+        if stairs.reversalIntensities:
+            assert stairs.reversalPoints
+
+        if stairs.reversalPoints:
             assert (len(stairs.reversalPoints) ==
                     len(stairs.reversalIntensities))
 
         if reversalIntensities:
             assert np.allclose(stairs.reversalIntensities,
                                reversalIntensities)
+
+        if reversalPoints:
+            assert stairs.reversalPoints == reversalPoints
 
 
 class _BaseTestMultiStairHandler(_BaseTestStairHandler):
@@ -134,8 +139,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.439, 0.439, 0.44, 0.441, 0.442, 0.443, 0.443, 0.443, 0.442
         ]
 
+        self.reversalPoints = [4, 10, 12, 18]
         self.reversalIntensities = list(
-                itemgetter(4, 8, 12, 16)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()
@@ -168,8 +174,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.746603441, 0.746603441, 0.738057142
         ]
 
+        self.reversalPoints = [4, 10, 12, 18]
         self.reversalIntensities = list(
-                itemgetter(4, 8, 12, 16)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()
@@ -201,8 +208,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.746603441, 0.746603441, 0.738057142
         ]
 
+        self.reversalPoints = [4, 10, 12, 18]
         self.reversalIntensities = list(
-                itemgetter(4, 8, 12, 16)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()
@@ -230,8 +238,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.8, 0.7, 0.6, 0.7, 0.6, 0.5, 0.6, 0.5, 0.4, 0.5
         ]
 
+        self.reversalPoints = [2, 3, 5, 6, 8, 9]
         self.reversalIntensities = list(
-                itemgetter(2, 3, 5, 6, 8, 9)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()
@@ -289,8 +298,9 @@ class TestStairHandler(_BaseTestStairHandler):
             0.8, 0.7, 0.6, 0.7, 0.6, 0.5, 0.6, 0.5, 0.4, 0.5
         ]
 
+        self.reversalPoints = [2, 3, 5, 6, 8, 9]
         self.reversalIntensities = list(
-                itemgetter(2, 3, 5, 6, 8, 9)(self.intensities)
+                itemgetter(*self.reversalPoints)(self.intensities)
         )
 
         self.simulate()


### PR DESCRIPTION
This PR changes the behavior of `data.StairHandler` such that it emits a warning when increasing the number of reversals if the `stepSizes` parameter requires more reversals than requested via the `nReversals` paramter.

Also adds new tests for staircase handlers, and improves older tests.