### PR TITLE
BF: setting iohub eyelink binoc srate +

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -2,8 +2,9 @@
 Simple iohub eye tracker device demo. Shows how monitoring for central
 fixation monitoring could be done.
 No iohub config .yaml files are needed for this demo.
-Change the eyetracker_config dict to use a different eye tracker
-implementation if using a system other than the eyelink.
+Demo config is setup for an EyeLink(C) 1000 Desktop System. 
+To to use a different eye tracker implementation, change the 
+iohub_tracker_class_path and eyetracker_config dict script variables.
 '''
 from psychopy import core, visual
 from psychopy.iohub.client import launchHubServer
@@ -13,17 +14,17 @@ TRIAL_COUNT = 2
 # Maximum trial time / time timeout
 T_MAX = 10.0
 
+iohub_tracker_class_path = 'eyetracker.hw.sr_research.eyelink.EyeTracker'
 eyetracker_config = dict()
 eyetracker_config['name'] = 'tracker'
 eyetracker_config['model_name'] = 'EYELINK 1000 DESKTOP'
-eyetracker_config['simulation_mode'] = True
-eyetracker_config['runtime_settings'] = dict(sampling_rate=500,
-                                             track_eyes='BINOCULAR')
+#eyetracker_config['simulation_mode'] = True
+eyetracker_config['runtime_settings'] = dict(sampling_rate=1000,
+                                             track_eyes='RIGHT')
 
 # Since no experiment or session code is given, no iohub hdf5 file
 # will be saved, but device events are still available at runtime.
-io = launchHubServer(**{'eyetracker.hw.sr_research.eyelink.EyeTracker':
-                        eyetracker_config})
+io = launchHubServer(**{iohub_tracker_class_path: eyetracker_config})
 
 # Get some iohub devices for future access.
 keyboard = io.devices.keyboard

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -1,0 +1,110 @@
+'''
+Simple iohub eye tracker device demo. Shows how monitoring for central
+fixation monitoring could be done.
+No iohub config .yaml files are needed for this demo.
+Change the eyetracker_config dict to use a different eye tracker
+implementation if using a system other than the eyelink.
+'''
+from psychopy import core, visual
+from psychopy.iohub.client import launchHubServer
+
+# Number if 'trials' to run in demo
+TRIAL_COUNT = 2
+# Maximum trial time / time timeout
+T_MAX = 10.0
+
+eyetracker_config = dict()
+eyetracker_config['name'] = 'tracker'
+eyetracker_config['model_name'] = 'EYELINK 1000 DESKTOP'
+eyetracker_config['simulation_mode'] = True
+eyetracker_config['runtime_settings'] = dict(sampling_rate=500,
+                                             track_eyes='BINOCULAR')
+
+# Since no experiment or session code is given, no iohub hdf5 file
+# will be saved, but device events are still available at runtime.
+io = launchHubServer(**{'eyetracker.hw.sr_research.eyelink.EyeTracker':
+                        eyetracker_config})
+
+# Get some iohub devices for future access.
+keyboard = io.devices.keyboard
+display = io.devices.display
+tracker = io.devices.tracker
+
+# run eyetracker calibration
+r = tracker.runSetupProcedure()
+win = visual.Window(display.getPixelResolution(),
+                    units='pix',
+                    fullscr=True,
+                    allowGUI=False
+                    )
+
+gaze_ok_region = visual.Circle(win, radius=200, units='pix')
+
+gaze_dot = visual.GratingStim(win, tex=None, mask='gauss', pos=(0, 0),
+                              size=(66, 66), color='green', units='pix')
+
+text_stim_str = 'Eye Position: %.2f, %.2f. In Region: %s\n'
+text_stim_str += 'Press space key to start next trial.'
+missing_gpos_str = 'Eye Position: MISSING. In Region: No\n'
+missing_gpos_str += 'Press space key to start next trial.'
+text_stim = visual.TextStim(win, text=text_stim_str,
+                            pos=[0, int((-win.size[1]/2)*0.8)], height=24,
+                                 color='black',
+                                 alignHoriz='center',
+                                 alignVert='center', 
+                                 wrapWidth=win.size[0] * .9)
+
+# Run Trials.....
+t = 0
+while t < TRIAL_COUNT:
+    io.clearEvents()
+    tracker.setRecordingState(True)
+    run_trial = True
+    tstart_time = core.getTime()
+    while run_trial is True:
+        # Get the latest gaze position in dispolay coord space..
+        gpos = tracker.getLastGazePosition()
+
+        # Update stim based on gaze position
+        valid_gaze_pos = isinstance(gpos, (tuple, list))
+        gaze_in_region = valid_gaze_pos and gaze_ok_region.contains(gpos)
+        if valid_gaze_pos:
+            # If we have a gaze position from the tracker, update gc stim
+            # and text stim.
+            if gaze_in_region:
+                gaze_in_region = 'Yes'
+            else:
+                gaze_in_region = 'No'
+            text_stim.text = text_stim_str % (gpos[0], gpos[1], gaze_in_region)
+
+            gaze_dot.setPos(gpos)
+        else:
+            # Otherwise just update text stim
+            text_stim.text = missing_gpos_str
+
+        # Redraw stim
+        gaze_ok_region.draw()
+        text_stim.draw()
+        if valid_gaze_pos:
+            gaze_dot.draw()
+
+        # Display updated stim on screen.
+        flip_time = win.flip()
+
+        # Check any new keyboard char events for a space key.
+        # If one is found, set the trial end variable.
+        #
+        if ' ' in keyboard.getPresses() or core.getTime()-tstart_time > T_MAX:
+            run_trial = False
+
+    # Current Trial is Done
+    # Stop eye data recording
+    tracker.setRecordingState(False)
+    t += 1
+
+# All Trials are done
+# End experiment
+win.close()
+tracker.setConnectionState(False)
+io.quit()
+core.quit()


### PR DESCRIPTION
1. BF: Setting sampling rate when using binocular mode in eyelink 1000 did not always update tracker to requested (valid) sampling rate. Also was printing debug messages.  
2. ADD: 'simple' eye tracker demo, uses launchHubServer, no .yaml config files, and no .hdf5 file recording.