### PR TITLE
RF: Explicitly name exceptions to catch

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -26,7 +26,7 @@ def isValidColor(color):
     try:
         color = float(color)
         return True
-    except Exception:
+    except ValueError:
         if isinstance(color, basestring) and len(color):
             return (color.lower() in colors255.keys()
                     or color[0] == '#' or color[0:2] == '0x')

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -682,7 +682,7 @@ class _BaseTrialHandler(object):
                 try:
                     # if it can convert to a number (from numpy) then do it
                     val = float(entry)
-                except Exception:
+                except ValueError:
                     val = unicode(entry)
                 _cell = _getExcelCellName(col=colN, row=lineN)
                 ws.cell(_cell).value = val
@@ -879,7 +879,7 @@ class TrialHandler(_BaseTrialHandler):
         # data first, then all others
         try:
             data = self.data
-        except Exception:
+        except AttributeError:
             data = None
         if data:
             strRepres += str('\tdata=')
@@ -1216,7 +1216,7 @@ class TrialHandler(_BaseTrialHandler):
                             thisAnal = thisAnal * sqrt(N) / sqrt(N - 1)
                     else:
                         thisAnal = eval("numpy.%s(thisData,1)" % analType)
-                except Exception:
+                except TypeError:
                     # that analysis doesn't work
                     dataHead.remove(dataType + '_' + analType)
                     dataOutInvalid.append(thisDataOut)
@@ -1560,7 +1560,7 @@ class TrialHandler2(_BaseTrialHandler):
         # data first, then all others
         try:
             data = self.data
-        except Exception:
+        except AttributeError:
             strRepres += '\t(no data)\n'
         else:
             strRepres += str('\tdata=')
@@ -2325,7 +2325,7 @@ class TrialHandlerExt(TrialHandler):
                             thisAnal = thisAnal * sqrt(N) / sqrt(N - 1)
                     else:
                         thisAnal = eval("numpy.%s(thisData,1)" % analType)
-                except Exception:
+                except TypeError:
                     # that analysis doesn't work
                     dataHead.remove(dataType + '_' + analType)
                     dataOutInvalid.append(thisDataOut)
@@ -2539,7 +2539,7 @@ def indicesFromString(indsString):
     try:
         inds = int(round(float(indsString)))
         return [inds]
-    except Exception:
+    except ValueError:
         pass
     # "-6::2"
     try:
@@ -2551,7 +2551,7 @@ def indicesFromString(indsString):
     try:
         inds = list(eval(indsString))
         return inds
-    except Exception:
+    except TypeError:
         pass
 
 
@@ -2709,7 +2709,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             for n in selection:
                 try:
                     assert n == int(n)
-                except Exception:
+                except AssertionError:
                     raise TypeError("importConditions() was given some "
                                     "`indices` but could not parse them")
     # the selection might now be a slice or a series of indices
@@ -4821,7 +4821,7 @@ def functionFromStaircase(intensities, responses, bins=10):
         # concatenate if multidimensional
         intensities = numpy.concatenate(intensities)
         responses = numpy.concatenate(responses)
-    except Exception:
+    except (ValueError, TypeError):
         intensities = numpy.array(intensities)
         responses = numpy.array(responses)
 
@@ -4917,7 +4917,7 @@ def isValidVariableName(name):
         return False, "Variables must be string-like"
     try:
         name = str(name)  # convert from unicode if possible
-    except Exception:
+    except ValueError:
         if type(name) in [unicode, numpy.unicode_]:
             msg = ("name %s (type %s) contains non-ASCII characters"
                    " (e.g. accents)")

--- a/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
+++ b/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
@@ -222,7 +222,7 @@ def initProcessStats():
 def getSysInfo(win): 
     try: 
         from collections import OrderedDict
-    except Exception: 
+    except ImportError:
         from psychopy.iohub import OrderedDict
     # based on sysInfo.py
     from pyglet.gl import gl_info, GLint, glGetIntegerv, GL_MAX_ELEMENTS_VERTICES

