### PR TITLE
BF: Unicode key presses and timestamp in event.py is throwing IndexError

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -336,12 +336,12 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
         _last = timeStamped.getLastResetTime()
         _clockLast = psychopy.core.monotonicClock.getLastResetTime()
         timeBaseDiff = _last - _clockLast
-        relTuple = [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[2] - timeBaseDiff)) for k in targets]
+        relTuple = [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[-1] - timeBaseDiff)) for k in targets]
         return relTuple
     elif timeStamped is True:
-        return [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[2])) for k in targets]
+        return [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[-1])) for k in targets]
     elif isinstance(timeStamped, (float, int, long)):
-        relTuple = [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[2] - timeStamped)) for k in targets]
+        relTuple = [filter(None, (k[0], modifiers and modifiers_dict(k[1]) or None, k[-1] - timeStamped)) for k in targets]
         return relTuple
 
 


### PR DESCRIPTION
In event.py, since the tuples added to the _keyBuffer are either 3 or… or 2 items in length depending on which part of the code handles the keypress, if a non-ascii character is pressed and timeStamped=True the tuple only has 2 items, yet the return in getKeys is trying to access a the third element of the tuple, so we're getting an index error. This simply changes k[2] to k[-1], to get the last item of the tuple, instead of the third item of the tuple.

This is a quick fix that I hope would have no ill effect, and I'm not super familiar with pyglet and keypresses, but one thing that I thought is worth asking about is if all of the tuples placed in _keyBuffer should be of the same length. See the differences between _onPygletKey and _onPygletText, one of which includes a boolean value indicating if modifiers are present (keyName, containsModifers, timeStamp) vs. (keyName, timeStamp).