### PR TITLE
BFs: clean up several minor bugs & issues

### DIFF
--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -4,7 +4,7 @@
 
 from __future__ import absolute_import
 
-from ..experiment import Param
+from ..experiment import Param, CodeGenerationException
 from ..components import getInitVals
 from psychopy.constants import FOREVER
 from ...localization import _translate
@@ -157,7 +157,8 @@ class BaseComponent(object):
         elif self.params['startType'].val == 'condition':
             code = "if (%(startVal)s) and %(name)s.status == NOT_STARTED:\n"
         else:
-            raise "Not a known startType (%(startType)s) for %(name)s" % self.params
+            msg = "Not a known startType (%(startType)s) for %(name)s"
+            raise CodeGenerationException(msg % self.params)
 
         buff.writeIndented(code % self.params)
 
@@ -192,8 +193,9 @@ class BaseComponent(object):
         elif self.params['stopType'].val == 'condition':
             code = "if %(name)s.status == STARTED and bool(%(stopVal)s):\n"
         else:
-            raise ("Didn't write any stop line for startType=%(startType)s, "
-                   "stopType=%(stopType)s") % self.params
+            msg = ("Didn't write any stop line for startType=%(startType)s, "
+                   "stopType=%(stopType)s")
+            raise CodeGenerationException(msg % self.params)
 
         buff.writeIndentedLines(code % self.params)
         buff.setIndentLevel(+1, relative=True)

