### PR TITLE
NF: Global Keyboard Events

### DIFF
--- a/docs/source/coder/coder.rst
+++ b/docs/source/coder/coder.rst
@@ -28,7 +28,8 @@ Basic Concepts
    codeStimuli
    codeLogging
    code*
-	
+   globalKeys
+
 .. _tutorials:
 
 PsychoPy Tutorials

--- a/docs/source/coder/globalKeys.rst
+++ b/docs/source/coder/globalKeys.rst
@@ -1,0 +1,314 @@
+Global Event Keys
+=================
+
+Global event keys are single keys (or combinations of a single key and one or
+more "modifier" keys such as Ctrl, Alt, etc.) with an associated Python
+callback function. This function will be executed if the key (or
+key/modifiers combination) was pressed.
+
+.. note::
+
+   Global event keys only work with the `pyglet` backend, which is the default.
+
+PsychoPy fully automatically monitors and processes key presses during most
+portions of the experimental run, for example during
+`core.wait()` periods, or when calling `win.flip()`. If a global
+event key press is detected, the specified function will be run
+immediately. You are not required to manually poll and check for key
+presses. This can be particularly useful to implement a global
+"shutdown" key, or to trigger laboratory equipment on a key press
+when testing your experimental script -- without cluttering the code.
+But of course the application is not limited to these two scenarios.
+In fact, you can associate any Python function with a global event key.
+
+All active global event keys are stored in `event.globalKeys`.
+
+Adding a global event key (simple)
+----------------------------------
+First, let's ensure no global event keys are currently set by calling
+func:`event.globalKeys.clear`.
+::
+    >>> from psychopy import event
+    >>> event.globalKeys.clear()
+
+To add a new global event key, you need to invoke
+func:`event.globalKeys.add`. This function has two required arguments: the
+key name, and the function to associate with that key.
+::
+    >>> key = 'a'
+    >>> def myfunc():
+    ...     pass
+    ...
+    >>> event.globalKeys.add(key=key, func=myfunc)
+
+Look at `event.globalKeys`, we can see that the global event key has indeed
+been created.
+::
+
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [A] -> 'myfunc' <function myfunc at 0x10669ba28>
+    >
+
+Your output should look similar. You may happen to spot
+We can take a closer look at the specific global key event we added.
+::
+
+    >>> event.globalKeys['a']
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+
+This output tells us that
+
+- our key `a` is associated with our function `myfunc`
+
+- `myfunc` will be called without passing any positional or keyword
+  arguments (`func_args` and `func_kwargs`, respectively)
+
+- the event name was automatically set to the name of the function.
+
+.. note::
+
+   Pressing the key won't do anything unless a :class:`psychopy.visual.Window`
+   is created and and its :func:~`psychopy.visual.Window.flip` method or
+   :func:`psychopy.core.wait` are called.
+
+Adding a global event key (advanced)
+------------------------------------
+We are going to associate a function with a more complex calling signature
+(with positional and keyword arguments) with a global event key. First, let's
+create the dummy function:
+::
+
+    >>> def myfunc2(*args, **kwargs):
+    ...     pass
+    ...
+
+Next, compile some positional and keyword arguments and a custom name for this
+event. Positional arguments must be passed as tists or uples, and keyword
+arguments as dictionaries.
+::
+
+    >>> args = (1, 2)
+    >>> kwargs = dict(foo=3, bar=4)
+    >>> name = 'my name'
+
+.. note::
+
+   Even when intending to pass only a single positional argument, `args` must be
+   a list or tuple, e.g., `args = [1]` or `args = (1,)`.
+
+
+Finally, specify the key and a combination of modifiers. While key names are
+just strings, modifiers are lists or tuples of modifier names.
+::
+
+    >>> key = 'b'
+    >>> modifiers = ['ctrl', 'alt']
+
+.. note::
+
+   Even when specifying only a single modifier key, `modifiers` must be a list
+   or tuple, e.g., `modifiers = ['ctrl']` or `modifiers = ('ctrl',)`.
+
+We are now ready to create the global event key.
+::
+
+    >>> event.globalKeys.add(key=key, modifiers=modifiers,
+    ... func=myfunc2, func_args=args, func_kwargs=kwargs,
+    ... name=name)
+
+Check that the global event key was successfully added.
+::
+
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [A] -> 'myfunc' <function myfunc at 0x10669ba28>
+        [CTRL] + [ALT] + [B] -> 'my name' <function myfunc2 at 0x112eecb90>
+    >
+
+The key combination `[CTRL] + [ALT] + [B]` is now associated with the function
+`myfunc2`, which will be called in the following way:
+::
+
+    myfunc2(1, 2, foo=2, bar=4)
+
+.. _indexing:
+
+Indexing
+--------
+`event.globalKeys` can be accessed like an ordinary dictionary. The index keys
+are `(key, modifiers)` namedtuples.
+::
+
+    >>> event.globalKeys.keys()
+    [_IndexKey(key='a', modifiers=()), _IndexKey(key='b', modifiers=('ctrl', 'alt'))]
+
+To access the global event associated with the key combination
+`[CTRL] + [ALT] + [B]`, we can do
+
+    >>> event.globalKeys['b', ['ctrl', 'alt']]
+    _GlobalEvent(func=<function myfunc2 at 0x112eecb90>, func_args=(1, 2), func_kwargs={'foo': 3, 'bar': 4}, name='my name')
+
+To make access more convenient, specifying the modifiers is optional in case
+none were passed to :func:`psychopy.event.globalKeys.add` when the global
+event key was added, meaning the following commands are identical.
+::
+
+    >>> event.globalKeys['a', ()]
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+    >>> event.globalKeys['a']
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+
+All elements of a global event can be accessed directly.
+::
+
+    >>> index = ('b', ['ctrl', 'alt'])
+    >>> event.globalKeys[index].func
+    <function myfunc2 at 0x112eecb90>
+    >>> event.globalKeys[index].func_args
+    (1, 2)
+    >>> event.globalKeys[index].func_kwargs
+    {'foo': 3, 'bar': 4}
+    >>> event.globalKeys[index].name
+    'my name'
+
+Number of active event keys
+---------------------------
+The number of currently active event keys can be retrieved by passing
+`event.globalKeys` to the `len()` function.
+::
+
+    >>> len(event.globalKeys)
+    2
+
+Removing global event keys
+--------------------------
+There are three ways to remove global event keys:
+
+- using :func:`psychopy.event.globalKeys.remove`,
+- using `del`, and
+- using :func:`psychopy.event.globalKeys.pop`.
+
+:func:`psychopy.event.globalKeys.remove`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To remove a single key, pass the key name and modifiers (if any) to
+:func:`psychopy.event.globalKeys.remove`.
+::
+
+    >>> event.globalKeys.remove(key='a')
+
+A convenience method to quickly delete *all* global event keys is to pass
+`key='all'`
+::
+
+    >>> event.globalKeys.remove(key='all')
+
+`del`
+~~~~~
+Like with other dictionaries, items can be removed from `event.globalKeys`
+by using the `del` statement. The provided index key must be specified as
+described in :ref:`indexing`.
+::
+
+    >>> index = ('b', ['ctrl', 'alt'])
+    >>> del event.globalKeys[index]
+
+:func:`psychopy.event.globalKeys.pop`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Again, as other dictionaries, `event.globalKeys` provides a `pop` method to
+retrieve an item and remove it from the dict. The first argument to `pop` is the
+index key, specified as described in :ref:`indexing`. The second argument is
+optional. Its value will be returned in case no item with the matching indexing
+key could be found, for example if the item had already been removed previously.
+::
+
+    >>> r = event.globalKeys.pop('a', None)
+    >>> print(r)
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+    >>> r = event.globalKeys.pop('a', None)
+    >>> print(r)
+    None
+
+Global shutdown key
+-------------------
+The PsychoPy preferences for `shutdownKey` and `shutdownKeyModifiers`
+(both unset by default) will be used to automatically create a global
+shutdown key. To demonstrate this automated behavior, let us first change
+the preferences programmatically (these changes will be lost when quitting the
+current Python session).
+::
+
+    >>> from psychopy.preferences import prefs
+    >>> prefs.general['shutdownKey'] = 'q'
+
+We can now check if a global shutdown key has been automatically created.
+::
+
+    >>> from psychopy import event
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [Q] -> 'shutdown (auto-created from prefs)' <function quit at 0x10c171938>
+    >
+
+And indeed, it worked!
+
+What happened behind the scences? When importing the `psychopy.event`
+module, the initialization of `event.globalKeys` checked for valid shutdown key
+preferences and automatically initialized a shutdown key accordingly.
+This key is associated with the :func:~`psychopy.core.quit` function, which will
+shut down PsychoPy.
+::
+
+   >>> from psychopy.core import quit
+   >>> event.globalKeys['q'].func == quit
+   True
+
+Of course you can very easily add a global shutdown key manually, too. You
+simply have to associate a key with :func:~`psychopy.core.quit`.
+::
+
+    >>> from psychopy import core, event
+    >>> event.globalKeys.add(key='q', func=core.quit, name='shutdown')
+
+That's it!
+
+A working example
+-----------------
+In the above code snippets, our global event keys were not actually functional,
+as we didn't create a window, which is required to actually collect the key
+presses. Our working example will thus first create a window and then add
+global event keys to change the window color and quit the experiment,
+respectively.
+::
+
+    #!/usr/bin/env python2
+    # -*- coding: utf-8 -*-
+
+    from __future__ import print_function
+    from psychopy import core, event, visual
+
+
+    def change_color(win, log=False):
+        win.color = 'blue' if win.color == 'gray' else 'gray'
+        if log:
+            print('Changed color to %s' % win.color)
+
+
+    win = visual.Window(color='gray')
+    text = visual.TextStim(win,
+                           text='Press C to change color,\n CTRL + Q to quit.')
+
+    # Global event key to change window background color.
+    event.globalKeys.add(key='c',
+                         func=change_color,
+                         func_args=[win],
+                         func_kwargs=dict(log=True),
+                         name='change window color')
+
+    # Global event key (with modifier) to quit the experiment ("shutdown key").
+    event.globalKeys.add(key='q', modifiers=['ctrl'], func=core.quit)
+
+    while True:
+        text.draw()
+        win.flip()
+

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -35,6 +35,8 @@ _localized = {
     'audioDriver': _translate("audio driver"),
     'flac': _translate('flac audio compression'),
     'parallelPorts': _translate("parallel ports"),
+    'shutdownKey': _translate("shutdown key"),
+    'shutdownKeyModifiers': _translate("shutdown key modifier keys"),
     'showStartupTips': _translate("show start-up tips"),
     'largeIcons': _translate("large icons"),
     'defaultView': _translate("default view"),

--- a/psychopy/demos/coder/basic/global_event_keys.py
+++ b/psychopy/demos/coder/basic/global_event_keys.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""
+This demo shows how to use "global event keys" to interact with a running
+experiment. The keys do not have to be checked manually, but
+rather get handled automatically by PsychoPy.
+
+This works when calling win.flip() repeatedly (as in this example)
+and when using core.wait() (not demonstrated here). If using core.wait(),
+be sure to set the `hogCPUperiod` parameter equal to the entire
+waiting duration, e.g. `core.wait(10, hogCPUperiod=10)`.
+
+"""
+
+from __future__ import print_function
+from psychopy import core, event, visual
+
+
+win = visual.Window()
+rect = visual.Rect(win, fillColor='blue', pos=(0, -0.2))
+text = visual.TextStim(
+    win,
+    pos=(0, 0.5),
+    text=('Press\n\n'
+          'B for blue rectangle,\n'
+          'CTRL + R for red rectangle,\n'
+          'Q or ESC to quit.'))
+
+# Add an event key.
+event.globalKeys.add(key='b', func=setattr,
+                     func_args=(rect, 'fillColor', 'blue'),
+                     name='blue rect')
+
+# Add an event key with a "modifier" (CTRL).
+event.globalKeys.add(key='r', modifiers=['ctrl'], func=setattr,
+                     func_args=(rect, 'fillColor', 'red'),
+                     name='red rect')
+
+# Add multiple shutdown keys "at once".
+for key in ['q', 'escape']:
+    event.globalKeys.add(key, func=core.quit)
+
+# Print all currently defined global event keys.
+print(event.globalKeys)
+print(repr(event.globalKeys))
+
+while True:
+    text.draw()
+    rect.draw()
+    win.flip()

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -12,8 +12,11 @@ See demo_mouse.py and i{demo_joystick.py} for examples
 from __future__ import absolute_import
 
 import sys
+import string
 import copy
 import numpy
+from collections import namedtuple, OrderedDict, MutableMapping
+from psychopy.preferences import prefs
 
 # try to import pyglet & pygame and hope the user has at least one of them!
 try:
@@ -143,6 +146,27 @@ def _onPygletKey(symbol, modifiers, emulated=False):
         keySource = 'Keypress'
     _keyBuffer.append((thisKey, modifiers, keyTime))  # tuple
     logging.data("%s: %s" % (keySource, thisKey))
+    _process_global_event_key(thisKey, modifiers)
+
+
+def _process_global_event_key(key, modifiers):
+    # The statement can be simplified to:
+    # `if modifiers == 0` once PR #1373 is merged.
+    if (modifiers is None) or (modifiers == 0):
+        modifier_keys = ()
+    else:
+        modifier_keys = ['%s' % m.strip('MOD_').lower() for m in
+                         (pyglet.window.key.modifiers_string(modifiers)
+                          .split('|'))]
+
+    index_key = globalKeys._gen_index_key((key, modifier_keys))
+
+    if index_key in globalKeys:
+        event = globalKeys[index_key]
+        logging.exp('Global key event: %s. Calling %s.'
+                    % (event.name, event.func))
+        r = event.func(*event.func_args, **event.func_kwargs)
+        return r
 
 
 def _onPygletMousePress(x, y, button, modifiers, emulated=False):
@@ -803,3 +827,199 @@ def clearEvents(eventType=None):
                             locals.JOYBUTTONDOWN])
         else:
             junk = evt.get()
+
+
+class _GlobalEventKeys(MutableMapping):
+    """
+     Global event keys for the pyglet backend.
+
+     Global event keys are single keys (or combinations of a single key
+     and one or more "modifier" keys such as Ctrl, Alt, etc.) with an
+     associated Python callback function. This function will be executed
+     if the key (or key/modifiers combination) was pressed.
+
+     PsychoPy fully automatically monitors and processes key presses
+     during most portions of the experimental run, for example during
+     `core.wait()` periods, or when calling `win.flip()`. If a global
+     event key press is detected, the specified function will be run
+     immediately. You are not required to manually poll and check for key
+     presses. This can be particularly useful to implement a global
+     "shutdown" key, or to trigger laboratory equipment on a key press
+     when testing your experimental script -- without cluttering the code.
+     But of course the application is not limited to these two scenarios.
+     In fact, you can associate any Python function with a global event key.
+
+     The PsychoPy preferences for `shutdownKey` and `shutdownKeyModifiers`
+     (both unset by default) will be used to automatically create a global
+     shutdown key once the `psychopy.event` module is being imported.
+
+     :Notes:
+
+     All keyboard -> event associations are stored in the `self._events`
+     OrderedDict. The dictionary keys are namedtuples with the elements
+     `key` and `mofifiers`. `key` is a string defining an (ordinary)
+     keyboard key, and `modifiers` is a tuple of modifier key strings,
+     e.g., `('ctrl', 'alt')`. The user does not access this attribute
+     directly, but should index the class instance itself (via
+     `globalKeys[key, modifiers]`). That way, the `modifiers` sequence
+     will be transparently converted into a tuple (which is a hashable
+     type) before trying to index `self._events`.
+
+     """
+    _GlobalEvent = namedtuple(
+        '_GlobalEvent',
+        ['func', 'func_args', 'func_kwargs', 'name'])
+
+    _IndexKey = namedtuple('_IndexKey', ['key', 'modifiers'])
+
+    _valid_keys = set(string.lowercase + string.digits
+                      + string.punctuation + ' \t')
+    _valid_keys.update(['escape', 'left', 'right', 'up', 'down'])
+
+    _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock', 'numlock',
+                        'scrolllock', 'command', 'option', 'windows'}
+
+    def __init__(self):
+        super(_GlobalEventKeys, self).__init__()
+        self._events = OrderedDict()
+
+        if prefs.general['shutdownKey']:
+            msg = ('Found shutdown key definition in preferences; '
+                   'enabling shutdown key.')
+            logging.info(msg)
+            self.add(key=prefs.general['shutdownKey'],
+                     modifiers=prefs.general['shutdownKeyModifiers'],
+                     func=psychopy.core.quit,
+                     name='shutdown (auto-created from prefs)')
+
+    def __repr__(self):
+        info = ''
+        for index_key, event in self._events.items():
+            info += '\n\t'
+            if index_key.modifiers:
+                _modifiers = ['[%s]' % m.upper() for m in index_key.modifiers]
+                info += '%s + ' % ' + '.join(_modifiers)
+            info += ("[%s] -> '%s' %s"
+                     % (index_key.key.upper(), event.name, event.func))
+
+        return '<_GlobalEventKeys : %s\n>' % info
+
+    def __str__(self):
+        return ('<_GlobalEventKeys : %i key->event mappings defined.>'
+                % len(self))
+
+    def __len__(self):
+        return len(self._events)
+
+    def __getitem__(self, key):
+        index_key = self._gen_index_key(key)
+        return self._events[index_key]
+
+    def __setitem__(self, key, value):
+        msg = 'Please use `.add()` to add a new global event key.'
+        raise NotImplementedError(msg)
+
+    def __delitem__(self, key):
+        index_key = self._gen_index_key(key)
+        event = self._events.pop(index_key, None)
+
+        if event is None:
+            msg = 'Requested to remove unregistered global event key.'
+            raise KeyError(msg)
+        else:
+            logging.exp("Removed global key event: '%s'." % event.name)
+
+    def __iter__(self):
+        return self._events.iterkeys()
+
+    def _gen_index_key(self, key):
+        if isinstance(key, (str, unicode)):  # Single key, passed as a string.
+            index_key = self._IndexKey(key, ())
+        else:  # Convert modifiers into a hashable type.
+            index_key = self._IndexKey(key[0], tuple(key[1]))
+
+        return index_key
+
+    def add(self, key, func, func_args=(), func_kwargs=None,
+            modifiers=(), name=None):
+        """
+        Add a global event key.
+
+        :Parameters:
+
+        key : string
+            The key to add.
+
+        func : function
+            The function to invoke once the specified keys were pressed.
+
+        func_args : iterable
+            Positional arguments to be passed to the specified function.
+
+        func_kwargs : dict
+            Keyword arguments to be passed to the specified function.
+
+        modifiers : collection of strings
+            Modifier keys. Valid keys are:
+            'shift', 'ctrl', 'alt' (not on macOS), 'capslock', 'numlock',
+            'scrolllock', 'command' (macOS only), 'option' (macOS only)
+
+        name : string
+            The name of the event. Will be used for logging. If None,
+            will use the name of the specified function.
+
+        :Raises:
+
+        ValueError
+            If the specified key or modifiers are invalid, or if the
+            key / modifier combination has already been assigned to a global
+            event.
+
+        """
+        if key not in self._valid_keys:
+            raise ValueError('Unknown key specified: %s' % key)
+
+        if not set(modifiers).issubset(self._valid_modifiers):
+            raise ValueError('Unknown modifier key specified.')
+
+        index_key = self._gen_index_key((key, modifiers))
+        if index_key in self._events:
+            msg = ('The specified key is already assigned to a global event. '
+                   'Use `.remove()` to remove it first.')
+            raise ValueError(msg)
+
+        if func_kwargs is None:
+            func_kwargs = {}
+        if name is None:
+            name = func.__name__
+
+        self._events[index_key] = self._GlobalEvent(func, func_args,
+                                                    func_kwargs, name)
+        logging.exp('Added new global key event: %s' % name)
+
+    def remove(self, key, modifiers=()):
+        """
+        Remove a global event key.
+
+        :Parameters:
+
+        key : string
+            A single key name. If `'all'`, remove all event keys.
+
+        modifiers : collection of strings
+            Modifier keys. Valid keys are:
+            'shift', 'ctrl', 'alt' (not on macOS), 'capslock', 'numlock',
+            'scrolllock', 'command' (macOS only), 'option' (macOS only),
+            'windows' (Windows only)
+
+        """
+        if key == 'all':
+            self._events = OrderedDict()
+            logging.exp('Removed all global key events.')
+            return
+
+        del self[key, modifiers]
+
+
+if havePyglet:
+    globalKeys = _GlobalEventKeys()

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC', '/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -44,6 +44,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/tests/test_events/test_keyboard_events.py
+++ b/psychopy/tests/test_events/test_keyboard_events.py
@@ -2,20 +2,19 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from psychopy import event, monitors
+from psychopy import event, core
 from psychopy.preferences import prefs
 from psychopy.visual import Window
 
-from pyglet.window.key import (
-    MOD_SHIFT,
-    MOD_CTRL,
-    MOD_ALT,
-    MOD_CAPSLOCK,
-    MOD_NUMLOCK,
-    MOD_WINDOWS,
-    MOD_COMMAND,
-    MOD_OPTION,
-    MOD_SCROLLLOCK)
+from pyglet.window.key import (MOD_SHIFT,
+                               MOD_CTRL,
+                               MOD_ALT,
+                               MOD_CAPSLOCK,
+                               MOD_NUMLOCK,
+                               MOD_WINDOWS,
+                               MOD_COMMAND,
+                               MOD_OPTION,
+                               MOD_SCROLLLOCK)
 
 
 @pytest.mark.keyboard
@@ -96,7 +95,7 @@ class TestGLobalEventKeys(object):
         e = list(global_keys)[0]
 
         assert key, modifiers == e
-        assert global_keys[e].func == quit
+        assert global_keys[e].func == core.quit
 
     def test_add(self):
         key = 'a'

--- a/psychopy/tests/test_events/test_keyboard_events.py
+++ b/psychopy/tests/test_events/test_keyboard_events.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from psychopy import event
+from psychopy import event, monitors
+from psychopy.preferences import prefs
+from psychopy.visual import Window
+
 from pyglet.window.key import (
     MOD_SHIFT,
     MOD_CTRL,
@@ -63,6 +66,258 @@ class TestKeyboardEvents(object):
 
         with pytest.raises(ValueError):
             event._onPygletKey(key, modifiers, emulated=True)
+
+
+@pytest.mark.keyboard
+class TestGLobalEventKeys(object):
+    @classmethod
+    def setup_class(self):
+        self.win = Window([128, 128], winType='pyglet', pos=[50, 50], autoLog=False)
+
+    @classmethod
+    def teardown_class(self):
+        self.win.close()
+
+    def setup_method(self, test_method):
+        # Disable auto-creation of shutdown key.
+        prefs.general['shutdownKey'] = ''
+
+    def _func(self, *args, **kwargs):
+        return [args, kwargs]
+
+    def test_shutdownKey_prefs(self):
+        key = 'escape'
+        modifiers = ('ctrl', 'alt')
+
+        prefs.general['shutdownKey'] = key
+        prefs.general['shutdownKeyModifiers'] = modifiers
+
+        global_keys = event._GlobalEventKeys()
+        e = list(global_keys)[0]
+
+        assert key, modifiers == e
+        assert global_keys[e].func == quit
+
+    def test_add(self):
+        key = 'a'
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func)
+
+        assert global_keys[key, ()].func == func
+        assert global_keys[key, ()].name == func.__name__
+
+    def test_add_key_twice(self):
+        key = 'a'
+        func = self._func
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func)
+
+        with pytest.raises(ValueError):
+            global_keys.add(key=key, func=func)
+
+    def test_add_name(self):
+        key = 'a'
+        name = 'foo'
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func, name=name)
+        assert global_keys[key, ()].name == name
+
+    def test_add_args(self):
+        key = 'a'
+        func = self._func
+        args = (1, 2, 3)
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func, func_args=args)
+
+        assert global_keys[key, ()].func_args == args
+
+    def test_add_kwargs(self):
+        key = 'a'
+        func = self._func
+        kwargs = dict(foo=1, bar=2)
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func, func_kwargs=kwargs)
+
+        assert global_keys[key, ()].func_kwargs == kwargs
+
+    def test_add_args_and_kwargs(self):
+        key = 'a'
+        func = self._func
+        args = (1, 2, 3)
+        kwargs = dict(foo=1, bar=2)
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func, func_args=args,
+                        func_kwargs=kwargs)
+
+        assert global_keys[key, ()].func_args == args
+        assert global_keys[key, ()].func_kwargs == kwargs
+
+    def test_add_invalid_key(self):
+        key = 'foo'
+        func = self._func
+        global_keys = event._GlobalEventKeys()
+
+        with pytest.raises(ValueError):
+            global_keys.add(key=key, func=func)
+
+    def test_add_invalid_modifiers(self):
+        key = 'a'
+        modifiers = ('foo', 'bar')
+        func = self._func
+        global_keys = event._GlobalEventKeys()
+
+        with pytest.raises(ValueError):
+            global_keys.add(key=key, modifiers=modifiers, func=func)
+
+    def test_remove(self):
+        keys = ['a', 'b', 'c']
+        modifiers = ('ctrl',)
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        [global_keys.add(key=key, modifiers=modifiers, func=func)
+         for key in keys]
+
+        global_keys.remove(keys[0], modifiers)
+        with pytest.raises(KeyError):
+            _ = global_keys[keys[0], modifiers]
+
+    def test_remove_modifiers_list(self):
+        key = 'a'
+        modifiers = ['ctrl', 'alt']
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, modifiers=modifiers, func=func)
+
+        global_keys.remove(key, modifiers)
+        with pytest.raises(KeyError):
+            _ = global_keys[key, modifiers]
+
+    def test_remove_invalid_key(self):
+        key = 'a'
+        global_keys = event._GlobalEventKeys()
+
+        with pytest.raises(KeyError):
+            global_keys.remove(key)
+
+    def test_remove_all(self):
+        keys = ['a', 'b', 'c']
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        [global_keys.add(key=key, func=func) for key in keys]
+
+        global_keys.remove('all')
+        assert len(global_keys) == 0
+
+    def test_getitem(self):
+        key = 'escape'
+        modifiers = ('ctrl', 'alt')
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, modifiers=modifiers, func=func)
+
+        assert global_keys[key, modifiers] == global_keys._events[key, modifiers]
+
+    def test_getitem_string(self):
+        key = 'escape'
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func)
+
+        assert global_keys[key] == global_keys._events[key, ()]
+
+    def test_getitem_modifiers_list(self):
+        key = 'escape'
+        modifiers = ['ctrl', 'alt']
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, modifiers=modifiers, func=func)
+
+        assert (global_keys[key, modifiers] ==
+                global_keys._events[key, tuple(modifiers)])
+
+    def test_setitem(self):
+        keys = 'a'
+        modifiers = ()
+        global_keys = event._GlobalEventKeys()
+
+        with pytest.raises(NotImplementedError):
+            global_keys[keys, modifiers] = None
+
+    def test_delitem(self):
+        key = 'escape'
+        modifiers = ('ctrl', 'alt')
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, modifiers=modifiers, func=func)
+
+        del global_keys[key, modifiers]
+        with pytest.raises(KeyError):
+            _ = global_keys[key, modifiers]
+
+    def test_delitem_string(self):
+        key = 'escape'
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, func=func)
+
+        del global_keys[key]
+        with pytest.raises(KeyError):
+            _ = global_keys[key]
+
+    def test_len(self):
+        prefs.general['shutdownKey'] = ''
+        key = 'escape'
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        assert len(global_keys) == 0
+
+        global_keys.add(key=key, func=func)
+        assert len(global_keys) == 1
+
+        del global_keys[key, ()]
+        assert len(global_keys) == 0
+
+    def test_event_processing(self):
+        key = 'a'
+        modifiers = 0
+        func = self._func
+        args = (1, 2, 3)
+        kwargs = dict(foo=1, bar=2)
+
+        event.globalKeys.add(key=key, func=func, func_args=args,
+                             func_kwargs=kwargs)
+
+        r = event._process_global_event_key(key, modifiers)
+        assert r[0] == args
+        assert r[1] == kwargs
+
+    def test_index_keys(self):
+        key = 'escape'
+        modifiers = ('ctrl', 'alt')
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+        global_keys.add(key=key, modifiers=modifiers, func=func)
+
+        index_key = global_keys.keys()[-1]
+        assert index_key.key == key
+        assert index_key.modifiers == modifiers
 
 
 if __name__ == '__main__':

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -227,6 +227,7 @@ class TestPygletNorm(_baseTest):
         if havePygame:
             assert pygame.display.get_init() == 0
 
+
 class xxxTestPygameNorm(_baseTest):
     @classmethod
     def setup_class(self):


### PR DESCRIPTION
Having to check manually for keypresses to abort the experiment is cumbersome and error-prone; and I often forget to add this feature for parts of my code and have to resort to the OS task manager to kill the PsychoPy fullscreen window if I need to quit my experiment prematurely.

This PR adds the ability to specify a _shutdown key_ in the preferences, which will then be checked for during all `event._onPygletKey()` invocations. `event._onPygletKey()` is the pyglet window's keyboard event handler. These events are dispatched on each `flip()` and during `wait()` periods when using `wait(X, hogCPUperiod=X)`. If the shutdown key is pressed, a `CRITICAL` event will be logged, and `core.quit()` will be called.

The PR is to be considered a proposal and is up for discussion. Please let me know what you think of the general idea as such, and of the specific implementation.