### PR TITLE
BF: StairHandler.nReversals must not be None

### DIFF
--- a/psychopy/data.py
+++ b/psychopy/data.py
@@ -2936,11 +2936,12 @@ class StairHandler(_BaseTrialHandler):
         self._variableStep = True if len(self.stepSizes) > 1 else False
         self.stepSizeCurrent = self.stepSizes[0]
 
-        if nReversals is not None and len(self.stepSizes) > nReversals:
-            logging.warn(
-                "Increasing number of minimum required reversals to "
-                "the number of step sizes (%i)." % len(self.stepSizes)
-            )
+        if nReversals is None:
+            self.nReversals = len(self.stepSizes)
+        elif len(self.stepSizes) > nReversals:
+            msg = ('Increasing number of minimum required reversals to the '
+                   'number of step sizes, (%i).' % len(self.stepSizes))
+            logging.warn(msg)
             self.nReversals = len(self.stepSizes)
         else:
             self.nReversals = nReversals

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -316,12 +316,13 @@ class TestStairHandler(_BaseTestStairHandler):
         assert staircase.nReversals == len(step_sizes)
 
         staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
-                                      nReversals=1)
+                                      nReversals=len(step_sizes) - 1)
         assert staircase.nReversals == len(step_sizes)
 
         staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
-                                      nReversals=10)
-        assert staircase.nReversals == 10
+                                      nReversals=len(step_sizes) + 1)
+        assert staircase.nReversals == len(step_sizes) + 1
+
 
 class TestQuestHandler(_BaseTestStairHandler):
     """

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -73,8 +73,8 @@ class _BaseTestStairHandler(object):
             # The first trial can never be a reversal.
             assert stairs.nReversals <= len(stairs.data) - 1
 
-            assert stairs.nReversals == len(stairs.reversalPoints)
-            assert stairs.nReversals == len(stairs.reversalIntensities)
+            assert len(stairs.reversalPoints) >= stairs.nReversals
+            assert len(stairs.reversalIntensities) >= stairs.nReversals
 
         if stairs.reversalPoints:
             assert stairs.reversalIntensities
@@ -307,6 +307,21 @@ class TestStairHandler(_BaseTestStairHandler):
         self.simulate()
         self.checkSimulationResults()
 
+    def test_nReversals(self):
+        start_val = 1
+        step_sizes = range(5)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=None)
+        assert staircase.nReversals == len(step_sizes)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=1)
+        assert staircase.nReversals == len(step_sizes)
+
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=10)
+        assert staircase.nReversals == 10
 
 class TestQuestHandler(_BaseTestStairHandler):
     """
@@ -329,6 +344,8 @@ class TestQuestHandler(_BaseTestStairHandler):
             gamma=gamma, delta=delta, grain=grain, range=range,
             minVal=minVal, maxVal=maxVal
         )
+
+        self.stairs.nReversals = None
 
         self.responses = makeBasicResponseCycles(
             cycles=3, nCorrect=2, nIncorrect=2, length=10


### PR DESCRIPTION
`StairHandler.nReversals` should never be `None`, but be set to a value equal to or greater than the length of the `stepSizes` parameter. Otherwise, we will finish the staircase prematurely during `calculateNextIntensity()`. 

This closes #1342.
