### PR TITLE
DOC: Move platform-specific packages from general dependency list

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -71,8 +71,15 @@ Then, if you want **everything** available you could paste this in to your termi
   pip install numpy scipy matplotlib pandas pyopengl pyglet pillow moviepy lxml openpyxl xlrd configobj pyyaml gevent greenlet msgpack-python psutil tables requests[security] pyosf cffi pysoundcard pysoundfile seaborn psychopy_ext python-bidi psychopy
   pip install pyserial pyparallel egi iolabs
   pip install pytest coverage sphinx
+
+Needed on Windows::
+
   pip install pypiwin32
-  pip install pyobjc
+
+Needed on Mac OS X::
+
+  pip install pyobjc # takes a while!
+
 
 OR you could just install the subsets of packages that you want::
 
@@ -91,14 +98,6 @@ OR you could just install the subsets of packages that you want::
 
   # alternative audio (easier than pyo to install)
   pip install cffi pysoundcard pysoundfile
-
-Needed on Windows::
-
-  pip install pypiwin32
-
-Needed on Mac OS X::
-
-  pip install pyobjc # takes a while!
 
 Handy extra options::
 


### PR DESCRIPTION
Slight rearrangement of the Dependencies section of the installation doc page. pypiwin32 and pyobjc were included in a list of packages that could be installed in one go, but these two are platform specific. They were removed from the first list, and the sections stating that they were required for Windows and Mac, respectively, were moved just under the longer list.