### PR TITLE
RF/NF/TEST: DlgFromDict improvements & Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-lxml
   - travis_retry sudo apt-get install -qq python-configobj python-imaging python-openpyxl python-mock python-wxgtk2.8 libavbin0 python-pyo
   - travis_retry sudo apt-get install -qq python-pandas
+  - travis_retry sudo apt-get install -qq python-qt4
   - travis_retry sudo pip install -qq codecov
 install:
   - travis_retry sudo apt-get install -qq flac

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -328,6 +328,14 @@ class DlgFromDict(Dlg):
     """Creates a dialogue box that represents a dictionary of values.
     Any values changed by the user are change (in-place) by this
     dialogue box.
+
+    Parameters
+    ----------
+
+    sort_keys : bool
+        Whether the dictionaries keys should be ordered alphabetically
+        for displaying.
+
     e.g.:
 
     ::
@@ -353,13 +361,16 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=(), order=(),
-                 tip=None, screen=-1):
+                 tip=None, screen=-1, sort_keys=True):
         if not tip:
             tip = {}
         Dlg.__init__(self, title, screen=screen)
         self.dictionary = dictionary
         keys = self.dictionary.keys()
-        keys.sort()
+
+        if sort_keys:
+            keys.sort()
+
         if len(order):
             keys = order + list(set(keys).difference(set(order)))
         types = dict([])

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -333,7 +333,7 @@ class DlgFromDict(Dlg):
     ----------
 
     sort_keys : bool
-        Whether the dictionaries keys should be ordered alphabetically
+        Whether the dictionary keys should be ordered alphabetically
         for displaying.
 
     copy_dict : bool

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -10,7 +10,7 @@ try:
     from PyQt4 import QtGui
     QtWidgets = QtGui  # in qt4 these were all in one package
     from PyQt4.QtCore import Qt
-except Exception:
+except ImportError:
     from PyQt5 import QtWidgets
     from PyQt5 import QtGui
     from PyQt5.QtCore import Qt

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -395,7 +395,7 @@ class DlgFromDict(Dlg):
         if sort_keys:
             self._keys.sort()
         if order:
-            self._keys = order + list(set(self._keys).difference(set(order)))
+            self._keys = list(order) + list(set(self._keys).difference(set(order)))
 
         types = dict()
 

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -336,6 +336,12 @@ class DlgFromDict(Dlg):
         Whether the dictionaries keys should be ordered alphabetically
         for displaying.
 
+    copy_dict : bool
+        If False, modify ``dictionary`` in-place. If True, a copy of
+        the dictionary is created, and the altered version (after
+        user interaction) can be retrieved from
+        :attr:~`psychopy.gui.DlgFromDict.dictionary`.
+
     e.g.:
 
     ::
@@ -361,11 +367,16 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=(), order=(),
-                 tip=None, screen=-1, sort_keys=True):
+                 tip=None, screen=-1, sort_keys=True, copy_dict=False):
         if not tip:
             tip = {}
         Dlg.__init__(self, title, screen=screen)
-        self.dictionary = dictionary
+
+        if copy_dict:
+            self.dictionary = dictionary.copy()
+        else:
+            self.dictionary = dictionary
+
         keys = self.dictionary.keys()
 
         if sort_keys:

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -342,6 +342,11 @@ class DlgFromDict(Dlg):
         user interaction) can be retrieved from
         :attr:~`psychopy.gui.DlgFromDict.dictionary`.
 
+    show : bool
+        Whether to immediately display the dialog upon instantiation.
+         If False, it can be displayed at a later time by calling
+         its `show()` method.
+
     e.g.:
 
     ::
@@ -367,7 +372,8 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=None, order=None,
-                 tip=None, screen=-1, sort_keys=True, copy_dict=False):
+                 tip=None, screen=-1, sort_keys=True, copy_dict=False,
+                 show=True):
         if fixed is None:
             fixed = []
         if order is None:
@@ -382,16 +388,16 @@ class DlgFromDict(Dlg):
         else:
             self.dictionary = dictionary
 
-        keys = self.dictionary.keys()
+        self._keys = self.dictionary.keys()
 
         if sort_keys:
-            keys.sort()
+            self._keys.sort()
         if order:
-            keys = order + list(set(keys).difference(set(order)))
+            self._keys = order + list(set(self._keys).difference(set(order)))
 
         types = dict()
 
-        for field in keys:
+        for field in self._keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''
             if field in tip.keys():
@@ -404,9 +410,15 @@ class DlgFromDict(Dlg):
             else:
                 self.addField(field, self.dictionary[field], tip=tooltip)
 
+        if show:
+            self.show()
+
+    def show(self):
+        """Display the dialog.
+        """
         ok_data = self.exec_()
         if ok_data:
-            for n, thisKey in enumerate(keys):
+            for n, thisKey in enumerate(self._keys):
                 self.dictionary[thisKey] = ok_data[n]
 
 

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -373,7 +373,7 @@ class DlgFromDict(Dlg):
         if order is None:
             order = []
         if not tip:
-            tip = {}
+            tip = dict()
 
         Dlg.__init__(self, title, screen=screen)
 
@@ -386,10 +386,11 @@ class DlgFromDict(Dlg):
 
         if sort_keys:
             keys.sort()
-
         if order:
             keys = order + list(set(keys).difference(set(order)))
-        types = dict([])
+
+        types = dict()
+
         for field in keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -374,11 +374,13 @@ class DlgFromDict(Dlg):
     def __init__(self, dictionary, title='', fixed=None, order=None,
                  tip=None, screen=-1, sort_keys=True, copy_dict=False,
                  show=True):
-        if fixed is None:
+        # We don't explicitly check for None identity of `fixed` and
+        # `order` for backward-compatibility reasons.
+        if not fixed:
             fixed = []
-        if order is None:
+        if not order:
             order = []
-        if not tip:
+        if tip is None:
             tip = dict()
 
         Dlg.__init__(self, title, screen=screen)

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -366,10 +366,15 @@ class DlgFromDict(Dlg):
     See GUI.py for a usage demo, including order and tip (tooltip).
     """
 
