### PR TITLE
Use Image.frombytes() instead of removed .fromstring()

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -844,7 +844,7 @@ class Window(object):
         GL.glReadPixels(0, 0, self.size[0], self.size[1],
                         GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, bufferDat)
         try:
-            im = Image.fromstring(mode='RGBA', size=self.size, data=bufferDat)
+            im = Image.frombytes(mode='RGBA', size=self.size, data=bufferDat)
         except Exception:
             im = Image.frombytes(mode='RGBA', size=self.size, data=bufferDat)
         im = im.transpose(Image.FLIP_TOP_BOTTOM)
@@ -976,7 +976,7 @@ class Window(object):
         #GL.glGetTexImage(GL.GL_TEXTURE_1D, 0,
         #                 GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, bufferDat)
         try:
-            im = Image.fromstring(mode='RGBA', size=(horz, vert), data=bufferDat)
+            im = Image.frombytes(mode='RGBA', size=(horz, vert), data=bufferDat)
         except:
             im = Image.frombytes(mode='RGBA', size=(horz, vert), data=bufferDat)
         region = im.transpose(Image.FLIP_TOP_BOTTOM)


### PR DESCRIPTION
This prevents the following error

	  Traceback (most recent call last):
	  ...
	  ...
	    last_screen = win.getMovieFrame()
	  File "C:\Users\eoin.travers\Programs\WinPython-64bit-2.7.10.3\python-2.7.10.amd64\lib\site-packages\psychopy\visual\window.py", line 798, in getMovieFrame
	    im = self._getFrame(buffer=buffer)
	  File "C:\Users\eoin.travers\Programs\WinPython-64bit-2.7.10.3\python-2.7.10.amd64\lib\site-packages\psychopy\visual\window.py", line 820, in _getFrame
	    im = Image.fromstring(mode='RGBA', size=self.size, data=bufferDat)
	  File "C:\Users\eoin.travers\Programs\WinPython-64bit-2.7.10.3\python-2.7.10.amd64\lib\site-packages\PIL\Image.py", line 2053, in fromstring
	    "Please call frombytes() instead.")
	Exception: fromstring() has been removed. Please call frombytes() instead.