### PR TITLE
NF: Allow to disable keyboard buffer clearing in waitKeys()

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -376,22 +376,18 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
             is given then the time will be relative to the `Clock`'s last
             reset.
         clearEvents : **True** or False
-            Whether to clear the keyboard buffer (and discard preceding
-            keypresses) before starting to monitor for keypresses. If
-            `keyList` is specified, only those keys are removed from the
-            keyboard buffer.
+            Whether to clear the keyboard event buffer (and discard preceding
+            keypresses) before starting to monitor for new keypresses.
 
     Returns None if times out.
 
     """
-    if clearEvents:  # Only consider keypresses from here onwards.
-        if not keyList:
-            # We need to invoke clearEvents(), but our keyword argument is
-            # also called clearEvents. We can work around this conflict by
-            # accessing the global scope explicitly.
-            globals()['clearEvents']('keyboard')
-        else:
-            getKeys(keyList=keyList)
+    if clearEvents:
+        # Only consider keypresses from here onwards.
+        # We need to invoke clearEvents(), but our keyword argument is
+        # also called clearEvents. We can work around this conflict by
+        # accessing the global scope explicitly.
+        globals()['clearEvents']('keyboard')
 
     # Check for keypresses until maxWait is exceeded
     #

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -351,7 +351,7 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
 
 
 def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
-             timeStamped=False, clearBuffer=True):
+             timeStamped=False, clearEvents=True):
     """Same as `~psychopy.event.getKeys`, but halts everything
     (including drawing) while awaiting input from keyboard.
 
@@ -375,7 +375,7 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
             keynames. Each tuple has (keyname, time). If a `core.Clock`
             is given then the time will be relative to the `Clock`'s last
             reset.
-        clearBuffer : **True** or False
+        clearEvents : **True** or False
             Whether to clear the keyboard buffer (and discard preceding
             keypresses) before starting to monitor for keypresses. If
             `keyList` is specified, only those keys are removed from the
@@ -384,9 +384,9 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
     Returns None if times out.
 
     """
-    if clearBuffer:  # Only consider keypresses from here onwards.
+    if clearEvents:  # Only consider keypresses from here onwards.
         if not keyList:
-            clearEvents('keyboard')
+            globals()['clearEvents']('keyboard')
         else:
             getKeys(keyList=keyList)
 

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -397,9 +397,11 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
     #
     # NB pygame.event does have a wait() function that will
     # do this and maybe leave more cpu idle time?
+
     timer = psychopy.core.Clock()
-    key = None
-    while key is None and timer.getTime() < maxWait:
+    got_keypress = False
+
+    while not got_keypress and timer.getTime() < maxWait:
         # Pump events on pyglet windows if they exist.
         if havePyglet:
             defDisplay = pyglet.window.get_platform().get_default_display()
@@ -409,12 +411,14 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
         # Get keypresses and return if anything is pressed.
         keys = getKeys(keyList=keyList, modifiers=modifiers,
                        timeStamped=timeStamped)
-        if len(keys):
-            return keys
+        if keys:
+            got_keypress = True
 
-    # If maxWait is exceeded (exits while-loop), return None
-    logging.data('No keypress (maxWait exceeded)')
-    return None
+    if got_keypress:
+        return keys
+    else:
+        logging.data('No keypress (maxWait exceeded)')
+        return None
 
 
 def xydist(p1=(0.0, 0.0), p2=(0.0, 0.0)):

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -794,7 +794,7 @@ class BuilderKeyResponse(object):
         self.clock = psychopy.core.Clock()  # we'll use this to measure the rt
 
 
-def clearEvents(eventType=None, keyList=None, modifiers=None):
+def clearEvents(eventType=None):
     """Clears all events currently in the event buffer.
 
     Optional argument, eventType, specifies only certain types to be
@@ -803,10 +803,6 @@ def clearEvents(eventType=None, keyList=None, modifiers=None):
     :Parameters:
         eventType : **None**, 'mouse', 'joystick', 'keyboard'
             If this is not None then only events of the given type are cleared
