### PR TITLE
corrected attribute naming

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -240,7 +240,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         if self.status != STOPPED:
             self.status = STOPPED
             self._unload()
-            self._reset()
+            self.reset()
             if log and self.autoLog:
                 self.win.logOnFlip("Set %s stopped" % (self.name),
                                    level=logging.EXP, obj=self)


### PR DESCRIPTION
It seems for MovieStim3() the `_reset` attribute is being replaced by `reset`.

The erroneous call breaks the `stop` atribute:

```
    mov.stop()
  File "/usr/lib64/python2.7/site-packages/psychopy/visual/movie3.py", line 243, in stop
    self._reset()
AttributeError: 'MovieStim3' object has no attribute '_reset'
``` 

This behaviour is fixed by the PR