--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -137,6 +137,9 @@ class BaseComponent(object):
         All objects have now migrated to using writeStartTestCode and
         writeEndTestCode
         """
+        # unused internally; deprecated March 2016 v1.83.x, will remove 1.85
+        print('Deprecation warning: writeTimeTestCode() is not supported;\n'
+              'will be removed in v1.85.00, use writeStartTestCode() instead')
         if self.params['duration'].val == '':
             code = "if %(startTime)s <= t:\n"
         else:

--- a/psychopy/app/builder/components/cedrusBox.py
+++ b/psychopy/app/builder/components/cedrusBox.py
@@ -273,8 +273,7 @@ class cedrusButtonBoxComponent(KeyboardComponent):
         if forceEnd is True:
             code = ("# a response ends the routine\n"
                     "continueRoutine = False\n")
-            buff.writeIndentedLines(code % self.params)
-
+            buff.writeIndentedLines(code)
         buff.setIndentLevel(-(dedentAtEnd), relative=True)
 
     # this was commented-out (removed Feb 2016, available in history):

--- a/psychopy/app/builder/components/cedrusBox.py
+++ b/psychopy/app/builder/components/cedrusBox.py
@@ -108,7 +108,6 @@ class cedrusButtonBoxComponent(KeyboardComponent):
                 "if not %(name)s:\n"
                 "    logging.error('could not find a Cedrus device.')\n"
                 "    core.quit()\n"
-                "%(name)s.status = NOT_STARTED\n"
                 "%(name)s.clock = core.Clock()\n")
         buff.writeIndentedLines(code % self.params)
 

--- a/psychopy/app/builder/components/code.py
+++ b/psychopy/app/builder/components/code.py
@@ -72,7 +72,7 @@ class CodeComponent(BaseComponent):
                          "saving files, resetting computer); "
                          "right-click checks syntax")
         self.params['End Experiment'] = Param(
-            endRoutine, valType='extendedCode', allowedTypes=[],
+            endExperiment, valType='extendedCode', allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
             label=_localized['End Experiment'])

--- a/psychopy/app/builder/components/dots.py
+++ b/psychopy/app/builder/components/dots.py
@@ -38,7 +38,6 @@ class DotsComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
-        # initialise main parameters from base stimulus
         super(DotsComponent, self).__init__(
             exp, parentName, name=name, units=units,
             color=color, colorSpace=colorSpace,

--- a/psychopy/app/builder/components/grating.py
+++ b/psychopy/app/builder/components/grating.py
@@ -30,7 +30,6 @@ class GratingComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
-        # initialise main parameters from base stimulus
         super(GratingComponent, self).__init__(
             exp, parentName, name=name, units=units,
             color=color, colorSpace=colorSpace,

--- a/psychopy/app/builder/components/image.py
+++ b/psychopy/app/builder/components/image.py
@@ -30,7 +30,6 @@ class ImageComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
-        # initialise main parameters from base stimulus
         super(ImageComponent, self).__init__(
             exp, parentName, name=name, units=units,
             color=color, colorSpace=colorSpace,

--- a/psychopy/app/builder/components/image.py
+++ b/psychopy/app/builder/components/image.py
@@ -94,7 +94,7 @@ class ImageComponent(BaseVisualComponent):
         msg = _translate(
             "Should the image be flipped horizontally (left to right)?")
         self.params['flipHoriz'] = Param(
-            flipVert, valType='bool',
+            flipHoriz, valType='bool',
             updates='constant', allowedUpdates=[],
             hint=msg,
             label=_localized["flipHoriz"], categ="Advanced")

--- a/psychopy/app/builder/components/keyboard.py
+++ b/psychopy/app/builder/components/keyboard.py
@@ -116,9 +116,7 @@ class KeyboardComponent(BaseComponent):
             label=_localized['syncScreenRefresh'])
 
     def writeRoutineStartCode(self, buff):
-        code = ("%(name)s = event.BuilderKeyResponse()  # create an "
-                "object of type KeyResponse\n"
-                "%(name)s.status = NOT_STARTED\n")
+        code = "%(name)s = event.BuilderKeyResponse()\n"
         buff.writeIndentedLines(code % self.params)
 
         if (self.params['store'].val == 'nothing' and

--- a/psychopy/app/builder/components/movie.py
+++ b/psychopy/app/builder/components/movie.py
@@ -27,7 +27,6 @@ class MovieComponent(BaseVisualComponent):
                  startEstim='', durationEstim='',
                  forceEndRoutine=False, backend='moviepy',
                  noAudio=False):
-        # initialise main parameters from base stimulus
         super(MovieComponent, self).__init__(
             exp, parentName, name=name, units=units,
             pos=pos, size=size, ori=ori,

--- a/psychopy/app/builder/components/patch.py
+++ b/psychopy/app/builder/components/patch.py
@@ -30,7 +30,6 @@ class PatchComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
-        # initialise main parameters from base stimulus
         super(PatchComponent, self).__init__(
             exp, parentName, name=name, units=units,
             color=color, colorSpace=colorSpace,

--- a/psychopy/app/builder/components/polygon.py
+++ b/psychopy/app/builder/components/polygon.py
@@ -34,7 +34,6 @@ class PolygonComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
-        # initialise main parameters from base stimulus
         super(PolygonComponent, self).__init__(
             exp, parentName, name=name, units=units,
             pos=pos, size=size, ori=ori,

--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -327,25 +327,22 @@ class SettingsComponent(object):
             size = wx.Display(screenNumber).GetGeometry()[2:4]
         else:
             size = self.params['Window size (pixels)']
-        code = ("win = visual.Window(size=%s, fullscr=%s, screen=%s, "
-                "allowGUI=%s, allowStencil=%s,\n")
+        code = ("win = visual.Window(\n    size=%s, fullscr=%s, screen=%s,"
+                "\n    allowGUI=%s, allowStencil=%s,\n")
         vals = (size, fullScr, screenNumber, allowGUI, allowStencil)
         buff.writeIndented(code % vals)
         code = ("    monitor=%(Monitor)s, color=%(color)s, "
                 "colorSpace=%(colorSpace)s,\n")
-        buff.writeIndented(code % self.params)
         if self.params['blendMode'].val:
-            buff.writeIndented(
-                "    blendMode=%(blendMode)s, useFBO=True,\n" % self.params)
+            code += "    blendMode=%(blendMode)s, useFBO=True,\n"
 
-        if self.params['Units'].val == 'use prefs':
-            # todo: fix PEP8 style in generated text
-            buff.write("    )\n")
-        else:
-            buff.write("    units=%s)\n" % self.params['Units'])
+        if self.params['Units'].val != 'use prefs':
+            code += "    units=%(Units)s"
+        code = code.rstrip(', \n') + ')\n'
+        buff.writeIndentedLines(code % self.params)
 
         if 'microphone' in self.exp.psychopyLibs:  # need a pyo Server
-            buff.writeIndentedLines("\n# Enable sound input/output:\n" +
+            buff.writeIndentedLines("\n# Enable sound input/output:\n"
                                     "microphone.switchOn()\n")
 
         code = ("# store frame rate of monitor if we can measure it\n"

--- a/psychopy/app/builder/components/settings.py
+++ b/psychopy/app/builder/components/settings.py
@@ -60,8 +60,7 @@ class SettingsComponent(object):
         if filename.startswith("u'xxxx"):
             folder = self.exp.prefsBuilder['savedDataFolder'].strip()
             filename = filename.replace("xxxx", folder)
-        else:
-            print(filename[0:6])
+
         # params
         self.params = {}
         self.order = ['expName', 'Show info dlg', 'Experiment info',

--- a/psychopy/app/builder/components/text.py
+++ b/psychopy/app/builder/components/text.py
@@ -32,7 +32,6 @@ class TextComponent(BaseVisualComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  flip='', startEstim='', durationEstim='', wrapWidth=''):
-        # initialise main parameters from base stimulus
         super(TextComponent, self).__init__(exp, parentName, name=name,
                                             units=units,
                                             color=color,

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -220,10 +220,11 @@ class Experiment(object):
             "RELEASED, FOREVER)\n"
             "import numpy as np  # whole numpy lib is available, "
             "prepend 'np.'\n"
-            "from numpy import %s\n" % ', '.join(_numpyImports) +
+            "from numpy import (%s,\n" % ', '.join(_numpyImports[:7]) +
+            "                   %s)\n" % ', '.join(_numpyImports[7:]) +
             "from numpy.random import %s\n" % ', '.join(_numpyRandomImports) +
             "import os  # handy system and path functions\n" +
-            "import sys # to get file system encoding\n"
+            "import sys  # to get file system encoding\n"
             "\n")
         self.settings.writeStartCode(script)  # present info dlg, make logfile
         # writes any components with a writeStartCode()

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1542,14 +1542,11 @@ class Routine(list):
         for event in self:
             event.writeRoutineStartCode(buff)
 
-        code = ('# keep track of which components have finished\n'
-                '%sComponents = []\n')
-        buff.writeIndentedLines(code % self.name)
-        # todo: rewrite to avoid append append ... append one by one
-        for thisCompon in self:
-            if 'startType' in thisCompon.params:
-                buff.writeIndented('%sComponents.append(%s)\n' %
-                                   (self.name, thisCompon.params['name']))
+        code = '# keep track of which components have finished\n'
+        buff.writeIndentedLines(code)
+        compStr = ', '.join([c.params['name'].val for c in self
+                             if 'startType' in c.params])
+        buff.writeIndented('%sComponents = [%s]\n' % (self.name, compStr))
         code = ("for thisComponent in %sComponents:\n"
                 "    if hasattr(thisComponent, 'status'):\n"
                 "        thisComponent.status = NOT_STARTED\n"

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -2000,16 +2000,6 @@ class NameSpace(object):
         return newName
 
 
-def _XMLremoveWhitespaceNodes(parent):
-    """Remove all text nodes from an xml document (likely to be whitespace)
-    """
-    for child in list(parent.childNodes):
-        if child.nodeType == node.TEXT_NODE and node.data.strip() == '':
-            parent.removeChild(child)
-        else:
-            removeWhitespaceNodes(child)
-
-
 def getCodeFromParamStr(val):
     """Convert a Param.val string to its intended python code
     (as triggered by special char $)

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2527,11 +2527,13 @@ class CoderFrame(wx.Frame):
                 self.thread = ScriptThread(target=self._runFileInDbg, gui=self)
                 self.thread.start()
             elif runScripts == 'import':
