### PR TITLE
Add files via upload

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -169,9 +169,18 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         if os.path.isfile(filename):
             self._mov = VideoFileClip(filename, audio=(1 - self.noAudio))
             if (not self.noAudio) and (self._mov.audio is not None):
-                self._audioStream = sound.Sound(
-                    self._mov.audio.to_soundarray(),
-                    sampleRate=self._mov.audio.fps)
+                try:
+                    self._audioStream = sound.Sound(
+                        self._mov.audio.to_soundarray(),
+                        sampleRate=self._mov.audio.fps)
+                except:
+                    # JWE added this as a patch for a moviepy oddity where the duration is inflated in the saved file
+                    # causes the audioclip to be the wrong length, so round down and it should work
+                    jwe_tmp = self._mov.subclip(0,round(self._mov.duration))
+                    self._audioStream = sound.Sound(
+                        jwe_tmp.audio.to_soundarray(),
+                        sampleRate=self._mov.audio.fps)
+                    del(jwe_tmp)
             else:  # make sure we set to None (in case prev clip had audio)
                 self._audioStream = None
         else:


### PR DESCRIPTION
Adds a workaround for a movie file created with moviepy that has an inflated duration.  The audio clip then can't be converted to an array because it's shorter than the stated duration.  The solution is to create a subclip of the file with a duration that is rounded down to the (hopefully correct) original duration.