### PR TITLE
RF: Remove unnecessary `global` statements

### DIFF
--- a/psychopy/app/projects.py
+++ b/psychopy/app/projects.py
@@ -23,14 +23,12 @@ from psychopy.app import dialogs
 from .localization import _translate
 
 # Projects FileHistory sub-menu
-global projHistory
 idBase = wx.NewId()
 projHistory = wx.FileHistory(maxFiles=10, idBase=idBase)
 projHistory.idBase = idBase
 for filename in prefs.appData['projects']['fileHistory']:
     projHistory.AddFileToHistory(filename)
 
-global usersList
 usersList = wx.FileHistory(maxFiles=10, idBase=wx.NewId())
 
 

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -29,7 +29,6 @@ from .. import serialdevice
 __docformat__ = "restructuredtext en"
 
 DEBUG = True
-global GL, visual  # will be imported
 
 plotResults = False
 if plotResults:

--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -53,8 +53,6 @@ if platform == 'win32':
 else:
     mediaLocation = ""
 
-global audioLib, audioDriver, Sound, init
-global pyoSndServer
 pyoSndServer = None
 Sound = None
 audioLib = None

--- a/psychopy/visual/textbox/__init__.py
+++ b/psychopy/visual/textbox/__init__.py
@@ -41,7 +41,6 @@ def is_sequence(arg):
         hasattr(arg, "__getitem__") or
         hasattr(arg, "__iter__"))
 
-global _system_font_manager
 _system_font_manager = None
 
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -98,10 +98,7 @@ try:
 except Exception:
     pass
 
-global DEBUG
 DEBUG = False
-
-global IOHUB_ACTIVE
 IOHUB_ACTIVE = False
 
 


### PR DESCRIPTION
Some modules had `global` statements at module top-level, which are redundant since top-level variables are global by definition.

Closes #1162.