### PR TITLE
Bf use version deploy tweaks

### DIFF
--- a/buildRelease.py
+++ b/buildRelease.py
@@ -37,7 +37,7 @@ def buildRelease(versionStr, noCommit=False, interactive=True):
     shutil.copytree("psychopy", dest, symlinks=False, ignore=ignores)
 
     #todo: would be nice to check here that we didn't accidentally add anything large (check new folder size)
-    Mb = float(subprocess.check_output(["du", "-bsc", dest]).split()[0])/10**6
+    Mb = float(subprocess.check_output(["du", "-ksc", dest]).split()[0])/10**3
     print "size for '%s' will be: %.2f Mb" %(versionStr, Mb)
     if noCommit:
         return False
@@ -58,10 +58,10 @@ def buildRelease(versionStr, noCommit=False, interactive=True):
             return False
     else:
         print "committing: git commit -m 'release version %s'" %versionStr
-        subprocess.call(["git", "commit", "-m", "'release version %s'" %versionStr], cwd=VERSIONS)
+        subprocess.call(["git", "commit", "-m", "release version %s" %versionStr], cwd=VERSIONS)
 
     print "tagging: git tag -m 'release %s'" %versionStr
-    ok = subprocess.call(["git", "tag", versionStr, "-m", "'release %s'" %versionStr], cwd=VERSIONS)
+    ok = subprocess.call(["git", "tag", versionStr, "-m", "release %s" %versionStr], cwd=VERSIONS)
 
     print "'versions' tags are now:", subprocess.check_output(["git","tag"], cwd=VERSIONS).split()
     ok = subprocess.call(["git", "push", "%s" %versionStr], cwd=VERSIONS)
@@ -80,6 +80,10 @@ if __name__=="__main__":
         noCommit = True
     else:
         noCommit = False
+    if "--noInteractive" not in sys.argv:
+        interactive = True
+    else:
+        interactive = False
     #todo: update versions first
     versionStr = raw_input("version:")
-    buildRelease(versionStr, noCommit=noCommit, interactive=True)
+    buildRelease(versionStr, noCommit=noCommit, interactive=interactive)

--- a/buildRelease.py
+++ b/buildRelease.py
@@ -1,5 +1,4 @@
 #!python
-
 """This script is used to:
     - update the version numbers
     - update the psychopyVersions repo:
@@ -15,21 +14,25 @@ from os.path import join
 from createInitFile import createInitFile
 
 MAIN = os.path.abspath(os.path.split(__file__)[0])
-VERSIONS = join(MAIN,'..','versions')
+VERSIONS = join(MAIN, '..', 'versions')
+
 
 def getSHA(cwd='.'):
-    if cwd=='.':
+    if cwd == '.':
         cwd = os.getcwd()
     #get the SHA of the git HEAD
-    SHA_string = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=cwd).split()[0]
+    SHA_string = subprocess.check_output(
+        ['git', 'rev-parse', '--short', 'HEAD'],
+        cwd=cwd).split()[0]
     #convert to hex from a string and return it
-    print 'SHA:', SHA_string, 'for repo:',cwd
+    print 'SHA:', SHA_string, 'for repo:', cwd
     return SHA_string
+
 
 def buildRelease(versionStr, noCommit=False, interactive=True):
     #
     createInitFile(dist='sdist', version=versionStr, sha=getSHA())
-    dest = join(VERSIONS,"psychopy")
+    dest = join(VERSIONS, "psychopy")
     shutil.rmtree(dest)
     ignores = shutil.ignore_patterns("demos", "docs", "tests", "pylink",
                                      "*.pyo", "*.pyc", "*.orig", "*.bak",
@@ -37,8 +40,9 @@ def buildRelease(versionStr, noCommit=False, interactive=True):
     shutil.copytree("psychopy", dest, symlinks=False, ignore=ignores)
 
     #todo: would be nice to check here that we didn't accidentally add anything large (check new folder size)
-    Mb = float(subprocess.check_output(["du", "-ksc", dest]).split()[0])/10**3
-    print "size for '%s' will be: %.2f Mb" %(versionStr, Mb)
+    Mb = float(subprocess.check_output(["du", "-ksc", dest]).split()[
+        0]) / 10**3
+    print "size for '%s' will be: %.2f Mb" % (versionStr, Mb)
     if noCommit:
         return False
 
@@ -52,30 +56,37 @@ def buildRelease(versionStr, noCommit=False, interactive=True):
     output = subprocess.check_output(["git", "add", "--all"], cwd=VERSIONS)
     if interactive:
         ok = subprocess.call(["cola"], cwd=VERSIONS)
-        if lastSHA==getSHA():
+        if lastSHA == getSHA():
             #we didn't commit the changes so quit
             print("no git commit was made: exiting")
             return False
     else:
-        print "committing: git commit -m 'release version %s'" %versionStr
-        subprocess.call(["git", "commit", "-m", "release version %s" %versionStr], cwd=VERSIONS)
+        print "committing: git commit -m 'release version %s'" % versionStr
+        subprocess.call(
+            ["git", "commit", "-m", "release version %s" % versionStr],
+            cwd=VERSIONS)
 
-    print "tagging: git tag -m 'release %s'" %versionStr
-    ok = subprocess.call(["git", "tag", versionStr, "-m", "release %s" %versionStr], cwd=VERSIONS)
+    print "tagging: git tag -m 'release %s'" % versionStr
+    ok = subprocess.call(
+        ["git", "tag", versionStr, "-m", "release %s" % versionStr],
+        cwd=VERSIONS)
 
-    print "'versions' tags are now:", subprocess.check_output(["git","tag"], cwd=VERSIONS).split()
-    ok = subprocess.call(["git", "push", "%s" %versionStr], cwd=VERSIONS)
+    print "'versions' tags are now:", subprocess.check_output(
+        ["git", "tag"],
+        cwd=VERSIONS).split()
+    ok = subprocess.call(["git", "push", "%s" % versionStr], cwd=VERSIONS)
     if ok:
-        print "Successfully pushed tag %s upstream" %versionStr
+        print "Successfully pushed tag %s upstream" % versionStr
     else:
-        print "Failed to push tag %s upstream" %versionStr
+        print "Failed to push tag %s upstream" % versionStr
 
     #revert thte __init__ file to non-ditribution state
     print 'reverting the main master branch: git reset --hard HEAD'
-    print subprocess.check_output(["git","reset", "--hard", "HEAD"], cwd=MAIN)
-    return True #success
+    print subprocess.check_output(["git", "reset", "--hard", "HEAD"], cwd=MAIN)
+    return True  #success
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     if "--noCommit" in sys.argv:
         noCommit = True
     else:


### PR DESCRIPTION
Here are some small tweaks for the ``psychopy/versions`` deploy script. This uses universal ``du`` commands (``-k`` instead of ``-b``) to accompate the BSD version of ``du``  in MacOS, and removes unnecessary quotes around the version number in tag and commit messages. Finally, there are some small PEP8 formatting updates as well.