### PR TITLE
RF: more lower_underscore to camelCase internals

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -490,13 +490,13 @@ class PsychoPyApp(wx.App):
                         wx.TheClipboard.SetData(wx.TextDataObject(str(rgb)))
                         wx.TheClipboard.Close()
                 dlg.Destroy()
-                parent.new_rgb = rgb
+                parent.newRBG = rgb
         frame = wx.Frame(None, wx.ID_ANY, "Color picker",
                          size=(0, 0))  # not shown
         ColorPicker(frame)
-        new_rgb = frame.new_rgb
+        newRBG = frame.newRBG
         frame.Destroy()
-        return new_rgb  # string
+        return newRBG  # string
 
     def openMonitorCenter(self, event):
         from psychopy.monitors import MonitorCenter
@@ -529,10 +529,10 @@ class PsychoPyApp(wx.App):
             import socket
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.settimeout(1.0)
-            iohub_address = '127.0.0.1', 9034
+            iohubAddress = '127.0.0.1', 9034
             import msgpack
-            tx_data = msgpack.Packer().pack(('STOP_IOHUB_SERVER',))
-            return sock.sendto(tx_data, iohub_address)
+            txData = msgpack.Packer().pack(('STOP_IOHUB_SERVER',))
+            return sock.sendto(txData, iohubAddress)
         except socket.error as e:
             msg = 'PsychoPyApp: terminateHubProcess socket.error: %s'
             logging.debug(msg % str(e))

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1066,19 +1066,19 @@ class BuilderFrame(wx.Frame):
         join = os.path.join
         PNG = wx.BITMAP_TYPE_PNG
         tbSize = toolbarSize
