### PR TITLE
BF: code snippet validation; closes #1132

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -667,8 +667,12 @@ class _BaseParamsDlg(wx.Dialog):
         # use monospace font to signal code:
         self.checkCodeWanted(self.startValCtrl)
         self.startValCtrl.Bind(wx.EVT_KEY_UP, self.checkCodeWanted)
+        self.startValCtrl.SetValidator(CodeSnippetValidator('startVal'))
+        self.startValCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
         self.checkCodeWanted(self.stopValCtrl)
         self.stopValCtrl.Bind(wx.EVT_KEY_UP, self.checkCodeWanted)
+        self.stopValCtrl.SetValidator(CodeSnippetValidator('stopVal'))
+        self.stopValCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
 
         return remaining, currRow
 

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -235,9 +235,12 @@ class ParamCtrls(object):
         if len(param.allowedVals) == 1 or param.readOnly:
             self.valueCtrl.Disable()  # visible but can't be changed
 
-        # add a NameValidator to name valueCtrl
+        # add a Validator to the valueCtrl
         if fieldName == "name":
             self.valueCtrl.SetValidator(validators.NameValidator())
+        elif fieldName in ('text', 'color', 'image', 'flip', 'opacity'):
+            # ... and anything that is valType code, or can be with $ ...
+            self.valueCtrl.SetValidator(validators.CodeValidator())
 
         # create the type control
         if len(param.allowedTypes):
@@ -682,8 +685,11 @@ class _BaseParamsDlg(wx.Dialog):
                            advanced=advanced, appPrefs=self.app.prefs)
         self.paramCtrls[fieldName] = ctrls
         if fieldName == 'name':
-            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.checkName)
+            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
             ctrls.valueCtrl.SetFocus()
+        elif fieldName in ('text', 'color', 'image', 'flip', 'opacity'):
+            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
+
         # self.valueCtrl = self.typeCtrl = self.updateCtrl
         _flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL | wx.LEFT | wx.RIGHT
         sizer.Add(ctrls.nameCtrl, (currRow, 0), border=5, flag=_flag)
@@ -775,7 +781,7 @@ class _BaseParamsDlg(wx.Dialog):
             self.OKbtn.Bind(wx.EVT_BUTTON, self.onOK)
         self.OKbtn.SetDefault()
 
-        self.checkName()  # disables OKbtn if bad name
+        self.doValidate()  # disables OKbtn if bad name
         buttons.Add(self.OKbtn, 0, wx.ALL, border=3)
         CANCEL = wx.Button(self, wx.ID_CANCEL, _translate(" Cancel "))
         buttons.Add(CANCEL, 0, wx.ALL, border=3)
@@ -1019,8 +1025,8 @@ class _BaseParamsDlg(wx.Dialog):
             else:
                 return "", True
 