-    def __init__(self, dictionary, title='', fixed=(), order=(),
+    def __init__(self, dictionary, title='', fixed=None, order=None,
                  tip=None, screen=-1, sort_keys=True, copy_dict=False):
+        if fixed is None:
+            fixed = []
+        if order is None:
+            order = []
         if not tip:
             tip = {}
+
         Dlg.__init__(self, title, screen=screen)
 
         if copy_dict:
@@ -382,7 +387,7 @@ class DlgFromDict(Dlg):
         if sort_keys:
             keys.sort()
 
-        if len(order):
+        if order:
             keys = order + list(set(keys).difference(set(order)))
         types = dict([])
         for field in keys:

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -374,13 +374,13 @@ class DlgFromDict(Dlg):
     def __init__(self, dictionary, title='', fixed=None, order=None,
                  tip=None, screen=-1, sort_keys=True, copy_dict=False,
                  show=True):
-        # We don't explicitly check for None identity of `fixed` and
-        # `order` for backward-compatibility reasons.
+        # We don't explicitly check for None identity
+        #  for backward-compatibility reasons.
         if not fixed:
             fixed = []
         if not order:
             order = []
-        if tip is None:
+        if not tip:
             tip = dict()
 
         Dlg.__init__(self, title, screen=screen)

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -264,7 +264,7 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=None, order=None, tip=None,
-                 sort_keys=True, copy_dict=True, show=True):
+                 sort_keys=True, copy_dict=False, show=True):
         # We don't explicitly check for None identity
         # for backward-compatibility reasons.
         if not fixed:

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -264,9 +264,11 @@ class DlgFromDict(Dlg):
             fixed = []
         if order is None:
             order = []
+        if not tip:
+            tip = dict()
 
-        Dlg.__init__(self, title)
         # app = ensureWxApp() done by Dlg