-        new_bmp = wx.Bitmap(join(rc, 'filenew%i.png' % tbSize), PNG)
-        open_bmp = wx.Bitmap(join(rc, 'fileopen%i.png' % tbSize), PNG)
-        save_bmp = wx.Bitmap(join(rc, 'filesave%i.png' % tbSize), PNG)
-        saveAs_bmp = wx.Bitmap(join(rc, 'filesaveas%i.png' % tbSize), PNG)
-        undo_bmp = wx.Bitmap(join(rc, 'undo%i.png' % tbSize), PNG)
-        redo_bmp = wx.Bitmap(join(rc, 'redo%i.png' % tbSize), PNG)
-        stop_bmp = wx.Bitmap(join(rc, 'stop%i.png' % tbSize), PNG)
-        run_bmp = wx.Bitmap(join(rc, 'run%i.png' % tbSize), PNG)
-        compile_bmp = wx.Bitmap(join(rc, 'compile%i.png' % tbSize), PNG)
-        settings_bmp = wx.Bitmap(join(rc, 'settingsExp%i.png' % tbSize), PNG)
-        preferences_bmp = wx.Bitmap(join(rc, 'preferences%i.png' % tbSize),
+        newBmp = wx.Bitmap(join(rc, 'filenew%i.png' % tbSize), PNG)
+        openBmp = wx.Bitmap(join(rc, 'fileopen%i.png' % tbSize), PNG)
+        saveBmp = wx.Bitmap(join(rc, 'filesave%i.png' % tbSize), PNG)
+        saveAsBmp = wx.Bitmap(join(rc, 'filesaveas%i.png' % tbSize), PNG)
+        undoBmp = wx.Bitmap(join(rc, 'undo%i.png' % tbSize), PNG)
+        redoBmp = wx.Bitmap(join(rc, 'redo%i.png' % tbSize), PNG)
+        stopBmp = wx.Bitmap(join(rc, 'stop%i.png' % tbSize), PNG)
+        runBmp = wx.Bitmap(join(rc, 'run%i.png' % tbSize), PNG)
+        compileBmp = wx.Bitmap(join(rc, 'compile%i.png' % tbSize), PNG)
+        settingsBmp = wx.Bitmap(join(rc, 'settingsExp%i.png' % tbSize), PNG)
+        preferencesBmp = wx.Bitmap(join(rc, 'preferences%i.png' % tbSize),
                                     PNG)
-        monitors_bmp = wx.Bitmap(join(rc, 'monitors%i.png' % tbSize), PNG)
+        monitorsBmp = wx.Bitmap(join(rc, 'monitors%i.png' % tbSize), PNG)
 
         ctrlKey = 'Ctrl+'  # OS-dependent tool-tips
         if sys.platform == 'darwin':
@@ -1088,60 +1088,60 @@ class BuilderFrame(wx.Frame):
         keys = {k: self.app.keys[k].replace('Ctrl+', ctrlKey)
                 for k in self.app.keys}
 
-        tb.AddSimpleTool(self.IDs.tbFileNew, new_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileNew, newBmp,
                          _translate("New [%s]") % keys['new'],
                          _translate("Create new experiment file"))
         tb.Bind(wx.EVT_TOOL, self.app.newBuilderFrame, id=self.IDs.tbFileNew)
-        tb.AddSimpleTool(self.IDs.tbFileOpen, open_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileOpen, openBmp,
                          _translate("Open [%s]") % keys['open'],
                          _translate("Open an existing experiment file"))
         tb.Bind(wx.EVT_TOOL, self.fileOpen, id=self.IDs.tbFileOpen)
-        tb.AddSimpleTool(self.IDs.tbFileSave, save_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileSave, saveBmp,
                          _translate("Save [%s]") % keys['save'],
                          _translate("Save current experiment file"))
         tb.EnableTool(self.IDs.tbFileSave, False)
         tb.Bind(wx.EVT_TOOL, self.fileSave, id=self.IDs.tbFileSave)
-        tb.AddSimpleTool(self.IDs.tbFileSaveAs, saveAs_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileSaveAs, saveAsBmp,
                          _translate("Save As... [%s]") % keys['saveAs'],
                          _translate("Save current experiment file as..."))
         tb.Bind(wx.EVT_TOOL, self.fileSaveAs, id=self.IDs.tbFileSaveAs)
-        tb.AddSimpleTool(self.IDs.tbUndo, undo_bmp,
+        tb.AddSimpleTool(self.IDs.tbUndo, undoBmp,
                          _translate("Undo [%s]") % keys['undo'],
                          _translate("Undo last action"))
         tb.Bind(wx.EVT_TOOL, self.undo, id=self.IDs.tbUndo)
-        tb.AddSimpleTool(self.IDs.tbRedo, redo_bmp,
+        tb.AddSimpleTool(self.IDs.tbRedo, redoBmp,
                          _translate("Redo [%s]") % keys['redo'],
                          _translate("Redo last action"))
         tb.Bind(wx.EVT_TOOL, self.redo, id=self.IDs.tbRedo)
         tb.AddSeparator()
         tb.AddSeparator()
-        tb.AddSimpleTool(self.IDs.tbPreferences, preferences_bmp,
+        tb.AddSimpleTool(self.IDs.tbPreferences, preferencesBmp,
                          _translate("Preferences"),
                          _translate("Application preferences"))
         tb.Bind(wx.EVT_TOOL, self.app.showPrefs, id=self.IDs.tbPreferences)
-        tb.AddSimpleTool(self.IDs.tbMonitorCenter, monitors_bmp,
+        tb.AddSimpleTool(self.IDs.tbMonitorCenter, monitorsBmp,
                          _translate("Monitor Center"),
                          _translate("Monitor settings and calibration"))
         tb.Bind(wx.EVT_TOOL, self.app.openMonitorCenter,
                 id=self.IDs.tbMonitorCenter)
         tb.AddSeparator()
         tb.AddSeparator()
-        tb.AddSimpleTool(self.IDs.tbExpSettings, settings_bmp,
+        tb.AddSimpleTool(self.IDs.tbExpSettings, settingsBmp,
                          _translate("Experiment Settings"),
                          _translate("Settings for this exp"))
         tb.Bind(wx.EVT_TOOL, self.setExperimentSettings,
                 id=self.IDs.tbExpSettings)
-        tb.AddSimpleTool(self.IDs.tbCompile, compile_bmp,
+        tb.AddSimpleTool(self.IDs.tbCompile, compileBmp,
                          _translate("Compile Script [%s]") %
                          keys['compileScript'],
                          _translate("Compile to script"))
         tb.Bind(wx.EVT_TOOL, self.compileScript,
                 id=self.IDs.tbCompile)
-        tb.AddSimpleTool(self.IDs.tbRun, run_bmp,
+        tb.AddSimpleTool(self.IDs.tbRun, runBmp,
                          _translate("Run [%s]") % keys['runScript'],
                          _translate("Run experiment"))
         tb.Bind(wx.EVT_TOOL, self.runFile, id=self.IDs.tbRun)
-        tb.AddSimpleTool(self.IDs.tbStop, stop_bmp,
+        tb.AddSimpleTool(self.IDs.tbStop, stopBmp,
                          _translate("Stop [%s]") % keys['stopScript'],
                          _translate("Stop experiment"))
         tb.Bind(wx.EVT_TOOL, self.stopFile, id=self.IDs.tbStop)

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1004,8 +1004,8 @@ class _BaseParamsDlg(wx.Dialog):
         else:
             namespace = self.frame.exp.namespace
             used = namespace.exists(newName)
-            same_as_old_name = bool(newName == self.params['name'].val)
-            if used and not same_as_old_name:
+            sameOldName = bool(newName == self.params['name'].val)
+            if used and not sameOldName:
                 msg = _translate(
                     "That name is in use (it's a %s). Try another name.")
                 return msg % namespace._localized[used], False
@@ -1064,19 +1064,19 @@ class DlgLoopProperties(_BaseParamsDlg):
         if loop:
             oldLoopName = loop.params['name'].val
         namespace = frame.exp.namespace
-        new_name = namespace.makeValid(oldLoopName)
+        newName = namespace.makeValid(oldLoopName)
 
         # create default instances of the diff loop types
         # for 'random','sequential', 'fullRandom'
         self.trialHandler = experiment.TrialHandler(
-            exp=self.exp, name=new_name, loopType='random',
+            exp=self.exp, name=newName, loopType='random',
             nReps=5, conditions=[])
         # for staircases:
         self.stairHandler = experiment.StairHandler(
-            exp=self.exp, name=new_name, nReps=50, nReversals='',
+            exp=self.exp, name=newName, nReps=50, nReversals='',
             stepSizes='[0.8,0.8,0.4,0.4,0.2]', stepType='log', startVal=0.5)
         self.multiStairHandler = experiment.MultiStairHandler(
-            exp=self.exp, name=new_name, nReps=50, stairType='simple',
+            exp=self.exp, name=newName, nReps=50, stairType='simple',
             switchStairs='random', conditions=[], conditionsFile='')
 
         # replace defaults with the loop we were given
@@ -1669,18 +1669,18 @@ class DlgExperimentProperties(_BaseParamsDlg):
         """
         if self.paramCtrls['Full-screen window'].valueCtrl.GetValue():
             # get screen size for requested display
-            num_displays = wx.Display.GetCount()
+            numDisplays = wx.Display.GetCount()
             try:
-                screen_value = int(
+                screenValue = int(
                     self.paramCtrls['Screen'].valueCtrl.GetValue())
             except ValueError:
                 # param control currently contains no integer value
-                screen_value = 1
-            if screen_value < 1 or screen_value > num_displays:
+                screenValue = 1
+            if screenValue < 1 or screenValue > numDisplays:
                 logging.error("User requested non-existent screen")
                 screenN = 0
             else:
-                screenN = screen_value - 1
+                screenN = screenValue - 1
             size = list(wx.Display(screenN).GetGeometry()[2:])
             # set vals and disable changes
             field = 'Window size (pixels)'
@@ -1742,13 +1742,13 @@ def _relpath(path, start='.'):
     if not path:
         raise ValueError("no path specified")
 
-    start_list = os.path.abspath(start).split(os.path.sep)
-    path_list = os.path.abspath(path).split(os.path.sep)
+    startList = os.path.abspath(start).split(os.path.sep)
+    pathList = os.path.abspath(path).split(os.path.sep)
 
     # Work out how much of the filepath is shared by start and path.
-    i = len(os.path.commonprefix([start_list, path_list]))
+    i = len(os.path.commonprefix([startList, pathList]))
 
-    rel_list = ['..'] * (len(start_list) - i) + path_list[i:]
-    if not rel_list:
+    relList = ['..'] * (len(startList) - i) + pathList[i:]
+    if not relList:
         return path
-    return os.path.join(*rel_list)
+    return os.path.join(*relList)

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -51,8 +51,8 @@ class NameValidator(wx.PyValidator):
         else:
             namespace = parent.frame.exp.namespace
             used = namespace.exists(newName)
-            same_as_old_name = bool(newName == parent.params['name'].val)
-            if used and not same_as_old_name:
+            sameAsOldName = bool(newName == parent.params['name'].val)
+            if used and not sameAsOldName:
                 msg = _translate(
                     "That name is in use (it's a %s). Try another name.")
                 return msg % used, False

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1790,17 +1790,17 @@ class CoderFrame(wx.Frame):
         join = os.path.join
         PNG = wx.BITMAP_TYPE_PNG
         size = toolbarSize
-        new_bmp = wx.Bitmap(join(rc, 'filenew%i.png' % size), PNG)
-        open_bmp = wx.Bitmap(join(rc, 'fileopen%i.png' % size), PNG)
-        save_bmp = wx.Bitmap(join(rc, 'filesave%i.png' % size), PNG)
-        saveAs_bmp = wx.Bitmap(join(rc, 'filesaveas%i.png' % size), PNG)
-        undo_bmp = wx.Bitmap(join(rc, 'undo%i.png' % size), PNG)
-        redo_bmp = wx.Bitmap(join(rc, 'redo%i.png' % size), PNG)
-        stop_bmp = wx.Bitmap(join(rc, 'stop%i.png' % size), PNG)
-        run_bmp = wx.Bitmap(join(rc, 'run%i.png' % size), PNG)
-        preferences_bmp = wx.Bitmap(join(rc, 'preferences%i.png' % size), PNG)
-        monitors_bmp = wx.Bitmap(join(rc, 'monitors%i.png' % size), PNG)
-        colorpicker_bmp = wx.Bitmap(join(rc, 'color%i.png' % size), PNG)
+        newBmp = wx.Bitmap(join(rc, 'filenew%i.png' % size), PNG)
+        openBmp = wx.Bitmap(join(rc, 'fileopen%i.png' % size), PNG)
+        saveBmp = wx.Bitmap(join(rc, 'filesave%i.png' % size), PNG)
+        saveAsBmp = wx.Bitmap(join(rc, 'filesaveas%i.png' % size), PNG)
+        undoBmp = wx.Bitmap(join(rc, 'undo%i.png' % size), PNG)
+        redoBmp = wx.Bitmap(join(rc, 'redo%i.png' % size), PNG)
+        stopBmp = wx.Bitmap(join(rc, 'stop%i.png' % size), PNG)
+        runBmp = wx.Bitmap(join(rc, 'run%i.png' % size), PNG)
+        preferencesBmp = wx.Bitmap(join(rc, 'preferences%i.png' % size), PNG)
+        monitorsBmp = wx.Bitmap(join(rc, 'monitors%i.png' % size), PNG)
+        colorpickerBmp = wx.Bitmap(join(rc, 'color%i.png' % size), PNG)
 
         # show key-bindings in tool-tips in an OS-dependent way
         if sys.platform == 'darwin':
@@ -1809,50 +1809,50 @@ class CoderFrame(wx.Frame):
             ctrlKey = 'Ctrl+'
         tb = self.toolbar
         key = _translate("New [%s]") % self.app.keys['new']
-        tb.AddSimpleTool(self.IDs.tbFileNew, new_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileNew, newBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Create new python file"))
         tb.Bind(wx.EVT_TOOL, self.fileNew, id=self.IDs.tbFileNew)
         key = _translate("Open [%s]") % self.app.keys['open']
-        tb.AddSimpleTool(self.IDs.tbFileOpen, open_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileOpen, openBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Open an existing file"))
         tb.Bind(wx.EVT_TOOL, self.fileOpen, id=self.IDs.tbFileOpen)
         key = _translate("Save [%s]") % self.app.keys['save']
-        tb.AddSimpleTool(self.IDs.tbFileSave, save_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileSave, saveBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Save current file"))
         tb.EnableTool(self.IDs.tbFileSave, False)
         tb.Bind(wx.EVT_TOOL, self.fileSave, id=self.IDs.tbFileSave)
         key = _translate("Save As... [%s]") % self.app.keys['saveAs']
-        tb.AddSimpleTool(self.IDs.tbFileSaveAs, saveAs_bmp,
+        tb.AddSimpleTool(self.IDs.tbFileSaveAs, saveAsBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Save current python file as..."))
         tb.Bind(wx.EVT_TOOL, self.fileSaveAs,
                 id=self.IDs.tbFileSaveAs)
         key = _translate("Undo [%s]") % self.app.keys['undo']
-        tb.AddSimpleTool(self.IDs.tbUndo, undo_bmp,
+        tb.AddSimpleTool(self.IDs.tbUndo, undoBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Undo last action"))
         tb.Bind(wx.EVT_TOOL, self.undo, id=self.IDs.tbUndo)
         key = _translate("Redo [%s]") % self.app.keys['redo']
-        tb.AddSimpleTool(self.IDs.tbRedo, redo_bmp,
+        tb.AddSimpleTool(self.IDs.tbRedo, redoBmp,
                          key.replace('Ctrl+', ctrlKey),
                          _translate("Redo last action"))
         tb.Bind(wx.EVT_TOOL, self.redo, id=self.IDs.tbRedo)
         tb.AddSeparator()
         tb.AddSeparator()
-        tb.AddSimpleTool(self.IDs.tbPreferences, preferences_bmp,
+        tb.AddSimpleTool(self.IDs.tbPreferences, preferencesBmp,
                          _translate("Preferences"),
                          _translate("Application preferences"))
         tb.Bind(wx.EVT_TOOL, self.app.showPrefs,
                 id=self.IDs.tbPreferences)
-        tb.AddSimpleTool(self.IDs.tbMonitorCenter, monitors_bmp,
+        tb.AddSimpleTool(self.IDs.tbMonitorCenter, monitorsBmp,
                          _translate("Monitor Center"),
                          _translate("Monitor settings and calibration"))
         tb.Bind(wx.EVT_TOOL, self.app.openMonitorCenter,
                 id=self.IDs.tbMonitorCenter)
-        tb.AddSimpleTool(self.IDs.tbColorPicker, colorpicker_bmp,
+        tb.AddSimpleTool(self.IDs.tbColorPicker, colorpickerBmp,
                          _translate("Color Picker -> clipboard"),
                          _translate("Color Picker -> clipboard"))
         tb.Bind(wx.EVT_TOOL, self.app.colorPicker,
@@ -1860,12 +1860,12 @@ class CoderFrame(wx.Frame):
         self.toolbar.AddSeparator()
         self.toolbar.AddSeparator()
         key = _translate("Run [%s]") % self.app.keys['runScript']
-        self.toolbar.AddSimpleTool(self.IDs.tbRun, run_bmp,
+        self.toolbar.AddSimpleTool(self.IDs.tbRun, runBmp,
                                    key.replace('Ctrl+', ctrlKey),
                                    _translate("Run current script"))
         self.toolbar.Bind(wx.EVT_TOOL, self.runFile, id=self.IDs.tbRun)
         key = _translate("Stop [%s]") % self.app.keys['stopScript']
-        self.toolbar.AddSimpleTool(self.IDs.tbStop, stop_bmp,
+        self.toolbar.AddSimpleTool(self.IDs.tbStop, stopBmp,
                                    key.replace('Ctrl+', ctrlKey),
                                    _translate("Stop current script"))
         tb.Bind(wx.EVT_TOOL, self.stopFile, id=self.IDs.tbStop)

--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -57,8 +57,8 @@ if sys.platform == 'win32':
         _winQPC(byref(_fcounter))
         return _fcounter.value / _qpfreq
 else:
-    cur_pyver = sys.version_info
-    if cur_pyver[0] == 2 and cur_pyver[1] <= 6:
+    curPyver = sys.version_info
+    if curPyver[0] == 2 and curPyver[1] <= 6:
         getTime = time.time
     else:
         import timeit

--- a/psychopy/compatibility.py
+++ b/psychopy/compatibility.py
@@ -86,18 +86,18 @@ def fromFile(filename):
                 currentHandler = psychopy.data.TrialHandler
                 # Temporarily replace new-style class
                 psychopy.data.TrialHandler = _oldStyleTrialHandler
-                old_contents = cPickle.load(f)
+                oldContents = cPickle.load(f)
                 psychopy.data.TrialHandler = currentHandler
                 contents = _convertToNewStyle(psychopy.data.TrialHandler,
-                                              old_contents)
+                                              oldContents)
             elif name == 'StairHandler':
                 currentHandler = psychopy.data.StairHandler
                 # Temporarily replace new-style class
                 psychopy.data.StairHandler = _oldStyleStairHandler
-                old_contents = cPickle.load(f)
+                oldContents = cPickle.load(f)
                 psychopy.data.StairHandler = currentHandler
                 contents = _convertToNewStyle(
-                    psychopy.data.StairHandler, old_contents)
+                    psychopy.data.StairHandler, oldContents)
             elif name == 'MultiStairHandler':
                 newStair = psychopy.data.StairHandler
                 newMulti = psychopy.data.MultiStairHandler
@@ -105,12 +105,12 @@ def fromFile(filename):
                 psychopy.data.StairHandler = _oldStyleStairHandler
                 # Temporarily replace new-style class
                 psychopy.data.MultiStairHandler = _oldStyleMultiStairHandler
-                old_contents = cPickle.load(f)
+                oldContents = cPickle.load(f)
                 psychopy.data.MultiStairHandler = newMulti
                 # Temporarily replace new-style class:
                 psychopy.data.StairHandler = newStair
                 contents = _convertToNewStyle(
-                    psychopy.data.MultiStairHandler, old_contents)
+                    psychopy.data.MultiStairHandler, oldContents)
             else:
                 raise TypeError, ("Didn't recognize %s" % name)
     return contents

--- a/psychopy/locale_setup.py
+++ b/psychopy/locale_setup.py
@@ -17,12 +17,12 @@ create multiple versions of an experiment.
 from __future__ import absolute_import
 
 import platform
-mac_ver = platform.mac_ver()[0]  # e.g., '10.9.5' or '' for non-Mac
+macVer = platform.mac_ver()[0]  # e.g., '10.9.5' or '' for non-Mac
 
-if mac_ver:
+if macVer:
     def _versionTuple(v):
         return tuple(map(int, v.split('.')))
-    ver = _versionTuple(mac_ver)
+    ver = _versionTuple(macVer)
     if ver > _versionTuple('10.10.2'):
         # set locale and prefs experiment-wide, without saving prefs to disk
         import locale

--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -303,14 +303,14 @@ class MainFrame(wx.Frame):
         infoBoxSizer = wx.StaticBoxSizer(infoBox, wx.VERTICAL)
 
         # scr distance
-        labl_scrDist = wx.StaticText(parent, -1,
+        labelScrDist = wx.StaticText(parent, -1,
                                      _translate("Screen Distance (cm):"),
                                      style=wx.ALIGN_RIGHT)
         self.ctrlScrDist = wx.TextCtrl(parent, idCtrlScrDist, "")
         wx.EVT_TEXT(self, idCtrlScrDist, self.onChangeScrDist)
 
         # scr width
-        labl_scrWidth = wx.StaticText(parent, -1,
+        labelScrWidth = wx.StaticText(parent, -1,
                                       _translate("Screen Width (cm):"),
                                       style=wx.ALIGN_RIGHT)
         self.ctrlScrWidth = wx.TextCtrl(parent, idCtrlScrWidth, "")
@@ -318,7 +318,7 @@ class MainFrame(wx.Frame):
 
         # scr pixels
         _size = _translate("Size (pixels; Horiz,Vert):")
-        labl_ScrPixels = wx.StaticText(parent, -1, _size,
+        labelScrPixels = wx.StaticText(parent, -1, _size,
                                        style=wx.ALIGN_RIGHT)
         self.ctrlScrPixHoriz = wx.TextCtrl(parent, -1, "", size=(50, 20))
         wx.EVT_TEXT(self, self.ctrlScrPixHoriz.GetId(),
@@ -330,14 +330,14 @@ class MainFrame(wx.Frame):
         ScrPixelsSizer.AddMany([self.ctrlScrPixHoriz, self.ctrlScrPixVert])
 
         # date
-        labl_calibDate = wx.StaticText(parent, -1,
+        labelCalibDate = wx.StaticText(parent, -1,
                                        _translate("Calibration Date:"),
                                        style=wx.ALIGN_RIGHT)
         self.ctrlCalibDate = wx.TextCtrl(parent, idCtrlCalibDate, "",
                                          size=(150, 20))
         self.ctrlCalibDate.Disable()
         # notes
-        labl_calibNotes = wx.StaticText(parent, -1,
+        labelCalibNotes = wx.StaticText(parent, -1,
                                         _translate("Notes:"),
                                         style=wx.ALIGN_RIGHT)
         self.ctrlCalibNotes = wx.TextCtrl(parent, idCtrlCalibNotes, "",
@@ -353,15 +353,15 @@ class MainFrame(wx.Frame):
         infoBoxGrid.AddMany([
             (1, 10), (1, 10),  # a pair of empty boxes each 1x10pix
             (1, 10), self.ctrlUseBits,
-            labl_scrDist, self.ctrlScrDist,
-            labl_ScrPixels, ScrPixelsSizer,
-            labl_scrWidth, self.ctrlScrWidth,
-            labl_calibDate, self.ctrlCalibDate
+            labelScrDist, self.ctrlScrDist,
+            labelScrPixels, ScrPixelsSizer,
+            labelScrWidth, self.ctrlScrWidth,
+            labelCalibDate, self.ctrlCalibDate
         ])
         infoBoxGrid.Layout()
         infoBoxSizer.Add(infoBoxGrid)
         # put the notes box below the main grid sizer
-        infoBoxSizer.Add(labl_calibNotes)
+        infoBoxSizer.Add(labelCalibNotes)
         infoBoxSizer.Add(self.ctrlCalibNotes, 1, wx.EXPAND)
         return infoBoxSizer
 

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -220,13 +220,13 @@ class Preferences(object):
         if result == True:
             return
         vtor = validate.Validator()
-        for section_list, key, _ in configobj.flatten_errors(cfg, result):
+        for sectionList, key, _ in configobj.flatten_errors(cfg, result):
             if key is not None:
-                _secList = ', '.join(section_list)
+                _secList = ', '.join(sectionList)
                 val = cfg.configspec[_secList][key]
                 cfg[_secList][key] = vtor.get_default_value(val)
             else:
                 msg = "Section [%s] was missing in file '%s'"
-                print(msg % (', '.join(section_list), cfg.filename))
+                print(msg % (', '.join(sectionList), cfg.filename))
 
 prefs = Preferences()

--- a/psychopy/tools/monitorunittools.py
+++ b/psychopy/tools/monitorunittools.py
@@ -77,15 +77,15 @@ def convertToPix(vertices, pos, units, win):
     self.pos is that some stimuli use other terms (e.g. ElementArrayStim
     uses fieldPos).
     """
-    unit2pix_func = _unit2PixMappings.get(units)
-    if unit2pix_func:
-        return unit2pix_func(vertices, pos, win)
+    unit2pixFunc = _unit2PixMappings.get(units)
+    if unit2pixFunc:
+        return unit2pixFunc(vertices, pos, win)
     else:
         msg = "The unit type [{0}] is not registered with PsychoPy"
         raise ValueError(msg.format(units))
 
 
-def addUnitTypeConversion(unit_label, mapping_func):
+def addUnitTypeConversion(unitLabel, mappingFunc):
     """Add support for converting units specified by unit_label to pixels
     to be used by convertToPix (therefore a valid unit for your PsychoPy
     stimuli)
@@ -101,10 +101,10 @@ def addUnitTypeConversion(unit_label, mapping_func):
 
         return pix
     """
-    if unit_label in _unit2PixMappings:
+    if unitLabel in _unit2PixMappings:
         msg = "The unit type label [{0}] is already registered with PsychoPy"
-        raise ValueError(msg.format(unit_label))
-    _unit2PixMappings[unit_label] = mapping_func
+        raise ValueError(msg.format(unitLabel))
+    _unit2PixMappings[unitLabel] = mappingFunc
 
 
 # Built in conversion functions follow ...

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -37,7 +37,7 @@ from psychopy.tools.monitorunittools import (cm2pix, deg2pix, pix2cm,
 from psychopy.visual.helpers import pointInPolygon, polygonsOverlap, setColor
 from psychopy.tools.typetools import float_uint8
 from psychopy.tools.arraytools import makeRadialMatrix
-from . import glob_vars
+from . import globalVars
 
 import numpy
 from numpy import pi
@@ -817,13 +817,13 @@ class TextureMixin(object):
                 if im.size[0] != powerOf2 or im.size[1] != powerOf2:
                     if not forcePOW2:
                         notSqr = True
-                    elif glob_vars.nImageResizes < reportNImageResizes:
+                    elif globalVars.nImageResizes < reportNImageResizes:
                         msg = ("Image '%s' was not a square power-of-two ' "
                                "'image. Linearly interpolating to be %ix%i")
                         logging.warning(msg % (tex, powerOf2, powerOf2))
-                        glob_vars.nImageResizes += 1
+                        globalVars.nImageResizes += 1
                         im = im.resize([powerOf2, powerOf2], Image.BILINEAR)
-                    elif glob_vars.nImageResizes == reportNImageResizes:
+                    elif globalVars.nImageResizes == reportNImageResizes:
                         logging.warning("Multiple images have needed resizing"
                                         " - I'll stop bothering you!")
                         im = im.resize([powerOf2, powerOf2], Image.BILINEAR)
@@ -1146,9 +1146,9 @@ class WindowMixin(object):
 
     def _selectWindow(self, win):
         # don't call switch if it's already the curr window
-        if win != glob_vars.currWindow and win.winType == 'pyglet':
+        if win != globalVars.currWindow and win.winType == 'pyglet':
             win.winHandle.switch_to()
-            glob_vars.currWindow = win
+            globalVars.currWindow = win
 
     def _updateList(self):
         """The user shouldn't need this method since it gets called

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -721,13 +721,13 @@ class TextureMixin(object):
             wasLum = True
         elif tex == "cross":
             X, Y = numpy.mgrid[-1:1:1j * res, -1:1:1j * res]
-            tf_neg_cross = (((X < -0.2) & (Y < -0.2)) |
-                            ((X < -0.2) & (Y > 0.2)) |
-                            ((X > 0.2) & (Y < -0.2)) |
-                            ((X > 0.2) & (Y > 0.2)))
-            # tf_neg_cross == True at places where the cross is transparent,
+            tfNegCross = (((X < -0.2) & (Y < -0.2)) |
+                          ((X < -0.2) & (Y > 0.2)) |
+                          ((X > 0.2) & (Y < -0.2)) |
+                          ((X > 0.2) & (Y > 0.2)))
+            # tfNegCross == True at places where the cross is transparent,
             # i.e. the four corners
-            intensity = numpy.where(tf_neg_cross, -1, 1)
+            intensity = numpy.where(tfNegCross, -1, 1)
             wasLum = True
         elif tex == "radRamp":  # a radial ramp
             rad = makeRadialMatrix(res)
@@ -737,33 +737,33 @@ class TextureMixin(object):
             wasLum = True
         elif tex == "raisedCos":  # A raised cosine
             wasLum = True
-            hamming_len = 1000  # affects the 'granularity' of the raised cos
+            hammingLen = 1000  # affects the 'granularity' of the raised cos
 
             rad = makeRadialMatrix(res)
             intensity = numpy.zeros_like(rad)
             intensity[numpy.where(rad < 1)] = 1
             frng = allMaskParams['fringeWidth']
-            raised_cos_idx = numpy.where(
+            raisedCosIdx = numpy.where(
                 [numpy.logical_and(rad <= 1, rad >= 1 - frng)])[1:]
 
             # Make a raised_cos (half a hamming window):
-            raised_cos = numpy.hamming(hamming_len)[:hamming_len / 2]
-            raised_cos -= numpy.min(raised_cos)
-            raised_cos /= numpy.max(raised_cos)
+            raisedCos = numpy.hamming(hammingLen)[:hammingLen / 2]
+            raisedCos -= numpy.min(raisedCos)
+            raisedCos /= numpy.max(raisedCos)
 
             # Measure the distance from the edge - this is your index into the
             # hamming window:
-            d_from_edge = numpy.abs(
-                (1 - allMaskParams['fringeWidth']) - rad[raised_cos_idx])
-            d_from_edge /= numpy.max(d_from_edge)
-            d_from_edge *= numpy.round(hamming_len / 2)
+            dFromEdge = numpy.abs(
+                (1 - allMaskParams['fringeWidth']) - rad[raisedCosIdx])
+            dFromEdge /= numpy.max(dFromEdge)
+            dFromEdge *= numpy.round(hammingLen / 2)
 
             # This is the indices into the hamming (larger for small distances
             # from the edge!):
-            portion_idx = (-1 * d_from_edge).astype(int)
+            portionIdx = (-1 * dFromEdge).astype(int)
 
             # Apply the raised cos to this portion:
-            intensity[raised_cos_idx] = raised_cos[portion_idx]
+            intensity[raisedCosIdx] = raisedCos[portionIdx]
 
             # Scale it into the interval -1:1:
             intensity = intensity - 0.5
@@ -771,12 +771,12 @@ class TextureMixin(object):
 
             # Sometimes there are some remaining artifacts from this process,
             # get rid of them:
-            artifact_idx = numpy.where(numpy.logical_and(intensity == -1,
-                                                         rad < 0.99))
-            intensity[artifact_idx] = 1
-            artifact_idx = numpy.where(numpy.logical_and(intensity == 1,
-                                                         rad > 0.99))
-            intensity[artifact_idx] = 0
+            artifactIdx = numpy.where(numpy.logical_and(intensity == -1,
+                                                        rad < 0.99))
+            intensity[artifactIdx] = 1
+            artifactIdx = numpy.where(numpy.logical_and(intensity == 1,
+                                                        rad > 0.99))
+            intensity[artifactIdx] = 0
 
         else:
             if type(tex) in [str, unicode, numpy.string_]:

--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -28,7 +28,7 @@ from psychopy.tools.attributetools import attributeSetter, logAttrib, setAttribu
 from psychopy.tools.monitorunittools import convertToPix
 from psychopy.visual.helpers import setColor
 from psychopy.visual.basevisual import MinimalStim, TextureMixin
-from . import glob_vars
+from . import globalVars
 
 import numpy
 
@@ -160,9 +160,9 @@ class ElementArrayStim(MinimalStim, TextureMixin):
 
     def _selectWindow(self, win):
         # don't call switch if it's already the curr window
-        if win != glob_vars.currWindow and win.winType == 'pyglet':
+        if win != globalVars.currWindow and win.winType == 'pyglet':
             win.winHandle.switch_to()
-            glob_vars.currWindow = win
+            globalVars.currWindow = win
 
     def _makeNx2(self, value, acceptedInput=('scalar', 'Nx1', 'Nx2')):
         """Helper function to change input to Nx2 arrays

--- a/psychopy/visual/filters.py
+++ b/psychopy/visual/filters.py
@@ -130,33 +130,33 @@ def makeMask(matrixSize, shape='circle', radius=1.0, center=(0.0, 0.0),
     elif shape == 'gauss':
         outArray = makeGauss(rad, mean=0.0, sd=0.33333)
     elif shape == 'raisedCosine':
-        hamming_len = 1000  # This affects the 'granularity' of the raised cos
-        fringe_proportion = fringeWidth  # This one affects the proportion of
+        hammingLen = 1000  # This affects the 'granularity' of the raised cos
+        fringeProportion = fringeWidth  # This one affects the proportion of
         # the stimulus diameter that is devoted to the raised cosine.
 
         rad = makeRadialMatrix(matrixSize, center, radius)
         outArray = numpy.zeros_like(rad)
         outArray[numpy.where(rad < 1)] = 1
-        raised_cos_idx = numpy.where(
-            [numpy.logical_and(rad <= 1, rad >= 1 - fringe_proportion)])[1:]
+        raisedCosIdx = numpy.where(
+            [numpy.logical_and(rad <= 1, rad >= 1 - fringeProportion)])[1:]
 
         # Make a raised_cos (half a hamming window):
-        raised_cos = numpy.hamming(hamming_len)[:hamming_len / 2]
-        raised_cos -= numpy.min(raised_cos)
-        raised_cos /= numpy.max(raised_cos)
+        raisedCos = numpy.hamming(hammingLen)[:hammingLen / 2]
+        raisedCos -= numpy.min(raisedCos)
+        raisedCos /= numpy.max(raisedCos)
 
         # Measure the distance from the edge - this is your index into the
         # hamming window:
-        d_from_edge = numpy.abs((1 - fringe_proportion) - rad[raised_cos_idx])
-        d_from_edge /= numpy.max(d_from_edge)
-        d_from_edge *= numpy.round(hamming_len / 2)
+        dFromEdge = numpy.abs((1 - fringeProportion) - rad[raisedCosIdx])
+        dFromEdge /= numpy.max(dFromEdge)
+        dFromEdge *= numpy.round(hammingLen / 2)
 
         # This is the indices into the hamming (larger for small distances
         # from the edge!):
-        portion_idx = (-1 * d_from_edge).astype(int)
+        portion_idx = (-1 * dFromEdge).astype(int)
 
         # Apply the raised cos to this portion:
-        outArray[raised_cos_idx] = raised_cos[portion_idx]
+        outArray[raisedCosIdx] = raisedCos[portion_idx]
 
         # Sometimes there are some remaining artifacts from this process, get
         # rid of them:

--- a/psychopy/visual/globalVars.py
+++ b/psychopy/visual/globalVars.py
@@ -4,13 +4,13 @@
 
 It needs to be imported by anything that uses those variables as:
 
-    from psychopy.visual import glob_vars
-    print(glob_vars.currWindow)  # read it
-    glob_vars.currentWindow = newWin  # change it
+    from psychopy.visual import globalVars
+    print(globalVars.currWindow)  # read it
+    globalVars.currentWindow = newWin  # change it
 
 Note that if you import using::
 
-    from psychopy.visual.glob_vars import currWindow
+    from psychopy.visual.globalVars import currWindow
 
 then if the variable changes your copy won't!
 """

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -27,7 +27,7 @@ _nImageResizes = 0
 try:
     import matplotlib
     if matplotlib.__version__ > '1.2':
-        from matplotlib.path import Path as mpl_Path
+        from matplotlib.path import Path as mplPath
     else:
         from matplotlib import nxutils
     haveMatplotlib = True
@@ -57,7 +57,7 @@ def pointInPolygon(x, y, poly):
     # faster if have matplotlib tools:
     if haveMatplotlib:
         if matplotlib.__version__ > '1.2':
-            return mpl_Path(poly).contains_point([x, y])
+            return mplPath(poly).contains_point([x, y])
         else:
             try:
                 return bool(nxutils.pnpoly(x, y, poly))
@@ -101,9 +101,9 @@ def polygonsOverlap(poly1, poly2):
     # faster if have matplotlib tools:
     if haveMatplotlib:
         if matplotlib.__version__ > '1.2':
-            if any(mpl_Path(poly1).contains_points(poly2)):
+            if any(mplPath(poly1).contains_points(poly2)):
                 return True
-            return any(mpl_Path(poly2).contains_points(poly1))
+            return any(mplPath(poly2).contains_points(poly1))
         else:
             try:  # deprecated in matplotlib 1.2
                 if any(nxutils.points_inside_poly(poly1, poly2)):

--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -515,9 +515,9 @@ class RatingScale(MinimalStim):
             win=self.win, visible=bool(not self.noMouse))
         # Mouse-click-able 'accept' button pulsates (cycles its brightness
         # over frames):
-        frames_per_cycle = 100
+        framesPerCycle = 100
         self.pulseColor = [0.6 + 0.22 * float(numpy.cos(i / 15.65))
-                           for i in range(frames_per_cycle)]
+                           for i in range(framesPerCycle)]
 
     def _initPosScale(self, pos, size, stretch, log=True):
         """position (x,y) and size (magnification) of the rating scale

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -27,7 +27,7 @@ from psychopy.tools.arraytools import val2array
 from psychopy.tools.monitorunittools import convertToPix
 from psychopy.tools.attributetools import setAttribute, attributeSetter
 from psychopy.visual.basevisual import MinimalStim, WindowMixin
-from . import glob_vars
+from . import globalVars
 
 try:
     from PIL import Image

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -65,7 +65,7 @@ from psychopy import makeMovies
 from .text import TextStim
 from .grating import GratingStim
 from .helpers import setColor
-from . import glob_vars
+from . import globalVars
 
 try:
     from PIL import Image
@@ -598,9 +598,9 @@ class Window(object):
 
         if self.winType == "pyglet":
             # make sure this is current context
-            if glob_vars.currWindow != self:
+            if globalVars.currWindow != self:
                 self.winHandle.switch_to()
-                glob_vars.currWindow = self
+                globalVars.currWindow = self
 
             GL.glTranslatef(0.0, 0.0, -5.0)
 
@@ -643,15 +643,15 @@ class Window(object):
         GL.glLoadIdentity()
         if self.viewScale is not None:
             GL.glScalef(self.viewScale[0], self.viewScale[1], 1)
-            abs_scale_x = abs(self.viewScale[0])
-            abs_scale_y = abs(self.viewScale[1])
+            absScaleX = abs(self.viewScale[0])
+            absScaleY = abs(self.viewScale[1])
         else:
-            abs_scale_x, abs_scale_y = 1, 1
+            absScaleX, absScaleY = 1, 1
 
         if self.viewPos is not None:
-            norm_rf_pos_x = self.viewPos[0] / abs_scale_x
-            norm_rf_pos_y = self.viewPos[1] / abs_scale_y
-            GL.glTranslatef(norm_rf_pos_x, norm_rf_pos_y, 0.0)
+            normRfPosX = self.viewPos[0] / absScaleX
+            normRfPosY = self.viewPos[1] / absScaleY
+            GL.glTranslatef(normRfPosX, normRfPosY, 0.0)
 
         if self.viewOri:  # float
             # the logic below for flip is partially correct, but does not
@@ -1179,9 +1179,9 @@ class Window(object):
         """
         global GL
         self.rgb = val2array(newRGB, False, length=3)
-        if self.winType == 'pyglet' and glob_vars.currWindow != self:
+        if self.winType == 'pyglet' and globalVars.currWindow != self:
             self.winHandle.switch_to()
-            glob_vars.currWindow = self
+            globalVars.currWindow = self
         GL.glClearColor((self.rgb[0] + 1.0) / 2.0,
                         (self.rgb[1] + 1.0) / 2.0,
                         (self.rgb[2] + 1.0) / 2.0,


### PR DESCRIPTION
avoid things that a user might access, like parameters, function names, color space names
skip clock.py _countdown_duration just in case
skip: contrib/*, hardware/*, iohub/*, gui/*, micriphone.py,  introspect.py, movie2.py, platform_specific