### PR TITLE
RF: Make Window's refreshThreshold public

### DIFF
--- a/docs/source/general/timing/detectingFrameDrops.rst
+++ b/docs/source/general/timing/detectingFrameDrops.rst
@@ -12,23 +12,33 @@ Occasionally you will drop frames if you:
 Things to avoid:
 
 * recreating textures for stimuli
-* building new stimuli from scratch (create them once at the top of your script and then change them using :meth:`stim.setOri(ori)`, `stim.setPos([x,y]...)`
+* building new stimuli from scratch (create them once at the top of your script
+and then change them using :meth:`stim.setOri(ori)`, `stim.setPos([x,y]...)`
 
 Turn on frame time recording
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The key sometimes is *knowing* if you are dropping frames. PsychoPy can help with that by keeping track of frame durations. By default, frame time tracking is turned off because many people don't need it, but it can be turned on any time after :class:`~psychopy.visual.Window` creation::
+The key sometimes is *knowing* if you are dropping frames. PsychoPy can help
+with that by keeping track of frame durations. By default, frame time tracking
+is turned off because many people don't need it, but it can be turned on any
+time after :class:`~psychopy.visual.Window` creation::
 
     from psychopy import visual
     win = visual.Window([800,600])
     win.recordFrameIntervals = True
 
-Since there are often dropped frames just after the system is initialised, it makes sense to start off with a fixation period, or a ready message and don't start recording frame times until that has ended. Obviously if you aren't refreshing the window at some point (e.g. waiting for a key press with an unchanging screen) then you should turn off the recording of frame times or it will give spurious results.
+Since there are often dropped frames just after the system is initialised, it
+makes sense to start off with a fixation period, or a ready message and don't
+start recording frame times until that has ended. Obviously if you aren't
+refreshing the window at some point (e.g. waiting for a key press with an
+unchanging screen) then you should turn off the recording of frame times or it
+will give spurious results.
 
 Warn me if I drop a frame
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The simplest way to check if a frame has been dropped is to get PsychoPy to report a warning if it thinks a frame was dropped::
+The simplest way to check if a frame has been dropped is to get PsychoPy to
+report a warning if it thinks a frame was dropped::
 
     from __future__ import division, print_function
 
@@ -55,7 +65,8 @@ Show me all the frame times that I recorded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 While recording frame times, these are simply appended, every frame to 
-win.frameIntervals (a list). You can simply plot these at the end of your script using pylab::
+win.frameIntervals (a list). You can simply plot these at the end of your script
+using matplotlib::
 
     import matplotlib.pyplot as plt
     plt.plot(win.frameIntervals)
@@ -65,15 +76,25 @@ Or you could save them to disk. A convenience function is provided for this::
 
     win.saveFrameIntervals(fileName=None, clear=True)
 
-The above will save the currently stored frame intervals (using the default filename, 'lastFrameIntervals.log') and then clears the data. The saved file is a simple text file.
+The above will save the currently stored frame intervals (using the default
+filename, 'lastFrameIntervals.log') and then clears the data. The saved file is
+ a simple text file.
 
-At any time you can also retrieve the time of the /last/ frame flip using win.lastFrameT (the time is synchronised with logging.defaultClock so it will match any logging commands that your script uses).
+At any time you can also retrieve the time of the /last/ frame flip using
+win.lastFrameT (the time is synchronised with logging.defaultClock so it will
+match any logging commands that your script uses).
 
 .. _blockingOnVBI:
 
 'Blocking' on the VBI
 ~~~~~~~~~~~~~~~~~~~~~
 
-As of version 1.62 PsychoPy 'blocks' on the vertical blank interval meaning that, once Window.flip() has been called, no code will be executed until that flip actually takes place. The timestamp for the above frame interval measurements is taken immediately after the flip occurs. Run the timeByFrames demo in Coder to see the precision of these measurements on your system. They should be within 1ms of your mean frame interval.
+As of version 1.62 PsychoPy 'blocks' on the vertical blank interval meaning
+that, once Window.flip() has been called, no code will be executed until that
+flip actually takes place. The timestamp for the above frame interval
+measurements is taken immediately after the flip occurs. Run the timeByFrames
+demo in Coder to see the precision of these measurements on your system. They
+should be within 1ms of your mean frame interval.
 
-Note that Intel integrated graphics chips (e.g. GMA 945) under win32 do not sync to the screen at all and so blocking on those machines is not possible. 
+Note that Intel integrated graphics chips (e.g. GMA 945) under win32 do not sync
+to the screen at all and so blocking on those machines is not possible.

--- a/docs/source/general/timing/detectingFrameDrops.rst
+++ b/docs/source/general/timing/detectingFrameDrops.rst
@@ -1,7 +1,7 @@
 .. _detectDroppedFrames:
 
 Detecting dropped frames
---------------------------
+------------------------
 
 Occasionally you will drop frames if you:
 
@@ -15,37 +15,51 @@ Things to avoid:
 * building new stimuli from scratch (create them once at the top of your script and then change them using :meth:`stim.setOri(ori)`, `stim.setPos([x,y]...)`
 
 Turn on frame time recording
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The key sometimes is *knowing* if you are dropping frames. PsychoPy can help with that by keeping track of frame durations. By default, frame time tracking is turned off because many people don't need it, but it can be turned on any time after :class:`~psychopy.visual.Window` creation  :meth:`setRecordFrameIntervals`, e.g.:
+The key sometimes is *knowing* if you are dropping frames. PsychoPy can help with that by keeping track of frame durations. By default, frame time tracking is turned off because many people don't need it, but it can be turned on any time after :class:`~psychopy.visual.Window` creation::
 
     from psychopy import visual
     win = visual.Window([800,600])
-    win.setRecordFrameIntervals(True) 
+    win.recordFrameIntervals = True
 
 Since there are often dropped frames just after the system is initialised, it makes sense to start off with a fixation period, or a ready message and don't start recording frame times until that has ended. Obviously if you aren't refreshing the window at some point (e.g. waiting for a key press with an unchanging screen) then you should turn off the recording of frame times or it will give spurious results.
 
 Warn me if I drop a frame
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The simplest way to check if a frame has been dropped is to get PsychoPy to report a warning if it thinks a frame was dropped::
 
+    from __future__ import division, print_function
+
     from psychopy import visual, logging
     win = visual.Window([800,600])
-    win.setRecordFrameIntervals(True)
-    win._refreshThreshold=1/85.0+0.004 #i've got 85Hz monitor and want to allow 4ms tolerance
-    #set the log module to report warnings to the std output window (default is errors only)
+
+    win.recordFrameIntervals = True
+
+    # By default, the threshold is set to 120% of the estimated refresh
+    # duration, but arbitrary values can be set.
+    #
+    # I've got 85Hz monitor and want to allow 4 ms tolerance; any refresh that
+    # takes longer than the specified period will be considered a "dropped"
+    # frame and increase the count of win.nDroppedFrames.
+    win.refreshThreshold = 1/85 + 0.004
+
+    # Set the log module to report warnings to the standard output window
+    # (default is errors only).
     logging.console.setLevel(logging.WARNING)
 
+    print('Overall, %i frames were dropped.' % win.nDroppedFrames)
+
 Show me all the frame times that I recorded
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 While recording frame times, these are simply appended, every frame to 
 win.frameIntervals (a list). You can simply plot these at the end of your script using pylab::
 
-    import pylab
-    pylab.plot(win.frameIntervals)
-    pylab.show()
+    import matplotlib.pyplot as plt
+    plt.plot(win.frameIntervals)
+    plt.show()
 
 Or you could save them to disk. A convenience function is provided for this::
 
@@ -58,7 +72,7 @@ At any time you can also retrieve the time of the /last/ frame flip using win.la
 .. _blockingOnVBI:
 
 'Blocking' on the VBI
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 As of version 1.62 PsychoPy 'blocks' on the vertical blank interval meaning that, once Window.flip() has been called, no code will be executed until that flip actually takes place. The timestamp for the above frame interval measurements is taken immediately after the flip occurs. Run the timeByFrames demo in Coder to see the precision of these measurements on your system. They should be within 1ms of your mean frame interval.
 

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -471,7 +471,7 @@ class RunTimeInfo(dict):
                        'monitor', 'pos', 'screen', 'rgb', 'size']
         winAttrListVerbose = ['allowGUI', 'useNativeGamma',
                               'recordFrameIntervals', 'waitBlanking',
-                              '_haveShaders', '_refreshThreshold']
+                              '_haveShaders', 'refreshThreshold']
         if verbose:
             winAttrList += winAttrListVerbose
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -404,7 +404,7 @@ class Window(object):
 
         self.lastFrameT = core.getTime()
         self.waitBlanking = waitBlanking
-        self._refreshThreshold = 1 / 1.0  # initial val needed by flip()
+        self.refreshThreshold = 1 / 1.0  # initial val needed by flip()
 
         # over several frames with no drawing
         self._monitorFrameRate = None
@@ -414,9 +414,9 @@ class Window(object):
             self._monitorFrameRate = self.getActualFrameRate()
         if self._monitorFrameRate is not None:
             self.monitorFramePeriod = 1.0 / self._monitorFrameRate
-            self._refreshThreshold = (1.0 / self._monitorFrameRate) * 1.2
+            self.refreshThreshold = (1.0 / self._monitorFrameRate) * 1.2
         else:
-            self._refreshThreshold = (1.0 / 60) * 1.2  # maybe a flat panel?
+            self.refreshThreshold = (1.0 / 60) * 1.2  # maybe a flat panel?
         openWindows.append(self)
 
         self.autoLog = autoLog
@@ -756,7 +756,7 @@ class Window(object):
                 self.recordFrameIntervalsJustTurnedOn = False
             else:  # past the first frame since turned on
                 self.frameIntervals.append(deltaT)
-                if deltaT > self._refreshThreshold:
+                if deltaT > self.refreshThreshold:
                     self.nDroppedFrames += 1
                     if self.nDroppedFrames < reportNDroppedFrames:
                         txt = 't of last frame was %.2fms (=1/%i)'

--- a/psychopy/visual/windowframepack.py
+++ b/psychopy/visual/windowframepack.py
@@ -57,7 +57,7 @@ class ProjectorFramePacker(object):
         # This part is increasingly ugly.  Add a function to set these values?
         win._monitorFrameRate = 180.0
         win.monitorFramePeriod = 1.0 / win._monitorFrameRate
-        win._refreshThreshold = (1.0 / win._monitorFrameRate) * 1.2
+        win.refreshThreshold = (1.0 / win._monitorFrameRate) * 1.2
 
         # enable Blue initially, since projector output sequence is BGR
         GL.glColorMask(False, False, True, True)


### PR DESCRIPTION
`visual.Window._refreshThreshold` must be modified by the users to fine-tune checking for dropped frames when using `Window.recordFrameIntervals = True`. It is used for no other purpose and should therefore be public. This PR renames the attribute to `visual.Window.refreshThreshold`, making it part of the public API.