### PR TITLE
DOC: Correcting (sometimes) erroneous (English) tooltips

### DIFF
--- a/psychopy/app/builder/components/cedrusBox.py
+++ b/psychopy/app/builder/components/cedrusBox.py
@@ -46,7 +46,7 @@ class cedrusButtonBoxComponent(KeyboardComponent):
         self.url = "http://www.psychopy.org/builder/components/cedrusButtonBox.html"
         self.exp.requirePsychopyLibs(['hardware'])
 
-        self.params['correctAns'].hint = _translate("What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $thisTrial.correctAns")
+        self.params['correctAns'].hint = _translate("What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.")
         self.params['correctAns'].valType = 'code'
         self.params['allowedKeys'].hint = _translate('Keys to be read (blank for any) or key numbers separated by commas')
         self.params['deviceNumber'] = Param(deviceNumber, valType='code', allowedTypes=[],

--- a/psychopy/app/builder/components/ioLabs.py
+++ b/psychopy/app/builder/components/ioLabs.py
@@ -50,7 +50,7 @@ class ioLabsButtonBoxComponent(KeyboardComponent):
         self.order = ['forceEndRoutine', 'active', #NB name and timing params always come 1st
             'lights', 'store', 'storeCorrect', 'correctAns']
 
-        self.params['correctAns'].hint = _translate("What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $thisTrial.correctAns")
+        self.params['correctAns'].hint = _translate("What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.")
         self.params['store'].allowedVals = ['last button', 'first button', 'all buttons', 'nothing']
         self.params['store'].hint = _translate('Choose which (if any) responses to store at end of a trial')
         self.params['active'] = Param(active, valType='code', allowedTypes=[],

--- a/psychopy/app/builder/components/keyboard.py
+++ b/psychopy/app/builder/components/keyboard.py
@@ -66,7 +66,7 @@ class KeyboardComponent(BaseComponent):
             label=_localized['storeCorrect'])
         self.params['correctAns']=Param(correctAns, valType='str', allowedTypes=[],
             updates='constant', allowedUpdates=[],
-            hint=_translate("What is the 'correct' key? Might be helpful to add a correctAns column and use $thisTrial.correctAns"),
+            hint=_translate("What is the 'correct' key? Might be helpful to add a correctAns column and use $correctAns to compare to the key press."),
             label=_localized['correctAns'])
         self.params['syncScreenRefresh'] = Param(syncScreenRefresh, valType='bool',
             label=_localized['syncScreenRefresh'],

--- a/psychopy/app/locale/ja_JP/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/ja_JP/LC_MESSAGE/messages.po
@@ -1181,7 +1181,7 @@ msgstr "キーボックスのタイマーを使用"
 msgid ""
 "What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-"
 "button box. Enter 'None' (no quotes) if withholding a response is correct. "
-"Might be helpful to add a correctAns column and use $thisTrial.correctAns"
+"Might be helpful to add a correctAns column and use $correctAns to compare to the key press."
 msgstr "正答のボタンを指定します 押さないのが正答であればNoneを指定します"
 
 #: psychopy/app/builder/components/cedrusBox.py:51
@@ -1533,7 +1533,7 @@ msgstr "ライトOFF"
 msgid ""
 "What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-"
 "button box. Enter 'None' (no quotes) if withholding a response is correct. "
-"Might be helpful to add a correctAns column and use $thisTrial.correctAns"
+"Might be helpful to add a correctAns column and use $correctAns to compare to the key press."
 msgstr "正答のボタンを指定します 押さないのが正答であればNoneを指定します"
 
 #: psychopy/app/builder/components/ioLabs.py:55
@@ -1614,7 +1614,7 @@ msgstr "反応の正誤を記録します"
 #: psychopy/app/builder/components/keyboard.py:70
 msgid ""
 "What is the 'correct' key? Might be helpful to add a correctAns column and "
-"use $thisTrial.correctAns"
+"use $correctAns to compare to the key press."
 msgstr ""
 "正答とするキーを指定します 条件ファイルにcorrectAnsという列を追加して"
 "$thisTrial.correctAnsとすると条件ファイルで正答を指定できます"

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -940,7 +940,7 @@ KeyboardComponent.correctAns.staticUpdater:None
 KeyboardComponent.correctAns.categ:Basic
 KeyboardComponent.correctAns.val:
 KeyboardComponent.correctAns.allowedTypes:[]
-KeyboardComponent.correctAns.hint:What is the 'correct' key? Might be helpful to add a correctAns column and use $thisTrial.correctAns
+KeyboardComponent.correctAns.hint:What is the 'correct' key? Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
 KeyboardComponent.correctAns.allowedUpdates:[]
 KeyboardComponent.correctAns.allowedVals:[]
 KeyboardComponent.correctAns.label:Correct answer
@@ -3092,7 +3092,7 @@ cedrusButtonBoxComponent.correctAns.staticUpdater:None
 cedrusButtonBoxComponent.correctAns.categ:Basic
 cedrusButtonBoxComponent.correctAns.val:
 cedrusButtonBoxComponent.correctAns.allowedTypes:[]
-cedrusButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $thisTrial.correctAns
+cedrusButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
 cedrusButtonBoxComponent.correctAns.allowedUpdates:[]
 cedrusButtonBoxComponent.correctAns.allowedVals:[]
 cedrusButtonBoxComponent.correctAns.label:Correct answer
@@ -3284,7 +3284,7 @@ ioLabsButtonBoxComponent.correctAns.staticUpdater:None
 ioLabsButtonBoxComponent.correctAns.categ:Basic
 ioLabsButtonBoxComponent.correctAns.val:0
 ioLabsButtonBoxComponent.correctAns.allowedTypes:[]
-ioLabsButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $thisTrial.correctAns
+ioLabsButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
 ioLabsButtonBoxComponent.correctAns.allowedUpdates:[]
 ioLabsButtonBoxComponent.correctAns.allowedVals:[]
 ioLabsButtonBoxComponent.correctAns.label:Correct answer


### PR DESCRIPTION
Suggesting via a tooltip that users refer to a variable in Builder as
“thisTrial.correctAns” will often lead to inscrutable bugs in loops
called anything other than “trials”. The prefix is redundant anyway, so
this suggestion now removed and replaced with the unprefixed variable.

NB What are the implications for the translated versions of these
English tooltip strings?