### PR TITLE
PsychoJS - remove EventName column from data file

### DIFF
--- a/psychopy/app/builder/components/keyboard/__init__.py
+++ b/psychopy/app/builder/components/keyboard/__init__.py
@@ -521,6 +521,3 @@ class KeyboardComponent(BaseComponent):
                     "    {loopName}.addData('{name}.rt', {name}.rt)\n}}\n"
                     .format(loopName=currLoop.params['name'], name=name))
             buff.writeIndentedLines(code)
-
-        if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.addData('eventName','keyboard');\n" % self.exp._expHandler.name)

--- a/psychopy/app/builder/components/settings/__init__.py
+++ b/psychopy/app/builder/components/settings/__init__.py
@@ -631,9 +631,9 @@ class SettingsComponent(object):
                 "}\n"
                 )
         buff.writeIndentedLines(abbrevFunc)
-        recordLoopIterationFunc = ("\nfunction recordLoopIteration(name) {\n"
+        recordLoopIterationFunc = ("\nfunction recordLoopIteration(currentLoop) {\n"
                     "  return function () {\n"
-                    "    thisExp.addData('eventName',name+'.loopEnd');\n"
+                    "    currentLoop.updateAttributesAtBegin();\n"
                     "    thisExp.nextEntry();\n"
                     "    return psychoJS.NEXT;\n"
                     "  }\n"

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -1089,8 +1089,8 @@ class TrialHandler(object):
                     )
         if self.params['isTrials'].val == True:
             code += (
-                   "      thisScheduler.add(recordLoopIteration('{name}'));\n"
-                   .format(params=self.params, name=thisChild.params['name'])
+                   "      thisScheduler.add(recordLoopIteration({name}));\n"
+                   .format(name=self.params['name'])
                    )
         buff.writeIndentedLines(code)
         code = ("    }}\n"
@@ -2083,10 +2083,6 @@ class Routine(list):
                 "  if ('status' in thisComponent) {{\n"
                 "    thisComponent.status = psychoJS.NOT_STARTED;\n"
                 "  }}\n"
-                "}}\n"
-                "for (var l = 0; l < thisExp._unfinishedLoops.length; l++) {{\n"
-                "  var loop = thisExp._unfinishedLoops[l];\n"
-                "  loop.updateAttributesAtBegin();\n"
                 "}}\n"
                 "\nreturn psychoJS.NEXT;\n"
                 "}}\n"


### PR DESCRIPTION
The “eventName” column in the data file is not
needed or meaningful since now only one line is
written to the data file for each iteration of a
“trials” loop.

Also, call the trialhandler’s updateAttributesAtBegin()
function in the recordLoopIteration() function that
is scheduled at the end of each iteration of a “trials”
loop instead of in the routineStartJS code.