### PR TITLE
ENH: moved continueRoutine=True from Routine.writeStartCode to Routin…

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1526,6 +1526,7 @@ class Routine(list):
         buff.writeIndentedLines(code % self.name)
         self._clockName = self.name + "Clock"
         buff.writeIndented('%s = core.Clock()\n' % self._clockName)
+        buff.writeIndented('continueRoutine = True\n')
         for thisCompon in self:
             thisCompon.writeInitCode(buff)
 
@@ -1556,8 +1557,7 @@ class Routine(list):
         code = ("for thisComponent in %sComponents:\n"
                 "    if hasattr(thisComponent, 'status'):\n"
                 "        thisComponent.status = NOT_STARTED\n"
-                '\n# -------Start Routine "%s"-------\n'
-                'continueRoutine = True\n')
+                '\n# -------Start Routine "%s"-------\n')
         buff.writeIndentedLines(code % (self.name, self.name))
         if useNonSlip:
             code = 'while continueRoutine and routineTimer.getTime() > 0:\n'


### PR DESCRIPTION
…e.writeInitCode

closes #1143

This change allows Code Components to set continueRoutine=False in the
Begin Routine section rather than on every frame, which makes better
logical sense, because the writeInitCode occurs before the
Components.writeBeginRoutine()