### PR TITLE
BF: cm2deg returns wrong value when correctFlat=True

### DIFF
--- a/psychopy/tools/monitorunittools.py
+++ b/psychopy/tools/monitorunittools.py
@@ -125,7 +125,7 @@ def cm2deg(cm, monitor, correctFlat=False):
         msg = "Monitor %s has no known distance (SEE MONITOR CENTER)"
         raise ValueError(msg % monitor.name)
     if correctFlat:
-        return np.arctan(np.radians(cm / dist))
+        return np.degrees(np.arctan(cm / dist))
     else:
         return cm / (dist * 0.017455)
 


### PR DESCRIPTION
Following codes convert contents of _points_ to other units and re-convert to original units.

```
import psychopy.monitors.calibTools
from psychopy.tools.monitorunittools import cm2deg, deg2cm, deg2pix, pix2deg

points = [[-4.0, 4.0],
          [ 0.0, 0.0],
          [ 4.0,-4.0]]

monitor = psychopy.monitors.calibTools.Monitor('test', width=55, distance=60)
monitor.setSizePix((1920,1080))

print '====== deg2cm -> cm2deg======'
p1 = deg2cm(points, monitor, correctFlat=False)
p2 = cm2deg(p1, monitor, correctFlat=False)
print 'deg2cm\n', p1
print 'cm2deg\n', p2


print '====== deg2pix -> pix2deg======'
p1 = deg2pix(points, monitor, correctFlat=False)
p2 = pix2deg(p1, monitor, correctFlat=False)
print 'deg2pix\n', p1
print 'pix2deg\n', p2


print '====== deg2cm -> cm2deg (correctFlat)======'
p1 = deg2cm(points, monitor, correctFlat=True)
p2 = cm2deg(p1, monitor, correctFlat=True)
print 'deg2cm\n', p1
print 'cm2deg\n', p2


print '====== deg2pix -> pix2deg (correctFlat) ======'
p1 = deg2pix(points, monitor, correctFlat=True)
p2 = pix2deg(p1, monitor, correctFlat=True)
print 'deg2pix\n', p1
print 'pix2deg\n', p2
```
Running above codes on the latest PsychoPy, I've got following output. Return values of cm2eg and pix2deg are strange if correctFlat==True.

> ====== deg2cm -> cm2deg======
> deg2cm
> [[-4.1892  4.1892]
>  [ 0.      0.    ]
>  [ 4.1892 -4.1892]]
> cm2deg
> [[-4.  4.]
>  [ 0.  0.]
>  [ 4. -4.]]
> ====== deg2pix -> pix2deg======
> deg2pix
> [[-146.24116364  146.24116364]
>  [   0.            0.        ]
>  [ 146.24116364 -146.24116364]]
> pix2deg
> [[-4.  4.]
>  [ 0.  0.]
>  [ 4. -4.]]
> ====== deg2cm -> cm2deg (correctFlat)======
> deg2cm
> [[-4.20585397  4.20585397]
>  [ 0.          0.        ]
>  [ 4.20585397 -4.20585397]]
> cm2deg
> [[-0.00122343  0.00122343]
>  [ 0.          0.        ]
>  [ 0.00122343 -0.00122343]]
> ====== deg2pix -> pix2deg (correctFlat) ======
> deg2pix
> [[-146.82253843  146.82253843]
>  [   0.            0.        ]
>  [ 146.82253843 -146.82253843]]
> pix2deg
> [[-0.00122343  0.00122343]
>  [ 0.          0.        ]
>  [ 0.00122343 -0.00122343]]

pix2deg uses cm2deg internally, and  cm2deg calculates return values as following (lines 127-128 of psychopy.tools.monitorunittools.py):

```
    if correctFlat:
        return np.arctan(np.radians(cm / dist))
```

I think the equation should be np.degrees(np.arctan(cm / dist)). 