### PR TITLE
nReps and sequential/random/fullRandom

### DIFF
--- a/psychopy/app/builder/components/keyboard/__init__.py
+++ b/psychopy/app/builder/components/keyboard/__init__.py
@@ -524,4 +524,3 @@ class KeyboardComponent(BaseComponent):
 
         if currLoop.params['name'].val == self.exp._expHandler.name:
             buff.writeIndented("%s.addData('eventName','keyboard');\n" % self.exp._expHandler.name)
-            buff.writeIndented("%s.nextEntry();\n" % self.exp._expHandler.name)

--- a/psychopy/app/builder/components/keyboard/__init__.py
+++ b/psychopy/app/builder/components/keyboard/__init__.py
@@ -523,4 +523,5 @@ class KeyboardComponent(BaseComponent):
             buff.writeIndentedLines(code)
 
         if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)
+            buff.writeIndented("%s.addData('eventName','keyboard');\n" % self.exp._expHandler.name)
+            buff.writeIndented("%s.nextEntry();\n" % self.exp._expHandler.name)

--- a/psychopy/app/builder/components/settings/__init__.py
+++ b/psychopy/app/builder/components/settings/__init__.py
@@ -631,7 +631,17 @@ class SettingsComponent(object):
                 "}\n"
                 )
         buff.writeIndentedLines(abbrevFunc)
+        recordLoopIterationFunc = ("\nfunction recordLoopIteration(name) {\n"
+                    "  return function () {\n"
+                    "    thisExp.addData('eventName',name+'.loopEnd');\n"
+                    "    thisExp.nextEntry();\n"
+                    "    return psychoJS.NEXT;\n"
+                    "  }\n"
+                    "}\n"
+                )
+        buff.writeIndentedLines(recordLoopIterationFunc)
         quitFunc = ("\nfunction quitPsychoJS() {\n"
+                    "    thisExp.save();\n"
                     "    win.close()\n"
                     "    psychoJS.core.quit();\n"
                     "    return psychoJS.QUIT;\n"

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1054,15 +1054,15 @@ class TrialHandler(object):
                 "      trialList:psychoJS.data.importConditions({params[conditionsFile]}),\n"
                 "      seed:{seed}, name:'{params[name]}'}});\n"
                 "    thisExp.addLoop({params[name]}); // add the loop to the experiment\n"
-                "    {thisName} = {params[name]}.trialList[0]; // so we can initialise stimuli with some values\n"
+                "    {thisName} = {params[name]}.trialList[{params[name]}.trialSequence[0]]; // so we can initialise stimuli with some values\n"
                 "    // abbreviate parameter names if possible (e.g. rgb={thisName}.rgb)\n"
                 "    abbrevNames({thisName});\n"
                 .format(params=self.params, thisName=self.thisName, seed=seed))
         buff.writeIndentedLines(code)
         # for the scheduler
         code = ("    // Schedule each of the trials in the list to occur\n"
-                "    for (var i = 0; i < {params[name]}.trialList.length; ++i) {{\n"
-                "      {thisName} = {params[name]}.trialList[i];\n"
+                "    for (var i = 0; i < {params[name]}.trialSequence.length; ++i) {{\n"
+                "      {thisName} = {params[name]}.trialList[{params[name]}.trialSequence[i]];\n"
                 "      thisScheduler.add(abbrevNames({thisName}));\n"
                 .format(params=self.params, thisName=self.thisName, seed=seed))
         buff.writeIndentedLines(code)
@@ -1087,6 +1087,11 @@ class TrialHandler(object):
                     "      thisScheduler.add({name}LoopEnd);\n"
                     .format(params=self.params, name=thisChild.params['name'])
                     )
+        if self.params['isTrials'].val == True:
+            code += (
+                   "      thisScheduler.add(recordLoopIteration('{name}'));\n"
+                   .format(params=self.params, name=thisChild.params['name'])
+                   )
         buff.writeIndentedLines(code)
         code = ("    }}\n"
                 "  }} catch (exception) {{\n"
@@ -1147,7 +1152,7 @@ class TrialHandler(object):
                 "    params = Object.keys({params[name]}.trialList[0]);\n"
                 "  }}\n\n"
                 "  // save data for this loop\n"
-                "  thisExp.save({{stimOut: params, dataOut: ['n','all_mean','all_std', 'all_raw']}});\n"
+                "  thisExp.loopEnded({params[name]});\n"
                 "  return psychoJS.NEXT;\n"
                 "  }}\n"
                 .format(params=self.params))
@@ -2078,6 +2083,10 @@ class Routine(list):
                 "  if ('status' in thisComponent) {{\n"
                 "    thisComponent.status = psychoJS.NOT_STARTED;\n"
                 "  }}\n"
+                "}}\n"
+                "for (var l = 0; l < thisExp._unfinishedLoops.length; l++) {{\n"
+                "  var loop = thisExp._unfinishedLoops[l];\n"
+                "  loop.updateAttributesAtBegin();\n"
                 "}}\n"
                 "\nreturn psychoJS.NEXT;\n"
                 "}}\n"


### PR DESCRIPTION
add psychoJS support for nReps and
sequential/random/fullRandom trial sequences.
Add columns from conditions files to data output.
Make loops marked as “isTrials” cause a data line
to be written each iteration. Add an “eventName”
column to the data file to identify whether a data
line was caused by a keyboard event or a loop iteration.
write out experiment data when quitPsychoJS() is called.

This commit goes with the one with the same name in the
psychojs project