### PR TITLE
change viewOri checking to != from is not

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -280,7 +280,7 @@ class Window(object):
         self.viewScale = val2array(viewScale)
         self.viewPos = val2array(viewPos, withScalar=False)
         self.viewOri = float(viewOri)
-        if self.viewOri is not 0. and self.viewPos is not None:
+        if self.viewOri != 0. and self.viewPos is not None:
             raise NotImplementedError("Window: viewPos & viewOri are currently incompatible")
         self.stereo = stereo  # use quad buffer if requested (and if possible)
 


### PR DESCRIPTION
ex:

```
0.0 is not 0.  # this works, until assignments
>>> False

viewOri = 0.0
viewOri is not 0.  # this does not return the desired result
>>> True

viewOri != 0  # desired result
>>> False
```