### PR TITLE
Bugfixing sound

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -9,6 +9,7 @@ from psychopy import core, logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from ._base import _SoundBase
+from . import _bestDriver
 
 try:
     import pyo

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -82,7 +82,7 @@ class _StreamsDict(dict):
 
         usage:
 
-            label, stream = streams.getSimilar(sampleRate=44100,  # must match
+            label, stream = streams._getSimilar(sampleRate=44100,  # must match
                                                channels=-1,  # any
                                                blockSize=-1)  # wildcard
         """
@@ -329,7 +329,7 @@ class SoundDeviceSound(_SoundBase):
         except SoundFormatError as err:
             # try to use something similar (e.g. mono->stereo)
             # then check we have an appropriate stream open
-            altern = streams.getSimilar(sampleRate=self.sampleRate,
+            altern = streams._getSimilar(sampleRate=self.sampleRate,
                                         channels=-1,
                                         blockSize=-1)
             if altern is None:


### PR DESCRIPTION
I encountered these bugs on a Windows computer but fixed them using my linux (don't have a Windows nearby), so I was not able to verify that it works. At least it can't get more broken than it was ;-)

Wondering if *_bestDriver* should be moved from `sound/__init__.py` to `sound/backend_pyo.py` since that's the only place it's used?