--- a/psychopy/demos/coder/sysInfo.py
+++ b/psychopy/demos/coder/sysInfo.py
@@ -30,7 +30,7 @@ print("pyglet", pyglet.version)
 try:
     import pyo
     print("pyo", '%i.%i.%i' % pyo.getVersion())
-except Exception:
+except ImportError:
     print('pyo [not installed]')
 
 from psychopy import __version__

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -10,7 +10,7 @@ try:
     from PyQt4 import QtGui
     QtWidgets = QtGui  # in qt4 these were all in one package
     from PyQt4.QtCore import Qt
-except Exception:
+except ImportError:
     from PyQt5 import QtWidgets
     from PyQt5 import QtGui
     from PyQt5.QtCore import Qt

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -37,7 +37,7 @@ if plotResults:
 try:
     from psychopy.ext import _bits
     haveBitsDLL = True
-except Exception:
+except ImportError:
     haveBitsDLL = False
 
 if DEBUG:  # we don't want error skipping in debug mode!
@@ -47,12 +47,12 @@ else:
     try:
         from . import shaders
         haveShaders = True
-    except Exception:
+    except ImportError:
         haveShaders = False
 
 try:
     import configparser
-except Exception:
+except ImportError:
     import ConfigParser as configparser
 
 # Bits++ modes

--- a/psychopy/hardware/crs/colorcal.py
+++ b/psychopy/hardware/crs/colorcal.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 import sys
 try:
     import serial
-except Exception:
+except ImportError:
     serial = False
 import numpy
 
@@ -88,7 +88,7 @@ class ColorCAL(object):
         # try to open the port
         try:
             self.com = serial.Serial(self.portString)
-        except Exception:
+        except serial.SerialException:
             msg = ("Couldn't connect to port %s. Is it being used by "
                    "another program?")
             self._error(msg % self.portString)
@@ -103,7 +103,7 @@ class ColorCAL(object):
             try:
                 if not self.com.isOpen():
                     self.com.open()
-            except Exception:
+            except serial.SerialException:
                 msg = "Opened serial port %s, but couldn't connect to ColorCAL"
                 self._error(msg % self.portString)
             else:

--- a/psychopy/hardware/joystick/__init__.py
+++ b/psychopy/hardware/joystick/__init__.py
@@ -34,13 +34,13 @@ from __future__ import absolute_import
 try:
     import pygame.joystick
     havePygame = True
-except Exception:
+except ImportError:
     havePygame = False
 
 try:
     from pyglet import input as pyglet_input  # pyglet 1.2+
     havePyglet = True
-except Exception:
+except ImportError:
     havePyglet = False
 
 from psychopy import logging, visual

--- a/psychopy/hardware/minolta.py
+++ b/psychopy/hardware/minolta.py
@@ -117,7 +117,7 @@ class LS100(object):
         if sys.platform in ['darwin', 'win32']:
             try:
                 self.com = serial.Serial(self.portString)
-            except Exception:
+            except serial.SerialException:
                 msg = ("Couldn't connect to port %s. Is it being used by "
                        "another program?")
                 self._error(msg % self.portString)
@@ -135,7 +135,7 @@ class LS100(object):
             try:
                 if not self.com.isOpen():
                     self.com.open()
-            except Exception:
+            except serial.SerialException:
                 msg = "Opened serial port %s, but couldn't connect to LS100"
                 self._error(msg % self.portString)
             else:

--- a/psychopy/hardware/pr.py
+++ b/psychopy/hardware/pr.py
@@ -84,7 +84,7 @@ class PR650(object):
         if sys.platform in ('darwin', 'win32') or _linux:
             try:
                 self.com = serial.Serial(self.portString)
-            except Exception:
+            except serial.SerialException:
                 msg = ("Couldn't connect to port %s. Is it being used by"
                        " another program?")
                 self._error(msg % self.portString)
@@ -97,13 +97,9 @@ class PR650(object):
             self.com.setParity('N')  # none
             self.com.setStopbits(1)
             try:
-                # Pyserial >=2.6 throws an exception when trying to open a
-                # serial port that is already open. Catching that exception
-                # is not an option here because PySerial only defines a
-                # single exception type (SerialException)
                 if not self.com.isOpen():
                     self.com.open()
