### PR TITLE
FF: bug with grating/envelope component params in builder

### DIFF
--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -85,7 +85,7 @@ Section "PsychoPy" SEC01
   SetOverwrite on
   ;AppDir is the path to the psychopy app folder
   Var /GLOBAL AppDir
-  StrCpy $AppDir "$INSTDIR\Lib\site-packages\PsychoPy-${PRODUCT_VERSION}-py2.7.egg\psychopy\app"
+  StrCpy $AppDir "$INSTDIR\Lib\site-packages\psychopy\app"
 
   File /r /x *.pyo /x *.chm /x Editra /x doc "C:\python27\*.*"
 ; avbin to system32

--- a/docs/source/coder/coder.rst
+++ b/docs/source/coder/coder.rst
@@ -28,7 +28,8 @@ Basic Concepts
    codeStimuli
    codeLogging
    code*
-	
+   globalKeys
+
 .. _tutorials:
 
 PsychoPy Tutorials

--- a/docs/source/coder/globalKeys.rst
+++ b/docs/source/coder/globalKeys.rst
@@ -1,0 +1,314 @@
+Global Event Keys
+=================
+
+Global event keys are single keys (or combinations of a single key and one or
+more "modifier" keys such as Ctrl, Alt, etc.) with an associated Python
+callback function. This function will be executed if the key (or
+key/modifiers combination) was pressed.
+
+.. note::
+
+   Global event keys only work with the `pyglet` backend, which is the default.
+
+PsychoPy fully automatically monitors and processes key presses during most
+portions of the experimental run, for example during
+`core.wait()` periods, or when calling `win.flip()`. If a global
+event key press is detected, the specified function will be run
+immediately. You are not required to manually poll and check for key
+presses. This can be particularly useful to implement a global
+"shutdown" key, or to trigger laboratory equipment on a key press
+when testing your experimental script -- without cluttering the code.
+But of course the application is not limited to these two scenarios.
+In fact, you can associate any Python function with a global event key.
+
+All active global event keys are stored in `event.globalKeys`.
+
+Adding a global event key (simple)
+----------------------------------
+First, let's ensure no global event keys are currently set by calling
+func:`event.globalKeys.clear`.
+::
+    >>> from psychopy import event
+    >>> event.globalKeys.clear()
+
+To add a new global event key, you need to invoke
+func:`event.globalKeys.add`. This function has two required arguments: the
+key name, and the function to associate with that key.
+::
+    >>> key = 'a'
+    >>> def myfunc():
+    ...     pass
+    ...
+    >>> event.globalKeys.add(key=key, func=myfunc)
+
+Look at `event.globalKeys`, we can see that the global event key has indeed
+been created.
+::
+
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [A] -> 'myfunc' <function myfunc at 0x10669ba28>
+    >
+
+Your output should look similar. You may happen to spot
+We can take a closer look at the specific global key event we added.
+::
+
+    >>> event.globalKeys['a']
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+
+This output tells us that
+
+- our key `a` is associated with our function `myfunc`
+
+- `myfunc` will be called without passing any positional or keyword
+  arguments (`func_args` and `func_kwargs`, respectively)
+
+- the event name was automatically set to the name of the function.
+
+.. note::
+
+   Pressing the key won't do anything unless a :class:`psychopy.visual.Window`
+   is created and and its :func:~`psychopy.visual.Window.flip` method or
+   :func:`psychopy.core.wait` are called.
+
+Adding a global event key (advanced)
+------------------------------------
+We are going to associate a function with a more complex calling signature
+(with positional and keyword arguments) with a global event key. First, let's
+create the dummy function:
+::
+
+    >>> def myfunc2(*args, **kwargs):
+    ...     pass
+    ...
+
+Next, compile some positional and keyword arguments and a custom name for this
+event. Positional arguments must be passed as tists or uples, and keyword
+arguments as dictionaries.
+::
+
+    >>> args = (1, 2)
+    >>> kwargs = dict(foo=3, bar=4)
+    >>> name = 'my name'
+
+.. note::
+
+   Even when intending to pass only a single positional argument, `args` must be
+   a list or tuple, e.g., `args = [1]` or `args = (1,)`.
+
+
+Finally, specify the key and a combination of modifiers. While key names are
+just strings, modifiers are lists or tuples of modifier names.
+::
+
+    >>> key = 'b'
+    >>> modifiers = ['ctrl', 'alt']
+
+.. note::
+
+   Even when specifying only a single modifier key, `modifiers` must be a list
+   or tuple, e.g., `modifiers = ['ctrl']` or `modifiers = ('ctrl',)`.
+
+We are now ready to create the global event key.
+::
+
+    >>> event.globalKeys.add(key=key, modifiers=modifiers,
+    ... func=myfunc2, func_args=args, func_kwargs=kwargs,
+    ... name=name)
+
+Check that the global event key was successfully added.
+::
+
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [A] -> 'myfunc' <function myfunc at 0x10669ba28>
+        [CTRL] + [ALT] + [B] -> 'my name' <function myfunc2 at 0x112eecb90>
+    >
+
+The key combination `[CTRL] + [ALT] + [B]` is now associated with the function
+`myfunc2`, which will be called in the following way:
+::
+
+    myfunc2(1, 2, foo=2, bar=4)
+
+.. _indexing:
+
+Indexing
+--------
+`event.globalKeys` can be accessed like an ordinary dictionary. The index keys
+are `(key, modifiers)` namedtuples.
+::
+
+    >>> event.globalKeys.keys()
+    [_IndexKey(key='a', modifiers=()), _IndexKey(key='b', modifiers=('ctrl', 'alt'))]
+
+To access the global event associated with the key combination
+`[CTRL] + [ALT] + [B]`, we can do
+
+    >>> event.globalKeys['b', ['ctrl', 'alt']]
+    _GlobalEvent(func=<function myfunc2 at 0x112eecb90>, func_args=(1, 2), func_kwargs={'foo': 3, 'bar': 4}, name='my name')
+
+To make access more convenient, specifying the modifiers is optional in case
+none were passed to :func:`psychopy.event.globalKeys.add` when the global
+event key was added, meaning the following commands are identical.
+::
+
+    >>> event.globalKeys['a', ()]
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+    >>> event.globalKeys['a']
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+
+All elements of a global event can be accessed directly.
+::
+
+    >>> index = ('b', ['ctrl', 'alt'])
+    >>> event.globalKeys[index].func
+    <function myfunc2 at 0x112eecb90>
+    >>> event.globalKeys[index].func_args
+    (1, 2)
+    >>> event.globalKeys[index].func_kwargs
+    {'foo': 3, 'bar': 4}
+    >>> event.globalKeys[index].name
+    'my name'
+
+Number of active event keys
+---------------------------
+The number of currently active event keys can be retrieved by passing
+`event.globalKeys` to the `len()` function.
+::
+
+    >>> len(event.globalKeys)
+    2
+
+Removing global event keys
+--------------------------
+There are three ways to remove global event keys:
+
+- using :func:`psychopy.event.globalKeys.remove`,
+- using `del`, and
+- using :func:`psychopy.event.globalKeys.pop`.
+
+:func:`psychopy.event.globalKeys.remove`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To remove a single key, pass the key name and modifiers (if any) to
+:func:`psychopy.event.globalKeys.remove`.
+::
+
+    >>> event.globalKeys.remove(key='a')
+
+A convenience method to quickly delete *all* global event keys is to pass
+`key='all'`
+::
+
+    >>> event.globalKeys.remove(key='all')
+
+`del`
+~~~~~
+Like with other dictionaries, items can be removed from `event.globalKeys`
+by using the `del` statement. The provided index key must be specified as
+described in :ref:`indexing`.
+::
+
+    >>> index = ('b', ['ctrl', 'alt'])
+    >>> del event.globalKeys[index]
+
+:func:`psychopy.event.globalKeys.pop`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Again, as other dictionaries, `event.globalKeys` provides a `pop` method to
+retrieve an item and remove it from the dict. The first argument to `pop` is the
+index key, specified as described in :ref:`indexing`. The second argument is
+optional. Its value will be returned in case no item with the matching indexing
+key could be found, for example if the item had already been removed previously.
+::
+
+    >>> r = event.globalKeys.pop('a', None)
+    >>> print(r)
+    _GlobalEvent(func=<function myfunc at 0x10669ba28>, func_args=(), func_kwargs={}, name='myfunc')
+    >>> r = event.globalKeys.pop('a', None)
+    >>> print(r)
+    None
+
+Global shutdown key
+-------------------
+The PsychoPy preferences for `shutdownKey` and `shutdownKeyModifiers`
+(both unset by default) will be used to automatically create a global
+shutdown key. To demonstrate this automated behavior, let us first change
+the preferences programmatically (these changes will be lost when quitting the
+current Python session).
+::
+
+    >>> from psychopy.preferences import prefs
+    >>> prefs.general['shutdownKey'] = 'q'
+
+We can now check if a global shutdown key has been automatically created.
+::
+
+    >>> from psychopy import event
+    >>> event.globalKeys
+    <_GlobalEventKeys :
+        [Q] -> 'shutdown (auto-created from prefs)' <function quit at 0x10c171938>
+    >
+
+And indeed, it worked!
+
+What happened behind the scences? When importing the `psychopy.event`
+module, the initialization of `event.globalKeys` checked for valid shutdown key
+preferences and automatically initialized a shutdown key accordingly.
+This key is associated with the :func:~`psychopy.core.quit` function, which will
+shut down PsychoPy.
+::
+
+   >>> from psychopy.core import quit
+   >>> event.globalKeys['q'].func == quit
+   True
+
+Of course you can very easily add a global shutdown key manually, too. You
+simply have to associate a key with :func:~`psychopy.core.quit`.
+::
+
+    >>> from psychopy import core, event
+    >>> event.globalKeys.add(key='q', func=core.quit, name='shutdown')
+
+That's it!
+
+A working example
+-----------------
+In the above code snippets, our global event keys were not actually functional,
+as we didn't create a window, which is required to actually collect the key
+presses. Our working example will thus first create a window and then add
+global event keys to change the window color and quit the experiment,
+respectively.
+::
+
+    #!/usr/bin/env python2
+    # -*- coding: utf-8 -*-
+
+    from __future__ import print_function
+    from psychopy import core, event, visual
+
+
+    def change_color(win, log=False):
+        win.color = 'blue' if win.color == 'gray' else 'gray'
+        if log:
+            print('Changed color to %s' % win.color)
+
+
+    win = visual.Window(color='gray')
+    text = visual.TextStim(win,
+                           text='Press C to change color,\n CTRL + Q to quit.')
+
+    # Global event key to change window background color.
+    event.globalKeys.add(key='c',
+                         func=change_color,
+                         func_args=[win],
+                         func_kwargs=dict(log=True),
+                         name='change window color')
+
+    # Global event key (with modifier) to quit the experiment ("shutdown key").
+    event.globalKeys.add(key='q', modifiers=['ctrl'], func=core.quit)
+
+    while True:
+        text.draw()
+        win.flip()
+

