### PR TITLE
DOC: Fix typos and sphinx warnings in documentation

### DIFF
--- a/docs/source/api/encryption.rst
+++ b/docs/source/api/encryption.rst
@@ -8,6 +8,6 @@ python package, pyFileSec, which grew out of PsychoPy. pyFileSec is distributed
 with the StandAlone versions of PsychoPy, or can be installed using pip or easy_install
 via https://pypi.python.org/pypi/PyFileSec/
 
-Some elaboration of pyFileSec usage and security strategy can be found here: http://pythonhosted.org//PyFileSec
+Some elaboration of pyFileSec usage and security strategy can be found here: http://pythonhosted.org/PyFileSec
 
 Basic usage is illustrated in the Coder demo > misc > encrypt_data.py

--- a/docs/source/coder/codeLogging.rst
+++ b/docs/source/coder/codeLogging.rst
@@ -17,7 +17,7 @@ Multiple `targets` can also be created to receive log messages. Each target has 
     #overwrite (filemode='w') a detailed log of the last run in this dir
     lastLog=logging.LogFile("lastRun.log", level=logging.INFO, filemode='w')
     #also append warnings to a central log file
-    centralLog=logging.LogFile("c:/psychopyExps.log", level=logging.WARNING, filemode='a')
+    centralLog=logging.LogFile("C:\\psychopyExps.log", level=logging.WARNING, filemode='a')
 
 Updating the logs
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/general/glossary.rst
+++ b/docs/source/general/glossary.rst
@@ -31,7 +31,7 @@ Glossary
         'Traditional' computer monitor (rather than an LCD or plasma flat screen).
 
     xlsx
-        **Excel OpenXML file format**. A spreadsheet data format developed by Microsoft but with an open (published format). This is the native file format for Excel (2007 or later) and can be opened by most modern spreadsheet applications including OpenOffice (3.0+), google docs, Apple iWork 08.
+        **Excel OpenXML file format**. A spreadsheet data format developed by Microsoft but with an open (published) format. This is the native file format for Excel (2007 or later) and can be opened by most modern spreadsheet applications including OpenOffice (3.0+), google docs, Apple iWork 08.
 
     GPU
         **Graphics Processing Unit** is the processor on your graphics card. The GPUs of modern computers are incredibly powerful and it is by allowing the GPU to do a lot of the work of rendering that PsychoPy is able to achieve good timing precision despite being written in an interpreted language

--- a/docs/source/general/glossary.rst
+++ b/docs/source/general/glossary.rst
@@ -33,10 +33,8 @@ Glossary
     xlsx
         **Excel OpenXML file format**. A spreadsheet data format developed by Microsoft but with an open (published format). This is the native file format for Excel (2007 or later) and can be opened by most modern spreadsheet applications including OpenOffice (3.0+), google docs, Apple iWork 08.
 
-	GPU
-		**Graphics Processing Unit** is the processor on your graphics card. The GPUs of modern computers are incredibly powerful and it is by allowing the GPU to do a lot of the work of rendering that PsychoPy is able to achieve good timing precision despite being written in an interpreted language
-	
-	CPU
-		**Central Processing Unit** is the main processor of your computer. This has a lot to do, so we try to minimise the amount of processing that is needed, especially during a trial, when time is tight to get the stimulus presented on every screen refresh.
-	
-	
+    GPU
+        **Graphics Processing Unit** is the processor on your graphics card. The GPUs of modern computers are incredibly powerful and it is by allowing the GPU to do a lot of the work of rendering that PsychoPy is able to achieve good timing precision despite being written in an interpreted language
+
+    CPU
+        **Central Processing Unit** is the main processor of your computer. This has a lot to do, so we try to minimise the amount of processing that is needed, especially during a trial, when time is tight to get the stimulus presented on every screen refresh.

--- a/docs/source/general/projects.rst
+++ b/docs/source/general/projects.rst
@@ -14,14 +14,14 @@ There are several reasons you may want to do this:
 Sharing with collaborators
 ------------------------------
 
-You may find it simple to share files with your collaborators using dropbox but that means your data are stored by a commercial company over which you have no control and with no interest in scientific integrity. Check with your ethics committee how they feel about your data (e.g. personal details of participants?) being stored on dropbox. OSF, by comparison, is designed for scientists to stored their data securely and forever
+You may find it simple to share files with your collaborators using dropbox but that means your data are stored by a commercial company over which you have no control and with no interest in scientific integrity. Check with your ethics committee how they feel about your data (e.g. personal details of participants?) being stored on dropbox. OSF, by comparison, is designed for scientists to stored their data securely and forever.
 
 Once you've created a project on OSF you can add other contributors to it and when they log in via PsychoPy they will see the projects they share with you (as well as the project they have created themselves). Then they can sync with that project just like any other.
 
 Sharing files/projects with others
 --------------------------------------------------
 
-Optionally, you can make your project (or subsets of it) publiclay accessible so that others can view the files. This has various advantages, to the scientific field but also to you as a scientist.
+Optionally, you can make your project (or subsets of it) publicly accessible so that others can view the files. This has various advantages, to the scientific field but also to you as a scientist.
 
 Good for open science:
   * Sharing your work allows scientists to work out why one experiment gave a different result to another; there are often subtleties in the exact construction of a study that didn't get described fully in the methods section. By sharing the actual experiment, rather than just a description of it, we can reduce the failings of replications