-            except Exception:
+            except serial.SerialException:
                 msg = "Opened serial port %s, but couldn't connect to PR650"
                 self._error(msg % self.portString)
             else:
@@ -309,7 +305,7 @@ class PR655(PR650):
         # try to open the port
         try:
             self.com = serial.Serial(self.portString)
-        except Exception:
+        except serial.SerialException:
             msg = ("Couldn't connect to port %s. Is it being used by "
                    "another program?")
             self._error(msg % self.portString)
@@ -322,7 +318,7 @@ class PR655(PR650):
                 self.com.close()  # attempt to close if it's currently open
                 self.com.open()
                 self.isOpen = 1
-            except Exception:
+            except serial.SerialException:
                 msg = ("Found a device on serial port %s, but couldn't "
                        "open that port")
                 self._error(msg % self.portString)
@@ -342,7 +338,7 @@ class PR655(PR650):
             time.sleep(0.1)
             self.com.close()
             logging.debug('Closed PR655 port')
-        except Exception:
+        except serial.SerialException:
             pass
 
     def startRemoteMode(self):

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -68,7 +68,7 @@ class SerialDevice(object):
                     rtscts=0,)              # enable RTS/CTS flow control
 
                 self.portString = portString
-            except Exception:
+            except serial.SerialException:
                 if port:
                     # the user asked for this port and we couldn't connect
                     logging.warn("Couldn't connect to port %s" % portString)
@@ -80,7 +80,7 @@ class SerialDevice(object):
             if not self.com.isOpen():
                 try:
                     self.com.open()
-                except Exception:
+                except serial.SerialException:
                     msg = ("Couldn't open port %s. Is it being used by "
                            "another program?")
                     logging.info(msg % self.portString)

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -175,7 +175,7 @@ class RunTimeInfo(dict):
                 if len(auth) and '=' in auth:
                     try:
                         author = str(eval(auth[auth.find('=') + 1:]))
-                    except Exception:
+                    except ValueError:
                         pass
             if not version and '__version__' in lines:
                 linespl = lines.splitlines()
@@ -185,7 +185,7 @@ class RunTimeInfo(dict):
                 if len(ver) and ver.find('=') > 0:
                     try:
                         version = str(eval(ver[ver.find('=') + 1:]))
-                    except Exception:
+                    except ValueError:
                         pass
 
         if author or verbose:

--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -23,7 +23,7 @@ from psychopy.clock import  MonotonicClock, monotonicClock
 
 try:
     import ujson as json
-except Exception:
+except ImportError:
     import json
 
 try:

--- a/psychopy/iohub/devices/daq/hw/labjack/win32/python26/pylabjack/__init__.py
+++ b/psychopy/iohub/devices/daq/hw/labjack/win32/python26/pylabjack/__init__.py
@@ -7,12 +7,12 @@ import Modbus
 
 try:
     import skymote
-except Exception:
+except ImportError:
     pass
 
 try:
     import u12
-except Exception:
+except ImportError:
     pass
 
 import u6

--- a/psychopy/iohub/devices/daq/hw/labjack/win32/python27/pylabjack/__init__.py
+++ b/psychopy/iohub/devices/daq/hw/labjack/win32/python27/pylabjack/__init__.py
@@ -7,12 +7,12 @@ import Modbus
 
 try:
     import skymote
-except Exception:
+except ImportError:
     pass
 
 try:
     import u12
-except Exception:
+except ImportError:
     pass
 
 import u6

--- a/psychopy/iohub/devices/eyetracker/hw/theeyetribe/pyTribe.py
+++ b/psychopy/iohub/devices/eyetracker/hw/theeyetribe/pyTribe.py
@@ -10,7 +10,7 @@ from gevent import sleep, socket, queue
 from gevent.server import StreamServer
 try:
     import ujson as json
-except Exception:
+except ImportError:
     import json
 from ..... import print2err,printExceptionDetailsToStdErr,Computer,OrderedDict
 

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/eyetracker.py
@@ -20,7 +20,7 @@ from ...eye_events import *
 
 try:
     from tobiiCalibrationGraphics import TobiiPsychopyCalibrationGraphics
