### PR TITLE
RF: Remove unnecessary `global` statements

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -44,7 +44,6 @@ getTime = None
 #        time.time is used. For Python 2.7 and above, the timeit.default_timer
 #        function is used.
 if sys.platform == 'win32':
-    global _fcounter, _qpfreq, _winQPC
     from ctypes import byref, c_int64, windll
     _fcounter = c_int64()
     _qpfreq = c_int64()

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -54,21 +54,15 @@ if havePyglet:
         MOD_SCROLLLOCK
     )
 
-    global _keyBuffer
     _keyBuffer = []
-    global mouseButtons
     mouseButtons = [0, 0, 0]
-    global mouseWheelRel
     mouseWheelRel = numpy.array([0.0, 0.0])
-    global mouseClick
     # list of 3 clocks that are reset on mouse button presses
     mouseClick = [psychopy.core.Clock(), psychopy.core.Clock(),
                   psychopy.core.Clock()]
-    global mouseTimes
     # container for time elapsed from last reset of mouseClick[n] for any
     # button pressed
     mouseTimes = [0.0, 0.0, 0.0]
-    global mouseMove
     # clock for tracking time of mouse movement, reset when mouse is moved,
     # reset on mouse motion:
     mouseMove = psychopy.core.Clock()

--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -58,7 +58,6 @@ fix_encoding.fix_encoding()
 def _localFunc():
     return None
 
-global IO_HUB_DIRECTORY
 IO_HUB_DIRECTORY=module_directory(_localFunc)
 
 import devices

--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -18,12 +18,7 @@ import json
 from psychopy import gui, iohub
 from psychopy.iohub import FileDialog
 
-global _hubFiles
-
-try:
-    len(_hubFiles)
-except Exception:
-    _hubFiles=[]
+_hubFiles=[]
 
 def openHubFile(filepath,filename,mode):
     """

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -15,7 +15,6 @@ Distributed under the terms of the GNU General Public License (GPL version 3 or 
 #
 # http://docs.python.org/2/library/unicodedata.html
 
-global Keyboard
 Keyboard=None
 
 import numpy as N

--- a/psychopy/iohub/devices/xinput/xinput.py
+++ b/psychopy/iohub/devices/xinput/xinput.py
@@ -23,7 +23,6 @@ from .. import Computer
 ## XInput Functions
 #
 
-global _xinput_dll    
 
 def loadDLL():
     global _xinput_dll


### PR DESCRIPTION
Carefully remove unnecessary `global` statements at the module top level.