+                raise NotImplementedError()
                 # simplest possible way, but fragile
                 # USING import of scripts (clunky)
-                if importName in sys.modules:  # delete the sys reference to it
-                    sys.modules.pop(importName)
-                exec('import %s' % (importName))  # or run first time
+                # if importName in sys.modules:  # delete the sys reference to it
+                #     sys.modules.pop(importName)
+                # exec('import %s' % (importName))  # or run first time
+
                 # NB execfile() would be better doesn't run the import
                 # statements properly! functions defined in the script have
                 # a separate namespace to the main body of the script(!?)

--- a/psychopy/app/connections.py
+++ b/psychopy/app/connections.py
@@ -584,7 +584,7 @@ class InstallUpdateDialog(wx.Dialog):
                     nUpdates += 1
                     logging.info('Updated PsychoPy path in %s' % filename)
                 except Exception:
-                    info += 'Failed to update PsychoPy path in ', filename
+                    info += 'Failed to update PsychoPy path in %s' % filename
                     return -1, info
         return nUpdates, info
 

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -20,6 +20,16 @@ from psychopy.platform_specific import rush  # pylint: disable=W0611
 from psychopy import logging
 from psychopy.constants import STARTED, NOT_STARTED, FINISHED
 
+try:
+    import pyglet
+    havePyglet = True
+    # may not want to check, to preserve terminal window focus
+    checkPygletDuringWait = True
+except ImportError:
+    havePyglet = False
+    checkPygletDuringWait = False
+
+
 runningThreads = []  # just for backwards compatibility?
 
 # Set getTime in core to == the monotonicClock instance created in the
