### PR TITLE
Added missing sys import call

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -16,6 +16,7 @@ except ImportError as err:
     # convert this import error to our own, pyo probably not installed
     raise exceptions.DependencyError(repr(err))
 
+import sys
 import threading
 pyoSndServer = None
 


### PR DESCRIPTION
Hi Jon,

I noticed that RC 1.85.00 was crashing on any sound playback - both coder and builder.   This was due to a missing sys import under sound/backend_pyo.py which i've added in.

However, I also noticed that even if you put "pygame" as the default, it crashes with the same error - and tries to use backend_pyo.py instead of backend_pygame.py.   Not sure if this is an additional error, but couldn't spot anything obvious.

Best wishes,

Frank