+        Dlg.__init__(self, title)
 
         if copy_dict:
             self.dictionary = dictionary.copy()
@@ -277,12 +279,11 @@ class DlgFromDict(Dlg):
 
         if sort_keys:
             keys.sort()
-
-        tip = tip or {}
-
         if order:
             keys = order + list(set(keys).difference(set(order)))
-        types = dict([])
+
+        types = dict()
+
         for field in keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''
@@ -295,6 +296,7 @@ class DlgFromDict(Dlg):
                               tip=tooltip)
             else:
                 self.addField(field, self.dictionary[field], tip=tooltip)
+
         # show it and collect data
         self.show()
         if self.OK:

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -234,6 +234,11 @@ class DlgFromDict(Dlg):
         user interaction) can be retrieved from
         :attr:~`psychopy.gui.DlgFromDict.dictionary`.
 
+    show : bool
+        Whether to immediately display the dialog upon instantiation.
+         If False, it can be displayed at a later time by calling
+         its `show()` method.
+
     e.g.:
 
     ::
@@ -259,7 +264,7 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=None, order=None, tip=None,
-                 sort_keys=True, copy_dict=True):
+                 sort_keys=True, copy_dict=True, show=True):
         if fixed is None:
             fixed = []
         if order is None:
@@ -275,16 +280,16 @@ class DlgFromDict(Dlg):
         else:
             self.dictionary = dictionary
 
-        keys = self.dictionary.keys()
+        self._keys = self.dictionary.keys()
 
         if sort_keys:
-            keys.sort()
+            self._keys.sort()
         if order:
-            keys = order + list(set(keys).difference(set(order)))
+            self._keys = order + list(set(self._keys).difference(set(order)))
 
         types = dict()
 
-        for field in keys:
+        for field in self._keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''
             if field in tip.keys():
@@ -297,10 +302,15 @@ class DlgFromDict(Dlg):
             else:
                 self.addField(field, self.dictionary[field], tip=tooltip)
 
-        # show it and collect data
+        if show:
+            self.show()
+
+    def show(self):
+        """Display the dialog.
+        """
         self.show()
         if self.OK:
-            for n, thisKey in enumerate(keys):
+            for n, thisKey in enumerate(self._keys):
                 self.dictionary[thisKey] = self.data[n]
 
 

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -265,13 +265,13 @@ class DlgFromDict(Dlg):
 
     def __init__(self, dictionary, title='', fixed=None, order=None, tip=None,
                  sort_keys=True, copy_dict=True, show=True):
-        # We don't explicitly check for None identity of `fixed` and
-        # `order` for backward-compatibility reasons.
+        # We don't explicitly check for None identity
+        # for backward-compatibility reasons.
         if not fixed:
             fixed = []
         if not order:
             order = []
-        if tip is None:
+        if not tip:
             tip = dict()
 
         # app = ensureWxApp() done by Dlg

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -225,7 +225,7 @@ class DlgFromDict(Dlg):
     ----------
 
     sort_keys : bool
-        Whether the dictionaries keys should be ordered alphabetically
+        Whether the dictionary keys should be ordered alphabetically
         for displaying.
 
     copy_dict : bool

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -287,7 +287,7 @@ class DlgFromDict(Dlg):
         if sort_keys:
             self._keys.sort()
         if order:
-            self._keys = order + list(set(self._keys).difference(set(order)))
+            self._keys = list(order) + list(set(self._keys).difference(set(order)))
 
         types = dict()
 

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -228,6 +228,12 @@ class DlgFromDict(Dlg):
         Whether the dictionaries keys should be ordered alphabetically
         for displaying.
 
+    copy_dict : bool
+        If False, modify ``dictionary`` in-place. If True, a copy of
+        the dictionary is created, and the altered version (after
+        user interaction) can be retrieved from
+        :attr:~`psychopy.gui.DlgFromDict.dictionary`.
+
     e.g.:
 
     ::
