### PR TITLE
Fix problem with empty cells when importing a csv conditions file

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2631,6 +2631,8 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             thisTrial = {}
             for fieldN, fieldName in enumerate(fieldNames):
                 val = trialsArr[trialN][fieldN]
+                #if it is a numpy.nan, convert to None
+                if numpy.isnan(val): val = None
                 if type(val) == numpy.string_:
                     val = unicode(val.decode('utf-8'))
                     # if it looks like a list, convert it:


### PR DESCRIPTION
empty cells in csv conditions files break the future loading of the
experiment flow in the builder. Empty cells in the
csv are read as type numpy.nan and stored as "nan" in the psyexp file.
This change converts them to python type None which is the same type that
empty cells in xlsx conditions files are read in as...