### PR TITLE
Fix for audio glitch

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -207,14 +207,16 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         """Continue a paused movie from current position.
         """
         status = self.status
-        if self._audioStream is not None:
-            self._audioStream.play()
         if status != PLAYING:
+            if self._audioStream is not None:
+            	self._audioStream.play()
+            if status == PAUSED:
+            	if self.getCurrentFrameTime() < 0:
+            		self._audioSeek(0)
+            	else:
+            		self._audioSeek(self.getCurrentFrameTime())
             self.status = PLAYING
             self._videoClock.reset(-self.getCurrentFrameTime())
-
-            if status == PAUSED:
-                self._audioSeek(self.getCurrentFrameTime())
 
             if log and self.autoLog:
                 self.win.logOnFlip("Set %s playing" % (self.name),


### PR DESCRIPTION
The structure of the “play” function would previously cause doubled-up
audio, or in some cases cause the audio not to start playing at all. As far as I can tell, there were as many as three issues. 

1. For some reason, audioseek was not being called consistently, sometimes causing inconsistent behavior when looping. In principle moving the IF statement relative to the setting of self.status shouldn't change anything, but it may have helped?
2. The _audioStream.play() call would occur even if the movie was already playing, causing doubling up sometimes.
3. If you used seek(0), in some cases getCurrentFrameTime could return a negative value (as it returns frame - frameinterval), and in those cases the audio would not play properly (usually not at all). This seemed to be latency-based and inconsistent. This change ensures that audioseek can't be passed a negative number.

These changes should make moviestim3 audio much more consistent, I hope.