### PR TITLE
ENH scaling of window.viewPos according to window units

### DIFF
--- a/psychopy/tests/test_all_visual/test_winScalePos.py
+++ b/psychopy/tests/test_all_visual/test_winScalePos.py
@@ -1,51 +1,66 @@
 
 from psychopy import visual
 from psychopy.tests import utils
-import os, pytest
+import os
+import pytest
 
-v = [(1,1),(1,-1),(-1,-1),(-1,1)]  # vertices to use = square
+v = [(1, 1), (1, -1), (-1, -1), (-1, 1)]  # vertices to use = square
 n = 15  # size of the base square
-pimg = ( n, n)  # position for the image
-pgrn = (-n,-n)  # position for green square
+pimg = (n, n)  # position for the image
+pgrn = (-n, -n)  # position for green square
 img_name = os.path.join(utils.TESTS_DATA_PATH, 'filltext.png')
+
 
 class Test_Win_Scale_Pos_Ori(object):
     def setup_class(self):
-        self.win = visual.Window(size=(200,200), units='pix', allowGUI=False, autoLog=False)
+        self.win = visual.Window(size=(200, 200), units='pix',
+                                 allowGUI=False, autoLog=False)
+
     def teardown_class(self):
         self.win.close()
 
     @pytest.mark.scalepos
     def test_winScalePosOri(self):
         """test window.viewScale and .viewPos simultaneous
-        negative-going scale should mirror-reverse, and position should account for that
-        visually, the green square/rect should move clockwise around the text
+        negative-going scale should mirror-reverse, and position should
+        account for that visually, the green square/rect should move clockwise
+        around the text
 
         Non-zero viewOri would not currently pass with a nonzero viewPos
         """
         with pytest.raises(NotImplementedError):
-            w = visual.Window(size=(200,200), viewPos=(1,1), viewOri=1)
+            _, = visual.Window(size=(200, 200), viewPos=(1, 1), viewOri=1)
 
         for ori in [0, 45]:
             self.win.viewOri = ori
-            for offset in [(0,0), (-.4,0)]:
+            for offset in [(0, 0), (-.4, 0)]:
                 if ori and (offset[0] or offset[1]):
                     continue  # this combination is NotImplemented
                 self.win.viewPos = offset
-                for scale in [[1,1],  # normal: green at lower left
-                              [1,-1],  # mirror vert only: green appears to move up, text mirrored
-                              [-1,-1],  # mirror horiz & vert: green appears to move right, text normal but upside down
-                              [-1,1],  # mirror horiz only: green appears to move down, text mirrored
-                        [2,2],[2,-2],[-2,-2],[-2,2]]:  # same, but both larger
+                for scale in [[1, 1],  # normal: green at lower left
+                              [1, -1],  # mirror vert only: green appears to
+                                        # move up, text mirrored
+                              [-1, -1],  # mirror horiz & vert: green appears
+                                         # to move right, text normal but
+                                         # upside down
+                              [-1, 1],  # mirror horiz only: green appears to
+                                        # move down, text mirrored
+                              [2, 2],  # same, but both larger
+                              [2, -2],
+                              [-2, -2],
+                              [-2, 2]]:
                     self.win.viewScale = scale
                     self.win.flip()
-                    grn = visual.ShapeStim(self.win, vertices=v, pos=pgrn, size=n, fillColor='darkgreen')
-                    img = visual.ImageStim(self.win, image=img_name, size=2*n, pos=pimg)
+                    grn = visual.ShapeStim(self.win, vertices=v, pos=pgrn,
+                                           size=n, fillColor='darkgreen')
+                    img = visual.ImageStim(self.win, image=img_name, size=2*n,
+                                           pos=pimg)
                     grn.draw()
                     img.draw()
 
                     oristr = str(ori)
                     scalestr = str(scale[0]) + ',' + str(scale[1])
                     posstr = str(offset[0]) + ',' + str(offset[1])
-                    filename = 'winScalePos_ori%s_scale%s_pos%s.png' % (oristr, scalestr, posstr)
+                    filename = 'winScalePos_ori%s_scale%s_pos%s.png' % \
+                        (oristr, scalestr, posstr)
                     utils.compareScreenshot(filename, self.win, crit=15)

