### PR TITLE
removed unneeded import

### DIFF
--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -45,7 +45,6 @@ import psychopy.event
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
-from psychopy import makeMovies
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
 
 if sys.platform == 'win32' and not haveAvbin:


### PR DESCRIPTION
which also make the module fail with an import error.

Using `MovieStim` fails with:

```
  File "/usr/lib64/python2.7/site-packages/psychopy/visual/movie.py", line 48, in <module>
    from psychopy import makeMovies
ImportError: cannot import name makeMovies
```

The function for which the import is attempted is nonexistent and unused.