-        keyList : **None** or []
-            Allows the user to specify a set of keys to remove from the
-            keyboard buffer. If the keyList is `None`, the buffer will be
-            cleared completely. This argument is unless `eventType
 
     """
     # pyglet

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -350,10 +350,10 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
         return relTuple
 
 
-def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False, timeStamped=False):
+def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
+             timeStamped=False, clearBuffer=True):
     """Same as `~psychopy.event.getKeys`, but halts everything
-    (including drawing) while awaiting input from keyboard. Implicitly
-    clears keyboard, so any preceding keypresses will be lost.
+    (including drawing) while awaiting input from keyboard.
 
     :Parameters:
         maxWait : any numeric value.
@@ -364,14 +364,23 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False, timeStamped=Fa
             keynames. Each tuple has (keyname, modifiers). The modifiers
             are a dict of keyboard modifier flags keyed by the modifier
             name (eg. 'shift', 'ctrl').
+        timeStamped : **False**, True, or `Clock`
+            If True will return a list of tuples instead of a list of
+            keynames. Each tuple has (keyname, time). If a `core.Clock`
+            is given then the time will be relative to the `Clock`'s last
+            reset.
+        clearBuffer : **True** or False
+            Whether to clear the keyboard buffer (and discard preceding
+            keypresses) or not.
 
     Returns None if times out.
-    """
 
+    """
     # NB pygame.event does have a wait() function that will
     # do this and maybe leave more cpu idle time?
     key = None
-    clearEvents('keyboard')  # So that we only take presses from here onwards.
+    if clearBuffer:  # Only consider keypresses from here onwards.
+        clearEvents('keyboard')
 
     # Check for keypresses until maxWait is exceeded
     timer = psychopy.core.Clock()
@@ -383,12 +392,13 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False, timeStamped=Fa
                 win.dispatch_events()
 
         # Get keypresses and return if anything is pressed
-        keys = getKeys(keyList=keyList, modifiers=modifiers, timeStamped=timeStamped)
+        keys = getKeys(keyList=keyList, modifiers=modifiers,
+                       timeStamped=timeStamped)
         if len(keys):
             return keys
 
     # If maxWait is exceeded (exits while-loop), return None
-    logging.data("No keypress (maxWait exceeded)")
+    logging.data('No keypress (maxWait exceeded)')
     return None
 
 

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -265,7 +265,7 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
         keyList : **None** or []
             Allows the user to specify a set of keys to check for.
             Only keypresses from this set of keys will be removed from
-            the keyboard buffer. If the keyList is None all keys will be
+            the keyboard buffer. If the keyList is `None`, all keys will be
             checked and the key buffer will be cleared completely.
             NB, pygame doesn't return timestamps (they are always 0)
         modifiers : **False** or True
@@ -359,6 +359,12 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
         maxWait : any numeric value.
             Maximum number of seconds period and which keys to wait for.
             Default is float('inf') which simply waits forever.
+        keyList : **None** or []
+            Allows the user to specify a set of keys to check for.
+            Only keypresses from this set of keys will be removed from
+            the keyboard buffer. If the keyList is `None`, all keys will be
+            checked and the key buffer will be cleared completely.
+            NB, pygame doesn't return timestamps (they are always 0)
         modifiers : **False** or True
             If True will return a list of tuples instead of a list of 
             keynames. Each tuple has (keyname, modifiers). The modifiers
@@ -371,27 +377,33 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
             reset.
         clearBuffer : **True** or False
             Whether to clear the keyboard buffer (and discard preceding
-            keypresses) or not.
+            keypresses) before starting to monitor for keypresses. If
+            `keyList` is specified, only those keys are removed from the
+            keyboard buffer.
 
     Returns None if times out.
 
     """
-    # NB pygame.event does have a wait() function that will
-    # do this and maybe leave more cpu idle time?
-    key = None
     if clearBuffer:  # Only consider keypresses from here onwards.
-        clearEvents('keyboard')
+        if not keyList:
+            clearEvents('keyboard')
+        else:
+            getKeys(keyList=keyList)
 
     # Check for keypresses until maxWait is exceeded
+    #
+    # NB pygame.event does have a wait() function that will
+    # do this and maybe leave more cpu idle time?
     timer = psychopy.core.Clock()
+    key = None
     while key is None and timer.getTime() < maxWait:
-        # Pump events on pyglet windows if they exist
+        # Pump events on pyglet windows if they exist.
         if havePyglet:
             defDisplay = pyglet.window.get_platform().get_default_display()
             for win in defDisplay.get_windows():
                 win.dispatch_events()
 
-        # Get keypresses and return if anything is pressed
+        # Get keypresses and return if anything is pressed.
         keys = getKeys(keyList=keyList, modifiers=modifiers,
                        timeStamped=timeStamped)
         if len(keys):

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -386,6 +386,9 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
     """
     if clearEvents:  # Only consider keypresses from here onwards.
         if not keyList:
+            # We need to invoke clearEvents(), but our keyword argument is
+            # also called clearEvents. We can work around this conflict by
+            # accessing the global scope explicitly.
             globals()['clearEvents']('keyboard')
         else:
             getKeys(keyList=keyList)

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -791,7 +791,7 @@ class BuilderKeyResponse(object):
         self.clock = psychopy.core.Clock()  # we'll use this to measure the rt
 
 
-def clearEvents(eventType=None):
+def clearEvents(eventType=None, keyList=None, modifiers=None):
     """Clears all events currently in the event buffer.
 
     Optional argument, eventType, specifies only certain types to be
@@ -800,6 +800,11 @@ def clearEvents(eventType=None):
     :Parameters:
         eventType : **None**, 'mouse', 'joystick', 'keyboard'
             If this is not None then only events of the given type are cleared
+        keyList : **None** or []
+            Allows the user to specify a set of keys to remove from the
+            keyboard buffer. If the keyList is `None`, the buffer will be
+            cleared completely. This argument is unless `eventType
+
     """
     # pyglet
     if not havePygame or not display.get_init():

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -178,6 +178,7 @@ class _baseTest(object):
 
         assert 'x' in key_events
         assert 'y' in key_events
+        assert 'z' not in key_events
         assert 'z' in event.getKeys()
 
     def test_xydist(self):

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -161,6 +161,25 @@ class _baseTest(object):
         assert 'y' in key_events
         assert 'z' in key_events
 
+    def test_waitKeys_keyList_clearBuffer_True(self):
+        """
+        Only remove the keys specified in `keyList` from the keyboard buffer.
+        """
+        keys = ['x', 'y', 'z']
+        [event._onPygletKey(symbol=key, modifiers=0, emulated=True)
+         for key in keys]
+
+        key_thread_1 = DelayedFakeKey(keys[0])
+        key_thread_2 = DelayedFakeKey(keys[1])
+
+        key_thread_1.start()
+        key_thread_2.start()
+        key_events = event.waitKeys(keyList=keys[:-1], clearBuffer=True)
+
+        assert 'x' in key_events
+        assert 'y' in key_events
+        assert 'z' in event.getKeys()
+
     def test_xydist(self):
         assert event.xydist([0,0], [1,1]) == np.sqrt(2)
 

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -191,15 +191,6 @@ class _baseTest(object):
         assert 'z' in key_events
 
     def test_waitKeys_keyList_clearEvents_True(self):
-        """
-        Only remove the keys specified in `keyList` from the keyboard buffer.
-        We use DelayedAddFakeKeysToBuffer here to avoid having to call
-        event._onPygletKey() multiple times, because waitKeys() constantly asks
-        pyglet to dispatch keyboard events and might start processing before we
-        have finished placing all of our fake keys in the buffer.
-        DelayedAddFakeKeysToBuffer, in contrast, puts all events into the buffer
-        _at once_, avoiding this sort of race condition.
-        """
         keys = ['x', 'y', 'z']
         DelayedAddFakeKeysToBuffer(keys).start()
         key_events = event.waitKeys(keyList=keys[:-1], clearEvents=True)

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -151,6 +151,16 @@ class _baseTest(object):
             assert result[0][0] == k
             assert result[0][1] - delay < .01  # should be ~0 except for execution time
 
+    def test_waitKeys_clearBuffer_False(self):
+        keys = ['x', 'y', 'z']
+        [event._onPygletKey(symbol=key, modifiers=0, emulated=True)
+         for key in keys]
+
+        key_events = event.waitKeys(keyList=keys[1:], clearBuffer=False)
+        assert 'x' not in key_events
+        assert 'y' in key_events
+        assert 'z' in key_events
+
     def test_xydist(self):
         assert event.xydist([0,0], [1,1]) == np.sqrt(2)
 

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -174,17 +174,23 @@ class _baseTest(object):
             assert result[0][0] == k
             assert result[0][1] - delay < .01  # should be ~0 except for execution time
 
-    def test_waitKeys_clearBuffer_False(self):
+    def test_waitKeys_clearEvents_True(self):
+        key = 'x'
+        DelayedAddFakeKeysToBuffer(key).start()
+        key_events = event.waitKeys(clearEvents=True)
+        assert key_events == [key]
+
+    def test_waitKeys_clearEvents_False(self):
         keys = ['x', 'y', 'z']
         [event._onPygletKey(symbol=key, modifiers=0, emulated=True)
          for key in keys]
 
-        key_events = event.waitKeys(keyList=keys[1:], clearBuffer=False)
+        key_events = event.waitKeys(keyList=keys[1:], clearEvents=False)
         assert 'x' not in key_events
         assert 'y' in key_events
         assert 'z' in key_events
 
-    def test_waitKeys_keyList_clearBuffer_True(self):
+    def test_waitKeys_keyList_clearEvents_True(self):
         """
         Only remove the keys specified in `keyList` from the keyboard buffer.
         We use DelayedAddFakeKeysToBuffer here to avoid having to call
@@ -196,7 +202,7 @@ class _baseTest(object):
         """
         keys = ['x', 'y', 'z']
         DelayedAddFakeKeysToBuffer(keys).start()
-        key_events = event.waitKeys(keyList=keys[:-1], clearBuffer=True)
+        key_events = event.waitKeys(keyList=keys[:-1], clearEvents=True)
 
         assert 'x' in key_events
         assert 'y' in key_events


### PR DESCRIPTION
`event.waitKeys()` always used to clear the keyboard buffer implicitly. This PR adds a new keyword argument to control this behavior explicitly.