@@ -42,15 +52,6 @@ def getTime():
     whereas on windows it returned time since loading of the module, as now)
     """
     return monotonicClock.getTime()
-
-try:
-    import pyglet
-    havePyglet = True
-    # may not want to check, to preserve terminal window focus
-    checkPygletDuringWait = True
-except ImportError:
-    havePyglet = False
-    checkPygletDuringWait = False
 
 
 def quit():

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -80,7 +80,7 @@ def shellCall(shellCmd, stdin='', stderr=False):
     elif type(shellCmd) in (list, tuple):  # handles whitespace in filenames
         shellCmdList = shellCmd
     else:
-        raise ValueError('shellCmd requires a list or string')
+        return None, 'shellCmd requires a list or string'
     proc = subprocess.Popen(shellCmdList, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdoutData, stderrData = proc.communicate(stdin)

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -77,10 +77,10 @@ def shellCall(shellCmd, stdin='', stderr=False):
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
         shellCmdList = shlex.split(shellCmd)
-    elif type(shellCmd) == list:  # handles whitespace in filenames
+    elif type(shellCmd) in (list, tuple):  # handles whitespace in filenames
         shellCmdList = shellCmd
     else:
-        return None, 'shellCmd requires a list or string'
+        raise ValueError('shellCmd requires a list or string')
     proc = subprocess.Popen(shellCmdList, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdoutData, stderrData = proc.communicate(stdin)

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -851,7 +851,6 @@ class TrialHandler(_BaseTrialHandler):
         self.thisTrial = []
         self.finished = False
         self.extraInfo = extraInfo
-        self._warnUseOfNext = True
         self.seed = seed
         # create dataHandler
         self.data = DataHandler(trials=self)
@@ -1542,7 +1541,6 @@ class TrialHandler2(_BaseTrialHandler):
         self.thisTrial = {}
         self.finished = False
         self.extraInfo = extraInfo
-        self._warnUseOfNext = True
         self.seed = seed
         self._rng = numpy.random.RandomState(seed=seed)
 
@@ -1961,7 +1959,6 @@ class TrialHandlerExt(TrialHandler):
         self.thisTrial = []
         self.finished = False
         self.extraInfo = extraInfo
-        self._warnUseOfNext = True
         self.seed = seed
         # create dataHandler
         if self.trialWeights is None:
@@ -2938,7 +2935,6 @@ class StairHandler(_BaseTrialHandler):
         # correct since last stim change (minus are incorrect):
         self.correctCounter = 0
         self._nextIntensity = self.startVal
-        self._warnUseOfNext = True
         self.minVal = minVal
         self.maxVal = maxVal
         self.autoLog = autoLog

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -695,18 +695,6 @@ class _BaseTrialHandler(object):
 
         ew.save(filename=fileName)
 
-    def nextTrial(self):
-        """DEPRECATION WARNING: nextTrial() will be deprecated
-        please use next() instead.
-        jwp: 19/6/06
-        """
-        if self._warnUseOfNext:
-            logging.warning("""DEPRECATION WARNING: nextTrial() will be
-        deprecated. please use next() instead. jwp: 19/6/06
-        """)
-            self._warnUseOfNext = False
-        return self.next()
-
     def getOriginPathAndFile(self, originPath=None):
         """Attempts to determine the path of the script that created this
         data file and returns both the path to that script and its contents.
