### PR TITLE
RF: reduce use of exec( )

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -960,7 +960,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         if self.OK:
             self.params = self.getParams()
             #convert endPoints from str to list
-            exec("self.params['endPoints'].val = %s" %self.params['endPoints'].val)
+            self.params['endPoints'].val = eval("%s" % self.params['endPoints'].val)
             #then sort the list so the endpoints are in correct order
             self.params['endPoints'].val.sort()
             if loop: # editing an existing loop

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -304,7 +304,7 @@ class Experiment(object):
             name=name.replace('olour','olor')
             params[name].val = val
         elif name=='times':#deprecated in v1.60.00
-            exec('times=%s' %val)
+            times=eval('%s' %val)
             params['startType'].val =unicode('time (s)')
             params['startVal'].val = unicode(times[0])
             params['stopType'].val =unicode('time (s)')
@@ -364,7 +364,8 @@ class Experiment(object):
             elif name == 'Selected rows': #changed in 1.81.00 from 'code' to 'str' to allow string or variable
                 params[name].valType = 'str'
             #conversions based on valType
-            if params[name].valType=='bool': exec("params[name].val=%s" %params[name].val)
+            if params[name].valType=='bool':
+                params[name].val = eval("%s" %params[name].val)
         if 'updates' in paramNode.keys():
             params[name].updates = paramNode.get('updates')
     def loadFromXML(self, filename):
@@ -468,14 +469,14 @@ class Experiment(object):
                 if loopName != elementNode.get('name'):
                     modified_names.append(elementNode.get('name'))
                 self.namespace.add(loopName)
-                exec('loop=%s(exp=self,name="%s")' %(loopType,loopName))
+                loop = eval('%s(exp=self,name="%s")' %(loopType,loopName))
                 loops[loopName]=loop
                 for paramNode in elementNode:
                     self._getXMLparam(paramNode=paramNode,params=loop.params)
                     #for conditions convert string rep to actual list of dicts
                     if paramNode.get('name')=='conditions':
                         param=loop.params['conditions']
-                        exec('param.val=%s' %(param.val))#e.g. param.val=[{'ori':0},{'ori':3}]
+                        param.val = eval('%s' %(param.val))#e.g. param.val=[{'ori':0},{'ori':3}]
                 # get condition names from within conditionsFile, if any:
                 try: conditionsFile = loop.params['conditionsFile'].val #psychophysicsstaircase demo has no such param
                 except: conditionsFile = None

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -986,7 +986,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
             symbols.remove('successfulParse')
             for thisSymbol in symbols:
                 #create an actual obj from the name
-                exec('thisObj=%s' %thisSymbol)
+                thisObj = eval('%s' % thisSymbol)
                 #(try to) get the attributes of the object
                 try:
                     newAttrs = dir(thisObj)
@@ -1020,7 +1020,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
                 thisObj= thisIs = thisHelp = thisType = thisAttrs = None
                 keyIsStr = tokenDict[thisKey]['is']
                 try:
-                    exec('thisObj=%s' %keyIsStr)
+                    thisObj = eval('%s' % keyIsStr)
                     if type(thisObj)==types.FunctionType:
                         thisIs = 'returned from functon'
                     else:

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -1118,7 +1118,7 @@ class TrialHandler(_BaseTrialHandler):
                         else:
                             thisAnal = thisAnal*numpy.sqrt(N)/numpy.sqrt(N-1)
                     else:
-                        exec("thisAnal = numpy.%s(thisData,1)" %analType)
+                        thisAnal = eval("numpy.%s(thisData,1)" %analType)
                 except:
                     dataHead.remove(dataType+'_'+analType)#that analysis doesn't work
                     dataOutInvalid.append(thisDataOut)
@@ -2067,7 +2067,7 @@ class TrialHandlerExt(TrialHandler):
                         else:
                             thisAnal = thisAnal*numpy.sqrt(N)/numpy.sqrt(N-1)
                     else:
-                        exec("thisAnal = numpy.%s(thisData,1)" %analType)
+                        thisAnal = eval("numpy.%s(thisData,1)" %analType)
                 except:
                     dataHead.remove(dataType+'_'+analType)#that analysis doesn't work
                     dataOutInvalid.append(thisDataOut)
@@ -2347,7 +2347,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                     val = unicode(val.decode('utf-8'))
                     #if it looks like a list, convert it:
                     if val.startswith('[') and val.endswith(']'):
-                        #exec('val=%s' %unicode(val.decode('utf8')))
+                        #val=eval('%s' %unicode(val.decode('utf8')))
                         val = eval(val)
                 thisTrial[fieldName] = val
             trialList.append(thisTrial)

--- a/psychopy/tools/plottools.py
+++ b/psychopy/tools/plottools.py
@@ -18,7 +18,7 @@ def plotFrameIntervals(intervals):
 
     if type(intervals)==str:
         f = open(intervals, 'r')
-        exec("intervals = [%s]" %(f.readline()))
+        intervals = eval("[%s]" %(f.readline()))
     #    hist(intervals, int(len(intervals)/10))
     plot(intervals)
     show()


### PR DESCRIPTION
prefer eval( )
retain exec( ) for imports
skip exec() used to append to a list; should be changed but risk of breakage is higher