### PR TITLE
BF: Invalid modifiers were passed to event._onPygletKey()

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -116,11 +116,16 @@ def _onPygletKey(symbol, modifiers, emulated=False):
     S Mathot 2012: Implement fallback to _onPygletText
 
     5AM Solutions 2016: Add the keyboard modifier flags to the key buffer.
-    """
 
+    """
     global useText
+
     keyTime = psychopy.core.getTime()  # capture when the key was pressed
     if emulated:
+        if not isinstance(modifiers, int):
+            msg = 'Modifiers must be passed as an integer value.'
+            raise ValueError(msg)
+
         thisKey = unicode(symbol)
         keySource = 'EmulatedKey'
     else:

--- a/psychopy/hardware/emulator.py
+++ b/psychopy/hardware/emulator.py
@@ -47,7 +47,7 @@ class ResponseEmulator(threading.Thread):
                 # avoid cryptic error if int
                 key = str(key)[0]
             if type(key) == str:
-                event._onPygletKey(symbol=key, modifiers=None, emulated=True)
+                event._onPygletKey(symbol=key, modifiers=0, emulated=True)
             else:
                 logging.error('ResponseEmulator: only keyboard events '
                               'are supported')
@@ -122,7 +122,7 @@ class SyncGenerator(threading.Thread):
             if self.stopflag:
                 break
             # "emit" a sync pulse by placing a key in the buffer:
