### PR TITLE
Bind the window's FBO after switching to that window.

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1151,9 +1151,7 @@ class WindowMixin(object):
 
     def _selectWindow(self, win):
         # don't call switch if it's already the curr window
-        if win != globalVars.currWindow and win.winType == 'pyglet':
-            win.winHandle.switch_to()
-            globalVars.currWindow = win
+        self.win._setCurrent()
 
     def _updateList(self):
         """The user shouldn't need this method since it gets called

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1150,7 +1150,7 @@ class WindowMixin(object):
                                   'visual.BaseVisualStim.draw')
 
     def _selectWindow(self, win):
-        """Switch drawing to the a specified window. Calls the window's 
+        """Switch drawing to the specified window. Calls the window's 
         _setCurrent() method which handles the switch.
         """
         self.win._setCurrent()

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1150,7 +1150,9 @@ class WindowMixin(object):
                                   'visual.BaseVisualStim.draw')
 
     def _selectWindow(self, win):
-        # don't call switch if it's already the curr window
+        """Switch drawing to the a specified window. Calls the window's 
+        _setCurrent() method which handles the switch.
+        """
         self.win._setCurrent()
 
     def _updateList(self):

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -553,7 +553,7 @@ class Window(object):
         """
         if self != globalVars.currWindow and self.winType == 'pyglet':
             self.winHandle.switch_to()
-            globalVars.currWindow = win
+            globalVars.currWindow = self
 
             # if we are using an FBO, bind it
             if self.useFBO:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -548,6 +548,23 @@ class Window(object):
             self.frameIntervals = []
             self.frameClock.reset()
 
+    def _setCurrent(self):
+        """Make this window current.
+        """
+        if self != globalVars.currWindow and self.winType == 'pyglet':
+            self.winHandle.switch_to()
+            globalVars.currWindow = win
+
+            # if we are using an FBO, bind it
+            if self.useFBO:
+                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT,
+                                        self.frameBuffer)
+                GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+                GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+                GL.glActiveTexture(GL.GL_TEXTURE0)
+                GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+                GL.glEnable(GL.GL_STENCIL_TEST)
+
     def onResize(self, width, height):
         """A default resize event handler.
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -549,7 +549,8 @@ class Window(object):
             self.frameClock.reset()
 
     def _setCurrent(self):
-        """Make this window current.
+        """Make this window current. If useFBO=True, the framebuffer is bound
+        after the context switch. 
         """
         if self != globalVars.currWindow and self.winType == 'pyglet':
             self.winHandle.switch_to()
@@ -561,6 +562,8 @@ class Window(object):
                                         self.frameBuffer)
                 GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
                 GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+
+                # NB - check if we need these
                 GL.glActiveTexture(GL.GL_TEXTURE0)
                 GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
                 GL.glEnable(GL.GL_STENCIL_TEST)


### PR DESCRIPTION
Fixes #1412 

Note, I moved the switching logic to the window class as a new method. The stereoscopy libraries need to override window switching logic to work correctly for some display types. Making this change will allow existing psychopy stimuli to be drawn stereoscopically using the `stim.draw(win)` syntax, providing greater compatibility.