### PR TITLE
BF: Allow to open prefs when no audio backend is installed

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -367,8 +367,8 @@ class PrefCtrls(object):
             self.valueCtrl.SetValue(value)
         elif spec.startswith('option') or name == 'audioDevice':
             if name == 'audioDevice':
-                value = value[0]
                 options = copy.copy(value)
+                value = value[0]
                 try:
                     from psychopy import sound
                     if hasattr(sound, 'getDevices'):

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -10,6 +10,7 @@ import copy
 
 from . import localization, dialogs
 from psychopy import logging
+from psychopy.exceptions import DependencyError
 from .localization import _translate
 
 # this will be overridden by the size of the scrolled panel making the prefs
@@ -366,14 +367,17 @@ class PrefCtrls(object):
             self.valueCtrl.SetValue(value)
         elif spec.startswith('option') or name == 'audioDevice':
             if name == 'audioDevice':
-                options = copy.copy(value)
-                from psychopy import sound
-                if hasattr(sound, 'getDevices'):
-                    devs = sound.getDevices('output')
-                    for thisDevName in devs:
-                        if thisDevName not in options:
-                            options.append(thisDevName)
                 value = value[0]
+                options = copy.copy(value)
+                try:
+                    from psychopy import sound
+                    if hasattr(sound, 'getDevices'):
+                        devs = sound.getDevices('output')
+                        for thisDevName in devs:
+                            if thisDevName not in options:
+                                options.append(thisDevName)
+                except DependencyError:
+                    pass
             else:
                 options = spec.replace("option(", "").replace("'", "")
                 # item -1 is 'default=x' from spec


### PR DESCRIPTION
The preferences window imports `psychopy.sound` when compiling
the list of wigdets / settings to display. However, this would fail
if no audio backend is installed.

This commit catches this DependencyError and allows to open the preferences
window nonetheless.