-except Exception:
+except ImportError:
     print2err("Error importing TobiiPsychopyCalibrationGraphics")
     printExceptionDetailsToStdErr()
 
@@ -63,7 +63,7 @@ class EyeTracker(EyeTrackerDevice):
                 from eyex_classes import TobiiEyeXTracker
             else:
                 from tobiiclasses import TobiiTracker
-        except Exception:
+        except ImportError:
             print2err("Error importing tobiiclasses")
             printExceptionDetailsToStdErr()
 

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiclasses.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiclasses.py
@@ -45,7 +45,7 @@ try:
         from tobii.eye_tracking_io.time.sync import SyncManager as TobiiPySyncManager
         from tobii.eye_tracking_io.time.sync import State as TobiiPySyncState
         from tobii.eye_tracking_io.types import Point2D, Point3D
-except Exception:
+except ImportError:
     # This only happens when it is Sphinx auto-doc loading the file
     printExceptionDetailsToStdErr()
 

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -27,7 +27,7 @@ try:
     import ujson
 
     jdumps = ujson.dumps
-except Exception:
+except ImportError:
     import json
 
     jdumps = json.dumps

--- a/psychopy/iohub/devices/mcu/iosync/pysync.py
+++ b/psychopy/iohub/devices/mcu/iosync/pysync.py
@@ -114,7 +114,7 @@ import numpy as np
 try:
     from psychopy.iohub import OrderedDict, print2err,Computer
     getTime=Computer.getTime
-except Exception:
+except ImportError:
     from timeit import default_timer as getTime
     from collections import OrderedDict
     

--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -27,7 +27,7 @@ currentSec= Computer.currentSec
 
 try:
     import ujson as json
-except Exception:
+except ImportError:
     import json
 
 import msgpack

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -391,7 +391,7 @@ try:
                           'for interoperability.' % (version, rversion))
         return NormalizedVersion(rversion)
 
-except Exception:
+except ImportError:
     # just use the version provided if verlib is not installed.
     validate_version=lambda version: version
 

--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -33,7 +33,7 @@ try:
     from matplotlib.backends.backend_wxagg import (FigureCanvasWxAgg
                                                    as FigureCanvas)
     from matplotlib.figure import Figure
-except Exception:
+except ImportError:
     pass
 import numpy
 

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -10,7 +10,7 @@ from psychopy import __version__, logging, hardware
 try:
     import serial
     haveSerial = True
-except Exception:
+except ImportError:
     haveSerial = False
 import os
 import time

--- a/psychopy/platform_specific/darwin.py
+++ b/psychopy/platform_specific/darwin.py
@@ -9,7 +9,7 @@ try:
     import ctypes
     import ctypes.util
     importCtypesFailed = False
-except Exception:
+except ImportError:
     importCtypesFailed = True
     logging.debug("rush() not available because import ctypes "
                   "failed in contrib/darwin.py")

--- a/psychopy/platform_specific/linux.py
+++ b/psychopy/platform_specific/linux.py
@@ -12,7 +12,7 @@ try:
     import ctypes.util
     c = ctypes.cdll.LoadLibrary(ctypes.util.find_library('c'))
     importCtypesFailed = False
-except Exception:
+except ImportError:
     importCtypesFailed = True
     logging.debug("rush() not available because import ctypes, ctypes.util "
                   "failed in psychopy/platform_specific/linux.py")

--- a/psychopy/platform_specific/win32.py
+++ b/psychopy/platform_specific/win32.py
@@ -21,7 +21,7 @@ try:
     from ctypes import windll
     windll = windll.kernel32
     importWindllFailed = False
