### PR TITLE
BF: Properly handle screenHz argument of StaticPeriod

### DIFF
--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -138,7 +138,7 @@ class StaticPeriod(object):
         be reset and starts again
         """
         self.status = STARTED
-        self.countdown.reset(duration)
+        self.countdown.reset(duration - self.frameTime)
         # turn off recording of frame intervals throughout static period
         if self.win:
             self.win.recordFrameIntervals = False

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -136,6 +136,8 @@ class StaticPeriod(object):
     def start(self, duration):
         """Start the period. If this is called a second time, the timer will
         be reset and starts again
+
+        :param duration: The duration of the period, in seconds.
         """
         self.status = STARTED
         self.countdown.reset(duration - self.frameTime)

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -349,6 +349,26 @@ def testStaticPeriod():
     assert win.recordFrameIntervals == False
     static.complete()
     assert static._winWasRecordingIntervals == win.recordFrameIntervals
+    win.close()
+
+    # Test if screenHz parameter is respected, i.e., if after completion of the
+    # StaticPeriod, 1/screenHz seconds are still remaining, so the period will
+    # complete after the next flip.
+    refresh_rate = 100.0
+    period_duration = 0.1
+    timer = CountdownTimer()
+    win = Window(autoLog=False)
+
+    static = StaticPeriod(screenHz=refresh_rate, win=win)
+    static.start(period_duration)
+    timer.reset(period_duration )
+    static.complete()
+
+    assert np.allclose(timer.getTime(),
+                       1/refresh_rate,
+                       atol=0.001)
+    win.close()
+
 
 @pytest.mark.quit
 def test_quit():
@@ -376,5 +396,6 @@ if __name__ == '__main__':
     testWait()
     testLoggingDefaultClock()
     testTimebaseQuality()
+    testStaticPeriod()
     printf("\n** Next Test will Take ~ 1 minute...**\n")
     testDelayDurationAccuracy()


### PR DESCRIPTION
It appears the `StaticPeriod` never actually did what the documentation
promised when specifying the `screenHz` keyword argument. The [docs](http://www.psychopy.org/api/core.html#psychopy.core.StaticPeriod)
say:

```
# the period takes into account the next frame flip
# time should now be at exactly 0.5s later than when ISI.start()
# was called
```

This was indeed never the case (I checked the entire git history via `git log -L :StaticPeriod:core.py`). Instead, the `StaticPeriod` would always wait for the entire specified duration, ignoring the refresh rate and not reserving time for an additional flip. Hence, a user assuming the documented behavior would overshoot by one frame.

I consider this a serious bug we should probably announce somewhere in **bold** letters or something. I don't know if my fix will have any consequences on any Builder components/implementations. At least the `StaticComponent` makes use of the `StaticPeriod`, and supplies the `screenHz` parameter.

**Although the TravisCI test suite already passes, please do not pull until we're sure about possible side effects of this fix.**

**Edit:** Clarified the current (buggy) behavior.