@@ -892,7 +880,7 @@ class TrialHandler(_BaseTrialHandler):
     def __str__(self, verbose=False):
         """string representation of the object
         """
-        strRepres = 'psychopy.data.TrialHandler(\n'
+        strRepres = 'psychopy.data.{}(\n'.format(self.__class__.__name__)
         attribs = dir(self)
 
         # data first, then all others
@@ -1575,14 +1563,14 @@ class TrialHandler2(_BaseTrialHandler):
     def __str__(self, verbose=False):
         """string representation of the object
         """
-        strRepres = 'psychopy.data.TrialHandler(\n'
+        strRepres = 'psychopy.data.{}(\n'.format(self.__class__.__name__)
         attribs = dir(self)
         # data first, then all others
         try:
             data = self.data
         except Exception:
-            data = None
-        if data:
+            strRepres += '\t(no data)\n'
+        else:
             strRepres += str('\tdata=')
             strRepres += str(data) + '\n'
         for thisAttrib in attribs:
@@ -2804,7 +2792,7 @@ def createFactorialTrialList(factors):
 class StairHandler(_BaseTrialHandler):
     """Class to handle smoothly the selection of the next trial
     and report current values etc.
-    Calls to nextTrial() will fetch the next object given to this
+    Calls to next() will fetch the next object given to this
     handler, according to the method specified.
 
     See ``Demos >> ExperimentalControl >> JND_staircase_exp.py``

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -24,7 +24,7 @@ import warnings
 import collections
 
 try:
-    #import openpyxl
+    # import openpyxl
     from openpyxl.cell import get_column_letter
     from openpyxl.reader.excel import load_workbook
     haveOpenpyxl = True
@@ -1751,7 +1751,7 @@ class TrialHandler2(_BaseTrialHandler):
                 Collision method passed to
                 :func:`~psychopy.tools.fileerrortools.handleFileCollision`
 
-             encoding:
+            encoding:
                 The encoding to use when saving a the file.
                 Defaults to `utf-8`.
 
@@ -2494,23 +2494,13 @@ class TrialHandlerExt(TrialHandler):
             for key in self.extraInfo:
                 header.insert(0, key)
 
+        # write a header row:
         if not matrixOnly:
-            # write the header row:
-            nextLine = ''
-            for prmName in header:
-                nextLine = nextLine + prmName + delim
-            # todo: rewrite as: nextLine = delim.join([prm for prm in header])
-            # remove the final orphaned tab character
-            f.write(nextLine[:-1] + '\n')
-
+            f.write(delim.join(header) + '\n')
         # write the data matrix:
         for trial in dataOut:
-            # todo: rewrite as delim.join(...)
-            nextLine = ''
-            for prmName in header:
-                nextLine = nextLine + unicode(trial[prmName]) + delim
-            nextLine = nextLine[:-1]  # remove the final tab character
-            f.write(nextLine + '\n')
+            line = delim.join([unicode(trial[prm]) for prm in header])
+            f.write(line + '\n')
 
         if f != sys.stdout:
             f.close()

--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -94,7 +94,7 @@ def addLevel(level, levelName):
     _levelNames[levelName] = level
 
 
-global defaultClock
+# global defaultClock
 defaultClock = clock.monotonicClock
 
 

--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -573,18 +573,6 @@ class MainFrame(wx.Frame):
         # do the load and check new name
         self.currentCalibName = self.currentMon.setCurrent(newCalib)
 
-        # keys that may not exist
-        # todo remove this code - only needed for monitor objects made pre
-        # version 0.63
-        if not 'gammaGrid' in self.currentMon.currentCalib:
-            self.currentMon.currentCalib['gammaGrid'] = np.ones((4, 3), 'd')
-        if not 'lms_rgb' in self.currentMon.currentCalib:
-            self.currentMon.currentCalib['lms_rgb'] = np.ones((3, 3), 'd')
-        if not 'dkl_rgb' in self.currentMon.currentCalib:
-            self.currentMon.currentCalib['dkl_rgb'] = np.ones((3, 3), 'd')
-        if not 'sizePix' in self.currentMon.currentCalib:
-            self.currentMon.currentCalib['sizePix'] = [1024, 768]
-
         # insert values from new calib into GUI
         _date = monitors.strFromDate(self.currentMon.getCalibDate())
         self.ctrlCalibDate.SetValue(_date)

--- a/psychopy/monitors/getLumSeries.py
+++ b/psychopy/monitors/getLumSeries.py
@@ -6,6 +6,11 @@ existing namespace (e.g. avbin can load because scipy won't already have
 been loaded).
 """
 