--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -25,8 +25,12 @@ PsychoPy 1.85.1
   * several problems with **sound**
     * pyo not loading #1365
     * searching for 'auto' instead of 'default' device #d54d14fe
+    * fixed duration calculation (bug in soundfile) for sounddevice #e0e01ad
   * textbox v textstim demo wasn't working #b2913c12476
   * error with colors when using TextStim with blendmode='add'
+  * errors in installer package:
+    * windows installer could overwrite system path setting rather than append (NSIS short-string problem came back!)
+    * freetype 32 bit dll is being provided again (was in matplotlib before but disappeared?)
 
 PsychoPy 1.85.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/psychopy/app/builder/components/envelopegrating/__init__.py
+++ b/psychopy/app/builder/components/envelopegrating/__init__.py
@@ -54,14 +54,14 @@ class EnvGratingComponent(BaseVisualComponent):
         self.order = ['carrier', 'mask']
 
         # params
-        
+
         self.params['ori'] = Param(
             ori, valType='code', allowedTypes=[],
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Orientation of this stimulus (in deg)"),
             label=_localized['ori'],categ="Carrier")
-        
+
         msg = _translate("The (2D) texture of the background - can be sin, sqr,"
                          " sinXsin... or a filename (including path)")
         self.params['carrier'] = Param(
@@ -123,8 +123,8 @@ class EnvGratingComponent(BaseVisualComponent):
             updates='constant', allowedUpdates=[],
             hint=msg,
             label=_localized['interpolate'], categ="Carrier")