@@ -253,10 +259,15 @@ class DlgFromDict(Dlg):
     """
 
     def __init__(self, dictionary, title='', fixed=(), order=(), tip=None,
-                 sort_keys=True):
+                 sort_keys=True, copy_dict=True):
         Dlg.__init__(self, title)
         # app = ensureWxApp() done by Dlg
-        self.dictionary = dictionary
+
+        if copy_dict:
+            self.dictionary = dictionary.copy()
+        else:
+            self.dictionary = dictionary
+
         keys = self.dictionary.keys()
 
         if sort_keys:

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -220,6 +220,14 @@ class DlgFromDict(Dlg):
     """Creates a dialogue box that represents a dictionary of values.
     Any values changed by the user are change (in-place) by this
     dialogue box.
+
+    Parameters
+    ----------
+
+    sort_keys : bool
+        Whether the dictionaries keys should be ordered alphabetically
+        for displaying.
+
     e.g.:
 
     ::
@@ -244,12 +252,16 @@ class DlgFromDict(Dlg):
     See GUI.py for a usage demo, including order and tip (tooltip).
     """
 
-    def __init__(self, dictionary, title='', fixed=(), order=(), tip=None):
+    def __init__(self, dictionary, title='', fixed=(), order=(), tip=None,
+                 sort_keys=True):
         Dlg.__init__(self, title)
         # app = ensureWxApp() done by Dlg
         self.dictionary = dictionary
         keys = self.dictionary.keys()
-        keys.sort()
+
+        if sort_keys:
+            keys.sort()
+
         tip = tip or {}
         if len(order):
             keys = order + list(set(keys).difference(set(order)))

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -258,8 +258,13 @@ class DlgFromDict(Dlg):
     See GUI.py for a usage demo, including order and tip (tooltip).
     """
 
-    def __init__(self, dictionary, title='', fixed=(), order=(), tip=None,
+    def __init__(self, dictionary, title='', fixed=None, order=None, tip=None,
                  sort_keys=True, copy_dict=True):
+        if fixed is None:
+            fixed = []
+        if order is None:
+            order = []
+
         Dlg.__init__(self, title)
         # app = ensureWxApp() done by Dlg
 
@@ -274,7 +279,8 @@ class DlgFromDict(Dlg):
             keys.sort()
 
         tip = tip or {}
-        if len(order):
+
+        if order:
             keys = order + list(set(keys).difference(set(order)))
         types = dict([])
         for field in keys:

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -265,11 +265,13 @@ class DlgFromDict(Dlg):
 
     def __init__(self, dictionary, title='', fixed=None, order=None, tip=None,
                  sort_keys=True, copy_dict=True, show=True):
-        if fixed is None:
+        # We don't explicitly check for None identity of `fixed` and
+        # `order` for backward-compatibility reasons.
+        if not fixed:
             fixed = []
-        if order is None:
+        if not order:
             order = []
-        if not tip:
+        if tip is None:
             tip = dict()
 
         # app = ensureWxApp() done by Dlg

--- a/psychopy/tests/test_gui/test_DlgFromDictQt.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictQt.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+try:
+    from PyQt5.QtCore import Qt
+    from PyQt5.QtTest import QTest
+except ImportError:
+    from PyQt4.QtCore import Qt
+    from PyQt4.QtTest import QTest
+
+from collections import OrderedDict
+from psychopy.gui.qtgui import DlgFromDict
+
+
+class TestDlgFromDictQt():
+    def setup(self):
+        self.d = dict(
+            participant='000',
+            handedness=['r', 'l'],
+            exp_type=['foo', 'bar'],
+            exp_version='2017-01-02')
+
+        self.title = 'Experiment'
+
+    def test_title(self):
+        dlg = DlgFromDict(self.d, title=self.title, show=False)
+        assert dlg.windowTitle() == self.title
+
+    def test_sort_keys_true(self):
+        dlg = DlgFromDict(self.d, sort_keys=True, show=False)
+        keys = self.d.copy().keys()
+        keys.sort()
+        assert keys == dlg._keys
+
+    def test_sort_keys_false(self):
+        dlg = DlgFromDict(self.d, sort_keys=False, show=False)
+        keys = self.d.copy().keys()
+        assert keys == dlg._keys
+
+    def test_copy_dict_true(self):
+        dlg = DlgFromDict(self.d, copy_dict=True, show=False)
+        assert self.d is not dlg.dictionary
+
+    def test_copy_dict_false(self):
+        dlg = DlgFromDict(self.d, copy_dict=False, show=False)
+        assert self.d is dlg.dictionary
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main()

--- a/psychopy/tests/test_gui/test_DlgFromDictQt.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictQt.py
@@ -20,6 +20,12 @@ class TestDlgFromDictQt():
             exp_type=['foo', 'bar'],
             exp_version='2017-01-02')
 