+from psychopy import logging
+from calibTools import DACrange
+import numpy
+import time
+
 
 def getLumSeries(lumLevels=8,
                  winSize=(800, 600),

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -38,7 +38,7 @@ def useVersion(requestedVersion):
 
     Usage (at the top of an experiment script):
 
-        from psychopy.tools.versionchooser import useVersion
+        from psychopy import useVersion
         useVersion('1.80.04')
         from psychopy import visual, event, ...
     """

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -238,7 +238,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
     def setDepth(self, newDepth, operation='', log=None):
         """DEPRECATED. Depth is now controlled simply by drawing order.
         """
-        setAttribute(self, 'depth', log, operation)
+        setAttribute(self, 'depth', newDepth, log, operation)
 
     def _calcPosRendered(self):
         """Calculate the pos of the stimulus in pixels"""
@@ -262,7 +262,6 @@ class SimpleImageStim(MinimalStim, WindowMixin):
             else:
                 logging.error("couldn't find image...%s" % filename)
                 core.quit()
-                raise  # so thatensure we quit
         else:
             # not a string - have we been passed an image?
             try:
@@ -270,7 +269,6 @@ class SimpleImageStim(MinimalStim, WindowMixin):
             except AttributeError:  # apparently not an image
                 logging.error("couldn't find image...%s" % filename)
                 core.quit()
-                raise Exception  # ensure we quit
             self.filename = repr(filename)  # '<Image.Image image ...>'
 
         self.size = im.size

--- a/psychopy/visual/textbox/textgrid.py
+++ b/psychopy/visual/textbox/textgrid.py
@@ -145,7 +145,7 @@ class TextGrid(object):
             if self._apply_padding:
                 cline._trans_left = int(
                     (num_cols - line_length + 1) * self._pad_left_proportion)
-                cline._trans_top == int(
+                cline._trans_top = int(
                     (num_rows - line_count) * self._pad_top_proportion)
             else:
                 cline._trans_left = 0

--- a/psychopy/web.py
+++ b/psychopy/web.py
@@ -43,14 +43,14 @@ else:
 TIMEOUT = max(prefs.connections['timeout'], 2.0)
 socket.setdefaulttimeout(TIMEOUT)
 
-global proxies
+# global proxies
 proxies = None  # if this is populated then it has been set up already
 
 
 class NoInternetAccessError(Exception):
     """An internet connection is required but not available
     """
-global haveInternet
+# global haveInternet
 haveInternet = None  # gets set True or False when you check
 
 


### PR DESCRIPTION
As found by @hoechenberger and @jeremygray during whitespace and line-length refactoring; some issues fixed by removing unused code.

CHANGELOG
- fixed 12 or so minor bugs
- core.shellCall now accepts a tuple
- MonitorCenter objects made pre-version 0.63 may not work anymore
- TrialHandler .nextTrial() removed (was deprecated June 2006). Change: use .next() instead
- TrialHandler[2|Ext] objects now correctly report their class in str()
- BaseComponent.writeTimeTestCode() is deprecated (will be removed in 1.85).