@@ -40,7 +40,7 @@ Maintaining a validated history of your work
 --------------------------------------------------
 
 In many areas of science researchers are very careful about maintaining a full documented history of what their work; what they discovered, the data they collected and what they predicted for the next experiment. In the behavioural and social sciences we haven't been very good at that. With OSF:
-  * you can "preregister" your plans for the next experiment (so that people can't later acuse you of "p-hacking").
+  * you can "preregister" your plans for the next experiment (so that people can't later accuse you of "p-hacking").
   * all your files are timestamped so you can prove to others that they were collected on/by a certain date, removing any potential doubts about who collected data first
   * your projects (and individual files) have a unique URL on OSF so you can cite/reference resources.
   Additionally, "Registrations" (snapshots of your project at a fixed point in time) can be given a DOI, which guarantees they will exist permanently
@@ -55,7 +55,7 @@ PsychoPy doesn't currently have the facility to *create* user profiles or projec
 Login to OSF
 ~~~~~~~~~~~~~~~
 
-From the `Projects` menu you can log in to OSF with your username and password (this is never stored; see :ref:`OSFsecurity`). This user will stay logged in while the PsychoPy application remains open, or until you switch to a different user. If you selec "Remember me" then your login will be stored and you can log in again without typing your password each time.
+From the `Projects` menu you can log in to OSF with your username and password (this is never stored; see :ref:`OSFsecurity`). This user will stay logged in while the PsychoPy application remains open, or until you switch to a different user. If you select "Remember me" then your login will be stored and you can log in again without typing your password each time.
 
 Projects that you have previously synchronised will try to use the stored details of the known users if possible and will revert to username and password if not. Project files (defining the details of the project to sync) can be stored wherever you choose; either in a private or shared location. User details are stored in the home space of the user currently logged in to the operating system so are not shared with other users by default.
 
@@ -96,10 +96,10 @@ The sync process and rules:
   - on the first synchronisation all the files/folders will be merged:
     - the contents of the local folder will be uploaded to the server and vice versa
     - files that have the same name but different contents (irrespective of dates) will be flagged as conflicting (see below) and both copies kept
-  - on subsequent sync operations a two-way sync will be perfomed taking into account the previous state. **If you delete the files locally and then sync then they will be deleted remotely as well**
+  - on subsequent sync operations a two-way sync will be performed taking into account the previous state. **If you delete the files locally and then sync then they will be deleted remotely as well**
   - files that are the same (according to an md5 checksum) and have the same location will be left as they are
   - if a file is in conflict (it has been changed in both locations since the last sync) then both versions will be kept and will be tagged as conflicting
-  - if a file is deleted in one location but is also changed in the other (since the last sync) then it
+  - if a file is deleted in one location but is also changed in the other (since the last sync) then it will be recreated on the side where it was deleted with the state of the side where is was not deleted.
 
 Conflicting files will be labelled with their original filename plus the string "_CONFLICT<datetimestamp>"
 Deletion conflicts will be labelled with their original filename plus the string "_DELETED"

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -33,7 +33,7 @@ Start PsychoPy, and be sure to be in the Builder view.
     
 * If you have poked around a bit in the Builder already, be sure to start with a clean slate. To get a new Builder view, type `Ctrl-N` on Windows or Linux, or `Cmd-N` on Mac.
 * Click on a Text component
-    .. image:: ../../psychopy/app/builder/components/text.png
+    .. image:: ../../psychopy/app/builder/components/text/text.png
   
   and a Text Properties dialog will pop up.
     .. image:: images/textdialog.png

--- a/docs/source/recipes/classroomInstallation.rst
+++ b/docs/source/recipes/classroomInstallation.rst
@@ -55,7 +55,7 @@ If psychopy is not found on the path then there will be an import error. Try adj
 
 The shortcut in the Windows Start Menu will still be pointing to the local (now non-existent) PsychoPy library. Right-click it to change properties and set the shortcut to point to something like::
 
-    "C:\Program Files\PsychoPy2\pythonw.exe" "<NETWORK_LOC>\psychopyLib\psychopy\\app\psychopyApp.py"
+    "C:\Program Files\PsychoPy2\pythonw.exe" "<NETWORK_LOC>\psychopyLib\psychopy\app\psychopyApp.py"
     
 You probably spotted from this that the PsychoPy app is simply a Python script. You may want to update the file associations too, so that `.psyexp` and `.py` are opened with::
 

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -66,7 +66,7 @@ PsychoPy comes with all the source code included. You may not think you're much 
 To have a look at the source code do one of the following:
     - when you get an error message in the :ref:`coder` click on the hyperlinked error lines to see the relevant code
     - on Windows
-        - go to `Program Files\PsychoPy2\Lib\site-packages\Psychopy`
+        - go to `Program Files\\PsychoPy2\\Lib\\site-packages\\Psychopy`
         - have a look at some of the files there
     - on Mac
         - right click the PsychoPy app and select `Show Package Contents`


### PR DESCRIPTION
The projects documentation also had an incomplete sentence.

The "CPU" and "GPU" entry in the glossary were not included in the sorted list of entries and not linked from other pages (e.g. "rendering.rst") because of the different indentation.

Thanks!