### PR TITLE
moviestim3 sound module problem workaround for silent movies

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -180,8 +180,10 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
                         self._mov.audio.to_soundarray(),
                         sampleRate=self._mov.audio.fps)
                 except:
-                    # JWE added this as a patch for a moviepy oddity where the duration is inflated in the saved file
-                    # causes the audioclip to be the wrong length, so round down and it should work
+                    # JWE added this as a patch for a moviepy oddity where the
+                    # duration is inflated in the saved file causes the
+                    # audioclip to be the wrong length, so round down and it
+                    # should work
                     jwe_tmp = self._mov.subclip(0,round(self._mov.duration))
                     self._audioStream = sound.Sound(
                         jwe_tmp.audio.to_soundarray(),

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -31,7 +31,6 @@ reportNDroppedFrames = 10
 import os
 
 from psychopy import logging
-from psychopy import sound
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
@@ -120,6 +119,12 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         self._audioStream = None
         self.useTexSubImage2D = True
 
+        if noAudio:  # to avoid dependency problems in silent movies
+            self.sound = None
+        else:
+            from psychopy import sound
+            self.sound = sound
+
         self._videoClock = Clock()
         self.loadMovie(self.filename)
         self.setVolume(volume)
@@ -169,6 +174,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         if os.path.isfile(filename):
             self._mov = VideoFileClip(filename, audio=(1 - self.noAudio))
             if (not self.noAudio) and (self._mov.audio is not None):
+                sound = self.sound
                 try:
                     self._audioStream = sound.Sound(
                         self._mov.audio.to_soundarray(),
@@ -422,6 +428,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         self._audioSeek(t)
 
     def _audioSeek(self, t):
+        sound = self.sound
         # for sound we need to extract the array again and just begin at new
         # loc
         if self._audioStream is None:

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -184,7 +184,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
                     # duration is inflated in the saved file causes the
                     # audioclip to be the wrong length, so round down and it
                     # should work
-                    jwe_tmp = self._mov.subclip(0,round(self._mov.duration))
+                    jwe_tmp = self._mov.subclip(0, round(self._mov.duration))
                     self._audioStream = sound.Sound(
                         jwe_tmp.audio.to_soundarray(),
                         sampleRate=self._mov.audio.fps)


### PR DESCRIPTION
The related [issue is here](https://github.com/psychopy/psychopy/issues/1305).

I have changed the code to import the sound module depending on the noAudio flag. This removes the current and potentially future sound module dependency problems for movie presentations with no sound. This change does not effect the default behaviour.