-            
-            
+
+
         msg = _translate("The (2D) texture of the envelope - can be sin, sqr,"
                          " sinXsin... or a filename (including path)")
         self.params['envelope'] = Param(
@@ -133,7 +133,7 @@ class EnvGratingComponent(BaseVisualComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['envelope'], categ="Envelope")
-            
+
         msg = _translate("Spatial frequency of the modulation envelope repeats across the "
                          "grating in 1 or 2 dimensions, e.g. 4 or [2,3]")
         self.params['envsf'] = Param(
@@ -160,7 +160,7 @@ class EnvGratingComponent(BaseVisualComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['envori'], categ="Envelope")
-            
+
         msg = _translate("Modulation depth of modulation envelope")
         self.params['moddepth'] = Param(
             moddepth, valType='code', allowedTypes=[],
@@ -168,24 +168,25 @@ class EnvGratingComponent(BaseVisualComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['moddepth'], categ="Envelope")
-            
-        msg = _translate("Do you want a 'beat'? [beat = carrier*envelope, no beat = carrier*(1+envelope), True/False, Y/N]")
+
+        msg = _translate("Do you want a 'beat'? [beat = carrier*envelope, "
+                         "no beat = carrier*(1+envelope), True/False, Y/N]")
         self.params['beat'] = Param(
             beat, valType='str', allowedTypes=[],
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['beat'], categ="Envelope")
-            
-        msg = _translate("OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]")
+
+        msg = _translate("OpenGL Blendmode. Avg is most common mode"
+                         " in PsychoPy, add is useful if combining a beat with"
+                         " the carrier image or numpy array at point of display")
         self.params['blendmode'] = Param(
-            blendmode, valType='str', allowedTypes=[],
+            blendmode, valType='str', allowedVals=['avg', 'add'],
             updates='constant',
-            allowedVals=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['blendmode'], categ="Basic")
-            
 
     def writeInitCode(self, buff):
         # do we need units code?
@@ -194,10 +195,10 @@ class EnvGratingComponent(BaseVisualComponent):
         else:
             unitsStr = "units=%(units)s, " % self.params
         #buff.writeIndented("from psychopy.visual.secondorder import EnvelopeGrating\n")
-        
+
         # replaces variable params with defaults and sets sample updateing flag
         inits = getInitVals(self.params)
-        
+
         code = ("%s = visual.EnvelopeGrating(\n" % inits['name'] +
                 "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +
                 "    carrier=%(carrier)s, mask=%(mask)s,\n" % inits +
@@ -209,7 +210,7 @@ class EnvGratingComponent(BaseVisualComponent):
                 "    texRes=%(texture resolution)s,\n" % inits +
                 "    envelope=%(envelope)s, envori=%(envori)s,\n" % inits +
                 "    envsf=%(envsf)s, envphase=%(envphase)s, moddepth=%(moddepth)s, blendmode=%(blendmode)s" %inits )
-                
+
         if self.params['beat'].val in ['Y','y','Yes', 'yes','True','true']:
             code += ", beat=True"
         elif self.params['beat'].val in ['N','n','No', 'no','False','false']:
@@ -263,7 +264,6 @@ class EnvGratingComponent(BaseVisualComponent):
             self.writeParamUpdates(buff, 'set every frame')
             buff.setIndentLevel(-1, relative=True)  # to exit the if block
 
-       
     def writeRoutineEndCode(self, buff):
         super(EnvGratingComponent, self).writeRoutineEndCode(buff)
         #if self.params['blendmode'].val!='default':

--- a/psychopy/app/builder/components/grating/__init__.py
+++ b/psychopy/app/builder/components/grating/__init__.py
@@ -51,7 +51,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['tex'], categ="Grating")
+            label=_localized['tex'], categ="Advanced")
 
         msg = _translate("An image to define the alpha mask (ie shape)- "
                          "gauss, circle... or a filename (including path)")
@@ -60,7 +60,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['mask'], categ="Grating")
+            label=_localized['mask'], categ="Advanced")
 
         msg = _translate("Spatial frequency of image repeats across the "
                          "grating in 1 or 2 dimensions, e.g. 4 or [2,3]")
@@ -69,7 +69,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['sf'], categ="Grating")
+            label=_localized['sf'], categ="Advanced")
 
         msg = _translate("Spatial positioning of the image on the grating "
                          "(wraps in range 0-1.0)")
@@ -78,7 +78,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['phase'], categ="Grating")
+            label=_localized['phase'], categ="Advanced")
 
         msg = _translate(
             "Resolution of the texture for standard ones such as sin, sqr "
@@ -88,7 +88,7 @@ class GratingComponent(BaseVisualComponent):
             valType='code', allowedVals=['32', '64', '128', '256', '512'],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['texture resolution'], categ="Grating")
+            label=_localized['texture resolution'], categ="Advanced")
 
         msg = _translate("How should the image be interpolated if/when "
                          "rescaled")
@@ -96,13 +96,13 @@ class GratingComponent(BaseVisualComponent):
             interpolate, valType='str', allowedVals=['linear', 'nearest'],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['interpolate'], categ="Grating")