-    def checkName(self, event=None):
-        """Issue a form validation on name change.
+    def doValidate(self, event=None):
+        """Issue a form validation on event, e.g., name or text change.
         """
         self.Validate()
 
@@ -1168,7 +1174,7 @@ class DlgLoopProperties(_BaseParamsDlg):
                            flag=wx.EXPAND | wx.ALIGN_CENTRE_VERTICAL | wx.ALL)
             row += 1
 
-        self.globalCtrls['name'].valueCtrl.Bind(wx.EVT_TEXT, self.checkName)
+        self.globalCtrls['name'].valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
         self.Bind(wx.EVT_CHOICE, self.onTypeChanged,
                   self.globalCtrls['loopType'].valueCtrl)
         return panel

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -239,7 +239,7 @@ class ParamCtrls(object):
         # add a Validator to the valueCtrl
         if fieldName == "name":
             self.valueCtrl.SetValidator(NameValidator())
-        else:
+        elif isinstance(self.valueCtrl, (wx.TextCtrl, CodeBox)):
             # only want anything that is valType code, or can be with $
             self.valueCtrl.SetValidator(CodeSnippetValidator(fieldName))
 
@@ -688,8 +688,7 @@ class _BaseParamsDlg(wx.Dialog):
         if fieldName == 'name':
             ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
             ctrls.valueCtrl.SetFocus()
-        else:
-            # only want anything that is valType code, or can be with $
+        elif isinstance(ctrls.valueCtrl, (wx.TextCtrl, CodeBox)):
             ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
 
         # self.valueCtrl = self.typeCtrl = self.updateCtrl
@@ -705,6 +704,7 @@ class _BaseParamsDlg(wx.Dialog):
             sizer.AddGrowableRow(currRow)  # doesn't seem to work though
             # self.Bind(EVT_ETC_LAYOUT_NEEDED, self.onNewTextSize,
             #    ctrls.valueCtrl)
+            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
         elif fieldName in ('color', 'fillColor', 'lineColor'):
             ctrls.valueCtrl.Bind(wx.EVT_RIGHT_DOWN, self.launchColorPicker)
         elif valType == 'extendedCode':

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -783,7 +783,7 @@ class _BaseParamsDlg(wx.Dialog):
             self.OKbtn.Bind(wx.EVT_BUTTON, self.onOK)
         self.OKbtn.SetDefault()
 
-        self.doValidate()  # disables OKbtn if bad name
+        self.doValidate()  # disables OKbtn if bad name, syntax error, etc
         buttons.Add(self.OKbtn, 0, wx.ALL, border=3)
         CANCEL = wx.Button(self, wx.ID_CANCEL, _translate(" Cancel "))
         buttons.Add(CANCEL, 0, wx.ALL, border=3)

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -18,7 +18,8 @@ import wx
 from wx.lib import flatnotebook
 
 from ... import dialogs
-from .. import validators, experiment
+from .. import experiment
+from .. validators import NameValidator, CodeSnippetValidator
 from .dlgsConditions import DlgConditions
 from .dlgsCode import DlgCodeComponentProperties, CodeBox
 from psychopy import data, logging
@@ -237,10 +238,10 @@ class ParamCtrls(object):
 
         # add a Validator to the valueCtrl
         if fieldName == "name":
-            self.valueCtrl.SetValidator(validators.NameValidator())
-        elif fieldName in ('text', 'color', 'image', 'flip', 'opacity'):
-            # ... and anything that is valType code, or can be with $ ...
-            self.valueCtrl.SetValidator(validators.CodeValidator())
+            self.valueCtrl.SetValidator(NameValidator())
+        else:
+            # only want anything that is valType code, or can be with $
+            self.valueCtrl.SetValidator(CodeSnippetValidator(fieldName))
 
         # create the type control
         if len(param.allowedTypes):
@@ -687,7 +688,8 @@ class _BaseParamsDlg(wx.Dialog):
         if fieldName == 'name':
             ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
             ctrls.valueCtrl.SetFocus()
-        elif fieldName in ('text', 'color', 'image', 'flip', 'opacity'):
+        else:
+            # only want anything that is valType code, or can be with $
             ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
 
         # self.valueCtrl = self.typeCtrl = self.updateCtrl

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -686,10 +686,10 @@ class _BaseParamsDlg(wx.Dialog):
                            advanced=advanced, appPrefs=self.app.prefs)
         self.paramCtrls[fieldName] = ctrls
         if fieldName == 'name':
-            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
+            ctrls.valueCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
             ctrls.valueCtrl.SetFocus()
         elif isinstance(ctrls.valueCtrl, (wx.TextCtrl, CodeBox)):
-            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
+            ctrls.valueCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
 
         # self.valueCtrl = self.typeCtrl = self.updateCtrl
         _flag = wx.ALIGN_RIGHT | wx.ALIGN_CENTRE_VERTICAL | wx.LEFT | wx.RIGHT
@@ -704,7 +704,7 @@ class _BaseParamsDlg(wx.Dialog):
             sizer.AddGrowableRow(currRow)  # doesn't seem to work though
             # self.Bind(EVT_ETC_LAYOUT_NEEDED, self.onNewTextSize,
             #    ctrls.valueCtrl)
-            ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
+            ctrls.valueCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
         elif fieldName in ('color', 'fillColor', 'lineColor'):
             ctrls.valueCtrl.Bind(wx.EVT_RIGHT_DOWN, self.launchColorPicker)
         elif valType == 'extendedCode':

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -177,6 +177,5 @@ class CodeSnippetValidator(BaseValidator):
             warnings = [w for w in self.clsWarnings.values() if w != '']
             if not warnings:
                 warnings = ['']
-                self.clsWarnings = {}
             parent.nameOKlabel.SetLabel(warnings[0])
 

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -177,5 +177,6 @@ class CodeSnippetValidator(BaseValidator):
             warnings = [w for w in self.clsWarnings.values() if w != '']
             if not warnings:
                 warnings = ['']
+                self.clsWarnings = {}
             parent.nameOKlabel.SetLabel(warnings[0])
 

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -1,23 +1,35 @@
-'''
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+# Part of the PsychoPy library
+# Copyright (C) 2015 Jonathan Peirce
+# Distributed under the terms of the GNU General Public License (GPL).
+
+"""
 Module containing validators for various parameters.