+        self.od = OrderedDict(
+            [('participant', '000'),
+             ('handedness', ['r', 'l']),
+             ('exp_type', ['foo', 'bar']),
+             ('exp_version', '2017-01-02')])
+
         self.title = 'Experiment'
 
     def test_title(self):
@@ -44,6 +50,24 @@ class TestDlgFromDictQt():
     def test_copy_dict_false(self):
         dlg = DlgFromDict(self.d, copy_dict=False, show=False)
         assert self.d is dlg.dictionary
+
+    def test_order_list(self):
+        order = ['exp_type', 'participant', 'handedness', 'exp_version']
+        # Be certain we will actually request a different order
+        # further down.
+        assert order != self.od.keys()
+
+        dlg = DlgFromDict(self.od, order=order, show=False)
+        assert dlg.inputFieldNames == order
+
+    def test_order_tuple(self):
+        order = ('exp_type', 'participant', 'handedness', 'exp_version')
+        # Be certain we will actually request a different order
+        # further down.
+        assert list(order) != self.od.keys()
+
+        dlg = DlgFromDict(self.od, order=order, show=False)
+        assert dlg.inputFieldNames == list(order)
 
 
 if __name__ == '__main__':

--- a/psychopy/tests/test_gui/test_DlgFromDictQt.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictQt.py
@@ -75,6 +75,11 @@ class TestDlgFromDictQt():
         field = dlg.inputFields[dlg.inputFieldNames.index(fixed)]
         assert field.isEnabled() is False
 
+    def test_tooltips(self):
+        tip = dict(participant='Tooltip')
+        dlg = DlgFromDict(self.d, tip=tip, show=False)
+        field = dlg.inputFields[dlg.inputFieldNames.index('participant')]
+        assert field.toolTip() == tip['participant']
 
 if __name__ == '__main__':
     import pytest

--- a/psychopy/tests/test_gui/test_DlgFromDictQt.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictQt.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-try:
-    from PyQt5.QtCore import Qt
-    from PyQt5.QtTest import QTest
-except ImportError:
-    from PyQt4.QtCore import Qt
-    from PyQt4.QtTest import QTest
-
 from collections import OrderedDict
 from psychopy.gui.qtgui import DlgFromDict
 

--- a/psychopy/tests/test_gui/test_DlgFromDictQt.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictQt.py
@@ -69,6 +69,12 @@ class TestDlgFromDictQt():
         dlg = DlgFromDict(self.od, order=order, show=False)
         assert dlg.inputFieldNames == list(order)
 
+    def test_fixed(self):
+        fixed = 'exp_version'
+        dlg = DlgFromDict(self.d, fixed=fixed, show=False)
+        field = dlg.inputFields[dlg.inputFieldNames.index(fixed)]
+        assert field.isEnabled() is False
+
 
 if __name__ == '__main__':
     import pytest

--- a/psychopy/tests/test_gui/test_DlgFromDictWx.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictWx.py
@@ -62,6 +62,12 @@ class TestDlgFromDictWx():
         dlg = DlgFromDict(self.od, order=order, show=False)
         assert dlg.inputFieldNames == list(order)
 
+    def test_fixed(self):
+        fixed = 'exp_version'
+        dlg = DlgFromDict(self.d, fixed=fixed, show=False)
+        field = dlg.inputFields[dlg.inputFieldNames.index(fixed)]
+        assert field.Enabled is False
+
 
 if __name__ == '__main__':
     import pytest

