### PR TITLE
BF/RF: Replace deprecated pySerial method calls

### DIFF
--- a/psychopy/hardware/minolta.py
+++ b/psychopy/hardware/minolta.py
@@ -128,10 +128,10 @@ class LS100(object):
         if self.OK:
             self.com.close()  # not sure why this helps but on win32 it does!!
             # this is a slightly odd characteristic of the Minolta LS100
-            self.com.setByteSize(7)
-            self.com.setBaudrate(4800)
-            self.com.setParity(serial.PARITY_EVEN)  # none
-            self.com.setStopbits(serial.STOPBITS_TWO)
+            self.com.bytesize = 7
+            self.com.baudrate = 4800
+            self.com.parity = serial.PARITY_EVEN  # none
+            self.com.stopbits = serial.STOPBITS_TWO
             try:
                 if not self.com.isOpen():
                     self.com.open()

--- a/psychopy/hardware/pr.py
+++ b/psychopy/hardware/pr.py
@@ -93,9 +93,9 @@ class PR650(object):
             self._error(msg % sys.platform)
         # setup the params for PR650 comms
         if self.OK:
-            self.com.setBaudrate(9600)
-            self.com.setParity('N')  # none
-            self.com.setStopbits(1)
+            self.com.baudrate = 9600
+            self.com.parity = 'N'  # none
+            self.com.stopbits = 1
             try:
                 # Pyserial >=2.6 throws an exception when trying to open a
                 # serial port that is already open. Catching that exception
@@ -315,9 +315,9 @@ class PR655(PR650):
             self._error(msg % self.portString)
         # setup the params for PR650 comms
         if self.OK:
-            self.com.setBaudrate(9600)
-            self.com.setParity('N')  # none
-            self.com.setStopbits(1)
+            self.com.baudrate = 9600
+            self.com.parity = 'N'  # none
+            self.com.stopbits = 1
             try:
                 self.com.close()  # attempt to close if it's currently open
                 self.com.open()


### PR DESCRIPTION
pySerial 3.0 has fully switched to an API with getters and setters for attributes, and
removed the (previously deprecated) `set*` methods we've been using so far.

The changes introduced here are backward-compatible at least with pySerial 2.7.

Closes #1257.