### PR TITLE
BF: Do not set `colorSpace` to `None` of color is `None`

### DIFF
--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -193,7 +193,6 @@ def setColor(obj, color, colorSpace=None, operation='',
 
         if color is None:
             setattr(obj, rgbAttrib, None)  # e.g. obj.rgb=[0,0,0]
-            obj.__dict__[colorSpaceAttrib] = None  # e.g. obj.colorSpace='hex'
             obj.__dict__[colorAttrib] = None  # e.g. obj.color='#000000'
             setTexIfNoShaders(obj)
 


### PR DESCRIPTION
`visual.helpers.setColor()` would reset the object's color space to `None` if
the passed color was `None`. This is unnecessary and causes an error message
to be logged.

## Reproducible examples
**Snippet 1:**
```python
from psychopy.visual import Window
from psychopy.visual.circle import Circle

win = Window()
circle = Circle(win, fillColor=None)
win.close()
```
**Previous behavior:** Works as expected.
**New bahavior:** unchanged.

**Snippet 2:**
```python
from psychopy.visual import Window
from psychopy.visual.circle import Circle

win = Window()
circle = Circle(win)
circle.fillColor = None
win.close()
```

**Previous behavior:** logs an error: `ERROR 	Unknown colorSpace: None`.
**New bahavior:** Works as expected.

**Needs more testing before merging.**