--- a/psychopy/tests/test_all_visual/test_winScalePos.py
+++ b/psychopy/tests/test_all_visual/test_winScalePos.py
@@ -28,8 +28,13 @@ class Test_Win_Scale_Pos_Ori(object):
 
         Non-zero viewOri would not currently pass with a nonzero viewPos
         """
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(ValueError):
+            # units must be define for viewPos!
             _, = visual.Window(size=(200, 200), viewPos=(1, 1), viewOri=1)
+        with pytest.raises(NotImplementedError):
+            # simultaneous viewPos and viewOri prohibited at present
+            _, = visual.Window(size=(200, 200), units='pix',
+                               viewPos=(1, 1), viewOri=1)
 
         for ori in [0, 45]:
             self.win.viewOri = ori

--- a/psychopy/tests/test_all_visual/test_winScalePos.py
+++ b/psychopy/tests/test_all_visual/test_winScalePos.py
@@ -33,10 +33,16 @@ class Test_Win_Scale_Pos_Ori(object):
 
         for ori in [0, 45]:
             self.win.viewOri = ori
-            for offset in [(0, 0), (-.4, 0)]:
+            for offset in [(0, 0), (-0.4, 0)]:
                 if ori and (offset[0] or offset[1]):
                     continue  # this combination is NotImplemented
-                self.win.viewPos = offset
+                else:  # NB assumes test win is in pixels!
+                    # convert from normalised offset to pixels
+                    offset_pix = (round(offs * siz / 2.) for offs, siz in
+                                  zip(offset, self.win.size))
+
+                    self.win.viewPos = offset_pix
+
                 for scale in [[1, 1],  # normal: green at lower left
                               [1, -1],  # mirror vert only: green appears to
                                         # move up, text mirrored

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -446,6 +446,13 @@ class Window(object):
 
     @attributeSetter
     def viewPos(self, value):
+        """The origin of the window onto which stimulus-objects can be drawn.
+
+        The value should be given in the units defined for the window. NB:
+        Never change a single component (x or y) of the origin, instead replace
+        the viewPos-attribute in one shot, e.g.:
+            win.viewPos = [0.5, 0.1]  # if degrees, x=0.5, y=0.1
+        """
         # first convert to pixels, then normalise to window units
         viewPos_pix = convertToPix([0, 0], list(value),
                                    units=self.units, win=self)[:2]
@@ -671,15 +678,8 @@ class Window(object):
             absScaleX, absScaleY = 1, 1
 
         if self.viewPos is not None:
-            # # first convert to pixels, then normalise to window units
-            # viewPos_pix = convertToPix([0, 0], list(self.viewPos),
-            #                            units=self.units, win=self)[:2]
-            # viewPos_norm = viewPos_pix / (self.size / 2.0)
-            # # Clip to +/- 1; should going out-of-window raise an exception?
-            # viewPos_norm = numpy.clip(viewPos_norm, a_min=-1., a_max=1.)
-            # normRfPosX = viewPos_norm[0] / absScaleX
-            # normRfPosY = viewPos_norm[1] / absScaleY
-            #
+            # viewPos must be in normalised units, see the corresponding
+            # attributeSetter above
             normRfPosX = self.viewPos[0] / absScaleX
             normRfPosY = self.viewPos[1] / absScaleY
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -453,13 +453,19 @@ class Window(object):
         the viewPos-attribute in one shot, e.g.:
             win.viewPos = [0.5, 0.1]  # if degrees, x=0.5, y=0.1
         """
+        self.__dict__['viewPos'] = value
+        # setter takes care of normalisation
+        setattr(self, '_viewPosNorm', value)
+
+    @attributeSetter
+    def _viewPosNorm(self, value):
         # first convert to pixels, then normalise to window units
         viewPos_pix = convertToPix([0, 0], list(value),
                                    units=self.units, win=self)[:2]
         viewPos_norm = viewPos_pix / (self.size / 2.0)
         # Clip to +/- 1; should going out-of-window raise an exception?
         viewPos_norm = numpy.clip(viewPos_norm, a_min=-1., a_max=1.)
-        self.__dict__['viewPos'] = viewPos_norm
+        self.__dict__['_viewPosNorm'] = viewPos_norm
 
     def setViewPos(self, value, log=True):
         setAttribute(self, 'viewPos', value, log=log)
@@ -677,11 +683,11 @@ class Window(object):
         else:
             absScaleX, absScaleY = 1, 1
 
-        if self.viewPos is not None:
+        if self._viewPosNorm is not None:
             # viewPos must be in normalised units, see the corresponding
             # attributeSetter above
-            normRfPosX = self.viewPos[0] / absScaleX
-            normRfPosY = self.viewPos[1] / absScaleY
+            normRfPosX = self._viewPosNorm[0] / absScaleX
+            normRfPosY = self._viewPosNorm[1] / absScaleY
 
             GL.glTranslatef(normRfPosX, normRfPosY, 0.0)
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -296,6 +296,8 @@ class Window(object):
 
         # parameters for transforming the overall view
         self.viewScale = val2array(viewScale)
