### PR TITLE
Added missing dependency requests to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 
+requests
 numpy
 scipy
 matplotlib


### PR DESCRIPTION
I've tried to install Psychopy on ubuntu 16.04 using pip from master and there was one dependency left out in requirements.txt. This pull request adds that dependency.