### PR TITLE
Add volume to sounddevice Frequency and Array calls

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -398,7 +398,7 @@ class SoundDeviceSound(_SoundBase):
 
     def _setSndFromArray(self, thisArray):
 
-        self.sndArr = np.asarray(thisArray)
+        self.sndArr = np.asarray(thisArray) * self.volume
         if thisArray.ndim == 1:
             self.sndArr.shape = [len(thisArray),1]  # make 2D for broadcasting
         if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
@@ -483,7 +483,7 @@ class SoundDeviceSound(_SoundBase):
                 num=self.blockSize, endpoint=False
                 )
             xx.shape = [self.blockSize, 1]
-            block = np.sin(xx)
+            block = np.sin(xx) * self.volume
             # if run beyond our desired t then set to zeros
             if stopT > self.secs:
                 tRange = np.linspace(startT, stopT,

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -406,7 +406,6 @@ class SoundDeviceSound(_SoundBase):
         elif self.sndArr.shape[1] == 1:  # if channels in [-1,1] then pass
             pass
         else:
-            self.sndArr = np.asarray(thisArray)
             try:
                 self.sndArr.shape = [len(thisArray), 2]
             except ValueError:


### PR DESCRIPTION
From my testing of the new sounddevice backend there was no volume parameter being applied to the sound output from sounddevice for either Frequency or Array based sounds.

I have added these volume multiplication calls in https://github.com/gjcooper/psychopy/commit/a3b6dcb26c3a82bb0ec63f0d1079397065369936, however if there is a more appropriate place to apply them I am willing to change it.

From my local testing the changes do apply the correct volume settings.

_Additionally_, while I was working in the `_setSndFromArray` method I noticed a call that was duplicated (at the method level and within an else block. I have removed this in https://github.com/gjcooper/psychopy/commit/3ea295409446e33319b7fd1cfe216ba95ead8eca and it does not seem to change functionality at all.

Cheers
Gavin