+        if self.viewPos is not None and self.units is None:
+            raise ValueError('You must define the window units to use viewPos')
         self.viewPos = val2array(viewPos, withScalar=False)
         self.viewOri = float(viewOri)
         if self.viewOri != 0. and self.viewPos is not None:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -446,19 +446,22 @@ class Window(object):
 
     @attributeSetter
     def viewPos(self, value):
-        """The origin of the window onto which stimulus-objects can be drawn.
+        """The origin of the window onto which stimulus-objects are drawn.
 
         The value should be given in the units defined for the window. NB:
         Never change a single component (x or y) of the origin, instead replace
         the viewPos-attribute in one shot, e.g.:
-            win.viewPos = [0.5, 0.1]  # if degrees, x=0.5, y=0.1
+            win.viewPos = [new_xval, new_yval]  # This is the way to do it
+            win.viewPos[0] = new_xval  # DO NOT DO THIS! Errors will result.
         """
         self.__dict__['viewPos'] = value
-        # setter takes care of normalisation
-        setattr(self, '_viewPosNorm', value)
+        if value is not None:
+            # let setter take care of normalisation
+            setattr(self, '_viewPosNorm', value)
 
     @attributeSetter
     def _viewPosNorm(self, value):
+        """Normalised value of viewPos, hidden from user view."""
         # first convert to pixels, then normalise to window units
         viewPos_pix = convertToPix([0, 0], list(value),
                                    units=self.units, win=self)[:2]
@@ -683,9 +686,9 @@ class Window(object):
         else:
             absScaleX, absScaleY = 1, 1
 
-        if self._viewPosNorm is not None:
-            # viewPos must be in normalised units, see the corresponding
-            # attributeSetter above
+        if self.viewPos is not None:
+            # here we must use normalised units in _viewPosNorm,
+            # see the corresponding attributeSetter above
             normRfPosX = self._viewPosNorm[0] / absScaleX
             normRfPosY = self._viewPosNorm[1] / absScaleY
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -444,6 +444,19 @@ class Window(object):
         setAttribute(self, 'units', value, log=log)
 
     @attributeSetter
+    def viewPos(self, value):
+        # first convert to pixels, then normalise to window units
+        viewPos_pix = convertToPix([0, 0], list(value),
+                                   units=self.units, win=self)[:2]
+        viewPos_norm = viewPos_pix / (self.size / 2.0)
+        # Clip to +/- 1; should going out-of-window raise an exception?
+        viewPos_norm = numpy.clip(viewPos_norm, a_min=-1., a_max=1.)
+        self.__dict__['viewPos'] = viewPos_norm
+
+    def setViewPos(self, value, log=True):
+        setAttribute(self, 'viewPos', value, log=log)
+
+    @attributeSetter
     def waitBlanking(self, value):
         """*None*, True or False.
         After a call to flip() should we wait for the blank before the
@@ -657,15 +670,17 @@ class Window(object):
             absScaleX, absScaleY = 1, 1
 
         if self.viewPos is not None:
-            # first convert to pixels, then normalise to window units
-            viewPos_pix = convertToPix([0, 0], list(self.viewPos),
-                                       units=self.units, win=self)[:2]
-            viewPos_norm = viewPos_pix / (self.size / 2.0)
-            # Clip to +/- 1; should going out-of-window raise an exception?
-            viewPos_norm = numpy.clip(viewPos_norm, a_min=-1., a_max=1.)
-
-            normRfPosX = viewPos_norm[0] / absScaleX
-            normRfPosY = viewPos_norm[1] / absScaleY
+            # # first convert to pixels, then normalise to window units
+            # viewPos_pix = convertToPix([0, 0], list(self.viewPos),
+            #                            units=self.units, win=self)[:2]
+            # viewPos_norm = viewPos_pix / (self.size / 2.0)
+            # # Clip to +/- 1; should going out-of-window raise an exception?
+            # viewPos_norm = numpy.clip(viewPos_norm, a_min=-1., a_max=1.)
+            # normRfPosX = viewPos_norm[0] / absScaleX
+            # normRfPosY = viewPos_norm[1] / absScaleY
+            #
+            normRfPosX = self.viewPos[0] / absScaleX
+            normRfPosY = self.viewPos[1] / absScaleY
 
             GL.glTranslatef(normRfPosX, normRfPosY, 0.0)
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -38,7 +38,7 @@ if sys.platform == 'win32':
         haveAvbin = False
         # either avbin isn't installed or scipy.stats has been imported
         # (prevents avbin loading)
