### PR TITLE
FF: Fix error if removing loop or routine from flow

### DIFF
--- a/psychopy/app/builder/flow.py
+++ b/psychopy/app/builder/flow.py
@@ -536,7 +536,7 @@ class FlowPanel(wx.ScrolledWindow):
             self.frame.exp.namespace.remove(component.params['name'].val)
         # perform the actual removal
         flow.removeComponent(component, id=compID)
-        self.redraw()
+        self.draw()
 
     def OnPaint(self, event):
         # Create a buffered paint DC.  It will create the real


### PR DESCRIPTION
Removing a loop or routine raised an `AttributeError`.

Thanks!