### PR TITLE
RF: Create some instance properties in __init__()

### DIFF
--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -363,6 +363,9 @@ class RatingScale(MinimalStim):
         self.reset()  # sets .status, among other things
         self.win.setUnits(self.savedWinUnits, log=False)
 
+        self.timedOut = False
+        self.beyondMinTime = False
+
         # set autoLog (now that params have been initialised)
         self.autoLog = autoLog
         if autoLog:


### PR DESCRIPTION
`RatingScale.timedOut` and `RatingScale.beyondMinTime` were
previously only initially created during the first call to `draw()`; however, these
properties should already be created during object instantiation.

This allows to write code like:

```
rs = RatingScale(...)
while not rs.timedOut:
    pass
```
instead of:
```
rs = RatingScale(...)
rs.timedOut = False
while not rs.timedOut:
    pass
```