-    except Exception, e:
+    except Exception as e:
         # WindowsError on some systems
         # AttributeError if using avbin5 from pyglet 1.2?
         haveAvbin = False
@@ -119,7 +119,8 @@ openWindows = core.openWindows = OpenWinList()  # core needs this for wait()
 
 class Window(object):
     """Used to set up a context in which to draw objects,
-    using either `pyglet <http://www.pyglet.org>`_ or `pygame <http://www.pygame.org>`_
+    using either `pyglet <http://www.pyglet.org>`_ or
+    `pygame <http://www.pygame.org>`_
 
     The pyglet backend allows multiple windows to be created, allows the user
     to specify which screen to use (if more than one is available, duh!) and
@@ -156,7 +157,7 @@ class Window(object):
                  name='window1',
                  checkTiming=True,
                  useFBO=False,
-                 useRetina = False,
+                 useRetina=False,
                  autoLog=True):
         """
         These attributes can only be set at initialization. See further down
@@ -239,7 +240,7 @@ class Window(object):
             self._initParams.remove(unecess)
 
         # Check autoLog value
-        if not autoLog in (True, False):
+        if autoLog not in (True, False):
             raise ValueError(
                 'autoLog must be either True or False for visual.Window')
 
@@ -403,7 +404,7 @@ class Window(object):
             logging.exp("Created %s = %s" % (self.name, str(self)))
 
     def __del__(self):
-        if self._closed == False:
+        if self._closed is False:
             self.close()
 
     def __enter__(self):
@@ -595,7 +596,7 @@ class Window(object):
                 stencilOn = GL.glIsEnabled(GL.GL_STENCIL_TEST)
                 GL.glDisable(GL.GL_STENCIL_TEST)
 
-                if self.bits != None:
+                if self.bits is not None:
                     self.bits._prepareFBOrender()
 
                 # before flipping need to copy the renderBuffer to the
@@ -904,9 +905,11 @@ class Window(object):
         GL.glReadPixels(0, 0, self.size[0], self.size[1],
                         GL.GL_RGBA, GL.GL_UNSIGNED_BYTE, bufferDat)
         try:
-            im = Image.fromstring(mode='RGBA', size=tuple(self.size), data=bufferDat)
+            im = Image.fromstring(mode='RGBA', size=tuple(self.size),
+                                  data=bufferDat)
         except Exception:
-            im = Image.frombytes(mode='RGBA', size=tuple(self.size), data=bufferDat)
+            im = Image.frombytes(mode='RGBA', size=tuple(self.size),
+                                 data=bufferDat)
         im = im.transpose(Image.FLIP_TOP_BOTTOM)
         im = im.convert('RGB')
 
@@ -982,7 +985,7 @@ class Window(object):
                 numpyFrames.append(numpy.array(frame))
             clip = ImageSequenceClip(numpyFrames, fps=fps)
             if fileExt == '.gif':
-                clip.write_gif(fileName,fps=15)
+                clip.write_gif(fileName, fps=15)
             else:
                 clip.write_videofile(fileName, codec=codec)
         elif len(self.movieFrames) == 1:
@@ -1267,7 +1270,7 @@ class Window(object):
                    "Bits++/Bits# enabled. It was ambiguous what should "
                    "happen. Use the setGamma() function of the bits box "
                    "instead")
-            raise DeprecationError, msg
+            raise DeprecationWarning(msg)
         elif self.winType == 'pygame':
             pygame.display.set_gamma(self.gamma[0],
                                      self.gamma[1],
@@ -1395,7 +1398,7 @@ class Window(object):
             GL.glOrtho(0, width, 0, height, -1, 1)
             GL.glMatrixMode(GL.GL_MODELVIEW)
 
-        if self.useRetina and sys.platform=='darwin':
+        if self.useRetina and sys.platform == 'darwin':
             from pyglet.gl.cocoa import CocoaContext
             CocoaContext.attach = retinaAttach
             from pyglet.window.cocoa import CocoaWindow


### PR DESCRIPTION
See discussion in #1322 

__NB__ `tests/test_all_visual/test_winScalePos.py` fails, predictably. Before fixing the test, I'd like to get a quick review on my implementation.

* should the value be (silently) clipped to +/- 1?
* would it be better to write a setter?

I dabbled with using `@attributeSetter` for `viewPos`, but got repeated

```python
TypeError: 'attributeSetter' object does not support indexing
```

Closes #1322 