### PR TITLE
add locale setup to app (OS X)

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import, print_function
 
 import sys
 from psychopy.app._psychopyApp import PsychoPyApp, __version__
+# fix OS X locale-bug on startup: sets locale to LC_ALL (must be defined!)
+import psychopy.locale_setup  # noqa
 
 # NB the PsychoPyApp classes moved to _psychopyApp.py as of version 1.78.00
 # to allow for better upgrading possibilities from the mac app bundle. this


### PR DESCRIPTION
On OS X (ca. 10.10 +) in combination with at least iTerm2, the contents of `LC_ALL` is empty by the time `psychopy.compatibility` calls `import psychopy.data`. This leads to

```python
  File "/Users/cjb/miniconda_envs/psychopy/lib/python2.7/site-packages/matplotlib/__init__.py", line 1009, in _open_file_or_url
    with io.open(fname, encoding=encoding) as f:
LookupError: unknown encoding:
```
Due to `encoding` being `None`. It seems that the fix already exists in

`psychopy/locale_setup.py`

and only impacts OS X installations. This PR simply adds an import of it to `psychopyApp.py`, which fixes the problem for me (see [this gist](https://gist.github.com/cjayb/67d8f6ada85f8fcd58ff1d4e1fc20764) for the conda recipe reproducing my environment).

Update: I'm pretty sure this is related to #1315, so I'm going to be brave and say:

Closes #1315 