### PR TITLE
BF Get textstim_vs_textbox demo running again

### DIFF
--- a/psychopy/demos/coder/stimuli/textBoxStim/textstim_vs_textbox.py
+++ b/psychopy/demos/coder/stimuli/textBoxStim/textstim_vs_textbox.py
@@ -19,6 +19,7 @@ Created on Thu Mar 21 18:37:10 2013
 import string
 import random
 from psychopy import visual, core, event
+from psychopy.visual import textbox
 from psychopy.iohub.util import NumPyRingBuffer
 import pyglet.gl as gl
 
@@ -81,7 +82,7 @@ window=visual.Window(display_resolution,
                         )
 
 # Find a font that is available on the system.
-fm=visual.textbox.getFontManager()
+fm = textbox.getFontManager()
 available_font_names=fm.getFontFamilyStyles()
 prefered_fonts=[fn for fn,fs in available_font_names if fn in [
                                                             'Courier New',


### PR DESCRIPTION
As reported by @alexholcombe here: https://discourse.psychopy.org/t/textstim-vs-textbox-py-demo-not-working/2055 this demo had stopped working. Seems to be resolved by explicitly importing the textbox class. 
Perhaps there is a cleaner way to fix this?