### PR TITLE
"default" not correctly checked for speaker option

### DIFF
--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -135,7 +135,7 @@ if hasattr(backend, 'defaultOutput'):
         # a single option
         dev = prefs.general['audioDevice']
     # is it simply "default" (do nothing)
-    if dev=='auto' or travisCI:
+    if dev=='default' or travisCI:
         pass  # do nothing
     elif dev not in backend.getDevices(kind='output'):
         devNames = backend.getDevices(kind='output').keys()


### PR DESCRIPTION
If default is selected, it should do nothing - but because the condition was set to check for "auto" instead of "default", it gives an error log saying that default doesn't exist on the audio device list.