### PR TITLE
BF: Filename collisions

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -4334,8 +4334,7 @@ class MultiStairHandler(_BaseTrialHandler):
             label = thisStair.condition['label']
             thisStair.saveAsExcel(
                 fileName, sheetName=label, matrixOnly=matrixOnly,
-                appendFile=append, fileCollisionMethod='rename'
-            )
+                appendFile=append, fileCollisionMethod=fileCollisionMethod)
             append = True
 
     def saveAsText(self, fileName,

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -34,10 +34,12 @@ def handleFileCollision(fileName, fileCollisionMethod):
     elif fileCollisionMethod == 'rename':
         rootName, extension = os.path.splitext(fileName)
         matchingFiles = glob.glob("%s*%s" % (rootName, extension))
-        count = len(matchingFiles)
 
         # Build the renamed string.
-        fileName = "%s_%d%s" % (rootName, count, extension)
+        if not matchingFiles:
+            fileName = "%s%s" % (rootName, extension)
+        else:
+            fileName = "%s_%d%s" % (rootName, len(matchingFiles), extension)
 
         # Check to make sure the new fileName hasn't been taken too.
         if os.path.exists(fileName):


### PR DESCRIPTION
This PR fixes two bugs:
* `data.MultiStairHandler.saveAsExcel()` would ignore the `fileCollisionMethod` keyword argument
* `tools.fileerrortools.handleFileCollision()` would behave incorrectly if `fileCollisionMethod='rename'` was passed and no existing file could be found.

Closes #1207.