-            
-        msg = _translate("OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]")
+            label=_localized['interpolate'], categ="Advanced")
+
+        msg = _translate("OpenGL Blendmode: avg gives traditional transparency,"
+                         " add is important to combine gratings)]")
         self.params['blendmode'] = Param(
-            blendmode, valType='str', allowedTypes=[],
+            blendmode, valType='str', allowedVals=['avg', 'add'],
             updates='constant',
-            allowedVals=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['blendmode'], categ="Basic")

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -35,6 +35,8 @@ _localized = {
     'audioDriver': _translate("audio driver"),
     'flac': _translate('flac audio compression'),
     'parallelPorts': _translate("parallel ports"),
+    'shutdownKey': _translate("shutdown key"),
+    'shutdownKeyModifiers': _translate("shutdown key modifier keys"),
     'showStartupTips': _translate("show start-up tips"),
     'largeIcons': _translate("large icons"),
     'defaultView': _translate("default view"),

--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2936,11 +2936,12 @@ class StairHandler(_BaseTrialHandler):
         self._variableStep = True if len(self.stepSizes) > 1 else False
         self.stepSizeCurrent = self.stepSizes[0]
 
-        if nReversals is not None and len(self.stepSizes) > nReversals:
-            logging.warn(
-                "Increasing number of minimum required reversals to "
-                "the number of step sizes (%i)." % len(self.stepSizes)
-            )
+        if nReversals is None:
+            self.nReversals = len(self.stepSizes)
+        elif len(self.stepSizes) > nReversals:
+            msg = ('Increasing number of minimum required reversals to the '
+                   'number of step sizes, (%i).' % len(self.stepSizes))
+            logging.warn(msg)
             self.nReversals = len(self.stepSizes)
         else:
             self.nReversals = nReversals

--- a/psychopy/demos/coder/basic/global_event_keys.py
+++ b/psychopy/demos/coder/basic/global_event_keys.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+
+"""
+This demo shows how to use "global event keys" to interact with a running
+experiment. The keys do not have to be checked manually, but
+rather get handled automatically by PsychoPy.
+
+This works when calling win.flip() repeatedly (as in this example)
+and when using core.wait() (not demonstrated here). If using core.wait(),
+be sure to set the `hogCPUperiod` parameter equal to the entire
+waiting duration, e.g. `core.wait(10, hogCPUperiod=10)`.
+
+"""
+
+from __future__ import print_function
+from psychopy import core, event, visual
+
+
+win = visual.Window()
+rect = visual.Rect(win, fillColor='blue', pos=(0, -0.2))
+text = visual.TextStim(
+    win,
+    pos=(0, 0.5),
+    text=('Press\n\n'
+          'B for blue rectangle,\n'
+          'CTRL + R for red rectangle,\n'
+          'Q or ESC to quit.'))
+
+# Add an event key.
+event.globalKeys.add(key='b', func=setattr,
+                     func_args=(rect, 'fillColor', 'blue'),
+                     name='blue rect')
+
+# Add an event key with a "modifier" (CTRL).
+event.globalKeys.add(key='r', modifiers=['ctrl'], func=setattr,
+                     func_args=(rect, 'fillColor', 'red'),
+                     name='red rect')
+
+# Add multiple shutdown keys "at once".
+for key in ['q', 'escape']:
+    event.globalKeys.add(key, func=core.quit)
+
+# Print all currently defined global event keys.
+print(event.globalKeys)
+print(repr(event.globalKeys))
+
+while True:
+    text.draw()
+    rect.draw()
+    win.flip()

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -802,31 +802,34 @@ def clearEvents(eventType=None):
     :Parameters:
         eventType : **None**, 'mouse', 'joystick', 'keyboard'
             If this is not None then only events of the given type are cleared
+
     """
-    # pyglet
-    if not havePygame or not display.get_init():
-        # for each (pyglet) window, dispatch its events before checking event
-        # buffer
+    if not havePygame or not display.get_init():  # pyglet
+        # For each window, dispatch its events before
+        # checking event buffer.
         defDisplay = pyglet.window.get_platform().get_default_display()
         for win in defDisplay.get_windows():
             win.dispatch_events()  # pump events on pyglet windows
+
         if eventType == 'mouse':
-            return  # pump pyglet mouse events but don't flush keyboard buffer
-        global _keyBuffer
-        _keyBuffer = []
-    else:
-        # for pygame
-        if eventType == 'mouse':
-            junk = evt.get([locals.MOUSEMOTION, locals.MOUSEBUTTONUP,
-                            locals.MOUSEBUTTONDOWN])
-        elif eventType == 'keyboard':
-            junk = evt.get([locals.KEYDOWN, locals.KEYUP])
+            pass
         elif eventType == 'joystick':
-            junk = evt.get([locals.JOYAXISMOTION, locals.JOYBALLMOTION,
-                            locals.JOYHATMOTION, locals.JOYBUTTONUP,
-                            locals.JOYBUTTONDOWN])
+            pass
+        else:  # eventType='keyboard' or eventType=None.
+            global _keyBuffer
+            _keyBuffer = []
+    else:  # pygame
+        if eventType == 'mouse':
+            evt.get([locals.MOUSEMOTION, locals.MOUSEBUTTONUP,
+                     locals.MOUSEBUTTONDOWN])
+        elif eventType == 'keyboard':
+            evt.get([locals.KEYDOWN, locals.KEYUP])
+        elif eventType == 'joystick':
+            evt.get([locals.JOYAXISMOTION, locals.JOYBALLMOTION,
+                     locals.JOYHATMOTION, locals.JOYBUTTONUP,
+                     locals.JOYBUTTONDOWN])
         else:
-            junk = evt.get()
+            evt.get()
 
 
 class _GlobalEventKeys(MutableMapping):

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -12,8 +12,11 @@ See demo_mouse.py and i{demo_joystick.py} for examples
 from __future__ import absolute_import
 
 import sys
+import string
 import copy
 import numpy
+from collections import namedtuple, OrderedDict, MutableMapping
+from psychopy.preferences import prefs
 
 # try to import pyglet & pygame and hope the user has at least one of them!
 try:
@@ -143,6 +146,27 @@ def _onPygletKey(symbol, modifiers, emulated=False):
         keySource = 'Keypress'
     _keyBuffer.append((thisKey, modifiers, keyTime))  # tuple
     logging.data("%s: %s" % (keySource, thisKey))
+    _process_global_event_key(thisKey, modifiers)
+
+
+def _process_global_event_key(key, modifiers):
+    # The statement can be simplified to:
+    # `if modifiers == 0` once PR #1373 is merged.
+    if (modifiers is None) or (modifiers == 0):
+        modifier_keys = ()
+    else:
+        modifier_keys = ['%s' % m.strip('MOD_').lower() for m in
+                         (pyglet.window.key.modifiers_string(modifiers)
+                          .split('|'))]
+
+    index_key = globalKeys._gen_index_key((key, modifier_keys))
+
+    if index_key in globalKeys:
+        event = globalKeys[index_key]
+        logging.exp('Global key event: %s. Calling %s.'
+                    % (event.name, event.func))
+        r = event.func(*event.func_args, **event.func_kwargs)
+        return r
 
 
 def _onPygletMousePress(x, y, button, modifiers, emulated=False):
@@ -803,3 +827,199 @@ def clearEvents(eventType=None):
                             locals.JOYBUTTONDOWN])
         else:
             junk = evt.get()
+
+
+class _GlobalEventKeys(MutableMapping):
+    """
+     Global event keys for the pyglet backend.
+
+     Global event keys are single keys (or combinations of a single key
+     and one or more "modifier" keys such as Ctrl, Alt, etc.) with an
+     associated Python callback function. This function will be executed
+     if the key (or key/modifiers combination) was pressed.
+
+     PsychoPy fully automatically monitors and processes key presses
+     during most portions of the experimental run, for example during
+     `core.wait()` periods, or when calling `win.flip()`. If a global
+     event key press is detected, the specified function will be run
+     immediately. You are not required to manually poll and check for key
+     presses. This can be particularly useful to implement a global
+     "shutdown" key, or to trigger laboratory equipment on a key press
+     when testing your experimental script -- without cluttering the code.
+     But of course the application is not limited to these two scenarios.
+     In fact, you can associate any Python function with a global event key.
+
+     The PsychoPy preferences for `shutdownKey` and `shutdownKeyModifiers`
+     (both unset by default) will be used to automatically create a global
+     shutdown key once the `psychopy.event` module is being imported.
+
+     :Notes:
+
+     All keyboard -> event associations are stored in the `self._events`
+     OrderedDict. The dictionary keys are namedtuples with the elements
+     `key` and `mofifiers`. `key` is a string defining an (ordinary)
+     keyboard key, and `modifiers` is a tuple of modifier key strings,
+     e.g., `('ctrl', 'alt')`. The user does not access this attribute
+     directly, but should index the class instance itself (via
+     `globalKeys[key, modifiers]`). That way, the `modifiers` sequence
+     will be transparently converted into a tuple (which is a hashable
+     type) before trying to index `self._events`.
+
+     """
+    _GlobalEvent = namedtuple(
+        '_GlobalEvent',
+        ['func', 'func_args', 'func_kwargs', 'name'])
+
+    _IndexKey = namedtuple('_IndexKey', ['key', 'modifiers'])
+
+    _valid_keys = set(string.lowercase + string.digits
+                      + string.punctuation + ' \t')
+    _valid_keys.update(['escape', 'left', 'right', 'up', 'down'])
+
+    _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock', 'numlock',
+                        'scrolllock', 'command', 'option', 'windows'}
+
+    def __init__(self):
+        super(_GlobalEventKeys, self).__init__()
+        self._events = OrderedDict()
+
+        if prefs.general['shutdownKey']:
+            msg = ('Found shutdown key definition in preferences; '
+                   'enabling shutdown key.')
+            logging.info(msg)
+            self.add(key=prefs.general['shutdownKey'],
+                     modifiers=prefs.general['shutdownKeyModifiers'],
+                     func=psychopy.core.quit,
+                     name='shutdown (auto-created from prefs)')
+
+    def __repr__(self):
+        info = ''
+        for index_key, event in self._events.items():
+            info += '\n\t'
+            if index_key.modifiers:
+                _modifiers = ['[%s]' % m.upper() for m in index_key.modifiers]
+                info += '%s + ' % ' + '.join(_modifiers)
+            info += ("[%s] -> '%s' %s"
+                     % (index_key.key.upper(), event.name, event.func))
+
+        return '<_GlobalEventKeys : %s\n>' % info
+
+    def __str__(self):
+        return ('<_GlobalEventKeys : %i key->event mappings defined.>'
+                % len(self))
+
+    def __len__(self):
+        return len(self._events)
+
+    def __getitem__(self, key):
+        index_key = self._gen_index_key(key)
+        return self._events[index_key]
+
+    def __setitem__(self, key, value):
+        msg = 'Please use `.add()` to add a new global event key.'
+        raise NotImplementedError(msg)
+
+    def __delitem__(self, key):
+        index_key = self._gen_index_key(key)
+        event = self._events.pop(index_key, None)
+
+        if event is None:
+            msg = 'Requested to remove unregistered global event key.'
+            raise KeyError(msg)
+        else:
+            logging.exp("Removed global key event: '%s'." % event.name)
+
+    def __iter__(self):
+        return self._events.iterkeys()
+
+    def _gen_index_key(self, key):
+        if isinstance(key, (str, unicode)):  # Single key, passed as a string.
+            index_key = self._IndexKey(key, ())
+        else:  # Convert modifiers into a hashable type.
+            index_key = self._IndexKey(key[0], tuple(key[1]))
+
+        return index_key
+
+    def add(self, key, func, func_args=(), func_kwargs=None,
+            modifiers=(), name=None):
+        """
+        Add a global event key.
+
+        :Parameters:
+
+        key : string
+            The key to add.
+
+        func : function
+            The function to invoke once the specified keys were pressed.
+
+        func_args : iterable
+            Positional arguments to be passed to the specified function.
+
+        func_kwargs : dict
+            Keyword arguments to be passed to the specified function.
+
+        modifiers : collection of strings
+            Modifier keys. Valid keys are:
+            'shift', 'ctrl', 'alt' (not on macOS), 'capslock', 'numlock',
+            'scrolllock', 'command' (macOS only), 'option' (macOS only)
+
+        name : string
+            The name of the event. Will be used for logging. If None,
+            will use the name of the specified function.
+
+        :Raises:
+
+        ValueError
+            If the specified key or modifiers are invalid, or if the
+            key / modifier combination has already been assigned to a global
+            event.
+
+        """
+        if key not in self._valid_keys:
+            raise ValueError('Unknown key specified: %s' % key)
+
+        if not set(modifiers).issubset(self._valid_modifiers):
+            raise ValueError('Unknown modifier key specified.')
+
+        index_key = self._gen_index_key((key, modifiers))
+        if index_key in self._events:
+            msg = ('The specified key is already assigned to a global event. '
+                   'Use `.remove()` to remove it first.')
+            raise ValueError(msg)
+
+        if func_kwargs is None:
+            func_kwargs = {}
+        if name is None:
+            name = func.__name__
+
+        self._events[index_key] = self._GlobalEvent(func, func_args,
+                                                    func_kwargs, name)
+        logging.exp('Added new global key event: %s' % name)
+
+    def remove(self, key, modifiers=()):
+        """
+        Remove a global event key.
+
+        :Parameters:
+
+        key : string
+            A single key name. If `'all'`, remove all event keys.
+
+        modifiers : collection of strings
+            Modifier keys. Valid keys are:
+            'shift', 'ctrl', 'alt' (not on macOS), 'capslock', 'numlock',
+            'scrolllock', 'command' (macOS only), 'option' (macOS only),
+            'windows' (Windows only)
+
+        """
+        if key == 'all':
+            self._events = OrderedDict()
+            logging.exp('Removed all global key events.')
+            return
+
+        del self[key, modifiers]
+
+
+if havePyglet:
+    globalKeys = _GlobalEventKeys()

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC', '/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -48,6 +48,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -44,6 +44,9 @@
     flac = string(default='')
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
+    # Shutdown keys, following the pyglet naming scheme.
+    shutdownKey = string(default='')
+    shutdownKeyModifiers = list(default=list())
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -361,7 +361,7 @@ class SoundDeviceSound(_SoundBase):
         self.sampleRate = f.samplerate
         if self.channels == -1:  # if channels was auto then set to file val
             self.channels = f.channels
-        info = sf.info(filename)  # needed for duration?
+        fileDuration = float(len(f))/f.samplerate  # needed for duration?
         # process start time
         if self.startTime and self.startTime > 0:
             startFrame = self.startTime*self.sampleRate
@@ -372,10 +372,9 @@ class SoundDeviceSound(_SoundBase):
         # process stop time
         if self.stopTime and self.stopTime > 0:
             requestedDur = self.stopTime - self.t
-            maxDur = info.duration
-            self.duration = min(requestedDur, maxDur)
+            self.duration = min(requestedDur, fileDuration)
         else:
-            self.duration = info.duration - self.t
+            self.duration = fileDuration - self.t
         # can now calculate duration in frames
         self.durationFrames = int(round(self.duration*self.sampleRate))
         # are we preloading or streaming?
@@ -383,8 +382,8 @@ class SoundDeviceSound(_SoundBase):
             # no buffer - stream from disk on each call to nextBlock
             pass
         elif self.preBuffer == -1:
-            # no buffer - stream from disk on each call to nextBlock
-            sndArr = self.sndFile.read(frames=len(self.sndFile))
+            # full pre-buffer. Load requested duration to memory
+            sndArr = self.sndFile.read(frames=int(self.sampleRate*self.duration))
             self.sndFile.close()
             self._setSndFromArray(sndArr)
 

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -3707,7 +3707,7 @@ SettingsComponent.Save csv file.__class__:<class 'psychopy.app.builder.experimen
 SettingsComponent.Save csv file.label:Save csv file (summaries)
 SettingsComponent.OSF Project ID.default:''
 SettingsComponent.OSF Project ID.categ:Online
-SettingsComponent.OSF Project ID.allowedVals:[u'f8jfp: loc-gfmt', '']
+SettingsComponent.OSF Project ID.allowedVals:['']
 SettingsComponent.OSF Project ID.readOnly:False
 SettingsComponent.OSF Project ID.updates:None
 SettingsComponent.OSF Project ID.__dict__:{'staticUpdater': None, 'categ': 'Online', 'val': '', 'hint': u'The ID of this project (e.g. 5bqpc)', 'allowedTypes': [], 'allowedUpdates': None, 'label': 'OSF Project ID', 'readOnly': False, 'updates': None, 'valType': 'str'}

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -646,16 +646,16 @@ EnvGratingComponent.stopType.__class__:<class 'psychopy.app.builder.experiment.P
 EnvGratingComponent.stopType.label:stop type
 EnvGratingComponent.blendmode.default:'avg'
 EnvGratingComponent.blendmode.categ:Basic
-EnvGratingComponent.blendmode.allowedVals:[]
+EnvGratingComponent.blendmode.allowedVals:['avg', 'add']
 EnvGratingComponent.blendmode.readOnly:False
 EnvGratingComponent.blendmode.updates:constant
-EnvGratingComponent.blendmode.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'avg', 'hint': u'OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'OpenGL blend mode', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
+EnvGratingComponent.blendmode.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'avg', 'hint': u'OpenGL Blendmode. Avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': ['avg', 'add'], 'label': u'OpenGL blend mode', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
 EnvGratingComponent.blendmode.__weakref__:None
 EnvGratingComponent.blendmode.valType:str
 EnvGratingComponent.blendmode.staticUpdater:None
 EnvGratingComponent.blendmode.val:avg
 EnvGratingComponent.blendmode.allowedTypes:[]
-EnvGratingComponent.blendmode.hint:OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]
+EnvGratingComponent.blendmode.hint:OpenGL Blendmode. Avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display
 EnvGratingComponent.blendmode.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 EnvGratingComponent.blendmode.__class__:<class 'psychopy.app.builder.experiment.Param'>
 EnvGratingComponent.blendmode.label:OpenGL blend mode
@@ -685,7 +685,7 @@ EnvGratingComponent.size.valType:code
 EnvGratingComponent.size.staticUpdater:None
 EnvGratingComponent.size.val:(0.5, 0.5)
 EnvGratingComponent.size.allowedTypes:[]
-EnvGratingComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2]
+EnvGratingComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 EnvGratingComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 EnvGratingComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 EnvGratingComponent.size.label:Size [w,h]
@@ -1020,11 +1020,11 @@ GratingComponent.opacity.allowedUpdates:['constant', 'set every repeat', 'set ev
 GratingComponent.opacity.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.opacity.label:Opacity
 GratingComponent.tex.default:'sin'
-GratingComponent.tex.categ:Grating
+GratingComponent.tex.categ:Advanced
 GratingComponent.tex.allowedVals:[]
 GratingComponent.tex.readOnly:False
 GratingComponent.tex.updates:constant
-GratingComponent.tex.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': 'sin', 'hint': u'The (2D) texture of the grating - can be sin, sqr, sinXsin... or a filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Texture', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
+GratingComponent.tex.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'sin', 'hint': u'The (2D) texture of the grating - can be sin, sqr, sinXsin... or a filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Texture', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
 GratingComponent.tex.__weakref__:None
 GratingComponent.tex.valType:str
 GratingComponent.tex.staticUpdater:None
@@ -1051,16 +1051,16 @@ GratingComponent.colorSpace.__class__:<class 'psychopy.app.builder.experiment.Pa
 GratingComponent.colorSpace.label:Color space
 GratingComponent.blendmode.default:'avg'
 GratingComponent.blendmode.categ:Basic
-GratingComponent.blendmode.allowedVals:[]
+GratingComponent.blendmode.allowedVals:['avg', 'add']
 GratingComponent.blendmode.readOnly:False
 GratingComponent.blendmode.updates:constant
-GratingComponent.blendmode.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'avg', 'hint': u'OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'OpenGL blend mode', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
+GratingComponent.blendmode.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'avg', 'hint': u'OpenGL Blendmode: avg gives traditional transparency, add is important to combine gratings)]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': ['avg', 'add'], 'label': u'OpenGL blend mode', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
 GratingComponent.blendmode.__weakref__:None
 GratingComponent.blendmode.valType:str
 GratingComponent.blendmode.staticUpdater:None
 GratingComponent.blendmode.val:avg
 GratingComponent.blendmode.allowedTypes:[]
-GratingComponent.blendmode.hint:OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is useful if combining a beat with the carrier image or numpy array at point of display)]
+GratingComponent.blendmode.hint:OpenGL Blendmode: avg gives traditional transparency, add is important to combine gratings)]
 GratingComponent.blendmode.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 GratingComponent.blendmode.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.blendmode.label:OpenGL blend mode
@@ -1124,11 +1124,11 @@ GratingComponent.durationEstim.allowedUpdates:None
 GratingComponent.durationEstim.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.durationEstim.label:Expected duration (s)
 GratingComponent.mask.default:'None'
-GratingComponent.mask.categ:Grating
+GratingComponent.mask.categ:Advanced
 GratingComponent.mask.allowedVals:[]
 GratingComponent.mask.readOnly:False
 GratingComponent.mask.updates:constant
-GratingComponent.mask.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': 'None', 'hint': u'An image to define the alpha mask (ie shape)- gauss, circle... or a filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Mask', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
+GratingComponent.mask.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'None', 'hint': u'An image to define the alpha mask (ie shape)- gauss, circle... or a filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Mask', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
 GratingComponent.mask.__weakref__:None
 GratingComponent.mask.valType:str
 GratingComponent.mask.staticUpdater:None
@@ -1154,11 +1154,11 @@ GratingComponent.pos.allowedUpdates:['constant', 'set every repeat', 'set every 
 GratingComponent.pos.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.pos.label:Position [x,y]
 GratingComponent.interpolate.default:'linear'
-GratingComponent.interpolate.categ:Grating
+GratingComponent.interpolate.categ:Advanced
 GratingComponent.interpolate.allowedVals:['linear', 'nearest']
 GratingComponent.interpolate.readOnly:False
 GratingComponent.interpolate.updates:constant
-GratingComponent.interpolate.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': 'linear', 'hint': u'How should the image be interpolated if/when rescaled', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['linear', 'nearest'], 'label': u'Interpolate', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
+GratingComponent.interpolate.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'linear', 'hint': u'How should the image be interpolated if/when rescaled', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['linear', 'nearest'], 'label': u'Interpolate', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
 GratingComponent.interpolate.__weakref__:None
 GratingComponent.interpolate.valType:str
 GratingComponent.interpolate.staticUpdater:None
@@ -1199,11 +1199,11 @@ GratingComponent.units.allowedUpdates:None
 GratingComponent.units.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.units.label:Units
 GratingComponent.texture resolution.default:128
-GratingComponent.texture resolution.categ:Grating
+GratingComponent.texture resolution.categ:Advanced
 GratingComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 GratingComponent.texture resolution.readOnly:False
 GratingComponent.texture resolution.updates:constant
-GratingComponent.texture resolution.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': '128', 'hint': u'Resolution of the texture for standard ones such as sin, sqr etc. For most cases a value of 256 pixels will suffice', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['32', '64', '128', '256', '512'], 'label': u'Texture resolution', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
+GratingComponent.texture resolution.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': '128', 'hint': u'Resolution of the texture for standard ones such as sin, sqr etc. For most cases a value of 256 pixels will suffice', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['32', '64', '128', '256', '512'], 'label': u'Texture resolution', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
 GratingComponent.texture resolution.__weakref__:None
 GratingComponent.texture resolution.valType:code
 GratingComponent.texture resolution.staticUpdater:None
@@ -1214,11 +1214,11 @@ GratingComponent.texture resolution.allowedUpdates:[]
 GratingComponent.texture resolution.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.texture resolution.label:Texture resolution
 GratingComponent.phase.default:0.0
-GratingComponent.phase.categ:Grating
+GratingComponent.phase.categ:Advanced
 GratingComponent.phase.allowedVals:[]
 GratingComponent.phase.readOnly:False
 GratingComponent.phase.updates:constant
-GratingComponent.phase.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': 0.0, 'hint': u'Spatial positioning of the image on the grating (wraps in range 0-1.0)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Phase (in cycles)', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
+GratingComponent.phase.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 0.0, 'hint': u'Spatial positioning of the image on the grating (wraps in range 0-1.0)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Phase (in cycles)', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
 GratingComponent.phase.__weakref__:None
 GratingComponent.phase.valType:code
 GratingComponent.phase.staticUpdater:None
@@ -1289,11 +1289,11 @@ GratingComponent.startVal.allowedUpdates:None
 GratingComponent.startVal.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.startVal.label:Start
 GratingComponent.sf.default:None
-GratingComponent.sf.categ:Grating
+GratingComponent.sf.categ:Advanced
 GratingComponent.sf.allowedVals:[]
 GratingComponent.sf.readOnly:False
 GratingComponent.sf.updates:constant
-GratingComponent.sf.__dict__:{'staticUpdater': None, 'categ': 'Grating', 'val': 'None', 'hint': u'Spatial frequency of image repeats across the grating in 1 or 2 dimensions, e.g. 4 or [2,3]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Spatial frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
+GratingComponent.sf.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'None', 'hint': u'Spatial frequency of image repeats across the grating in 1 or 2 dimensions, e.g. 4 or [2,3]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Spatial frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
 GratingComponent.sf.__weakref__:None
 GratingComponent.sf.valType:code
 GratingComponent.sf.staticUpdater:None
@@ -1314,7 +1314,7 @@ GratingComponent.size.valType:code
 GratingComponent.size.staticUpdater:None
 GratingComponent.size.val:(0.5, 0.5)
 GratingComponent.size.allowedTypes:[]
-GratingComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2]
+GratingComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 GratingComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 GratingComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 GratingComponent.size.label:Size [w,h]
@@ -1614,7 +1614,7 @@ ImageComponent.size.valType:code
 ImageComponent.size.staticUpdater:None
 ImageComponent.size.val:(0.5, 0.5)
 ImageComponent.size.allowedTypes:[]
-ImageComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2]
+ImageComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 ImageComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 ImageComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 ImageComponent.size.label:Size [w,h]
@@ -2334,7 +2334,7 @@ MovieComponent.size.valType:code
 MovieComponent.size.staticUpdater:None
 MovieComponent.size.val:
 MovieComponent.size.allowedTypes:[]
-MovieComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2]
+MovieComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 MovieComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 MovieComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 MovieComponent.size.label:Size [w,h]
@@ -2799,7 +2799,7 @@ PatchComponent.size.valType:code
 PatchComponent.size.staticUpdater:None
 PatchComponent.size.val:(0.5, 0.5)
 PatchComponent.size.allowedTypes:[]
-PatchComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2]
+PatchComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 PatchComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 PatchComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 PatchComponent.size.label:Size [w,h]
@@ -3085,7 +3085,7 @@ PolygonComponent.size.staticUpdater:None
 PolygonComponent.size.val:(0.5, 0.5)
 PolygonComponent.size.allowedTypes:[]
 PolygonComponent.size.hint:Size of this stimulus [w,h]. Note that for a line only the first value is used, for triangle and rect the [w,h] is as expected,
- but for higher-order polygons it represents the [w,h] of the ellipse that the polygon sits on!!
+ but for higher-order polygons it represents the [w,h] of the ellipse that the polygon sits on!! 
 PolygonComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 PolygonComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
 PolygonComponent.size.label:Size [w,h]
@@ -3686,7 +3686,7 @@ SettingsComponent.HTML path.valType:str
 SettingsComponent.HTML path.staticUpdater:None
 SettingsComponent.HTML path.val:html
 SettingsComponent.HTML path.allowedTypes:[]
-SettingsComponent.HTML path.hint:Place the HTML files will be saved locally
+SettingsComponent.HTML path.hint:Place the HTML files will be saved locally 
 SettingsComponent.HTML path.allowedUpdates:None
 SettingsComponent.HTML path.__class__:<class 'psychopy.app.builder.experiment.Param'>
 SettingsComponent.HTML path.label:Output path
@@ -3707,7 +3707,7 @@ SettingsComponent.Save csv file.__class__:<class 'psychopy.app.builder.experimen
 SettingsComponent.Save csv file.label:Save csv file (summaries)
 SettingsComponent.OSF Project ID.default:''
 SettingsComponent.OSF Project ID.categ:Online
-SettingsComponent.OSF Project ID.allowedVals:['']
+SettingsComponent.OSF Project ID.allowedVals:[u'f8jfp: loc-gfmt', '']
 SettingsComponent.OSF Project ID.readOnly:False
 SettingsComponent.OSF Project ID.updates:None
 SettingsComponent.OSF Project ID.__dict__:{'staticUpdater': None, 'categ': 'Online', 'val': '', 'hint': u'The ID of this project (e.g. 5bqpc)', 'allowedTypes': [], 'allowedUpdates': None, 'label': 'OSF Project ID', 'readOnly': False, 'updates': None, 'valType': 'str'}

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -73,8 +73,8 @@ class _BaseTestStairHandler(object):
             # The first trial can never be a reversal.
             assert stairs.nReversals <= len(stairs.data) - 1
 
-            assert stairs.nReversals == len(stairs.reversalPoints)
-            assert stairs.nReversals == len(stairs.reversalIntensities)
+            assert len(stairs.reversalPoints) >= stairs.nReversals
+            assert len(stairs.reversalIntensities) >= stairs.nReversals
 
         if stairs.reversalPoints:
             assert stairs.reversalIntensities
@@ -307,6 +307,22 @@ class TestStairHandler(_BaseTestStairHandler):
         self.simulate()
         self.checkSimulationResults()
 
+    def test_nReversals(self):
+        start_val = 1
+        step_sizes = range(5)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=None)
+        assert staircase.nReversals == len(step_sizes)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=len(step_sizes) - 1)
+        assert staircase.nReversals == len(step_sizes)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=len(step_sizes) + 1)
+        assert staircase.nReversals == len(step_sizes) + 1
+
 
 class TestQuestHandler(_BaseTestStairHandler):
     """
@@ -329,6 +345,8 @@ class TestQuestHandler(_BaseTestStairHandler):
             gamma=gamma, delta=delta, grain=grain, range=range,
             minVal=minVal, maxVal=maxVal
         )
