### PR TITLE
Fixing a bug in pysoundcard that doesn't play sound from a file corre…

### DIFF
--- a/psychopy/sound.py
+++ b/psychopy/sound.py
@@ -410,10 +410,12 @@ class SoundPySoundCard(_SoundBase):
         self.loops = self.requestedLoops
         try:
             self.sndFile = sndfile.SoundFile(fileName)
-            self.sndArr = self.sndFile.read()
+            sndArr = self.sndFile.read()
             self.sndFile.close()
+            self._setSndFromArray(sndArr)
+
         except Exception:
-            msg = "Sound file %s could not be opened using pygame for sound."
+            msg = "Sound file %s could not be opened using pysoundcard for sound."
             logging.error(msg % fileName)
             raise ValueError(msg % fileName)
 


### PR DESCRIPTION
…ctly

I'm definitely not a master of audio programming, but I was able to get a sound file to play by making these changes.

The original error was from line 425, and was complaining that there is no attribute for "status":

    return self.__dict__['status']
    KeyError: 'status'



In sound.py, the comment in _setSndFromArray (about line 434) indicates that it is the function that will ultimately get called for pysoundcard, and the  _setSndFromFile wasn't ever calling it, hence self._snd was still None, and the module failed to load correctly (see line 174 also, it seems like there is an error that should have been called since self._snd is None?):

    if self._snd is None:
        pass # raise ValueError, "Could not make a "+value+" sound"

Therefore, my fix was to call _setSndFromArray from within _setSndFromFile. I also changed sndArray to be a local variable (removed self.), since this value would be set in _setSndFromArray . I can now play sound files. Please let me know if you have any comments.