### PR TITLE
Improvements to SoundDeviceSound and ImageStim

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -17,7 +17,7 @@ except ImportError as err:
     raise exceptions.DependencyError(repr(err))
 
 import threading
-
+pyoSndServer = None
 
 def init(rate=44100, stereo=True, buffer=128):
     """setup the pyo (sound) server

--- a/psychopy/tests/test_all_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_all_visual/test_all_stimuli.py
@@ -76,7 +76,8 @@ class _baseVisualTest(object):
             str(stim) #check that str(xxx) is working
     def test_imageAndGauss(self):
         win = self.win
-        fileName = os.path.join(utils.TESTS_DATA_PATH, 'testimage.jpg')
+        incorrectName = 'testimage.tif'  # should correctly find testImage.jpg
+        fileName = os.path.join(utils.TESTS_DATA_PATH, incorrectName)
         #use image stim
         size = numpy.array([2.0,2.0])*self.scaleFactor
         image = visual.ImageStim(win, image=fileName, mask='gauss',

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -23,7 +23,6 @@ import copy
 import sys
 import os
 
-import psychopy  # so we can get the __path__
 from psychopy import logging
 
 # tools must only be imported *after* event or MovieStim breaks on win32
@@ -34,7 +33,8 @@ from psychopy.tools.attributetools import (attributeSetter, logAttrib,
 from psychopy.tools.colorspacetools import dkl2rgb, lms2rgb
 from psychopy.tools.monitorunittools import (cm2pix, deg2pix, pix2cm,
                                              pix2deg, convertToPix)
-from psychopy.visual.helpers import pointInPolygon, polygonsOverlap, setColor
+from psychopy.visual.helpers import (pointInPolygon, polygonsOverlap,
+                                     setColor, findImageFile)
 from psychopy.tools.typetools import float_uint8
 from psychopy.tools.arraytools import makeRadialMatrix
 from . import globalVars
@@ -636,7 +636,6 @@ class TextureMixin(object):
         allMaskParams = {'fringeWidth': 0.2, 'sd': 3}
         allMaskParams.update(maskParams)
 
-        cos = numpy.cos
         sin = numpy.sin
         if type(tex) == numpy.ndarray:
             # handle a numpy array
@@ -782,18 +781,18 @@ class TextureMixin(object):
         else:
             if type(tex) in [str, unicode, numpy.string_]:
                 # maybe tex is the name of a file:
-                if not os.path.isfile(tex):
-                    msg = "Couldn't find image file '%s'; check path?"
+                filename = findImageFile(tex)
+                if not filename:
+                    msg = "Couldn't find image '%s'; check path? (tried: %s)"
                     logging.error(msg % tex)
                     logging.flush()
-                    msg = "Couldn't find image '%s'; check path? (tried: %s)"
-                    raise OSError, msg % (tex, os.path.abspath(tex))
+                    raise IOError, msg % (tex, os.path.abspath(tex))
                 try:
-                    im = Image.open(tex)
+                    im = Image.open(filename)
                     im = im.transpose(Image.FLIP_TOP_BOTTOM)
                 except IOError:
                     msg = "Found file '%s', failed to load as an image"
-                    logging.error(msg % (tex))
+                    logging.error(msg % (filename))
                     logging.flush()
                     msg = "Found file '%s' [= %s], failed to load as an image"
                     raise IOError, msg % (tex, os.path.abspath(tex))

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -7,11 +7,10 @@
 # Copyright (C) 2015 Jonathan Peirce
 # Distributed under the terms of the GNU General Public License (GPL).
 
-import sys
 import os
+import copy
 
-import psychopy  # so we can get the __path__
-from psychopy import core, logging, colors
+from psychopy import logging, colors
 
 # tools must only be imported *after* event or MovieStim breaks on win32
 # (JWP has no idea why!)
@@ -277,6 +276,39 @@ def setColor(obj, color, colorSpace=None, operation='',
 immutables = {int, float, str, tuple, long, bool,
               numpy.float64, numpy.float, numpy.int, numpy.long}
 
+def findImageFile(filename):
+    """Tests whether the filename is an image file. If not will try some common
+    alternatives (e.g. extensions .jpg .tif...)
+    """
+    # if user supplied correct path then reutnr quickly
+    isfile = os.path.isfile
+    if isfile(filename):
+        return filename
+    orig = copy.copy(filename)
+
+    # search for file using additional extensions
+
+    extensions = ('.jpg', '.png', '.tif', '.bmp', '.gif', '.jpeg', '.tiff')
+    # not supported: 'svg', 'eps'
+    def logCorrected(orig, actual):
+        logging.warn("Requested image {!r} not found but similar filename "
+                    "{!r} exists. This will be used instead but changing the "
+                    "filename is advised.".format(orig, actual))
+
+    # it already has one but maybe it's wrong? Remove it
+    if filename.endswith(extensions):
+        filename = os.path.splitext(orig)[0]
+    if isfile(filename):
+        # had an extension but didn't need one (mac?)
+        logCorrected(orig, filename)
+        return filename
+
+    # try adding the standard set of extensions
+    for ext in extensions:
+        if isfile(filename+ext):
+            filename += ext
+            logCorrected(orig, filename)
+            return filename
 
 def groupFlipVert(flipList, yReflect=0):
     """Reverses the vertical mirroring of all items in list ``flipList``.


### PR DESCRIPTION
SoundDeviceSound now supports MovieStim3

Images now check possible extensions:
  - first check if string is a note name
  - then check if is a file
  - if neither then, rather than raise error, we now check whether
    - removing the extension reveals a file
    - adding other common extensions (jpg, png, bmp etc) reveals file
Although it's possible that this will lead to an incorrect file, it will only do so when no option was available