### PR TITLE
BUG: Fixing variable naming errors in sound module

### DIFF
--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -1140,10 +1140,10 @@ def switchOn(sampleRate=48000, outputDevice=None, bufferSize=None):
     if pyo.serverCreated():
         sound.pyoSndServer.setSamplingRate(sampleRate)
     else:
-        # sound.initPyo() will create pyoSndServer. We want there only
+        # sound.init() will create pyoSndServer. We want there only
         # ever to be one server
         # will automatically use duplex=1 and stereo if poss
-        sound.initPyo(rate=sampleRate)
+        sound.init(rate=sampleRate)
     if outputDevice:
         sound.pyoSndServer.setOutputDevice(outputDevice)
     if bufferSize:

--- a/psychopy/sound/backend_pygame.py
+++ b/psychopy/sound/backend_pygame.py
@@ -5,6 +5,7 @@ from os import path
 from psychopy import logging,exceptions
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
+from ._base import _SoundBase
 
 try:
     import pygame
@@ -13,7 +14,7 @@ except ImportError as err:
     # convert this import error to our own, pyo probably not installed
     raise exceptions.DependencyError(repr(err))
 
-def initPygame(rate=22050, bits=16, stereo=True, buffer=1024):
+def init(rate=22050, bits=16, stereo=True, buffer=1024):
     """If you need a specific format for sounds you need to run this init
     function. Run this *before creating your visual.Window*.
 
@@ -87,7 +88,7 @@ class SoundPygame(_SoundBase):
 
         inits = mixer.get_init()
         if inits is None:
-            initPygame()
+            init()
             inits = mixer.get_init()
         self.sampleRate, self.format, self.isStereo = inits
 

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -220,7 +220,7 @@ class SoundPyo(_SoundBase):
         """
         global pyoSndServer
         if pyoSndServer is None or pyoSndServer.getIsBooted() == 0:
-            initPyo(rate=sampleRate)
+            init(rate=sampleRate)
 
         self.sampleRate = pyoSndServer.getSamplingRate()
         self.format = bits


### PR DESCRIPTION
I encountered these and changed the variable names. I have searched all psychopy files to make sure that no other code use the variable names that I changed before this commit.