### PR TITLE
DOC: Make pyglet and pygame links external

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -118,7 +118,7 @@ openWindows = core.openWindows = OpenWinList()  # core needs this for wait()
 
 class Window(object):
     """Used to set up a context in which to draw objects,
-    using either `pyglet <www.pyglet.org>`_ or `pygame <www.pygame.org>`_
+    using either `pyglet <http://www.pyglet.org>`_ or `pygame <http://www.pygame.org>`_
 
     The pyglet backend allows multiple windows to be created, allows the user
     to specify which screen to use (if more than one is available, duh!) and


### PR DESCRIPTION
The links to pyglet and pygame in the docstring for
psychopy.visual.Window were not prefixed with http:// so they were
rendered as relative links (e.g.
http://www.psychopy.org/api/visual/www.pyglet.org).