--- a/psychopy/tests/test_gui/test_DlgFromDictWx.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictWx.py
@@ -68,6 +68,12 @@ class TestDlgFromDictWx():
         field = dlg.inputFields[dlg.inputFieldNames.index(fixed)]
         assert field.Enabled is False
 
+    def test_tooltips(self):
+        tip = dict(participant='Tooltip')
+        dlg = DlgFromDict(self.d, tip=tip, show=False)
+        field = dlg.inputFields[dlg.inputFieldNames.index('participant')]
+        assert field.ToolTipString == tip['participant']
+
 
 if __name__ == '__main__':
     import pytest

--- a/psychopy/tests/test_gui/test_DlgFromDictWx.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictWx.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from collections import OrderedDict
+from psychopy.gui.wxgui import DlgFromDict
+
+
+class TestDlgFromDictWx():
+    def setup(self):
+        self.d = dict(
+            participant='000',
+            handedness=['r', 'l'],
+            exp_type=['foo', 'bar'],
+            exp_version='2017-01-02')
+
+        self.title = 'Experiment'
+
+    def test_title(self):
+        dlg = DlgFromDict(self.d, title=self.title, show=False)
+        assert dlg.Title == self.title
+
+    def test_sort_keys_true(self):
+        dlg = DlgFromDict(self.d, sort_keys=True, show=False)
+        keys = self.d.copy().keys()
+        keys.sort()
+        assert keys == dlg._keys
+
+    def test_sort_keys_false(self):
+        dlg = DlgFromDict(self.d, sort_keys=False, show=False)
+        keys = self.d.copy().keys()
+        assert keys == dlg._keys
+
+    def test_copy_dict_true(self):
+        dlg = DlgFromDict(self.d, copy_dict=True, show=False)
+        assert self.d is not dlg.dictionary
+
+    def test_copy_dict_false(self):
+        dlg = DlgFromDict(self.d, copy_dict=False, show=False)
+        assert self.d is dlg.dictionary
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main()

--- a/psychopy/tests/test_gui/test_DlgFromDictWx.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictWx.py
@@ -13,6 +13,12 @@ class TestDlgFromDictWx():
             exp_type=['foo', 'bar'],
             exp_version='2017-01-02')
 
+        self.od = OrderedDict(
+            [('participant', '000'),
+             ('handedness', ['r', 'l']),
+             ('exp_type', ['foo', 'bar']),
+             ('exp_version', '2017-01-02')])
+
         self.title = 'Experiment'
 
     def test_title(self):
@@ -37,6 +43,24 @@ class TestDlgFromDictWx():
     def test_copy_dict_false(self):
         dlg = DlgFromDict(self.d, copy_dict=False, show=False)
         assert self.d is dlg.dictionary
+
+    def test_order_list(self):
+        order = ['exp_type', 'participant', 'handedness', 'exp_version']
+        # Be certain we will actually request a different order
+        # further down.
+        assert order != self.od.keys()
+
+        dlg = DlgFromDict(self.od, order=order, show=False)
+        assert dlg.inputFieldNames == order
+
+    def test_order_tuple(self):
+        order = ('exp_type', 'participant', 'handedness', 'exp_version')
+        # Be certain we will actually request a different order
+        # further down.
+        assert list(order) != self.od.keys()
+
+        dlg = DlgFromDict(self.od, order=order, show=False)
+        assert dlg.inputFieldNames == list(order)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Allow to disable automatic sorting of dictionary keys when constructing the input fields
- Make in-place modification of passed dictionary optional
- Allow creation of a `DlgFromDict` object without automatically displaying the dialog; this is esp. useful for automated unit testing
- Make the `order` kwarg more robust: it should now be able to deal with more kinds of iterables
- Streamline the constructor signature a little bit to make it clearer, while ensuring backward-compatibility
- Small number of style improvements
- Add tests