### PR TITLE
Move volume calls to callback function (sounddevice backend)

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -175,6 +175,7 @@ class _SoundStream(object):
         toSpk *= 0  # it starts with the contents of the buffer before
         for thisSound in self.sounds:
             dat = thisSound._nextBlock()  # fetch the next block of data
+            dat *= thisSound.volume  # Set the volume block by block
             if self.channels == 2 and len(dat.shape) == 2:
                 toSpk[:len(dat), :] += dat  # add to out stream
             elif self.channels == 2 and len(dat.shape) == 1:
@@ -398,7 +399,7 @@ class SoundDeviceSound(_SoundBase):
 
     def _setSndFromArray(self, thisArray):
 
-        self.sndArr = np.asarray(thisArray) * self.volume
+        self.sndArr = np.asarray(thisArray)
         if thisArray.ndim == 1:
             self.sndArr.shape = [len(thisArray),1]  # make 2D for broadcasting
         if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
@@ -482,7 +483,7 @@ class SoundDeviceSound(_SoundBase):
                 num=self.blockSize, endpoint=False
                 )
             xx.shape = [self.blockSize, 1]
-            block = np.sin(xx) * self.volume
+            block = np.sin(xx)
             # if run beyond our desired t then set to zeros
             if stopT > self.secs:
                 tRange = np.linspace(startT, stopT,


### PR DESCRIPTION
Following on from the discussion in a previous pull request: https://github.com/psychopy/psychopy/pull/1378 I have finally had a chance to test implementation of the volume for the sounddevice backend within the callback on the `_SoundStream` object.

This involves reverting volume changes introduced in the previously merged pull request and adding an extra line in the callback.

Another option would be to apply it to the block (in `_nextBlock`) **just** before returning it to the callback method - which as far as I can see would have the same effect, and could be argued is a more natural place for it to be.

I have done some testing and have verified that the pull request as it currently stands works locally.