-'''
+"""
+
 import wx
 from ..localization import _translate
 from . import experiment
+from .components._base import _localized as _localizedComp
+# from .dialogs import _localized as _localizedDialogs  # circular
 
 
 class BaseValidator(wx.PyValidator):
     """
     Component name validator for _BaseParamsDlg class. It depends on access
-    to an experiment namespace. Validation checks if it is a valid Python
-    identifier and if it does not clash with existing names.
+    to an experiment namespace.
+
+    Validate calls check, which needs to be implemented per class.
+
+    Messages are passed to user as text in nameOklabel.
 
     @see: _BaseParamsDlg
     """
 
     def __init__(self):
         super(BaseValidator, self).__init__()
-        self.message = ""
 
     def Clone(self):
         return self.__class__()
@@ -33,7 +45,7 @@ class BaseValidator(wx.PyValidator):
             except Exception:
                 print("Couldn't find the root dialog for this event")
         message, valid = self.check(parent)
-        parent.nameOKlabel.SetLabel(message)
+        self.setMessage(parent, message)
         return valid
 
     def TransferFromWindow(self):
@@ -45,8 +57,15 @@ class BaseValidator(wx.PyValidator):
     def check(self, parent):
         raise NotImplementedError
 
+    def setMessage(self, parent, message):
+        raise NotImplementedError
+
 
 class NameValidator(BaseValidator):
+    """Validation checks if the value in Name field is a valid Python
+    identifier and if it does not clash with existing names.
+    """
+
     def __init__(self):
         super(NameValidator, self).__init__()
 
@@ -75,41 +94,88 @@ class NameValidator(BaseValidator):
             else:
                 return "", True
 
+    def setMessage(self, parent, message):
+        parent.nameOKlabel.SetLabel(message)
 
-class CodeValidator(BaseValidator):
-    """
-    Component code validator for _BaseParamsDlg class. It depends on access
-    to an experiment namespace. Validation checks if it is a valid Python
-    code, and if so, whether it contains identifiers that clash with
-    existing names (in the to-be-generated python script).
+
+class CodeSnippetValidator(BaseValidator):
+    """Validation checks if field value is valid Python code, and if so,
+    whether it contains bad identifiers (currently only self-reference).
 
     @see: _BaseParamsDlg
     """
+    # class attribute: dict of {fieldName: message} to handle all messages
+    clsWarnings = {}
 
-    def __init__(self):
-        super(CodeValidator, self).__init__()
+    def __init__(self, fieldName):
+        super(CodeSnippetValidator, self).__init__()
+        self.fieldName = fieldName
+        try:
+            self.displayName = _localizedComp[fieldName]
+        except KeyError:
+            # todo: want _localized[fieldName] from dialogs
+            self.displayName = _translate(fieldName)
+
+    def Clone(self):
+        return self.__class__(self.fieldName)
 
     def check(self, parent):
-        """checks intersection of names in code and namespace
+        """Checks intersection of names in code and namespace
+
+        Note: code snippets simply use existing names in the namespace,
+        like from condition-file headers. They do not add to the
+        namespace (unlike Name fields).
+
+        Code snippets in param fields will often be user-defined
+        vars, like condition names. Can also be expressions like
+        random(1,100). Hard to know what will be problematic.
+        But its always the case that self-reference is wrong.
         """
         control = self.GetWindow()
         if not hasattr(control, 'GetValue'):
             return '', True
         val = control.GetValue()  # same as parent.params[self.fieldName].val
+        if not isinstance(val, basestring):
+            return '', True
         codeWanted = experiment._unescapedDollarSign_re.search(val)
-        if codeWanted:  # ... or valType == 'code' -- require fieldName?
+        isCodeField = bool(parent.params[self.fieldName].valType == 'code')
+        if codeWanted or isCodeField:
             # get var names from val, check against namespace:
             code = experiment.getCodeFromParamStr(val)
             try:
                 names = compile(code, '', 'eval').co_names
             except SyntaxError:
-                pass
+                # empty '' compiles to a syntax error, ignore
+                if not code.strip() == '':
+                    msg = _translate('Python syntax error in field `{}`:  {}')
+                    return msg.format(self.displayName, code), False
             else:
-                namespace = parent.frame.exp.namespace
+                # namespace = parent.frame.exp.namespace
+                # parent.params['name'].val is not in namespace for new params
+                # handle dynamic changes to Name field:
+                parentName = parent.paramCtrls['name'].getValue()
                 for name in names:
-                    # params['name'] not in namespace yet if its a new param
-                    if (name == parent.params['name'].val or
-                            namespace.exists(name)):
-                        msg = _translate('Name `{}` is already used')
-                        return msg.format(name), False
+                    # `name` is a var name within a compiled code snippet
+                    if name == parentName:
+                        msg = _translate('Python variable `{}` in field `{}` is the same as Name')
+                        return msg.format(name, self.displayName), False
         return '', True
+
+    def setMessage(self, parent, message):
+        """Set nameOklabel to the first warning (if any).
+
+        Complexity: using a single nameOklabel for warnings for all fields
+        is going to experience potential conflict among multiple messages.
+        And we want to reset a given warning to 'all clear' when fixed by
+        user, but not reset all warnings
+        Solution: use a class attribute to collect warnings for all params.
+        should only be one param dialog open at a time, making this possible
+        """
+        if message or self.fieldName in self.clsWarnings.keys():
+            self.clsWarnings[self.fieldName] = message
+        if self.clsWarnings:
+            warnings = [w for w in self.clsWarnings.values() if w != '']
+            if not warnings:
+                warnings = ['']
+            parent.nameOKlabel.SetLabel(warnings[0])
+


### PR DESCRIPTION
Detects and warns about syntax errors and self-referential var names in code snippets.
Disables OK button. 
Not finished:
- text field in TextComponent. Guess: text-events are not triggering Validate()
- some field names are not localized in error messages