### PR TITLE
Add a visual indicator to tabs containing code (issue #1194)

### DIFF
--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -137,8 +137,12 @@ class DlgCodeComponentProperties(wx.Dialog):
                 asizer.Add(paramGuiDict.get(
                     guikey + '_codebox'), 1, wx.EXPAND, 0)
                 paramGuiDict.get(guikey + '_panel').SetSizer(asizer)
+                tabLabel = _translate(paramName)
+                # Add a visual indicator when tab contains code
+                if self.params.get(guikey.replace('_',' ')).val:
+                    tabLabel += ' *'
                 self.codeSections.AddPage(paramGuiDict.get(
-                    guikey + '_panel'), _translate(paramName))
+                    guikey + '_panel'), tabLabel)
 
         nameSizer = wx.BoxSizer(wx.HORIZONTAL)
         nameSizer.Add(self.nameLabel, 0, wx.ALL, 10)


### PR DESCRIPTION
`FlatNotebook`-tabs don't allow styling, so this code adds an asterisk after the tab name if the associated `CodeBox` isn't empty (see issue #1194).

Example:
![2016-07-11-132253_1600x900_scrot-fs8](https://cloud.githubusercontent.com/assets/920936/16729129/c9525dba-476a-11e6-965f-69c2f4d620b8.png)

The titles are only recalculated when opening the dialog, so switching between tabs after editing doesn't add the asterisks. This shouldn't be a problem, as it's mainly needed when opening the code dialog for the first time.