-            event._onPygletKey(symbol=self.sync, modifiers=None,
+            event._onPygletKey(symbol=self.sync, modifiers=0,
                                emulated=True)
             # wait for start of next volume, doing our own hogCPU for
             # tighter sync:

--- a/psychopy/hardware/forp.py
+++ b/psychopy/hardware/forp.py
@@ -124,7 +124,7 @@ class ButtonBox(object):
             self.pressEvents += decodedEvents
             if asKeys:
                 for code in decodedEvents:
-                    event._onPygletKey(symbol=code, modifiers=None)
+                    event._onPygletKey(symbol=code, modifiers=0)
                     # better as: emulated='fORP_bbox_asKey', but need to
                     # adjust event._onPygletKey and the symbol conversion
                     # pyglet.window.key.symbol_string(symbol).lower()

--- a/psychopy/tests/test_all_visual/test_ratingScale.py
+++ b/psychopy/tests/test_all_visual/test_ratingScale.py
@@ -195,7 +195,7 @@ class Test_class_RatingScale(object):
         r = RatingScale(self.win, tickMarks=[1,2,3], labels=None, autoLog=False)
         r = RatingScale(self.win, leftKeys=['s'], autoLog=False)
         r.markerPlaced = False
-        event._onPygletKey(symbol='s', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='s', modifiers=0, emulated=True)
         r.draw()
 
     def test_obsolete_args(self):
@@ -211,28 +211,28 @@ class Test_class_RatingScale(object):
         r.markerPlaced = True
 
         r.mouseOnly = False
-        event._onPygletKey(symbol='tab', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='tab', modifiers=0, emulated=True)
         r.draw()
 
         r.respKeys = ['s']
         r.enableRespKeys = True
-        event._onPygletKey(symbol='s', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='s', modifiers=0, emulated=True)
         r.draw()
 
         # test move left, move right:
         r = RatingScale(self.win, markerStart=3, autoLog=False)
         assert r.markerPlacedAt == 2
-        event._onPygletKey(symbol='left', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='left', modifiers=0, emulated=True)
         r.draw()
         assert r.markerPlaced  # and r.markerPlacedBySubject
         #assert r.markerPlacedAt == 1
-        event._onPygletKey(symbol='right', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='right', modifiers=0, emulated=True)
         r.draw()
         #assert r.markerPlacedAt == 2
 
         r.acceptKeys = ['s']
         r.beyondMinTime = True
-        event._onPygletKey(symbol='s', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='s', modifiers=0, emulated=True)
         r.draw()
 
     def test_somelines(self):
@@ -243,7 +243,7 @@ class Test_class_RatingScale(object):
         r.respKeys = ['s']
         r.allKeys = ['s']
         r.tickFromKeyPress = {u's': 1}
-        event._onPygletKey(symbol='s', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='s', modifiers=0, emulated=True)
         r.singleClick = True
         r.beyondMinTime = True
         r.draw()
@@ -285,7 +285,7 @@ class Test_class_RatingScale(object):
         core.wait(.001, 0)
         r.acceptKeys = r.allKeys = ['1']
         r.beyondMinTime = True
-        event._onPygletKey(symbol='1', modifiers=None, emulated=True)
+        event._onPygletKey(symbol='1', modifiers=0, emulated=True)
         r.draw()
         h = r.getHistory()
         assert h[0] == (None, 0)

--- a/psychopy/tests/test_events/test_keyboard_events.py
+++ b/psychopy/tests/test_events/test_keyboard_events.py
@@ -1,5 +1,8 @@
-import pytest
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
 
+import pytest
+from psychopy import event
 from pyglet.window.key import (
     MOD_SHIFT,
     MOD_CTRL,
@@ -11,7 +14,6 @@ from pyglet.window.key import (
     MOD_OPTION,
     MOD_SCROLLLOCK)
 
-from psychopy import event
 
 @pytest.mark.keyboard
 class TestKeyboardEvents(object):
@@ -53,3 +55,16 @@ class TestKeyboardEvents(object):
         assert keys[0][0] == 'a'
         assert keys[0][1]['alt']
         assert isinstance(keys[0][2], float)
+
+    def test_invalid_modifiers(self):
+        """Modifiers must be integers."""
+        key = 'a'
+        modifiers = None
+
+        with pytest.raises(ValueError):
+            event._onPygletKey(key, modifiers, emulated=True)
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main()

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -31,7 +31,7 @@ class DelayedFakeKey(threading.Thread):
         self.delay = delay
     def run(self):
         core.wait(self.delay)
-        event._onPygletKey(symbol=self.key, modifiers=None, emulated=True)
+        event._onPygletKey(symbol=self.key, modifiers=0, emulated=True)
 
 class _baseTest(object):
     #this class allows others to be created that inherit all the tests for
@@ -112,9 +112,9 @@ class _baseTest(object):
         assert event.getKeys() == []
         for k in ['s', 'return']:
             event.clearEvents()
-            event._onPygletKey(symbol=k, modifiers=None, emulated=True)
+            event._onPygletKey(symbol=k, modifiers=0, emulated=True)
             assert k in event.getKeys()
-            event._onPygletKey(symbol=17, modifiers=None, emulated=False)
+            event._onPygletKey(symbol=17, modifiers=0, emulated=False)
             assert '17' in event.getKeys()
 
             # test that key-based RT is about right
@@ -122,15 +122,15 @@ class _baseTest(object):
             c = core.Clock()
             t = 0.05
             core.wait(t)
-            event._onPygletKey(symbol=k, modifiers=None, emulated=True)
+            event._onPygletKey(symbol=k, modifiers=0, emulated=True)
             resp = event.getKeys(timeStamped=c)
             assert k in resp[0][0]
             assert t - 0.01 < resp[0][1] < t + 0.01
 
-            event._onPygletKey(symbol=k, modifiers=None, emulated=True)
+            event._onPygletKey(symbol=k, modifiers=0, emulated=True)
             assert k in event.getKeys(timeStamped=True)[0]
-            event._onPygletKey(symbol=k, modifiers=None, emulated=True)
-            event._onPygletKey(symbol='x', modifiers=None, emulated=True)  # nontarget
+            event._onPygletKey(symbol=k, modifiers=0, emulated=True)
+            event._onPygletKey(symbol='x', modifiers=0, emulated=True)  # nontarget
             assert k in event.getKeys(keyList=[k, 'd'])
 
             # waitKeys implicitly clears events, so use a thread to add a delayed key press


### PR DESCRIPTION
When invoking the `event._onPygletKey()` callback function while no modifier key was pressed, pyglet sets the `modifiers` parameter to 0. In fact, this parameter is always an integer, created by OR'ing
different modifier key states. The actual names of the modifier keys can be retrieved by passing this integer to `pyglet.window.key.modifiers_string()`.

However, at many places where `_onPygletKey()` was used to create "emulated" key presses, `modifiers=None` was passed. Nobody noticed so far because apparently the modifiers were not further processed in these cases (since, obviously, they were expected to be insignificant / not present). But passing non-integer modifiers is buggy behavior and actually caused issues for me when trying to implement modifier handling for the global event keys (tests incorrectly calling `_onPygletKey(..., modifiers=None)` would not pass anymore).

This PR
- replaces all incorrect invocations of `_onPygletKey()` and 
- changes the function to raise an exception if non-integer modifiers are supplied.
