### PR TITLE
BF: Builder PsychoJS code for text components formatted badly

### DIFF
--- a/psychopy/app/builder/components/text/__init__.py
+++ b/psychopy/app/builder/components/text/__init__.py
@@ -124,7 +124,7 @@ class TextComponent(BaseVisualComponent):
         if self.params['units'].val == 'from exp settings':
             unitsStr = ""
         else:
-            unitsStr = "units:'%(units)s', " % self.params
+            unitsStr = "units : %(units)s, " % self.params
         # do writing of init
         # replaces variable params with sensible defaults
         inits = getInitVals(self.params, 'PsychoJS')


### PR DESCRIPTION
The units parameter was being given additional quote symbols
leading to a syntax error (only happened when not inheritting
from default so wasn't noticed before)