-except Exception:
+except ImportError:
     importWindllFailed = True
     from .. import logging
     logging.debug("rush() not available because import windll "

--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -71,7 +71,7 @@ for thisLibName in prefs.general['audioLib']:
             msg = ("Audio lib options are currently only 'pyo' or "
                    "'pygame', not '%s'")
             raise ValueError(msg % thisLibName)
-    except Exception:
+    except ImportError:
         msg = '%s audio lib was requested but not loaded: %s'
         logging.warning(msg % (thisLibName, sys.exc_info()[1]))
         continue  # to try next audio lib

--- a/psychopy/tests/test_Installation.py
+++ b/psychopy/tests/test_Installation.py
@@ -45,7 +45,7 @@ def test_extra_imports():
     import egi
     try:
         import labjack
-    except Exception:
+    except ImportError:
         import u3, u6, ue9, LabJackPython
     import ioLabs
     #platform specific

--- a/psychopy/tests/test_all_visual/test_contains_overlaps.py
+++ b/psychopy/tests/test_all_visual/test_contains_overlaps.py
@@ -100,7 +100,7 @@ mpl_version = matplotlib.__version__
 try:
     from matplotlib import nxutils
     have_nxutils = True
-except Exception:
+except ImportError:
     have_nxutils = False
 
 # if matplotlib.__version__ > '1.2': try to use matplotlib Path objects

--- a/psychopy/tests/test_app/test_builder/genComponsTemplate.py
+++ b/psychopy/tests/test_app/test_builder/genComponsTemplate.py
@@ -28,7 +28,7 @@ except Exception:
         tmpApp = wx.App(False)
     try:
         from psychopy.app import localization
-    except Exception:
+    except ImportError:
         pass  # not needed if can't import it
     allComp = getAllComponents(fetchIcons=False)
 

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -42,8 +42,10 @@ class TestComponents(object):
                 tmpApp = wx.PySimpleApp()
             else:
                 tmpApp = wx.App(False)
-            try: from psychopy.app import localization
-            except Exception: pass  # not needed if can't import it
+            try:
+                from psychopy.app import localization
+            except ImportError:
+                pass  # not needed if can't import it
             cls.allComp = getAllComponents(fetchIcons=False)
 
     def setup(self):

--- a/psychopy/tests/test_hardware/test_ports.py
+++ b/psychopy/tests/test_hardware/test_ports.py
@@ -4,7 +4,7 @@ import psychopy.hardware as hw
 import pytest
 try:
     import mock
-except Exception:
+except ImportError:
     def require_mock(fn):
         def _inner():
             pytest.skip("Can't test without Mock")

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -100,7 +100,7 @@ def testDelayDurationAccuracy(sample_size=100):
         assert np.fabs(clockDurVsQpc.mean())<0.00001
         assert clockDurVsQpc.std()<0.000005
         printf("\nDuration Difference Test: PASSED")
-    except Exception:
+    except AssertionError:
         printf("\nDuration Difference Test: FAILED")
     printf("-------------------------------------\n")
 
@@ -169,7 +169,7 @@ def testTimebaseQuality(sample_size=1000):
         assert (callTimes[0].max()*1000.0)<0.1
         assert timer_clock_jumpbacks==0
         printf("\n%s Call Time / Resolution Test: PASSED"%(py_timer_name))
-    except Exception:
+    except AssertionError:
         printf("\n%s Call Time / Resolution Test: FAILED"%(py_timer_name))
 
     try:
@@ -177,7 +177,7 @@ def testTimebaseQuality(sample_size=1000):
         assert (callTimes[1].max()*1000.0)<0.1
         assert core_getTime_jumpbacks==0
         printf("\ncore.getTime() Call Time / Resolution Test: PASSED")
-    except Exception:
+    except AssertionError:
         printf("\ncore.getTime() Call Time / Resolution Test: FAILED")
 
     printf("-------------------------------------\n")
@@ -201,19 +201,19 @@ def testMonotonicClock():
         try:
             x=mc.timeAtLastReset
             assert 1=="MonotonicClock should not have an attribute called 'timeAtLastReset'."
-        except Exception:
+        except AssertionError:
             pass
 
         try:
             x=mc.reset()
             assert 1=="MonotonicClock should not have a method 'reset()'."
-        except Exception:
+        except AssertionError:
             pass
 
         try:
             x=mc.add()
             assert 1=="MonotonicClock should not have a method 'add()'."
-        except Exception:
+        except AssertionError:
             pass
 
         printf(">> MonotonicClock Test: PASSED")

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -8,7 +8,7 @@ from pyglet.window.mouse import LEFT, MIDDLE, RIGHT
 try:
     import pygame
     havePygame = True
-except Exception:
+except ImportError:
     havePygame = False
 import pytest
 import copy

--- a/psychopy/tests/test_misc/test_microphone.py
+++ b/psychopy/tests/test_misc/test_microphone.py
@@ -105,7 +105,7 @@ class TestMicrophoneNoSound(object):
     def setup_class(self):
         try:
             assert _getFlacPath()
-        except Exception:
+        except AssertionError:
             # some of the utils could be designed not to need flac but they
             # currently work on a file that is distributed in flac format
             pytest.skip()

--- a/psychopy/tests/test_sound/test_sound_pygame.py
+++ b/psychopy/tests/test_sound/test_sound_pygame.py
@@ -24,7 +24,7 @@ class TestPygame(object):
         self.contextName='pyo'
         try:
             assert sound.Sound == sound.SoundPygame
-        except Exception:
+        except AssertionError:
             pytest.xfail('need to be using pygame')
         self.tmp = mkdtemp(prefix='psychopy-tests-sound')
 

--- a/psychopy/tests/test_sound/test_sound_pyo.py
+++ b/psychopy/tests/test_sound/test_sound_pyo.py
@@ -23,7 +23,7 @@ class TestPyo(object):
         self.contextName='pyo'
         try:
             assert sound.Sound == sound.SoundPyo
-        except Exception:
+        except AssertionError:
             pytest.xfail('need to be using pyo')
         self.tmp = mkdtemp(prefix='psychopy-tests-sound')
 

--- a/psychopy/tests/utils.py
+++ b/psychopy/tests/utils.py
@@ -12,7 +12,7 @@ except ImportError:
 try:
     import pytest
     usePytest=True
-except Exception:
+except ImportError:
     usePytest=False
 
 from pytest import skip

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -31,7 +31,7 @@ try:
     else:
         from matplotlib import nxutils
     haveMatplotlib = True
-except Exception:
+except ImportError:
     haveMatplotlib = False
 
 

--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -57,7 +57,7 @@ import numpy
 try:
     from pyglet import media
     havePygletMedia = True
-except Exception:
+except ImportError:
     havePygletMedia = False
 
 from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -34,7 +34,7 @@ import numpy
 try:
     import pygame
     havePygame = True
-except Exception:
+except ImportError:
     havePygame = False
 
 defaultLetterHeight = {'cm': 1.0,

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -89,12 +89,12 @@ from . import shaders as _shaders
 try:
     from pyglet import media
     havePygletMedia = True
-except Exception:
+except ImportError:
     havePygletMedia = False
 
 try:
     import pygame
-except Exception:
+except ImportError:
     pass
 
 DEBUG = False

--- a/psychopy/voicekey/__init__.py
+++ b/psychopy/voicekey/__init__.py
@@ -23,7 +23,7 @@ import numpy as np
 try:
     import pyo64 as pyo
     have_pyo64 = True
-except Exception:
+except ImportError:
     import pyo
     have_pyo64 = False
 

--- a/psychopy/voicekey/parallel_vks.py
+++ b/psychopy/voicekey/parallel_vks.py
@@ -12,7 +12,7 @@ from . vk_tools import get_time, sleep
 try:
     from psychopy import parallel
     have_parallel = True
-except Exception:  # ImportError:
+except ImportError:  # ImportError:
     have_parallel = False
 
 

--- a/psychopy/voicekey/vk_tools.py
+++ b/psychopy/voicekey/vk_tools.py
@@ -12,7 +12,7 @@ import numpy as np
 from scipy.signal import butter, lfilter
 try:
     import pyo64 as pyo
-except Exception:
+except ImportError:
     import pyo
 
 


### PR DESCRIPTION
If my continuing efforts to improve the code base and introduce new and unncessary bugs, I have grepped the code for `except Exception` blocks, and explicitly named some more specific exceptions whenever there was an obvious way to do so. Anything that wasn't very clear, I left out.

Ref: #1262 