### PR TITLE
BF OSError: gamma.py can't find Carbon framework + better exception handling

### DIFF
--- a/psychopy/visual/gamma.py
+++ b/psychopy/visual/gamma.py
@@ -16,7 +16,13 @@ import os
 if sys.platform=='win32':
     from ctypes import windll
 elif sys.platform=='darwin':
-    carbon = ctypes.CDLL('/System/Library/Carbon.framework/Carbon')
+    try:
+        carbon = ctypes.CDLL('/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics')
+    except OSError:
+        try:
+            carbon = ctypes.CDLL('/System/Library/Frameworks/Carbon.framework/Carbon')
+        except Exception, e:
+            carbon = ctypes.CDLL('/System/Library/Carbon.framework/Carbon')
 elif sys.platform.startswith('linux'):
     #we need XF86VidMode
     xf86vm=ctypes.CDLL(ctypes.util.find_library('Xxf86vm'))

--- a/psychopy/visual/gamma.py
+++ b/psychopy/visual/gamma.py
@@ -21,7 +21,7 @@ elif sys.platform=='darwin':
     except OSError:
         try:
             carbon = ctypes.CDLL('/System/Library/Frameworks/Carbon.framework/Carbon')
-        except Exception, e:
+        except OSError:
             carbon = ctypes.CDLL('/System/Library/Carbon.framework/Carbon')
 elif sys.platform.startswith('linux'):
     #we need XF86VidMode


### PR DESCRIPTION
gamma.py looks for the Carbon framework in the wrong place under OS X 10.11. The framework binary was moved from

/System/Library/Carbon.framework/Carbon
to

/System/Library/Frameworks/Carbon.framework/Carbon
Additionally gamma.py only calls the CGSetDisplayTransferByTable(,,,,). This function was moved to the CoreGraphics framework.

Therefore, my suggestion is that gamma.py should try to load the CoreGraphics framework first and should use the Carbon framework only as fallback.

I implemented better exception handling additionally to pull request #1084