### PR TITLE
BF: Monitor centre not displaying vertical pixels

### DIFF
--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -585,7 +585,7 @@ class MainFrame(wx.Frame):
 
         _sizePix = self.currentMon.getSizePix() or [0, 0]
         self.ctrlScrPixHoriz.SetValue(locale.str(_sizePix[0]))
-        self.ctrlScrPixVert.SetValue(locale.str(_sizePix[0]))
+        self.ctrlScrPixVert.SetValue(locale.str(_sizePix[1]))
 
         # self.ctrlScrGamma.SetValue(str(self.currentMon.getGamma()))
         self.ctrlCalibNotes.SetValue(self.currentMon.getNotes() or '')


### PR DESCRIPTION
https://github.com/psychopy/psychopy/pull/1208  seems to have introduced a bug whereby Monitor Centre shows the horizontal pixel size in the vertical pixel field. Issue first reported here: http://discourse.psychopy.org/t/monitor-center-psychopy-v1-84-0rc5/877 by user Fahed