+
+        self.stairs.nReversals = None
 
         self.responses = makeBasicResponseCycles(
             cycles=3, nCorrect=2, nIncorrect=2, length=10

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -227,6 +227,7 @@ class TestPygletNorm(_baseTest):
         if havePygame:
             assert pygame.display.get_init() == 0
 
+
 class xxxTestPygameNorm(_baseTest):
     @classmethod
     def setup_class(self):

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -103,6 +103,25 @@ class _baseTest(object):
         for t in ['mouse', 'joystick', 'keyboard', None]:
             event.clearEvents(t)
 
+    def test_clearEvents_keyboard(self):
+        event._onPygletKey(symbol='x', modifiers=0, emulated=True)
+        event.clearEvents('keyboard')
+        assert not event._keyBuffer
+
+    def test_clearEvents_mouse(self):
+        """Keyboard buffer should not be affected.
+        """
+        event._onPygletKey(symbol='x', modifiers=0, emulated=True)
+        event.clearEvents('mouse')
+        assert event._keyBuffer
+
+    def test_clearEvents_joystick(self):
+        """Keyboard buffer should not be affected.
+        """
+        event._onPygletKey(symbol='x', modifiers=0, emulated=True)
+        event.clearEvents('joystick')
+        assert event._keyBuffer
+
     def test_keys(self):
         if travis:
             pytest.skip()  # failing on travis-ci


### PR DESCRIPTION
I had accidentally added a second copy of the allowedVals param to the blendMode attribute

Unfortunately which adding this commit I got the history order messed up (with an erroneous use of --rebase). Sorry!