### PR TITLE
RF2to3: remove the reference to .keys()

### DIFF
--- a/docs/source/developers/buildercomponent.rst
+++ b/docs/source/developers/buildercomponent.rst
@@ -73,7 +73,7 @@ During development, it can sometimes be helpful to save the params into the xxx_
     def writeInitCode(self,buff):
         # for debugging during Component development:
         buff.writeIndented("# self.params for aperture:\n")
-        for p in self.params.keys():
+        for p in self.params:
             try: buff.writeIndented("# %s: %s <type %s>\n" % (p, self.params[p].val, self.params[p].valType))
             except: pass
 

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -175,7 +175,7 @@ class PsychoPyApp(wx.App):
         if '--firstrun' in sys.argv:
             del sys.argv[sys.argv.index('--firstrun')]
             self.firstRun = True
-        if 'lastVersion' not in self.prefs.appData.keys():
+        if 'lastVersion' not in self.prefs.appData:
             # must be before 1.74.00
             last = self.prefs.appData['lastVersion'] = '1.73.04'
             self.firstRun = True

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -363,7 +363,7 @@ class RoutineCanvas(wx.ScrolledWindow):
         # set an id for the region of this component (so it can
         # act as a button). see if we created this already.
         id = None
-        for key in self.componentFromID.keys():
+        for key in self.componentFromID:
             if self.componentFromID[key] == component:
                 id = key
         if not id:  # then create one and add to the dict
@@ -411,7 +411,7 @@ class RoutineCanvas(wx.ScrolledWindow):
         # set an id for the region of this component (so it
         # can act as a button). see if we created this already
         id = None
-        for key in self.componentFromID.keys():
+        for key in self.componentFromID:
             if self.componentFromID[key] == component:
                 id = key
         if not id:  # then create one and add to the dict
@@ -610,7 +610,7 @@ class RoutinesNotebook(aui.AuiNotebook):
         name = routine.name
         # update experiment object, namespace, and flow window (if this is
         # being used)
-        if name in self.frame.exp.routines.keys():
+        if name in self.frame.exp.routines:
             # remove names of the routine and its components from namespace
             _nsp = self.frame.exp.namespace
             for c in self.frame.exp.routines[name]:
@@ -683,7 +683,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         self.sizerList = []
 
         for categ in categories:
-            if categ in _localized.keys():
+            if categ in _localized:
                 label = _localized[categ]
             else:
                 label = categ
@@ -732,7 +732,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         self.makeFavoriteButtons()
         # then add another copy for each category that the component itself
         # lists
-        for thisName in self.components.keys():
+        for thisName in self.components:
             thisComp = self.components[thisName]
             # NB thisComp is a class - we can't use its methods/attribs until
             # it is an instance
@@ -916,10 +916,10 @@ class FavoriteComponents(object):
         # set those that are favorites by default
         for comp in ('ImageComponent', 'KeyboardComponent',
                      'SoundComponent', 'TextComponent'):
-            if comp not in self.currentLevels.keys():
+            if comp not in self.currentLevels:
                 self.currentLevels[comp] = self.threshold
-        for comp in self.panel.components.keys():
-            if comp not in self.currentLevels.keys():
+        for comp in self.panel.components:
+            if comp not in self.currentLevels:
                 self.currentLevels[comp] = self.neutral
 
     def makeFavorite(self, compName):
@@ -981,7 +981,7 @@ class BuilderFrame(wx.Frame):
         self.filename = fileName
         self.htmlPath = None
 
-        if fileName in self.appData['frames'].keys():
+        if fileName in self.appData['frames']:
             self.frameData = self.appData['frames'][fileName]
         else:  # work out a new frame size/location
             dispW, dispH = self.app.getPrimaryDisplaySize()
@@ -1742,7 +1742,7 @@ class BuilderFrame(wx.Frame):
         self.appData['frames'][self.filename] = frameData
         # save the display data only for those frames in the history:
         tmp2 = {}
-        for f in self.appData['frames'].keys():
+        for f in self.appData['frames']:
             if f in self.appData['fileHistory']:
                 tmp2[f] = self.appData['frames'][f]
         self.appData['frames'] = copy.copy(tmp2)
@@ -1928,7 +1928,7 @@ class BuilderFrame(wx.Frame):
         demoList.sort(key=lambda entry: entry.lower)
         self.demos = {wx.NewId(): demoList[n]
                       for n in range(len(demoList))}
-        for thisID in self.demos.keys():
+        for thisID in self.demos:
             junk, shortname = os.path.split(self.demos[thisID])
             if (shortname.startswith('_') or
                     shortname.lower().startswith('readme.')):
@@ -2117,7 +2117,7 @@ class BuilderFrame(wx.Frame):
             # namespace:
             name = exp.namespace.makeValid(
                 name, prefix='routine')
-            if oldName in self.exp.routines.keys():
+            if oldName in self.exp.routines:
                 # Swap old with new names
                 self.exp.routines[oldName].name = name
                 self.exp.routines[name] = self.exp.routines.pop(oldName)

--- a/psychopy/app/builder/components/__init__.py
+++ b/psychopy/app/builder/components/__init__.py
@@ -136,7 +136,7 @@ def getComponents(folder=None, fetchIcons=True):
 
     components = {}
     # setup a default icon
-    if fetchIcons and 'default' not in icons.keys():
+    if fetchIcons and 'default' not in icons:
         icons['default'] = getIcons(filename=None)
 
     # go through components in directory
@@ -204,7 +204,7 @@ def getAllComponents(folderList=(), fetchIcons=True):
     components = getComponents(fetchIcons=fetchIcons)  # get the built-ins
     for folder in folderList:
         userComps = getComponents(folder)
-        for thisKey in userComps.keys():
+        for thisKey in userComps:
             components[thisKey] = userComps[thisKey]
     return components
 
@@ -224,7 +224,7 @@ def getInitVals(params, target="PsychoPy"):
     __init__ of a stimulus object, avoiding using a variable name if possible
     """
     inits = copy.deepcopy(params)
-    for name in params.keys():
+    for name in params:
 
         if target == "PsychoJS":
             # convert (0,0.5) to [0,0.5] but don't convert "rand()" to "rand[]"

--- a/psychopy/app/builder/components/_base.py
+++ b/psychopy/app/builder/components/_base.py
@@ -371,7 +371,7 @@ class BaseComponent(object):
             True/False = checkNeedToUpdate(self, updateType)
 
         """
-        for thisParamName in self.params.keys():
+        for thisParamName in self.params:
             if thisParamName == 'advancedParams':
                 continue
             thisParam = self.params[thisParamName]

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -372,7 +372,7 @@ class _BaseParamsDlg(wx.Dialog):
         self.title = title
         if (not editing and
                 title != 'Experiment Settings' and
-                'name' in self.params.keys()):
+                'name' in self.params):
             # then we're adding a new component, so provide known-valid name:
             makeValid = self.frame.exp.namespace.makeValid
             self.params['name'].val = makeValid(params['name'].val)
@@ -447,14 +447,14 @@ class _BaseParamsDlg(wx.Dialog):
             theseParams = categs[categName]
             page = wx.Panel(self.ctrls, -1)
             ctrls = self.addCategoryOfParams(theseParams, parent=page)
-            if categName in categLabel.keys():
+            if categName in categLabel:
                 cat = categLabel[categName]
             else:
                 cat = categName
             self.ctrls.AddPage(page, cat)
             # so the validator finds this set of controls
             self.panels.append(page)
-            if 'customize_everything' in self.params.keys():
+            if 'customize_everything' in self.params:
                 if self.params['customize_everything'].val.strip():
                     # set focus to the custom panel
                     page.SetFocus()
@@ -906,7 +906,7 @@ class _BaseParamsDlg(wx.Dialog):
         used in __init__ and are also returned from this method.
         """
         # get data from input fields
-        for fieldName in self.params.keys():
+        for fieldName in self.params:
             param = self.params[fieldName]
             if fieldName == 'advancedParams':
                 pass
@@ -1158,7 +1158,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         # that can be hidden or shown
         handler = self.trialHandler
         # loop through the params
-        keys = handler.params.keys()
+        keys = list(handler.params.keys())
         panel = wx.Panel(parent=self)
         panelSizer = wx.GridBagSizer(5, 5)
         panel.SetSizer(panelSizer)
@@ -1234,7 +1234,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         # that can be hidden or shown
         handler = self.multiStairHandler
         # loop through the params
-        keys = handler.params.keys()
+        keys = list(handler.params.keys())
         # add conditions stuff to the *end*
         # add conditions stuff to the *end*
         if 'conditionsFile' in keys:
@@ -1384,7 +1384,7 @@ class DlgLoopProperties(_BaseParamsDlg):
                     self.conditionsFile = gridGUI.fileName
         self.currentHandler.params['conditionsFile'].val = self.conditionsFile
         # as set via DlgConditions
-        if 'conditionsFile' in self.currentCtrls.keys():
+        if 'conditionsFile' in self.currentCtrls:
             valCtrl = self.currentCtrls['conditionsFile'].valueCtrl
             valCtrl.Clear()
             valCtrl.WriteText(self.conditionsFile)
@@ -1498,7 +1498,7 @@ class DlgLoopProperties(_BaseParamsDlg):
             self.duplCondNames = duplCondNames
 
             if (needUpdate or
-                    ('conditionsFile' in self.currentCtrls.keys() and
+                    ('conditionsFile' in list(self.currentCtrls.keys()) and
                      not duplCondNames)):
                 self.currentCtrls['conditionsFile'].setValue(newPath)
                 self.currentCtrls['conditions'].setValue(
@@ -1509,7 +1509,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         those handler params
         """
         # get data from input fields
-        for fieldName in self.currentHandler.params.keys():
+        for fieldName in self.currentHandler.params:
             if fieldName == 'endPoints':
                 continue  # this was deprecated in v1.62.00
             param = self.currentHandler.params[fieldName]
@@ -1538,7 +1538,7 @@ class DlgLoopProperties(_BaseParamsDlg):
         if val.find('...') == -1 and self.conditionsFile != val:
             self.conditionsFile = val
             if self.conditions:
-                self.exp.namespace.remove(self.conditions[0].keys())
+                self.exp.namespace.remove(list(self.conditions[0].keys()))
             if os.path.isfile(self.conditionsFile):
                 try:
                     self.conditions = data.importConditions(
@@ -1567,7 +1567,7 @@ class DlgLoopProperties(_BaseParamsDlg):
 
     def onOK(self, event=None):
         # intercept OK in case user deletes or edits the filename manually
-        if 'conditionsFile' in self.currentCtrls.keys():
+        if 'conditionsFile' in self.currentCtrls:
             self.refreshConditions()
         event.Skip()  # do the OK button press
 

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -43,7 +43,7 @@ class DlgCodeComponentProperties(wx.Dialog):
         # keep localized title to update dialog's properties later.
         self.localizedTitle = localizedTitle
         self.codeGuiElements = {}
-        if not editing and 'name' in self.params.keys():
+        if not editing and 'name' in self.params:
             # then we're adding a new component so ensure a valid name:
             makeValid = self.frame.exp.namespace.makeValid
             self.params['name'].val = makeValid(params['name'].val)
@@ -171,7 +171,7 @@ class DlgCodeComponentProperties(wx.Dialog):
         used in __init__ and are also returned from this method.
         """
         # get data from input fields
-        for fieldName in self.params.keys():
+        for fieldName in self.params:
             param = self.params[fieldName]
             if fieldName == 'name':
                 param.val = self.componentName.GetValue()

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -419,7 +419,7 @@ class Experiment(object):
                                 " and log files (blank defaults to the "
                                 "builder pref)"),
                 categ='Data')
-        elif 'val' in paramNode.keys():
+        elif 'val' in list(paramNode.keys()):
             if val == 'window units':  # changed this value in 1.70.00
                 params[name].val = 'from exp settings'
             # in v1.80.00, some RatingScale API and Param fields were changed
@@ -468,7 +468,7 @@ class Experiment(object):
                     logging.warn(msg % name)
                     logging.flush()
         # get the value type and update rate
-        if 'valType' in paramNode.keys():
+        if 'valType' in list(paramNode.keys()):
             params[name].valType = paramNode.get('valType')
             # compatibility checks:
             if name in ['allowedKeys'] and paramNode.get('valType') == 'str':
@@ -480,7 +480,7 @@ class Experiment(object):
             # conversions based on valType
             if params[name].valType == 'bool':
                 params[name].val = eval("%s" % params[name].val)
-        if 'updates' in paramNode.keys():
+        if 'updates' in list(paramNode.keys()):
             params[name].updates = paramNode.get('updates')
 
     def loadFromXML(self, filename):
@@ -1018,7 +1018,7 @@ class TrialHandler(object):
         if not self.exp.prefsBuilder['unclutteredNamespace']:
             code = ("# abbreviate parameter names if possible (e.g. rgb = %(name)s.rgb)\n"
                     "if %(name)s != None:\n"
-                    "    for paramName in %(name)s.keys():\n"
+                    "    for paramName in %(name)s:\n"
                     "        exec(paramName + '= %(name)s.' + paramName)\n")
             buff.writeIndentedLines(code % {'name': self.thisName})
 
@@ -1032,7 +1032,7 @@ class TrialHandler(object):
         if not self.exp.prefsBuilder['unclutteredNamespace']:
             code = ("# abbreviate parameter names if possible (e.g. rgb = %(name)s.rgb)\n"
                     "if %(name)s != None:\n"
-                    "    for paramName in %(name)s.keys():\n"
+                    "    for paramName in %(name)s:\n"
                     "        exec(paramName + '= %(name)s.' + paramName)\n")
             buff.writeIndentedLines(code % {'name': self.thisName})
 
@@ -1406,7 +1406,7 @@ class MultiStairHandler(object):
         if not self.exp.prefsBuilder['unclutteredNamespace']:
             code = ("# abbreviate parameter names if possible (e.g. "
                     "rgb=condition.rgb)\n"
-                    "for paramName in condition.keys():\n"
+                    "for paramName in condition:\n"
                     "    exec(paramName + '= condition[paramName]')\n")
             buff.writeIndentedLines(code)
 

--- a/psychopy/app/builder/flow.py
+++ b/psychopy/app/builder/flow.py
@@ -302,7 +302,7 @@ class FlowPanel(wx.ScrolledWindow):
         # add routine points to the timeline
         self.setDrawPoints('loops')
         self.draw()
-        if 'conditions' in loop.params.keys():
+        if 'conditions' in loop.params:
             condOrig = loop.params['conditions'].val
             condFileOrig = loop.params['conditionsFile'].val
         title = loop.params['name'].val + ' Properties'
@@ -333,7 +333,7 @@ class FlowPanel(wx.ScrolledWindow):
                 flow.addLoop(loop, startII, endII)
             self.frame.addToUndoStack("EDIT Loop `%s`" %
                                       (loop.params['name'].val))
-        elif 'conditions' in loop.params.keys():
+        elif 'conditions' in loop.params:
             loop.params['conditions'].val = condOrig
             loop.params['conditionsFile'].val = condFileOrig
         # remove the points from the timeline
@@ -504,7 +504,7 @@ class FlowPanel(wx.ScrolledWindow):
                     return  # have done the removal in final successful call
         # remove name from namespace only if it's a loop;
         # loops exist only in the flow
-        elif 'conditionsFile' in component.params.keys():
+        elif 'conditionsFile' in component.params:
             conditionsFile = component.params['conditionsFile'].val
             if conditionsFile and conditionsFile not in ['None', '']:
                 try:
@@ -845,7 +845,7 @@ class FlowPanel(wx.ScrolledWindow):
         name = loop.params['name'].val
         _show = self.appData['showLoopInfoInFlow']
         if _show and flowsize:
-            _cond = 'conditions' in loop.params.keys()
+            _cond = 'conditions' in list(loop.params)
             if _cond and loop.params['conditions'].val:
                 xnumTrials = 'x' + str(len(loop.params['conditions'].val))
             else:

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -724,7 +724,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
                     # did we get a word?
                     if prevWord:
                         # is it in dictionary?
-                        if prevWord in self.autoCompleteDict.keys():
+                        if prevWord in self.autoCompleteDict:
                             attrs = self.autoCompleteDict[prevWord]['attrs']
                             # does it have known attributes?
                             if type(attrs) == list and len(attrs) >= 1:
@@ -873,7 +873,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
             currWord = self.GetTextRange(startPos, endPos)
 
             # lookfor word in dictionary
-            if currWord in self.autoCompleteDict.keys():
+            if currWord in self.autoCompleteDict:
                 helpText = self.autoCompleteDict[currWord]['help']
                 thisIs = self.autoCompleteDict[currWord]['is']
                 thisType = self.autoCompleteDict[currWord]['type']
@@ -1731,7 +1731,7 @@ class CoderFrame(wx.Frame):
                 continue
             # otherwise create a submenu
             folderDisplayName = os.path.split(folder)[-1]
-            if folderDisplayName in _localized.keys():
+            if folderDisplayName in _localized:
                 folderDisplayName = _localized[folderDisplayName]
             submenu = wx.Menu()
             self.demosMenu.AppendSubMenu(submenu, folderDisplayName)

--- a/psychopy/app/coder/psychoParser.py
+++ b/psychopy/app/coder/psychoParser.py
@@ -50,7 +50,7 @@ def getTokensAndImports(buffer):
                     prevTok = prevTok.prev
 
             # do we have that token already?
-            if defineStr in definedTokens.keys():
+            if defineStr in definedTokens:
                 continue
             else:
                 # try to identify what new token =

--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -280,7 +280,7 @@ class GlobSizer(wx.GridBagSizer):
         # 2. Unspan all objects.
         objs = self._resetSpan()
         # 3. Move the _update_span objects to an adjacent row somewhere safe.
-        for obj in _update_span.keys():
+        for obj in _update_span:
             item = self.FindItem(obj)
             org_r, org_c = item.GetPos().Get()
             if org_r == row:
@@ -323,7 +323,7 @@ class GlobSizer(wx.GridBagSizer):
         # 2. Unspan all objects.
         objs = self._resetSpan()
         # 3. Move the _update_span objects to an adjacent col somewhere safe.
-        for obj in _update_span.keys():
+        for obj in _update_span:
             item = self.FindItem(obj)
             org_r, org_c = item.GetPos().Get()
             if org_c == col:

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -211,7 +211,7 @@ class PreferencesDlg(wx.Dialog):
         currentPane = self.nb.GetPageText(self.nb.GetSelection())
         # what the url should be called in psychopy.app.urls
         urlName = "prefs.%s" % currentPane
-        if urlName in self.app.urls.keys():
+        if urlName in self.app.urls:
             url = self.app.urls[urlName]
         else:
             # couldn't find that section - use default prefs
@@ -235,7 +235,7 @@ class PreferencesDlg(wx.Dialog):
             parent, -1, size=(dlgSize[0] - 100, dlgSize[1] - 200))
         vertBox = wx.BoxSizer(wx.VERTICAL)
         # add each pref for this section
-        for prefName in specSection.keys():
+        for prefName in specSection:
             if prefName in ['version']:  # any other prefs not to show?
                 continue
             # allowModuleImports pref is handled by generateSpec.py
@@ -291,8 +291,8 @@ class PreferencesDlg(wx.Dialog):
         # b) case-insensitive match for Cmd+ at start of string
         # c) reverse-map locale display names to canonical names (ja_JP)
         re_cmd2ctrl = re.compile('^Cmd\+', re.I)
-        for sectionName in self.prefsCfg.keys():
-            for prefName in self.prefsSpec[sectionName].keys():
+        for sectionName in self.prefsCfg:
+            for prefName in self.prefsSpec[sectionName]:
                 if prefName in ['version']:  # any other prefs not to show?
                     continue
                 ctrlName = sectionName + '.' + prefName

--- a/psychopy/app/projects.py
+++ b/psychopy/app/projects.py
@@ -86,7 +86,7 @@ projectCatalog = ProjectCatalog()
 idBase = wx.NewId()
 projHistory = wx.FileHistory(maxFiles=16, idBase=idBase)
 projHistory.idBase = idBase
-for key in projectCatalog.keys():
+for key in projectCatalog:
     projHistory.AddFileToHistory(key)
 
 

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -145,7 +145,7 @@ class ExperimentHandler(object):
             names = []
             vals = []
         else:
-            names = self.extraInfo.keys()
+            names = list(self.extraInfo)
             vals = self.extraInfo.values()
         return names, vals
 
@@ -279,8 +279,7 @@ class ExperimentHandler(object):
 
         for entry in self.entries:
             for name in names:
-                entry.keys()
-                if name in entry.keys():
+                if name in entry:
                     ename = unicode(entry[name])
                     if ',' in ename or '\n' in ename:
                         fmt = u'"%s"%s'

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -365,7 +365,7 @@ class StairHandler(_BaseTrialHandler):
         """
         if self.finished == False:
             # check that all 'otherData' is aligned with current trialN
-            for key in self.otherData.keys():
+            for key in self.otherData:
                 while len(self.otherData[key]) < self.thisTrialN:
                     self.otherData[key].append(None)
             # update pointer for next trial

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -378,7 +378,7 @@ class TrialHandler(_BaseTrialHandler):
         if (stimOut == [] and
                 len(self.trialList) and
                 hasattr(self.trialList[0], 'keys')):
-            stimOut = self.trialList[0].keys()
+            stimOut = list(self.trialList[0].keys())
             # these get added somewhere (by DataHandler?)
             if 'n' in stimOut:
                 stimOut.remove('n')
@@ -464,7 +464,7 @@ class TrialHandler(_BaseTrialHandler):
             dataOut = list(dataOut)
 
         # expand any 'all' dataTypes to be full list of available dataTypes
-        allDataTypes = self.data.keys()
+        allDataTypes = list(self.data.keys())
         # treat these separately later
         allDataTypes.remove('ran')
         # ready to go through standard data types
@@ -621,7 +621,7 @@ class TrialHandler(_BaseTrialHandler):
 
         # collect parameter names related to the stimuli:
         if self.trialList[0]:
-            header = self.trialList[0].keys()
+            header = list(self.trialList[0].keys())
         else:
             header = []
         # and then add parameter names related to data (e.g. RT)
@@ -647,7 +647,7 @@ class TrialHandler(_BaseTrialHandler):
                 # find out what trial type was on this trial
                 trialTypeIndex = self.sequenceIndices[trialN, rep]
                 # determine which repeat it is for this trial
-                if trialTypeIndex not in repsPerType.keys():
+                if trialTypeIndex not in repsPerType:
                     repsPerType[trialTypeIndex] = 0
                 else:
                     repsPerType[trialTypeIndex] += 1
@@ -829,7 +829,7 @@ class TrialHandler2(_BaseTrialHandler):
             self.trialList, self.columns = importConditions(trialList, True)
         else:
             self.trialList = trialList
-            self.columns = trialList[0].keys()
+            self.columns = list(trialList[0].keys())
         # convert any entry in the TrialList into a TrialType object (with
         # obj.key or obj[key] access)
         for n, entry in enumerate(self.trialList):
@@ -1544,7 +1544,7 @@ class TrialHandlerExt(TrialHandler):
             dataOut = list(dataOut)
 
         # expand any 'all' dataTypes to the full list of available dataTypes
-        allDataTypes = self.data.keys()
+        allDataTypes = list(self.data.keys())
         # treat these separately later
         allDataTypes.remove('ran')
         # ready to go through standard data types
@@ -1728,7 +1728,7 @@ class TrialHandlerExt(TrialHandler):
 
         # collect parameter names related to the stimuli:
         if self.trialList[0]:
-            header = self.trialList[0].keys()
+            header = list(self.trialList[0].keys())
         else:
             header = []
         # and then add parameter names related to data (e.g. RT)
@@ -1751,7 +1751,7 @@ class TrialHandlerExt(TrialHandler):
                 # find out what trial type was on this trial
                 trialTypeIndex = self.sequenceIndices[trialN, rep]
                 # determine which repeat it is for this trial
-                if trialTypeIndex not in repsPerType.keys():
+                if trialTypeIndex not in repsPerType:
                     repsPerType[trialTypeIndex] = 0
                 else:
                     repsPerType[trialTypeIndex] += 1

--- a/psychopy/demos/coder/experiment control/runtimeInfo.py
+++ b/psychopy/demos/coder/experiment control/runtimeInfo.py
@@ -52,7 +52,7 @@ print("If that's more detail than you want, try: runInfo = info.RunTimeInfo(...,
 
 print("\nYou can extract single items from info, using keys, e.g.:")
 print("  psychopyVersion = %s" % runInfo['psychopyVersion'])
-if "windowRefreshTimeAvg_ms" in runInfo.keys():
+if "windowRefreshTimeAvg_ms" in runInfo:
     print("or from the test of the screen refresh rate:")
     print("  %.2f ms = average refresh time" % runInfo["windowRefreshTimeAvg_ms"])
     print("  %.3f ms = standard deviation" % runInfo["windowRefreshTimeSD_ms"])

--- a/psychopy/demos/coder/iohub/iosync/eightbuttonbox.py
+++ b/psychopy/demos/coder/iohub/iosync/eightbuttonbox.py
@@ -65,8 +65,8 @@ class ButtonBoxState(object):
         self._released.clear()
 
         new_pressed = [bname for bname, mask in self.masks.items() if self._state & mask]
-        for b in self.masks.keys():
-            if b not in new_pressed and b in self._pressed.keys():
+        for b in self.masks:
+            if b not in new_pressed and b in self._pressed:
                 ptime = self._pressed[b]
                 ltime = self._last_event.get(b)
                 if ltime and etime-ltime >= self.debouncetime:
@@ -108,5 +108,5 @@ finally:
     if mcu:
         mcu.enableEventReporting(False)
     if io:
-        io.quit() 
+        io.quit()
 

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -402,7 +402,7 @@ class DlgFromDict(Dlg):
         for field in self._keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''
-            if field in tip.keys():
+            if field in tip:
                 tooltip = tip[field]
             if field in fixed:
                 self.addFixedField(field, self.dictionary[field], tip=tooltip)

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -294,7 +294,7 @@ class DlgFromDict(Dlg):
         for field in self._keys:
             types[field] = type(self.dictionary[field])
             tooltip = ''
-            if field in tip.keys():
+            if field in tip:
                 tooltip = tip[field]
             if field in fixed:
                 self.addFixedField(field, self.dictionary[field], tip=tooltip)

--- a/psychopy/hardware/bbtk/__init__.py
+++ b/psychopy/hardware/bbtk/__init__.py
@@ -197,7 +197,7 @@ class BlackBoxToolkit(serialdevice.SerialDevice):
                              'state': state,
                              'time': timeSecs})
             else:
-                for n in evtChannels.keys():
+                for n in evtChannels:
                     if state[n] != lastState[n]:
                         if state[n] == '1':
                             evt = evtChannels[n] + "_on"

--- a/psychopy/hardware/forp.py
+++ b/psychopy/hardware/forp.py
@@ -83,7 +83,7 @@ class ButtonBox(object):
         """ Resets the pressed statuses, so getEvents will return pressed
         buttons, even if they were already pressed in the last call.
         """
-        for k in self.buttonStatus.keys():
+        for k in self.buttonStatus:
             self.buttonStatus[k] = False
 
     def getEvents(self, returnRaw=False, asKeys=False, allowRepeats=False):

--- a/psychopy/hardware/minolta.py
+++ b/psychopy/hardware/minolta.py
@@ -150,7 +150,7 @@ class LS100(object):
                     if reply[0:2] == 'OK':
                         self.OK = True
                         break
-                    elif reply not in self.codes.keys():
+                    elif reply not in self.codes:
                         self.OK = False
                         break  # wasn't valid
                     else:

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -329,7 +329,7 @@ class RunTimeInfo(dict):
                 # requires pyo svn r1024 or higher:
                 inp, out = pyo.pa_get_devices_infos()
                 for devList in [inp, out]:
-                    for key in devList.keys():
+                    for key in devList:
                         if isinstance(devList[key]['name'], str):
                             devList[key]['name'] = devList[
                                 key]['name'].decode(osEncoding)

--- a/psychopy/iohub/constants.py
+++ b/psychopy/iohub/constants.py
@@ -7,101 +7,101 @@ Created on Thu Nov 08 15:13:55 2012
 """
 
 try:
-    
+
     class Constants(object):
         UNDEFINED=0
         _keys=None
         _names=None
         _classes=None
-    
+
         _initialized=False
-    
+
         @classmethod
         def getName(cls,id):
             """
             Return the constant's name given a valid constant id.
-            
+
             Args:
                 id (int): The constant's id value to look-up the string name for.
-                
+
             Returns:
                 str: The name for the given constant id.
             """
             return cls._names.get(id,cls._names[cls.UNDEFINED])
-     
+
         @classmethod
         def getID(cls,name):
             """
             Return the constant's id given a valid constant name string.
-            
+
             Args:
                 name (str): The constant's name value to look-up the int id for.
-                
+
             Returns:
                 int: The id for the given constant name.
             """
             return cls._names.get(name,None)
-    
+
         @classmethod
         def getClass(cls,id):
             """
-            Return the constant's ioHub CLass Name given constant id. 
+            Return the constant's ioHub CLass Name given constant id.
             If no class is associated with the specified constant value, None is returned.
-            
+
             Args:
                 id (int): The constant's id value to look-up the string name for.
-                
+
             Returns:
                 class: The ioHub class associated with the constant id provided.
             """
             return cls._classes.get(id,None)
-    
+
         @classmethod
         def initialize(cls,starting_index=1):
             if cls._initialized:
                 return
-    
+
             [setattr(cls,a,i+starting_index) for i,a in enumerate(dir(cls)) if ((a[0] != '_') and (not callable(getattr(cls,a))) and (getattr(cls,a) < 0))]
             cls._names=dict([(getattr(cls,a),a) for a in dir(cls) if ((a[0] != '_') and (not callable(getattr(cls,a))))])
             cls._keys=list(cls._names.keys())
             cls._names.update(dict([(v,k) for k,v in cls._names.iteritems()]))
             cls._initialized=True
-     
+
         @classmethod
         def getConstants(cls):
             return cls._names
-            
+
     class EventConstants(Constants):
         """
-        EventConstants provides access to the ioHub Device Event type constants, 
-        with methods to convert between the different associated constant value 
+        EventConstants provides access to the ioHub Device Event type constants,
+        with methods to convert between the different associated constant value
         types for a given event type:
-            
+
         * int constant
         * str constant
         * event class associated with a constant
-        
+
         The EventConstants class is initialized when ioHub is started. All
         constants and methods available are class level attributes and methods.
         Therefore do not ever create an instance of a Constants class; simply
         access it directly, such as::
-            
+
             int_kb_press_constant=iohub.EventConstants.KEYBOARD_PRESS
             str_kb_press_constant=iohub.EventConstants.getName(int_kb_press_constant)
             iohub_kb_press_class=iohub.EventConstants.getClass(int_kb_press_constant)
-            
+
             print 'Keyboard Press Event Type ID Constant: ',int_kb_press_constant
             print 'Keyboard Press Event  Type String Name Constant: ',str_kb_press_constant
             print 'Keyboard Press Event  Type ioHub Class: ',iohub_kb_press_class
-            
-        """        
+
+        """
 
         KEYBOARD_INPUT=20
         KEYBOARD_KEY=21
         KEYBOARD_PRESS=22
         KEYBOARD_RELEASE=23
         KEYBOARD_CHAR=24
-    
+
         MOUSE_INPUT=30
         MOUSE_BUTTON=31
         MOUSE_BUTTON_PRESS=32
@@ -112,12 +112,12 @@ try:
         MOUSE_SCROLL=35
         MOUSE_MOVE=36
         MOUSE_DRAG=37
-        
+
         TOUCH=40
         TOUCH_MOVE=41
         TOUCH_PRESS=42
         TOUCH_RELEASE=43
-        
+
         EYETRACKER=50
         MONOCULAR_EYE_SAMPLE=51
         BINOCULAR_EYE_SAMPLE=52
@@ -127,10 +127,10 @@ try:
         SACCADE_END=56
         BLINK_START=57
         BLINK_END=58
-    
+
         GAMEPAD_STATE_CHANGE=81
         GAMEPAD_DISCONNECT=82
-        
+
         DIGITAL_INPUT=101
         ANALOG_INPUT=102
         THRESHOLD = 103
@@ -138,7 +138,7 @@ try:
         SERIAL_INPUT = 105
         SERIAL_BYTE_CHANGE = 106
         PSTBOX_BUTTON = 107
-        
+
         MULTI_CHANNEL_ANALOG_INPUT=122
 
         MESSAGE=151
@@ -155,7 +155,7 @@ try:
 
             #: Constant for a Keyboard Char Event.
             #KEYBOARD_CHAR=24
-        
+
             #: Constant for a Mouse Button Press Event.
             MOUSE_BUTTON_PRESS=32
 
@@ -186,7 +186,7 @@ try:
 
             #: Constant for a Touch release Event.
             TOUCH_RELEASE=43
-            
+
             #: Constant for an Eye Tracker Monocular Sample Event.
             MONOCULAR_EYE_SAMPLE=51
 
@@ -210,7 +210,7 @@ try:
 
             #: Constant for an Eye Tracker Blink End Event.
             BLINK_END=58
-        
+
             #: Constant for a Gamepad Event.
             GAMEPAD_STATE_CHANGE=81
 
@@ -225,7 +225,7 @@ try:
 
             #: Constant for an Eight Channel Analog Input Sample Event.
             MULTI_CHANNEL_ANALOG_INPUT=122
-        
+
             #: Constant for a general purpose Serial Rx Event.
             SERIAL_INPUT = 105
 
@@ -234,21 +234,21 @@ try:
 
             #: Constant for a PST Box serial interface event due to a button state change.
             PSTBOX_BUTTON = 107
-            
+
             #: Constant for an Experiment Message Event.
             MESSAGE=151
 
             #: Constant for an Experiment Log Event.
             LOG=152
-        
+
         @classmethod
         def addClassMappings(cls,device_class,device_event_ids,event_classes):
             if cls._classes is None:
                 cls._classes={}
-    
+
             #import iohub
             #iohub.print2err("Adding Device Event Mappings for device: ",device_class.__name__)
-   
+
             for event_id in device_event_ids:
                 event_constant_string=cls.getName(event_id)
                 event_class=None
@@ -258,38 +258,38 @@ try:
                         cls._classes[event_class]=event_id
                         #iohub.print2err("\tAdding Event Class Mapping: ",event_constant_string, " = ",event_id)
                         break
-                
-                if event_id not in cls._classes.keys():
+
+                if event_id not in cls._classes:
                         from psychopy.iohub import print2err
                         print2err("\t*** ERROR ADDING EVENT CLASSS MAPPING: Could not find class: ",event_constant_string, " = ",event_id)
-    
+
     EventConstants.initialize()
-    
+
     class DeviceConstants(Constants):
         """
         DeviceConstants provides access to the ioHub Device type constants, with
-        methods to convert between the different associated constant value 
+        methods to convert between the different associated constant value
         types for a given device type::
-            
+
         * int constant
         * str constant
         * device class associated with a constant
-        
+
         The DeviceConstants class is initialized when ioHub is started. All
         constants and methods available are class level attributes and methods.
         Therefore do nit ever create an instance of a Constants class; simply
         access it directly, such as::
-            
+
             int_kb_dev_constant=iohub.DeviceConstants.KEYBOARD
             str_kb_dev_constant=iohub.DeviceConstants.getName(int_kb_dev_constant)
             iohub_kb_dev_class=iohub.DeviceConstants.getClass(int_kb_dev_constant)
-            
+
             print 'Keyboard Device Type ID Constant: ',int_kb_dev_constant
             print 'Keyboard Device Type String Name Constant: ',str_kb_dev_constant
             print 'Keyboard Device Type ioHub Class: ',iohub_kb_dev_class
-            
-        """        
-        
+
+        """
+
         OTHER = 1
         KEYBOARD = 20
         MOUSE = 30
@@ -298,7 +298,7 @@ try:
         NETWORK = 60
         EVENTPUBLISHER = 61
         REMOTEEVENTSUBSCRIBER = 62
-        
+
         XINPUT = 70
         GAMEPAD = 80
         MCU = 100
@@ -311,16 +311,16 @@ try:
 
         def __init__(self):
             # just so Sphinx will doc the class attributes. ;(
-            
+
             #: Constant for a Device Type not currently categoried.
             OTHER = 1
-            
+
             #: Constant for a Keyboard Device.
             KEYBOARD = 20
 
             #: Constant for a Mouse Device.
             MOUSE = 30
-            
+
             #: Constant for a Touch Device.
             TOUCH = 40
 
@@ -329,7 +329,7 @@ try:
 
             #: Constant for a Network Device
             EVENTPUBLISHER=61
-            
+
             #: Constant for a Network Device
             REMOTEEVENTSUBSCRIBER=62
 
@@ -358,24 +358,24 @@ try:
 
             #: Constant for a Computer Device.
             COMPUTER = 200
-    
-            
+
+
         @classmethod
         def addClassMapping(cls,device_class):
             if cls._classes is None:
                 cls._classes={}
-            
+
             device_constant_string=device_class.__name__.upper()
             device_id=getattr(cls,device_constant_string)
             cls._classes[device_id]=device_class
             cls._classes[device_class]=device_id
-    
+
     DeviceConstants.initialize()
-    
+
     class MouseConstants(Constants):
         """
         MouseConstants provides access to ioHub Mouse Device specific constants.
-        """    
+        """
         MOUSE_BUTTON_NONE=0
         MOUSE_BUTTON_LEFT=1
         MOUSE_BUTTON_RIGHT=2
@@ -386,7 +386,7 @@ try:
         MOUSE_BUTTON_7=64
         MOUSE_BUTTON_8=128
         MOUSE_BUTTON_9=256
-    
+
         MOUSE_BUTTON_STATE_RELEASED=10 # event has a  button released state
         MOUSE_BUTTON_STATE_PRESSED=11 # event has a  button pressed state
         MOUSE_BUTTON_STATE_DOUBLE_CLICK=12 # a button double click event
@@ -406,23 +406,23 @@ try:
 
             #: Constant representing that the middle Mouse button is pressed.
             MOUSE_BUTTON_MIDDLE=4
-        
+
             #: Constant representing a mouse button is in a released state.
-            MOUSE_BUTTON_STATE_RELEASED=10 
+            MOUSE_BUTTON_STATE_RELEASED=10
 
             #: Constant representing a mouse button is in a pressed state.
-            MOUSE_BUTTON_STATE_PRESSED=11 
+            MOUSE_BUTTON_STATE_PRESSED=11
 
             #: Constant representing a mouse is in a multiple click state.
-            MOUSE_BUTTON_STATE_MULTI_CLICK=12             
+            MOUSE_BUTTON_STATE_MULTI_CLICK=12
     MouseConstants.initialize()
-    
-    import sys    
+
+    import sys
     if sys.platform == 'win32':
-        
+
         class AsciiConstants(Constants):
             # Mainly from the pyHook lookup Table, some from Pyglet
-        
+
             BACKSPACE = 0x08
             TAB = 0x09
             LINEFEED = 0x0A
@@ -430,7 +430,7 @@ try:
             RETURN = 0x0D
             SYSREQ = 0x15
             ESCAPE = 0x1B
-        
+
             SPACE = 0x20
             EXCLAMATION = 0x21
             DOUBLEQUOTE = 0x22
@@ -447,7 +447,7 @@ try:
             MINUS = 0x2D
             PERIOD = 0x2E
             SLASH = 0x2F
-        
+
             n0_=0x30
             n1_=0x31
             n2_=0x32
@@ -458,7 +458,7 @@ try:
             n7_=0x37
             n8_=0x38
             n9_=0x39
-        
+
             COLON = 0x3A
             SEMICOLON = 0x3B
             LESS = 0x3C
@@ -466,7 +466,7 @@ try:
             GREATER = 0x3E
             QUESTION = 0x3F
             AT = 0x40
-        
+
             A=0x41
             B=0x42
             C=0x43
@@ -493,14 +493,14 @@ try:
             X=0x58
             Y=0x59
             Z=0x5A
-        
+
             BRACKETLEFT = 0x5B
             BACKSLASH = 0x5C
             BRACKETRIGHT = 0x5D
             ASCIICIRCUM = 0x5E
             UNDERSCORE = 0x5F
             GRAVE = 0x60
-        
+
             a = 0x61
             b = 0x62
             c = 0x63
@@ -527,18 +527,18 @@ try:
             x = 0x78
             y = 0x79
             z = 0x7A
-        
+
             BRACELEFT = 0x7B
             BAR = 0x7C
             BRACERIGHT = 0x7D
             ASCIITILDE = 0x7E
-        
+
             @classmethod
             def getName(cls,id):
                 return cls._names.get(id,None)
-        
+
         AsciiConstants.initialize()
-    
+
         class VirtualKeyCodes(Constants):
                 # Mainly from the pyHook lookup Table, some from Pyglet
                 VK_CANCEL  =  0x03
@@ -546,7 +546,7 @@ try:
                 VK_TAB  =  0x09
                 VK_CLEAR  =  0x0C
                 VK_RETURN  =  0x0D
-            
+
                 VK_SHIFT  =  0x10
                 VK_CONTROL  =  0x11
                 VK_MENU  =  0x12
@@ -563,7 +563,7 @@ try:
                 VK_NONCONVERT  =  0x1D
                 VK_ACCEPT  =  0x1E
                 VK_MODECHANGE  =  0x1F
-            
+
                 VK_SPACE  =  0x20
                 VK_PAGEUP  =  0x21
                 VK_PAGEDOWN  =  0x22
@@ -580,14 +580,14 @@ try:
                 VK_INSERT  =  0x2D
                 VK_DELETE  =  0x2E
                 VK_HELP  =  0x2F
-            
+
                 VK_LWIN = 0x5B
                 VK_RWIN = 0x5C
                 VK_APPS = 0x5D
                 VK_lcmd  =  0x5B
                 VK_rcmd  =  0x5C
                 VK_menu  =  0x5D
-            
+
                 VK_NUMPAD0  =  0x60
                 VK_NUMPAD1  =  0x61
                 VK_NUMPAD2  =  0x62
@@ -604,7 +604,7 @@ try:
                 VK_NUMPADSUBTRACT  =  0x6D
                 VK_NUMPADDECIMAL  =  0x6E
                 VK_NUMPADDIVIDE  =  0x6F
-            
+
                 VK_F1  =  0x70
                 VK_F2  =  0x71
                 VK_F3  =  0x72
@@ -629,7 +629,7 @@ try:
                 VK_F22  =  0x85
                 VK_F23  =  0x86
                 VK_F24  =  0x87
-            
+
                 VK_NUM_LOCK = 0x90
                 VK_SCROLL = 0x91
                 VK_LSHIFT = 0xA0
@@ -658,7 +658,7 @@ try:
                 VK_VOLUME_MUTE  =  0xAD
                 VK_VOLUME_DOWN  =  0xAE
                 VK_VOLUME_UP  =  0xAF
-            
+
                 VK_MEDIA_NEXT_TRACK  =  0xB0
                 VK_MEDIA_PREV_TRACK  =  0xB1
                 VK_MEDIA_STOP  =  0xB2
@@ -667,7 +667,7 @@ try:
                 VK_LAUNCH_MEDIA_SELECT  =  0xB5
                 VK_LAUNCH_APP1  =  0xB6
                 VK_LAUNCH_APP2  =  0xB7
-            
+
                 VK_PROCESSKEY  =  0xE5
                 VK_PACKET  =  0xE7
                 VK_ATTN  =  0xF6
@@ -679,11 +679,11 @@ try:
                 VK_NONAME  =  0xFC
                 VK_PA1  =  0xFD
                 VK_OEM_CLEAR  =  0xFE
-            
+
                 @classmethod
                 def getName(cls,id):
                     return cls._names.get(id,None)
-    
+
         VirtualKeyCodes.initialize()
 
     elif sys.platform == 'linux2':
@@ -695,40 +695,40 @@ try:
 
     elif sys.platform == 'darwin':
         class AnsiKeyCodes(Constants):
-            ANSI_Equal    = 0x18 
-            ANSI_Minus    = 0x1B 
-            ANSI_RightBracket         = 0x1E 
-            ANSI_LeftBracket          = 0x21 
-            ANSI_Quote    = 0x27 
-            ANSI_Semicolon            = 0x29 
-            ANSI_Backslash            = 0x2A 
-            ANSI_Comma    = 0x2B 
-            ANSI_Slash    = 0x2C 
-            ANSI_Period   = 0x2F 
-            ANSI_Grave    = 0x32 
-            ANSI_KeypadDecimal        = 0x41 
-            ANSI_KeypadMultiply       = 0x43 
-            ANSI_KeypadPlus           = 0x45 
-            ANSI_KeypadClear          = 0x47 
-            ANSI_KeypadDivide         = 0x4B 
-            ANSI_KeypadEnter          = 0x4C 
-            ANSI_KeypadMinus          = 0x4E 
-            ANSI_KeypadEquals         = 0x51 
-            ANSI_Keypad0  = 0x52 
-            ANSI_Keypad1  = 0x53 
-            ANSI_Keypad2  = 0x54 
-            ANSI_Keypad3  = 0x55 
-            ANSI_Keypad4  = 0x56 
-            ANSI_Keypad5  = 0x57 
-            ANSI_Keypad6  = 0x58 
-            ANSI_Keypad7  = 0x59 
+            ANSI_Equal    = 0x18
+            ANSI_Minus    = 0x1B
+            ANSI_RightBracket         = 0x1E
+            ANSI_LeftBracket          = 0x21
+            ANSI_Quote    = 0x27
+            ANSI_Semicolon            = 0x29
+            ANSI_Backslash            = 0x2A
+            ANSI_Comma    = 0x2B
+            ANSI_Slash    = 0x2C
+            ANSI_Period   = 0x2F
+            ANSI_Grave    = 0x32
+            ANSI_KeypadDecimal        = 0x41
+            ANSI_KeypadMultiply       = 0x43
+            ANSI_KeypadPlus           = 0x45
+            ANSI_KeypadClear          = 0x47
+            ANSI_KeypadDivide         = 0x4B
+            ANSI_KeypadEnter          = 0x4C
+            ANSI_KeypadMinus          = 0x4E
+            ANSI_KeypadEquals         = 0x51
+            ANSI_Keypad0  = 0x52
+            ANSI_Keypad1  = 0x53
+            ANSI_Keypad2  = 0x54
+            ANSI_Keypad3  = 0x55
+            ANSI_Keypad4  = 0x56
+            ANSI_Keypad5  = 0x57
+            ANSI_Keypad6  = 0x58
+            ANSI_Keypad7  = 0x59
             ANSI_Keypad8  = 0x5B
             ANSI_Keypad9  = 0x5C
 
             @classmethod
             def getName(cls,id):
                 return cls._names.get(id,None)
-        
+
         AnsiKeyCodes.initialize()
         AnsiKeyCodes._keys.remove(AnsiKeyCodes.getID('UNDEFINED'))
 
@@ -820,12 +820,12 @@ try:
             CHECK     = 0x2713 # Unicode CHECK MARK*/
             DIAMOND   = 0x25C6 #  Unicode BLACK DIAMOND*/
             BULLET   = 0x2022 # Unicode BULLET*/
-            APPLE_LOGO = 0xF8FF# Unicode APPLE LOGO*/    
-            
+            APPLE_LOGO = 0xF8FF# Unicode APPLE LOGO*/
+
             @classmethod
             def getName(cls,id):
                 return cls._names.get(id,None)
-        
+
         UnicodeChars.initialize()
         UnicodeChars._keys.remove(UnicodeChars.getID('UNDEFINED'))
 
@@ -887,76 +887,76 @@ try:
             VK_LEFT     = 0x7B
             VK_UP       = 0x7E
             VK_RIGHT    = 0x7C
-            VK_DOWN     = 0x7D      
+            VK_DOWN     = 0x7D
             VK_F1       = 0x7A
-            KEY_EQUAL = 24 
-            KEY_MINUS = 27 
-            KEY_RIGHT_SQUARE_BRACKET = 30 
-            KEY_LEFT_SQUARE_BRACKET = 33 
-            KEY_RETURN = 36 
-            KEY_SINGLE_QUOTE = 39 
-            KEY_SEMICOLAN  = 41 
-            KEY_BACKSLASH = 42 
-            KEY_COMMA = 43 
-            KEY_FORWARD_SLASH = 44 
-            KEY_PERIOD = 47 
-            KEY_TAB = 48 
-            KEY_SPACE = 49 
-            KEY_LEFT_SINGLE_QUOTE = 50 
-            KEY_DELETE = 51 
-            KEY_ENTER = 52 
-            KEY_ESCAPE = 53 
-            KEYPAD_PERIOD = 65 
-            KEYPAD_MULTIPLY = 67 
-            KEYPAD_PLUS = 69 
-            KEYPAD_CLEAR = 71 
-            KEYPAD_DIVIDE = 75 
+            KEY_EQUAL = 24
+            KEY_MINUS = 27
+            KEY_RIGHT_SQUARE_BRACKET = 30
+            KEY_LEFT_SQUARE_BRACKET = 33
+            KEY_RETURN = 36
+            KEY_SINGLE_QUOTE = 39
+            KEY_SEMICOLAN  = 41
+            KEY_BACKSLASH = 42
+            KEY_COMMA = 43
+            KEY_FORWARD_SLASH = 44
+            KEY_PERIOD = 47
+            KEY_TAB = 48
+            KEY_SPACE = 49
+            KEY_LEFT_SINGLE_QUOTE = 50
+            KEY_DELETE = 51
+            KEY_ENTER = 52
+            KEY_ESCAPE = 53
+            KEYPAD_PERIOD = 65
+            KEYPAD_MULTIPLY = 67
+            KEYPAD_PLUS = 69
+            KEYPAD_CLEAR = 71
+            KEYPAD_DIVIDE = 75
             KEYPAD_ENTER = 76   # numberpad on full kbd
-            KEYPAD_EQUALS = 78 	
-            KEYPAD_EQUAL = 81 
-            KEYPAD_0 = 82 
-            KEYPAD_1 = 83 
-            KEYPAD_2 = 84 
-            KEYPAD_3 = 85 
-            KEYPAD_4 = 86 
-            KEYPAD_5 = 87 
-            KEYPAD_6 = 88 
-            KEYPAD_7 = 89 	
-            KEYPAD_8 = 91 
-            KEYPAD_9 = 92 
-            KEY_F5 = 96 
-            KEY_F6 = 97 
-            KEY_F7 = 98 
-            KEY_F3 = 99 
-            KEY_F8 = 100 
-            KEY_F9 = 101 	
-            KEY_F11 = 103 	
-            KEY_F13 = 105 	
-            KEY_F14 = 107 	
-            KEY_F10 = 109	
-            KEY_F12 = 111 
-            KEY_F15 = 113 
-            KEY_HELP = 114 
-            KEY_HOME = 115 
-            KEY_PGUP = 116 
-            KEY_DELETE = 117 
-            KEY_F4 = 118 
-            KEY_END = 119 
-            KEY_F2 = 120 
-            KEY_PGDN = 121 
-            KEY_F1 = 122 
-            KEY_LEFT = 123 
-            KEY_RIGHT = 124 
-            KEY_DOWN = 125 
-            KEY_UP = 126 
+            KEYPAD_EQUALS = 78
+            KEYPAD_EQUAL = 81
+            KEYPAD_0 = 82
+            KEYPAD_1 = 83
+            KEYPAD_2 = 84
+            KEYPAD_3 = 85
+            KEYPAD_4 = 86
+            KEYPAD_5 = 87
+            KEYPAD_6 = 88
+            KEYPAD_7 = 89
+            KEYPAD_8 = 91
+            KEYPAD_9 = 92
+            KEY_F5 = 96
+            KEY_F6 = 97
+            KEY_F7 = 98
+            KEY_F3 = 99
+            KEY_F8 = 100
+            KEY_F9 = 101
+            KEY_F11 = 103
+            KEY_F13 = 105
+            KEY_F14 = 107
+            KEY_F10 = 109
+            KEY_F12 = 111
+            KEY_F15 = 113
+            KEY_HELP = 114
+            KEY_HOME = 115
+            KEY_PGUP = 116
+            KEY_DELETE = 117
+            KEY_F4 = 118
+            KEY_END = 119
+            KEY_F2 = 120
+            KEY_PGDN = 121
+            KEY_F1 = 122
+            KEY_LEFT = 123
+            KEY_RIGHT = 124
+            KEY_DOWN = 125
+            KEY_UP = 126
 
             @classmethod
             def getName(cls,id):
                 return cls._names.get(id,None)
-        
+
         VirtualKeyCodes.initialize()
         VirtualKeyCodes._keys.remove(VirtualKeyCodes.getID('UNDEFINED'))
-    
+
     class ModifierKeyCodes(Constants):
         _mod_names=['lctrl','rctrl','lshift',
                    'rshift','lalt','ralt',
@@ -981,23 +981,23 @@ try:
         scrolllock=modhelp*2
     ModifierKeyCodes.initialize()
     ModifierKeyCodes._keys.remove(ModifierKeyCodes.getID('UNDEFINED'))
-    
+
     class KeyboardConstants(Constants):
         '''
         Stores internal windows hook constants including hook types, mappings from virtual
         keycode name to value and value to name, and event type value to name.
         '''
-    
+
         _virtualKeyCodes=VirtualKeyCodes()
-        
+
         if sys.platform == 'win32':
             _asciiKeyCodes=AsciiConstants()
         if sys.platform == 'darwin':
             _unicodeChars=UnicodeChars()
             _ansiKeyCodes=AnsiKeyCodes()
-            
+
         _modifierCodes=ModifierKeyCodes()
-          
+
         @classmethod
         def getName(cls,id):
             return cls._names.get(id,None)
@@ -1019,8 +1019,8 @@ try:
         @classmethod
         def _getKeyNameAndModsForEvent(cls,keyEvent):
             return cls._getKeyName(keyEvent), cls.getModifiersForEvent(keyEvent)
-    
-    
+
+
         @classmethod
         def getModifiersForEvent(cls,event):
             return cls._modifierCodes2Labels(event.Modifiers)
@@ -1029,7 +1029,7 @@ try:
         def _modifierCodes2Labels(cls,mods):
             if mods == 0:
                 return []
-    
+
             modconstants=cls._modifierCodes
             modNameList=[]
             for k in modconstants._keys:
@@ -1040,16 +1040,16 @@ try:
                     if mods==0:
                         return modNameList
             return modNameList
-    
+
     KeyboardConstants.initialize()
-    
+
     class EyeTrackerConstants(Constants):
-        
+
         #
         ## Sample Filtering related constants
         #
-        
-        # Sample Filter Levels        
+
+        # Sample Filter Levels
         FILTER_LEVEL_OFF=0
         FILTER_OFF=0
         FILTER_LEVEL_1=1
@@ -1058,15 +1058,15 @@ try:
         FILTER_LEVEL_4=4
         FILTER_LEVEL_5=5
         FILTER_ON=9
-    
-        # Sample Filter Types        
+
+        # Sample Filter Types
         FILTER_FILE=10
         FILTER_NET=11
         FILTER_ONLINE=11
         FILTER_SERIAL=12
         FILTER_ANALOG=13
         FILTER_ALL=15
-    
+
         #
         ## Eye Type Constants
         #
@@ -1082,7 +1082,7 @@ try:
         #
         ## Calibration / Validation Related Constants
         #
-        
+
         # Target Point Count
         NO_POINTS=40
         ONE_POINT=41
@@ -1107,13 +1107,13 @@ try:
         # Target Pacing Types
         AUTO_CALIBRATION_PACING=90
         MANUAL_CALIBRATION_PACING=91
-            
+
         # Target Shape Types
         CIRCLE_TARGET=121
         CROSSHAIR_TARGET=122
         IMAGE_TARGET=123
         MOVIE_TARGET=124
-        
+
         # System Setup Method Initial State Constants
         DEFAULT_SETUP_PROCEDURE=100
         TRACKER_FEEDBACK_STATE=101
@@ -1137,21 +1137,21 @@ try:
         PUPIL_MAJOR_AXIS_MM = 80
         PUPIL_MINOR_AXIS_MM = 81
         PUPIL_RADIUS_MM = 82
-    
-            
+
+
         #
         ## Video Based Eye Tracking Method Constants
         #
         PUPIL_CR_TRACKING=140
         PUPIL_ONLY_TRACKING=141
-    
+
         #
         ## Video Based Pupil Center Calculation Algorithm Constants
         #
         ELLIPSE_FIT=146
         CIRCLE_FIT = 147
         CENTROID_FIT = 148
-    
+
         #
         ## Eye Tracker Interface Return Code Constants
         #
@@ -1159,7 +1159,7 @@ try:
         # EYETRACKER_ERROR deprecated for EYETRACKER_UNDEFINED_ERROR
         EYETRACKER_ERROR=201
         EYETRACKER_UNDEFINED_ERROR=201
-        # FUNCTIONALITY_NOT_SUPPORTED deprecated for 
+        # FUNCTIONALITY_NOT_SUPPORTED deprecated for
         # EYETRACKER_INTERFACE_METHOD_NOT_SUPPORTED
         FUNCTIONALITY_NOT_SUPPORTED=202
         EYETRACKER_INTERFACE_METHOD_NOT_SUPPORTED=202
@@ -1169,34 +1169,34 @@ try:
         EYETRACKER_NOT_CONNECTED=206
         EYETRACKER_MODEL_NOT_SUPPORTED=207
         EYETRACKER_RECEIVED_INVALID_INPUT=208
-        
+
     EyeTrackerConstants.initialize()
-    
-    
+
+
     #
     ## Gamepad related
     #
-    
+
     class XInputBatteryTypeConstants(Constants):
-        BATTERY_TYPE_DISCONNECTED = 0x00       # The device is not connected. 
-        BATTERY_TYPE_WIRED = 0x01              # The device is a wired device and does not 
-                                               # have a battery. 
-        BATTERY_TYPE_ALKALINE = 0x02           # The device has an alkaline battery. 
-        BATTERY_TYPE_NIMH = 0x03	               # The device has a nickel metal hydride battery. 
-        BATTERY_TYPE_UNKNOWN = 0xFF            # The device has an unknown battery type. 
-    XInputBatteryTypeConstants.initialize() 
+        BATTERY_TYPE_DISCONNECTED = 0x00       # The device is not connected.
+        BATTERY_TYPE_WIRED = 0x01              # The device is a wired device and does not
+                                               # have a battery.
+        BATTERY_TYPE_ALKALINE = 0x02           # The device has an alkaline battery.
+        BATTERY_TYPE_NIMH = 0x03	               # The device has a nickel metal hydride battery.
+        BATTERY_TYPE_UNKNOWN = 0xFF            # The device has an unknown battery type.
+    XInputBatteryTypeConstants.initialize()
     try:
         XInputBatteryTypeConstants._keys.remove(XInputBatteryTypeConstants.getID('UNDEFINED'))
     except Exception:
         pass
-    
+
     class XInputBatteryLevelConstants(Constants):
         # BatteryLevels
         BATTERY_LEVEL_EMPTY = 0x00
         BATTERY_LEVEL_LOW = 0x01
         BATTERY_LEVEL_MEDIUM = 0x02
         BATTERY_LEVEL_FULL = 0x03
-    
+
     XInputBatteryLevelConstants.initialize()
     try:
         XInputBatteryLevelConstants._keys.remove(XInputBatteryLevelConstants.getID('UNDEFINED'))
@@ -1205,36 +1205,36 @@ try:
 
     class XInputCapabilitiesConstants(Constants):
         UNDEFINED=9999999
-        # Device Type        
+        # Device Type
         XBOX360_GAMEPAD=0x01
         OTHER_XINPUT_GAMEPAD=0x0
-        
+
         #subtype
         XINPUT_GAMEPAD=0x08 # is defined as 0x01 in xinput.h, redining so no conflicts
         XINPUT_UNKNOWN_SUBTYPE=0x06
-        
+
 #        # Note:
-#        # Older XUSB Windows drivers report incomplete capabilities information, 
-#        # particularly for wireless devices. The latest XUSB Windows driver provides 
-#        # full support for wired and wireless devices, and more complete and accurate 
+#        # Older XUSB Windows drivers report incomplete capabilities information,
+#        # particularly for wireless devices. The latest XUSB Windows driver provides
+#        # full support for wired and wireless devices, and more complete and accurate
 #        # capabilties flags.
 #        XINPUT_CAPS_VOICE_SUPPORTED = 0x0004 # Device has an integrated voice device.
-#        
+#
 #        #XINPUT_CAPS_FFB_SUPPORTED =     # Device supports force feedback functionality.
-#                                        # Note that these force-feedback features 
-#                                        # beyond rumble are not currently supported 
+#                                        # Note that these force-feedback features
+#                                        # beyond rumble are not currently supported
 #                                        # through XINPUT on Windows.
-#        
+#
 #        #XINPUT_CAPS_WIRELESS =          # Device is wireless.
-#        
-#        #XINPUT_CAPS_PMD_SUPPORTED =     # Device supports plug-in modules. 
-#                                        # Note that plug-in modules like the text 
-#                                        # input device (TID) are not supported 
+#
+#        #XINPUT_CAPS_PMD_SUPPORTED =     # Device supports plug-in modules.
+#                                        # Note that plug-in modules like the text
+#                                        # input device (TID) are not supported
 #                                        # currently through XINPUT on Windows.
-#        
-#        #XINPUT_CAPS_NO_NAVIGATION =     # Device lacks menu navigation buttons 
+#
+#        #XINPUT_CAPS_NO_NAVIGATION =     # Device lacks menu navigation buttons
 #                                        # (START, BACK, DPAD).
-#        
+#
 #        #
 #        # XINPUT_GAMEPAD struct - wButtons masks
 #        #
@@ -1252,43 +1252,43 @@ try:
 #        XINPUT_GAMEPAD_B = 0x2000
 #        XINPUT_GAMEPAD_X = 0x4000
 #        XINPUT_GAMEPAD_Y = 0x8000
-#        
+#
 #        #
 #        # Gamepad thresholds
 #        #
 #        XINPUT_GAMEPAD_LEFT_THUMB_DEADZONE = 7849
 #        XINPUT_GAMEPAD_RIGHT_THUMB_DEADZONE = 8689
 #        XINPUT_GAMEPAD_TRIGGER_THRESHOLD = 30
-#        
+#
 #        #
 #        # Flags to pass to XInputGetCapabilities
 #        #
 #        XINPUT_FLAG_GAMEPAD = 0x00000001
-#        
-#        
+#
+#
 #        if XINPUT_USE_9_1_0 is False:
 #            #
 #            # Devices that support batteries
 #            #
 #            BATTERY_DEVTYPE_GAMEPAD = 0x00
 #            BATTERY_DEVTYPE_HEADSET = 0x01
-#            
+#
 #            # BatteryTypes
-#            BATTERY_TYPE_DISCONNECTED = 0x00       # The device is not connected. 
-#            BATTERY_TYPE_WIRED = 0x01              # The device is a wired device and does not 
-#                                                   # have a battery. 
-#            BATTERY_TYPE_ALKALINE = 0x02           # The device has an alkaline battery. 
-#            BATTERY_TYPE_NIMH = 0x03	               # The device has a nickel metal hydride battery. 
-#            BATTERY_TYPE_UNKNOWN = 0xFF            # The device has an unknown battery type. 
-#            
+#            BATTERY_TYPE_DISCONNECTED = 0x00       # The device is not connected.
+#            BATTERY_TYPE_WIRED = 0x01              # The device is a wired device and does not
+#                                                   # have a battery.
+#            BATTERY_TYPE_ALKALINE = 0x02           # The device has an alkaline battery.
+#            BATTERY_TYPE_NIMH = 0x03	               # The device has a nickel metal hydride battery.
+#            BATTERY_TYPE_UNKNOWN = 0xFF            # The device has an unknown battery type.
+#
 #            # BatteryLevels
 #            BATTERY_LEVEL_EMPTY = 0x00
 #            BATTERY_LEVEL_LOW = 0x01
 #            BATTERY_LEVEL_MEDIUM = 0x02
 #            BATTERY_LEVEL_FULL = 0x03
-#        
+#
 #            #
-#            # Multiple Controller Support 
+#            # Multiple Controller Support
 #            #
 #            XINPUT_USER_0=DWORD(0)
 #            XINPUT_USER_1=DWORD(1)
@@ -1297,16 +1297,16 @@ try:
 #            XUSER_MAX_COUNT=4
 #            XINPUT_USERS=(XINPUT_USER_0,XINPUT_USER_1,XINPUT_USER_2,XINPUT_USER_3)
 #            XUSER_INDEX_ANY = 0x000000FF
-#            
+#
 #            XINPUT_GAMEPAD_TL_LIT=DWORD(0)
 #            XINPUT_GAMEPAD_TR_LIT=DWORD(1)
 #            XINPUT_GAMEPAD_BR_LIT=DWORD(2)
 #            XINPUT_GAMEPAD_BL_LIT=DWORD(3)
-#                
+#
 #            #
 #            # Codes returned for the gamepad keystroke
 #            #
-#        
+#
 #            VK_PAD_A = 0x5800
 #            VK_PAD_B = 0x5801
 #            VK_PAD_X = 0x5802
@@ -1315,7 +1315,7 @@ try:
 #            VK_PAD_LSHOULDER = 0x5805
 #            VK_PAD_LTRIGGER = 0x5806
 #            VK_PAD_RTRIGGER  =  0x5807
-#            
+#
 #            VK_PAD_DPAD_UP = 0x5810
 #            VK_PAD_DPAD_DOWN = 0x5811
 #            VK_PAD_DPAD_LEFT = 0x5812
@@ -1324,7 +1324,7 @@ try:
 #            VK_PAD_BACK = 0x5815
 #            VK_PAD_LTHUMB_PRESS = 0x5816
 #            VK_PAD_RTHUMB_PRESS = 0x5817
-#            
+#
 #            VK_PAD_LTHUMB_UP = 0x5820
 #            VK_PAD_LTHUMB_DOWN = 0x5821
 #            VK_PAD_LTHUMB_RIGHT = 0x5822
@@ -1333,7 +1333,7 @@ try:
 #            VK_PAD_LTHUMB_UPRIGHT = 0x5825
 #            VK_PAD_LTHUMB_DOWNRIGHT = 0x5826
 #            VK_PAD_LTHUMB_DOWNLEFT = 0x5827
-#            
+#
 #            VK_PAD_RTHUMB_UP = 0x5830
 #            VK_PAD_RTHUMB_DOWN = 0x5831
 #            VK_PAD_RTHUMB_RIGHT = 0x5832
@@ -1342,23 +1342,23 @@ try:
 #            VK_PAD_RTHUMB_UPRIGHT = 0x5835
 #            VK_PAD_RTHUMB_DOWNRIGHT = 0x5836
 #            VK_PAD_RTHUMB_DOWNLEFT = 0x5837
-#        
-#            # 
+#
+#            #
 #            # Flags used in XINPUT_KEYSTROKE
 #            #
-#            XINPUT_KEYSTROKE_KEYDOWN = 0x0001       # The key was pressed. 
-#            XINPUT_KEYSTROKE_KEYUP  = 0x0002         # The key was released. 
-#            XINPUT_KEYSTROKE_REPEAT = 0x0004         # A repeat of a held key. 
-#        
+#            XINPUT_KEYSTROKE_KEYDOWN = 0x0001       # The key was pressed.
+#            XINPUT_KEYSTROKE_KEYUP  = 0x0002         # The key was released.
+#            XINPUT_KEYSTROKE_REPEAT = 0x0004         # A repeat of a held key.
+#
 #        #
 #        # Return Values
 #        #
-#        
+#
 #        ERROR_SUCCESS = 0
 #        ERROR_DEVICE_NOT_CONNECTED = 0x048F
-#        
+#
 #        if XINPUT_USE_9_1_0 is False:
-#            ERROR_EMPTY = 2 # made this up, need to confirm .... # 
+#            ERROR_EMPTY = 2 # made this up, need to confirm .... #
 
 
     XInputCapabilitiesConstants.initialize()
@@ -1366,7 +1366,7 @@ try:
         XInputCapabilitiesConstants._keys.remove(XInputCapabilitiesConstants.getID('UNDEFINED'))
     except Exception:
         pass
-    
+
     class XInputGamePadConstants(Constants):
         DPAD_UP = 0x0001
         DPAD_DOWN = 0x0002
@@ -1382,23 +1382,23 @@ try:
         B = 0x2000
         X = 0x4000
         Y = 0x8000
-   
+
         _batteryTypes=XInputBatteryTypeConstants()
         _batteryLevels=XInputBatteryLevelConstants()
         _capabilities=XInputCapabilitiesConstants()
-             
+
     XInputGamePadConstants.initialize()
     try:
         XInputGamePadConstants._keys.remove(XInputGamePadConstants.getID('UNDEFINED'))
     except Exception:
         pass
-            
+
 except Exception:
     import traceback
     traceback.print_exc()
     #from . import printExceptionDetailsToStdErr
     #printExceptionDetailsToStdErr()
-    
+
 #class SerialConstants(Constants):
 #    import serial
 #    XON=serial.XON

--- a/psychopy/iohub/datastore/pandas/examples/runtime_script/iohub_demo.py
+++ b/psychopy/iohub/datastore/pandas/examples/runtime_script/iohub_demo.py
@@ -9,7 +9,7 @@ from psychopy.data import TrialHandler,importConditions
 from psychopy.iohub import launchHubServer,Computer,EventConstants
 
 getTime=Computer.getTime
-    
+
 psychopy_mon_name='testMonitor'
 exp_code='io_stroop'
 io=launchHubServer(psychopy_monitor_name=psychopy_mon_name, experiment_code=exp_code)
@@ -29,7 +29,7 @@ def loggedFlip(letter_char,letter_color):
     global retrace_count
     gabor.draw()
     letter.setText(letter_char)
-    letter.setColor(letter_color)  
+    letter.setColor(letter_color)
     letter.draw()
     flip_time=win.flip()
     io.sendMessageEvent(category='VSYNC',text=str(retrace_count),sec_time=flip_time)
@@ -48,7 +48,7 @@ def openTrialHandler(xlsx_source):
         io.createTrialHandlerRecordTable(trials)
         return trials
 
-trials=openTrialHandler('D:\\Dropbox\\WinPython-32bit-2.7.5.3\\my-code\\psychopy\\psychopy\\iohub\\experimental_code\\pandas_tests\\conditions.csv') 
+trials=openTrialHandler('D:\\Dropbox\\WinPython-32bit-2.7.5.3\\my-code\\psychopy\\psychopy\\iohub\\experimental_code\\pandas_tests\\conditions.csv')
 
 color_mapping=dict(R=[1,0,0],G=[0,1,0],B=[0,0,1])
 key_mapping=dict(LEFT='R',DOWN='G',RIGHT='B')
@@ -57,47 +57,47 @@ for t,trial in enumerate(trials):
     tstart_flip_time=loggedFlip(trial['LETTER'],color_mapping[trial['COLOR']])
     io.sendMessageEvent(category='EXP',text='TRIAL_START',sec_time=tstart_flip_time)
     io.clearEvents()
-    
+
     #repeat drawing for each frame
     key_pressed=None
     while not key_pressed:
         gabor.setPhase(0.01,'+')
-        flip_time=loggedFlip(trial['LETTER'],color_mapping[trial['COLOR']])   
+        flip_time=loggedFlip(trial['LETTER'],color_mapping[trial['COLOR']])
         #handle key presses each frame
         key_events=kb.getEvents(event_type_id=EventConstants.KEYBOARD_RELEASE)
-        
+
         for ke in key_events:
-            if ke.key in key_mapping.keys():
+            if ke.key in key_mapping:
                 key_pressed=ke
                 break
             elif ke.key == 'ESCAPE':
                 break
-    
+
     if key_pressed is None:
         print "Experiment Terminated By User"
         io.quit()
         core.quit()
         import sys
         sys.exit(1)
-        
+
     tend_flip_time=loggedFlip(trial['LETTER'],color_mapping[trial['COLOR']])
     win.clearBuffer()
 
     if key_pressed.key=='ESCAPE':
         break
-    
+
     trial['RESPONSE']=key_mapping[key_pressed.key]
     trial['RT']=key_pressed.time-tstart_flip_time
     trial['TRIAL_START']=tstart_flip_time
     trial['TRIAL_END']=tend_flip_time
-    
-    for k,v in trial.iteritems():        
+
+    for k,v in trial.iteritems():
         print k,v,type(v)
-    print '---'        
+    print '---'
     io.sendMessageEvent(category='EXP',text='TRIAL_END',sec_time=tend_flip_time)
     io.addRowToConditionVariableTable(trial.values())
-         
-win.close()    
+
+win.close()
 io.quit()
 core.quit()
 

--- a/psychopy/iohub/devices/eyetracker/hw/smi/iviewx/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/smi/iviewx/eyetracker.py
@@ -19,7 +19,7 @@ import copy
 from ...... import print2err, convertCamelToSnake,printExceptionDetailsToStdErr
 from ......constants import EventConstants, EyeTrackerConstants
 from ..... import Computer
-from .... import EyeTrackerDevice   
+from .... import EyeTrackerDevice
 from ....eye_events import *
 
 import pyViewX
@@ -29,13 +29,13 @@ import gevent
 
 class EyeTracker(EyeTrackerDevice):
     """
-    The SMI iViewX implementation of the Common Eye Tracker Interface 
+    The SMI iViewX implementation of the Common Eye Tracker Interface
     can be used by providing the following EyeTracker path as the device
     class in the iohub_config.yaml device settings file:
-        
+
         eyetracker.hw.smi.iviewx.EyeTracker
     """
-        
+
     pyviewx2ivewxParamMappings={
                 EyeTrackerConstants.LEFT_EYE: pyViewX.ET_PARAM_EYE_LEFT,
                 EyeTrackerConstants.RIGHT_EYE: pyViewX.ET_PARAM_EYE_RIGHT,
@@ -46,9 +46,9 @@ class EyeTracker(EyeTrackerDevice):
 
     # >>> Overwritten class attributes
     DEVICE_TIMEBASE_TO_SEC=0.000001
-    
+
     # The iViewX currently supports a subset of all the eye tracker events listed
-    # below, but due to an outstanding bug in the ioHUb device interface, all event types 
+    # below, but due to an outstanding bug in the ioHUb device interface, all event types
     # possible for the given device class must be listed in the class definition.
     EVENT_CLASS_NAMES=['MonocularEyeSampleEvent','BinocularEyeSampleEvent','FixationStartEvent',
                          'FixationEndEvent', 'SaccadeStartEvent', 'SaccadeEndEvent',
@@ -56,9 +56,9 @@ class EyeTracker(EyeTrackerDevice):
 
     __slots__=['_api_pc_ip','_api_pc_port','_et_pc_ip','_et_pc_port',
                '_enable_data_filter','_ioKeyboardHandler','_kbEventQueue','_last_setup_result','_handle_sample_callback']
-    def __init__(self, *args,**kwargs):        
+    def __init__(self, *args,**kwargs):
         EyeTrackerDevice.__init__(self,*args,**kwargs)
-        try:             
+        try:
             self._ioKeyboardHandler=None
 
             # Get network config (used in setConnectionState(True).
@@ -72,7 +72,7 @@ class EyeTracker(EyeTrackerDevice):
             self.setConnectionState(True)
 
             # Callback sample notification support.
-            self._handle_sample_callback=pyViewX.pDLLSetSample(self._handleNativeEvent)            
+            self._handle_sample_callback=pyViewX.pDLLSetSample(self._handleNativeEvent)
 
             # Set the filtering level......
             filter_type, filter_level = self._runtime_settings['sample_filtering'].items()[0]
@@ -117,15 +117,15 @@ class EyeTracker(EyeTrackerDevice):
                     print2err("Warning: Unsupported iViewX sample filter level value: ",filter_level, "=", level_int)
             else:
                     print2err("Warning: Unsupported iViewX sample filter type: ", filter_type, ". Only FILTER_ALL is supported.")
-                
+
             ####
             # Native file saving...
-            ####            
-            #print2err("NOTE: Native file saving for the iViewX has not yet been implemented.") 
-            
             ####
-            # Get the iViewX device's system info, 
-            # and update appropriate attributes.            
+            #print2err("NOTE: Native file saving for the iViewX has not yet been implemented.")
+
+            ####
+            # Get the iViewX device's system info,
+            # and update appropriate attributes.
             ####
             sys_info=self._TrackerSystemInfo()
             if sys_info != EyeTrackerConstants.EYETRACKER_ERROR:
@@ -133,49 +133,49 @@ class EyeTracker(EyeTrackerDevice):
                 eyetracking_engine_version=sys_info['eyetracking_engine_version']
                 client_sdk_version=sys_info['client_sdk_version']
                 model_name=sys_info['model_name']
-                
+
                 self.software_version='Client SDK: {0} ; Tracker Engine: {1}'.format(client_sdk_version,eyetracking_engine_version)
                 self.getConfiguration()['software_version']=self.software_version
                 self.getConfiguration()['model_name']=model_name
                 self.model_name=model_name
-                
+
                 ####
                 # Set sampling rate CHECK ONLY.....
                 ####
                 requested_sampling_rate=self._runtime_settings['sampling_rate']
                 if requested_sampling_rate != sampling_rate:
                     print2err("WARNING: iViewX requested frame rate of {0} != current rate of {1}:".format(requested_sampling_rate,sampling_rate))
-                    
+
                 self._runtime_settings['sampling_rate']=sampling_rate
-            
+
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_OK
         except Exception:
             print2err(" ---- Error during SMI iView EyeTracker Initialization ---- ")
             printExceptionDetailsToStdErr()
             print2err(" ---- Error during SMI iView EyeTracker Initialization ---- ")
-                    
+
     def trackerTime(self):
         """
-        trackerTime returns the current iViewX Application or Server time in 
-        usec format as a long integer.        
+        trackerTime returns the current iViewX Application or Server time in
+        usec format as a long integer.
         """
         tracker_time = c_longlong(0)
         r=pyViewX.GetCurrentTimestamp(byref(tracker_time))
-        if r == pyViewX.RET_SUCCESS:    
+        if r == pyViewX.RET_SUCCESS:
             return tracker_time.value
-        print2err("iViewX trackerTime FAILED: error: {0} timeval: {1}".format(r,tracker_time))            
+        print2err("iViewX trackerTime FAILED: error: {0} timeval: {1}".format(r,tracker_time))
         return EyeTrackerConstants.EYETRACKER_ERROR
 
     def trackerSec(self):
         """
-        trackerSec returns the current iViewX Application or Server time in 
+        trackerSec returns the current iViewX Application or Server time in
         sec.msec-usec format.
         """
         tracker_time=c_longlong(0)
         r=pyViewX.GetCurrentTimestamp(byref(tracker_time))
-        if r == pyViewX.RET_SUCCESS:    
+        if r == pyViewX.RET_SUCCESS:
             return tracker_time.value*self.DEVICE_TIMEBASE_TO_SEC
-        print2err("iViewX trackerSec FAILED: error: {0} timeval: {1}".format(r,tracker_time))            
+        print2err("iViewX trackerSec FAILED: error: {0} timeval: {1}".format(r,tracker_time))
         return EyeTrackerConstants.EYETRACKER_ERROR
 
     def isConnected(self):
@@ -183,11 +183,11 @@ class EyeTracker(EyeTrackerDevice):
         isConnected indicates if there is an active connection between the ioHub
         Server and the eye tracking device.
 
-        Note that when the SMI iViewX EyeTracker class is created when the ioHub server starts, 
+        Note that when the SMI iViewX EyeTracker class is created when the ioHub server starts,
         a connection is automatically created with the eye tracking device.
 
         The ioHub must be connected to the eye tracker device for it to be able to receive
-        events from the eye tracking system. Eye tracking events are received when 
+        events from the eye tracking system. Eye tracking events are received when
         isConnected() == True and when isRecordingEnabled() == True.
         """
         try:
@@ -208,13 +208,13 @@ class EyeTracker(EyeTrackerDevice):
 
     def setConnectionState(self,enable):
         """
-        setConnectionState connects the ioHub Server to the SMI iViewX device if 
+        setConnectionState connects the ioHub Server to the SMI iViewX device if
         the enable arguement is True, otherwise an open connection is closed with
         the device. Calling this method multiple times with the same value has no effect.
-        
-        Note that when the SMI iViewX EyeTracker class is created when the ioHub server starts, 
+
+        Note that when the SMI iViewX EyeTracker class is created when the ioHub server starts,
         a connection is automatically created with the eye tracking device.
-        
+
         If the eye tracker is currently recording eye data and sending it to the
         ioHub server, the recording will be stopped prior to closing the connection.
         """
@@ -241,14 +241,14 @@ class EyeTracker(EyeTrackerDevice):
         except Exception,e:
             print2err(" ---- SMI EyeTracker isConnected ERROR ---- ")
             printExceptionDetailsToStdErr()
-            
+
     def sendMessage(self,message_contents,time_offset=None):
         """
-        The sendMessage method is currently not supported by the SMI iViewX 
+        The sendMessage method is currently not supported by the SMI iViewX
         implementation of the Common Eye Tracker Interface. Once native data file
         saving is implemented for the iViewX, this method will become available.
         """
-        try:   
+        try:
             # Possible return codes:
             #
             # RET_SUCCESS - intended functionality has been fulfilled
@@ -256,57 +256,57 @@ class EyeTracker(EyeTrackerDevice):
             r=pyViewX.SendImageMessage(pyViewX.String(message_contents))
             if r != pyViewX.RET_SUCCESS:
                 print2err("iViewX ERROR {0} when sendMessage to tracker: {1}".format(r,message_contents))
-                return EyeTrackerConstants.EYETRACKER_ERROR           
-            return EyeTrackerConstants.EYETRACKER_OK     
+                return EyeTrackerConstants.EYETRACKER_ERROR
+            return EyeTrackerConstants.EYETRACKER_OK
 
         except Exception, e:
             printExceptionDetailsToStdErr()
 
     def sendCommand(self, key, value=None):
         """
-        The sendCommand method can be used to make calls to the 
+        The sendCommand method can be used to make calls to the
         iViewX iV_SetTrackingParameter function. The sendCommand method requires
         valid key and value arguements.
-        
-        Currently supported 'key' arguement values, with their mapping to the 
+
+        Currently supported 'key' arguement values, with their mapping to the
         associated iViewX API constant, are:
-        
+
         EyeTrackerConstants.LEFT_EYE:   pyViewX.ET_PARAM_EYE_LEFT
         EyeTrackerConstants.RIGHT_EYE:  pyViewX.ET_PARAM_EYE_RIGHT
         EyeTrackerConstants.BINOCULAR:  pyViewX.ET_PARAM_EYE_BOTH
-        
-        If the key arguement supplied does not match one of the three 
+
+        If the key arguement supplied does not match one of the three
         EyeTrackerConstants values listed above, the method will return:
-        
+
         EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
-        
-        Currently supported 'value' arguement values, with their mapping to the 
+
+        Currently supported 'value' arguement values, with their mapping to the
         associated iViewX API constant, are:
 
         EyeTrackerConstants.BINOCULAR_CUSTOM:  pyViewX.ET_PARAM_SMARTBINOCULAR
         EyeTrackerConstants.MONOCULAR:         pyViewX.ET_PARAM_MONOCULAR
-        
-        If the value arguement supplied does not match one of the two 
-        SMI iView ioHub interface specific constants listed above, 
+
+        If the value arguement supplied does not match one of the two
+        SMI iView ioHub interface specific constants listed above,
         the method will return:
-        
+
         EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
-        
+
         Possible return values from the method are:
-        
+
         EyeTrackerConstants.EYETRACKER_OK:  intended functionality has been fulfilled
         EyeTrackerConstants.EYETRACKER_NOT_CONNECTED:  no connection established
         EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT:  parameter out of range
-        
-        If the iV_* function returns a code that is not expected, then the 
-        invalid (or undocumented) return code from the iV_* function call is 
-        returned as is by sendCommand.   
-        
+
+        If the iV_* function returns a code that is not expected, then the
+        invalid (or undocumented) return code from the iV_* function call is
+        returned as is by sendCommand.
+
         Examples, assuming an eyetracker device called 'tracker' has been
         created by ioHub:
-        
+
         tracker = <iohub connection variable name>.devices.tracker
-        
+
         tracker.sendCommand(EyeTrackerConstants.BINOCULAR,EyeTrackerConstants.BINOCULAR_CUSTOM)
 
         tracker.sendCommand(EyeTrackerConstants.LEFT_EYE,EyeTrackerConstants.BINOCULAR_CUSTOM)
@@ -316,7 +316,7 @@ class EyeTracker(EyeTrackerDevice):
         tracker.sendCommand(EyeTrackerConstants.LEFT_EYE,EyeTrackerConstants.MONOCULAR)
 
         tracker.sendCommand(EyeTrackerConstants.RIGHT_EYE,EyeTrackerConstants.MONOCULAR)
-        
+
         """
 
         if self.isConnected() is False:
@@ -325,15 +325,15 @@ class EyeTracker(EyeTrackerDevice):
         if key not in [EyeTrackerConstants.LEFT_EYE,
                        EyeTrackerConstants.RIGHT_EYE,
                        EyeTrackerConstants.BINOCULAR]:
-            return EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT 
-            
+            return EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
+
         if value not in [EyeTrackerConstants.BINOCULAR_CUSTOM,EyeTrackerConstants.MONOCULAR]:
-            return EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT      
-        
+            return EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
+
         result=pyViewX.SetTrackingParameter(self.pyviewx2ivewxParamMappings[key],
                                             self.pyviewx2ivewxParamMappings[value],
                                             0)
-                                            
+
         if result == pyViewX.RET_SUCCESS:
             return EyeTrackerConstants.EYETRACKER_OK
         if result == pyViewX.ERR_NOT_CONNECTED:
@@ -348,9 +348,9 @@ class EyeTracker(EyeTrackerDevice):
 
     def runSetupProcedure(self,starting_state=EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE):
         """
-        The SMI iViewX implementation of the runSetupProcedure supports the following 
+        The SMI iViewX implementation of the runSetupProcedure supports the following
         starting_state values:
-            
+
             #. DEFAULT_SETUP_PROCEDURE: This (default) mode starts by showing a dialog with the various options available during user setup.
             #. CALIBRATION_STATE: The eye tracker will immediately preform a calibration and then return to the experiment script.
             #. VALIDATION_STATE: The eye tracker will immediately preform a validation and then return to the experiment script. The return result is a dict containing the validation results.
@@ -359,24 +359,24 @@ class EyeTracker(EyeTrackerDevice):
         """
         if self.isConnected() is False:
             return EyeTrackerConstants.EYETRACKER_ERROR
-            
-        try:       
+
+        try:
             IMPLEMENTATION_SUPPORTED_STATES=[EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE,
                                              EyeTrackerConstants.CALIBRATION_STATE,
                                              EyeTrackerConstants.VALIDATION_STATE,
-                                             EyeTrackerConstants.TRACKER_FEEDBACK_STATE]            
+                                             EyeTrackerConstants.TRACKER_FEEDBACK_STATE]
 
             if isinstance(starting_state,basestring):
                 starting_state=EyeTrackerConstants.getID(starting_state)
-                        
+
             self._registerKeyboardMonitor()
 
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_OK
-                        
+
             if starting_state not in IMPLEMENTATION_SUPPORTED_STATES:
                 self._last_setup_result=EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
-            elif starting_state == EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE:                                
-                self._showSetupKeyOptionsDialog()                    
+            elif starting_state == EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE:
+                self._showSetupKeyOptionsDialog()
                 next_state=None
                 key_mapping={'C':self._calibrate,
                              'V':self._validate,
@@ -385,16 +385,16 @@ class EyeTracker(EyeTrackerDevice):
                              'ESCAPE':'CONTINUE',
                              'F1':self._showSetupKeyOptionsDialog}
                 while 1:
-                    if next_state is None:                    
+                    if next_state is None:
                         next_state=self._getKeyboardPress(key_mapping)
-                    
+
                     if callable(next_state):
                         next_state()
-                        next_state=None                            
-                                            
+                        next_state=None
+
                     elif next_state == 'CONTINUE':
                         break
-                       
+
             elif starting_state == EyeTrackerConstants.CALIBRATION_STATE:
                 self._calibrate()
             elif starting_state == EyeTrackerConstants.VALIDATION_STATE:
@@ -402,10 +402,10 @@ class EyeTracker(EyeTrackerDevice):
             elif starting_state == EyeTrackerConstants.TRACKER_FEEDBACK_STATE:
                 self._showEyeImageMonitor()
                 self._showTrackingMonitor()
-            else:    
+            else:
                 self._last_setup_result = EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
             self._unregisterKeyboardMonitor()
-            
+
             return self._last_setup_result
         except Exception, e:
             self._unregisterKeyboardMonitor()
@@ -421,11 +421,11 @@ class EyeTracker(EyeTrackerDevice):
                     f()
         except Exception:
             print2err('Exception while trying to call: {0}'.format(f))
-                    
+
     def _showSimpleWin32Dialog(self, message, caption):
         import win32gui
         win32gui.MessageBox(None, message, caption, 0)
-                    
+
     def _showSetupKeyOptionsDialog(self):
         msg_text="The following Keyboard Commands will be available during User Setup:\n"
         msg_text+="\n\tE : Display Eye Image Window.\n"
@@ -433,21 +433,21 @@ class EyeTracker(EyeTrackerDevice):
         msg_text+="\tC : Start Calibration Routine.\n"
         msg_text+="\tV : Start Validation Routine.\n"
         msg_text+="\tESCAPE : Exit the Setup Procedure.\n"
-        msg_text+="\tF1 : Show this Dialog.\n"  
+        msg_text+="\tF1 : Show this Dialog.\n"
         msg_text+="\nPress OK to begin"
-        
-        self._showSimpleWin32Dialog(msg_text,"Common Eye Tracker Interface - iViewX Calibration")                
-        
+
+        self._showSimpleWin32Dialog(msg_text,"Common Eye Tracker Interface - iViewX Calibration")
+
     def _showEyeImageMonitor(self):
 
         # pyViewX.ShowEyeImageMonitor return codes:
         #
         # RET_SUCCESS - intended functionality has been fulfilled
         # ERR_NOT_CONNECTED - no connection established
-        # ERR_WRONG_DEVICE - eye tracking device required for 
+        # ERR_WRONG_DEVICE - eye tracking device required for
         #                    this function is not connected
         result=pyViewX.ShowEyeImageMonitor()
-        
+
         if result == pyViewX.ERR_NOT_CONNECTED:
             self._showSimpleWin32Dialog("Eye Image Monitor can not be Displayed. An iViewX System is not Connected to the ioHub.",
                                   "Common Eye Tracker Interface - ERROR")
@@ -476,11 +476,11 @@ class EyeTracker(EyeTrackerDevice):
             self._showSimpleWin32Dialog("Tracking Monitor can not be Displayed. The iViewX Model being used does not support this Operation.",
                                   "Common Eye Tracker Interface - ERROR")
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_MODEL_NOT_SUPPORTED
-        
+
     def _calibrate(self):
         calibrationData=pyViewX.CalibrationStruct()
         _iViewConfigMappings._createCalibrationStruct(self,calibrationData)
-        
+
         # pyViewX.SetupCalibration return codes:
         #
         # RET_SUCCESS - intended functionality has been fulfilled
@@ -488,7 +488,7 @@ class EyeTracker(EyeTrackerDevice):
         # ERR_WRONG_DEVICE - eye tracking device required for this
         #                    function is not connected
         # ERR_WRONG_CALIBRATION_METHOD - eye tracking device required
-        #                                for this calibration method 
+        #                                for this calibration method
         #                                is not connected
 
         result = pyViewX.SetupCalibration(byref(calibrationData))
@@ -497,7 +497,7 @@ class EyeTracker(EyeTrackerDevice):
             self._showSimpleWin32Dialog("Calibration Could not be Performed. An invalid setting was passed to the procedure.",
                                   "Common Eye Tracker Interface - ERROR")
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_RECEIVED_INVALID_INPUT
-            
+
         elif result == pyViewX.ERR_WRONG_DEVICE:
             self._showSimpleWin32Dialog("Calibration Could not be Performed. The iViewX Model being used does not support this Operation.",
                                   "Common Eye Tracker Interface - ERROR")
@@ -508,17 +508,17 @@ class EyeTracker(EyeTrackerDevice):
                                   "Common Eye Tracker Interface - ERROR")
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_MODEL_NOT_SUPPORTED
 
-        
+
         # pyViewX.Calibrate return codes:
         #
         # RET_SUCCESS - intended functionality has been fulfilled
         # RET_CALIBRATION_ABORTED - Calibration was aborted
         # ERR_NOT_CONNECTED - no connection established
-        # ERR_WRONG_DEVICE - eye tracking device required for 
+        # ERR_WRONG_DEVICE - eye tracking device required for
         #                    this function is not connected
         # ERR_WRONG_CALIBRATION_METHOD - eye tracking device required
-        #                    for this calibration method is not connected            
-        result = pyViewX.Calibrate()  
+        #                    for this calibration method is not connected
+        result = pyViewX.Calibrate()
 
         if result == pyViewX.ERR_NOT_CONNECTED:
             self._showSimpleWin32Dialog("Tracking Monitor can not be Displayed. An iViewX System is not Connected to the ioHub.",
@@ -540,7 +540,7 @@ class EyeTracker(EyeTrackerDevice):
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_OK
             self._showSimpleWin32Dialog("Calibration Completed. Press 'V' to Validate, ESCAPE to exit Setup, F1 to view all Options.",
                                   "Common Eye Tracker Interface")
-            
+
     def _validate(self):
         # pyViewX.Validate return codes:
         #
@@ -548,7 +548,7 @@ class EyeTracker(EyeTrackerDevice):
         # ERR_NOT_CONNECTED - no connection established
         # ERR_NOT_CALIBRATED - system is not calibrated
         # ERR_WRONG_DEVICE - eye tracking device required for this
-        #                    function is not connected               
+        #                    function is not connected
         result=pyViewX.Validate()
 
         if result == pyViewX.ERR_NOT_CONNECTED:
@@ -565,9 +565,9 @@ class EyeTracker(EyeTrackerDevice):
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_MODEL_NOT_SUPPORTED
         else:
             self._last_setup_result=EyeTrackerConstants.EYETRACKER_OK
-            
+
             show_validation_results= self.getConfiguration()['calibration'].get('show_validation_accuracy_window',False)
-    
+
             # pyViewX.GetAccuracy return codes:
             #
             # RET_SUCCESS - intended functionality has been fulfilled
@@ -578,7 +578,7 @@ class EyeTracker(EyeTrackerDevice):
             # ERR_WRONG_PARAMETER - parameter out of range
             accuracy_results=pyViewX.AccuracyStruct()
             result = pyViewX.GetAccuracy(byref(accuracy_results),show_validation_results)
-    
+
             if result == pyViewX.ERR_NOT_CONNECTED:
                 self._showSimpleWin32Dialog("Validation Procedure Failed. An iViewX System is not Connected to the ioHub.",
                                       "Common Eye Tracker Interface - ERROR")
@@ -599,27 +599,27 @@ class EyeTracker(EyeTrackerDevice):
                 self._last_setup_result=dict()
                 for a in accuracy_results.__slots__:
                     self._last_setup_result[a]=getattr(accuracy_results,a)
-            
+
                 self._showSimpleWin32Dialog("Validation Completed. Press ESCAPE to return to the Experiment Script, F1 to view all Options.",
                                       "Common Eye Tracker Interface")
-        
+
     def _getKeyboardPress(self,key_mappings):
         from ..... import KeyboardPressEvent
         while 1:
             while len(self._kbEventQueue)>0:
                 event=copy.deepcopy((self._kbEventQueue.pop(0)))
                 ke=KeyboardPressEvent.createEventAsNamedTuple(event)
-                key=ke.key.upper() 
-                if key in key_mappings.keys():
+                key=ke.key.upper()
+                if key in key_mappings:
                     del self._kbEventQueue[:]
                     return key_mappings[key]
             gevent.sleep(0.02)
-                        
+
     def _registerKeyboardMonitor(self):
-        kbDevice=None        
+        kbDevice=None
         if self._iohub_server:
             for dev in self._iohub_server.devices:
-                if dev.__class__.__name__ == 'Keyboard':             
+                if dev.__class__.__name__ == 'Keyboard':
                     kbDevice=dev
 
         if kbDevice:
@@ -646,13 +646,13 @@ class EyeTracker(EyeTrackerDevice):
                     self.kb = None
 
             self._ioKeyboardHandler = KeyboardEventHandler(self, kbDevice)
-             
+
     def _unregisterKeyboardMonitor(self):
         if self._ioKeyboardHandler:
             self._ioKeyboardHandler.free()
             self._ioKeyboardHandler = None
 
-            
+
 
     def isRecordingEnabled(self,*args,**kwargs):
         """
@@ -668,7 +668,7 @@ class EyeTracker(EyeTrackerDevice):
     def setRecordingState(self, recording):
         """
         setRecordingState enables (recording=True) or disables (recording=False)
-        the recording of eye data by the eye tracker and the sending of any eye 
+        the recording of eye data by the eye tracker and the sending of any eye
         data to the ioHub Server. The eye tracker must be connected to the ioHub Server
         by using the setConnectionState() method for recording to be possible.
         """
@@ -681,7 +681,7 @@ class EyeTracker(EyeTrackerDevice):
                 self._latest_sample = None
                 self._latest_gaze_position = None
 
-                # just incase recording is running , 
+                # just incase recording is running ,
                 # try to stop it and clear the smi memory buffers.
                 pyViewX.StopRecording()
                 pyViewX.ClearRecordingBuffer()
@@ -696,11 +696,11 @@ class EyeTracker(EyeTrackerDevice):
                     EyeTrackerDevice.enableEventReporting(self, False)
                     return False#EyeTrackerConstants.EYETRACKER_ERROR
                 if r == pyViewX.ERR_WRONG_DEVICE:
-                    print2err("iViewX setRecordingState True Failed: ERR_WRONG_DEVICE") 
+                    print2err("iViewX setRecordingState True Failed: ERR_WRONG_DEVICE")
                     pyViewX.SetSampleCallback(pyViewX.pDLLSetSample(0))
                     EyeTrackerDevice.enableEventReporting(self, False)
                     return False#EyeTrackerConstants.EYETRACKER_ERROR
-                          
+
             elif recording is False and self.isRecordingEnabled():
                 self._latest_sample=None
                 self._latest_gaze_position=None
@@ -713,12 +713,12 @@ class EyeTracker(EyeTrackerDevice):
                 if r == pyViewX.RET_SUCCESS or r == pyViewX.ERR_EMPTY_DATA_BUFFER or r == pyViewX.ERR_FULL_DATA_BUFFER:
                     EyeTrackerDevice.enableEventReporting(self, False)
                     return self.isRecordingEnabled()
-                
+
                 if r == pyViewX.ERR_NOT_CONNECTED:
-                    print2err("iViewX setRecordingState(False) Failed: ERR_NOT_CONNECTED") 
+                    print2err("iViewX setRecordingState(False) Failed: ERR_NOT_CONNECTED")
                     return False#EyeTrackerConstants.EYETRACKER_ERROR
                 if r == pyViewX.ERR_WRONG_DEVICE:
-                    print2err("iViewX setRecordingState(False) Failed: ERR_WRONG_DEVICE") 
+                    print2err("iViewX setRecordingState(False) Failed: ERR_WRONG_DEVICE")
                     return False #EyeTrackerConstants.EYETRACKER_ERROR
 
         except Exception, e:
@@ -740,9 +740,9 @@ class EyeTracker(EyeTrackerDevice):
     def getLastSample(self):
         """
         getLastSample returns the most recent BinocularEyeSampleEvent received
-        from the iViewX system. Any position fields are in Display 
-        device coordinate space. If the eye tracker is not recording or is not 
-        connected, then None is returned.        
+        from the iViewX system. Any position fields are in Display
+        device coordinate space. If the eye tracker is not recording or is not
+        connected, then None is returned.
         """
         try:
             return self._latest_sample
@@ -751,7 +751,7 @@ class EyeTracker(EyeTrackerDevice):
 
     def getLastGazePosition(self):
         """
-        getLastGazePosition returns the most recent x,y eye position, in Display 
+        getLastGazePosition returns the most recent x,y eye position, in Display
         device coordinate space, received by the ioHub server from the iViewX device.
         In the case of binocular recording, and if both eyes are successfully being tracked,
         then the average of the two eye positions is returned.
@@ -765,44 +765,44 @@ class EyeTracker(EyeTrackerDevice):
     def _handleNativeEvent(self,*args,**kwargs):
         """
         TODO: Add support for Fixation events. Currently callback only supports samples.
-        
-        The _handleEvent method can be used by the native device interface (implemented 
+
+        The _handleEvent method can be used by the native device interface (implemented
         by the ioHub Device class) to register new native device events
-        by calling this method of the ioHub Device class. 
-        
-        When a native device interface uses the _handleNativeEvent method it is 
+        by calling this method of the ioHub Device class.
+
+        When a native device interface uses the _handleNativeEvent method it is
         employing an event callback approach to notify the ioHub Process when new
         native device events are available. This is in contrast to devices that use
         a polling method to check for new native device events, which would implement
         the _poll() method instead of this method.
-        
+
         Generally speaking this method is called by the native device interface
         once for each new event that is available for the ioHub Process. However,
         with good cause, there is no reason why a single call to this
-        method could not handle multiple new native device events. 
+        method could not handle multiple new native device events.
 
-        .. note::         
-            If using _handleNativeEvent, be sure to remove the device_timer 
+        .. note::
+            If using _handleNativeEvent, be sure to remove the device_timer
             property from the devices configuration section of the iohub_config.yaml.
 
         Any arguments or kwargs passed to this method are determined by the ioHub
         Device implementation and should contain all the information needed to create
         an ioHub Device Event.
-        
-        Since any callbacks should take as little time to process as possible, 
+
+        Since any callbacks should take as little time to process as possible,
         a two stage approach is used to turn a native device event into an ioHub
         Device event representation:
             #. This method is called by the native device interface as a callback, providing the necessary information to be able to create an ioHub event. As little processing should be done in this method as possible.
             #. The data passed to this method, along with the time the callback was called, are passed as a tuple to the Device classes _addNativeEventToBuffer method.
             #. During the ioHub Servers event processing routine, any new native events that have been added to the ioHub Server using the _addNativeEventToBuffer method are passed individually to the _getIOHubEventObject method, which must also be implemented by the given Device subclass.
             #. The _getIOHubEventObject method is responsible for the actual conversion of the native event representation to the required ioHub Event representation for the accociated event type.
-            
+
         Args:
             args(tuple): tuple of non keyword arguements passed to the callback.
-            
+
         Kwargs:
             kwargs(dict): dict of keyword arguements passed to the callback.
-            
+
         Returns:
             None
         """
@@ -810,36 +810,36 @@ class EyeTracker(EyeTrackerDevice):
             poll_time=Computer.getTime()
             tracker_time=self.trackerSec()
             confidence_interval=0.0
-            DEVICE_TIMEBASE_TO_SEC=EyeTracker.DEVICE_TIMEBASE_TO_SEC  
-                  
+            DEVICE_TIMEBASE_TO_SEC=EyeTracker.DEVICE_TIMEBASE_TO_SEC
+
             sample = args[0]
-    
+
             event_type=EventConstants.BINOCULAR_EYE_SAMPLE
-            # TODO: Detrmine if binocular data is averaged or not for 
-            #       given model , tracking params, and indicate 
+            # TODO: Detrmine if binocular data is averaged or not for
+            #       given model , tracking params, and indicate
             #       so using the recording_eye_type
             #       EyeTrackerConstants.BINOCULAR or EyeTrackerConstants.BINOCULAR_AVERAGED
             logged_time=poll_time
             event_timestamp=sample.timestamp*DEVICE_TIMEBASE_TO_SEC
             event_delay=tracker_time-event_timestamp
             iohub_time=poll_time-event_delay
-     
+
             plane_number=sample.planeNumber
-            
+
             left_eye_data=sample.leftEye
             right_eye_data=sample.rightEye
-    
+
             status=0
-            
+
             left_pupil_measure=left_eye_data.diam
-            right_pupil_measure=right_eye_data.diam                   
+            right_pupil_measure=right_eye_data.diam
             pupil_measure_type=EyeTrackerConstants.PUPIL_DIAMETER
-            
+
             left_gazeX=left_eye_data.gazeX
             right_gazeX=right_eye_data.gazeX
             left_gazeY=left_eye_data.gazeY
             right_gazeY=right_eye_data.gazeY
-            
+
             if right_pupil_measure > 0.0 and right_gazeX != 0.0 and right_gazeY != 0.0:
                 right_gazeX,right_gazeY=self._eyeTrackerToDisplayCoords((right_gazeX,right_gazeY))
             else:
@@ -847,7 +847,7 @@ class EyeTracker(EyeTrackerDevice):
                 right_gazeX=EyeTrackerConstants.UNDEFINED
                 right_gazeY=EyeTrackerConstants.UNDEFINED
                 status=2
-                
+
             if left_pupil_measure > 0.0 and left_gazeX != 0.0 and left_gazeY != 0.0:
                 left_gazeX,left_gazeY=self._eyeTrackerToDisplayCoords((left_gazeX,left_gazeY))
             else:
@@ -855,14 +855,14 @@ class EyeTracker(EyeTrackerDevice):
                 left_gazeX=EyeTrackerConstants.UNDEFINED
                 left_gazeY=EyeTrackerConstants.UNDEFINED
                 status+=20
-    
+
             left_eyePositionX=left_eye_data.eyePositionX
             right_eyePositionX=right_eye_data.eyePositionX
             left_eyePositionY=left_eye_data.eyePositionY
             right_eyePositionY=right_eye_data.eyePositionY
             left_eyePositionZ=left_eye_data.eyePositionZ
             right_eyePositionZ=right_eye_data.eyePositionZ
-       
+
             binocSample=[
                          0,
                          0,
@@ -913,9 +913,9 @@ class EyeTracker(EyeTrackerDevice):
                          EyeTrackerConstants.UNDEFINED,
                          EyeTrackerConstants.UNDEFINED,
                          EyeTrackerConstants.UNDEFINED,
-                         status    
-                         ]             
-                                        
+                         status
+                         ]
+
 
             self._addNativeEventToBuffer(binocSample)
         except Exception:
@@ -923,34 +923,34 @@ class EyeTracker(EyeTrackerDevice):
             printExceptionDetailsToStdErr()
         finally:
             return 0
-            
+
     def _getIOHubEventObject(self,native_event_data):
         """
-        The _getIOHubEventObject method is called by the ioHub Process to convert 
-        new native device event objects that have been received to the appropriate 
-        ioHub Event type representation. 
-        
+        The _getIOHubEventObject method is called by the ioHub Process to convert
+        new native device event objects that have been received to the appropriate
+        ioHub Event type representation.
+
         Args:
             native_event_data: object or tuple of (callback_time, native_event_object)
-           
+
         Returns:
             tuple: The appropriate ioHub Event type in list form.
         """
 
         self._latest_sample=native_event_data
-        
+
         getAttribIndex=BinocularEyeSampleEvent.CLASS_ATTRIBUTE_NAMES.index
-        
-        left_pupil_measure=native_event_data[getAttribIndex('left_pupil_measure1')]        
+
+        left_pupil_measure=native_event_data[getAttribIndex('left_pupil_measure1')]
         left_gazeX=native_event_data[getAttribIndex('left_gaze_x')]
         left_gazeY=native_event_data[getAttribIndex('left_gaze_y')]
         right_gazeX=native_event_data[getAttribIndex('right_gaze_x')]
         right_gazeY=native_event_data[getAttribIndex('right_gaze_y')]
         right_pupil_measure=native_event_data[getAttribIndex('right_pupil_measure1')]
-        
+
         ic=0
         EyeTracker._gx=0.0
-        EyeTracker._gy=0.0  
+        EyeTracker._gy=0.0
         if right_pupil_measure>0.0 and right_gazeX != 0.0 and  right_gazeY != 0.0:
             EyeTracker._gx=EyeTracker._gx+right_gazeX
             EyeTracker._gy=EyeTracker._gy+right_gazeY
@@ -960,7 +960,7 @@ class EyeTracker(EyeTrackerDevice):
             EyeTracker._gx=EyeTracker._gx+left_gazeX
             EyeTracker._gy=EyeTracker._gy+left_gazeY
             ic+=1
-            
+
         if ic == 2:
             EyeTracker._gx= EyeTracker._gx/2.0
             EyeTracker._gy= EyeTracker._gy/2.0
@@ -980,25 +980,25 @@ class EyeTracker(EyeTrackerDevice):
             gaze_x=gaze_x/dw
             gaze_y=gaze_y/dh
             left,top,right,bottom=self._display_device.getCoordBounds()
-            w,h=right-left,top-bottom            
-            x,y=left+w*gaze_x,bottom+h*(1.0-gaze_y) 
+            w,h=right-left,top-bottom
+            x,y=left+w*gaze_x,bottom+h*(1.0-gaze_y)
             return x,y
         except Exception,e:
             printExceptionDetailsToStdErr()
-        
+
     def _displayToEyeTrackerCoords(self,display_x,display_y):
         """
         """
-        try:                        
+        try:
             cl,ct,cr,cb=self._display_device.getCoordBounds()
             cw,ch=cr-cl,ct-cb
-            
+
             dl,dt,dr,db=self._display_device.getBounds()
             dw,dh=dr-dl,db-dt
-            
-            cxn,cyn=(display_x+cw/2)/cw , 1.0-(display_y-ch/2)/ch       
-            return cxn*dw,  cyn*dh          
-           
+
+            cxn,cyn=(display_x+cw/2)/cw , 1.0-(display_y-ch/2)/ch
+            return cxn*dw,  cyn*dh
+
         except Exception,e:
             printExceptionDetailsToStdErr()
 
@@ -1017,10 +1017,10 @@ class EyeTracker(EyeTrackerDevice):
                                                                         systemInfo.API_Buildnumber
                                                                        ),
                             model_name = systemInfo.iV_ETDevice
-                                        
+
                             )
-            print2err("GetSystemInfo FAILED: " + str(res))  
-            return EyeTrackerConstants.EYETRACKER_ERROR         
+            print2err("GetSystemInfo FAILED: " + str(res))
+            return EyeTrackerConstants.EYETRACKER_ERROR
         except Exception,e:
             printExceptionDetailsToStdErr()
     def _close(self):
@@ -1030,24 +1030,24 @@ class EyeTracker(EyeTrackerDevice):
 # C DLL to ioHub settings mappings
 
 class _iViewConfigMappings(object):
-    # supported calibration modes    
+    # supported calibration modes
     calibration_methods = dict( NO_POINTS=0,TWO_POINTS=2,THREE_POINTS=3,FIVE_POINTS=5, NINE_POINTS=9, THIRTEEN_POINTS=13)
     graphics_env = dict(INTERNAL=1, EXTERNAL=0)
     auto_pace = dict (True=1, False=0, Yes=1, No=0, On=1, Off=0)
     pacing_speed = dict(SLOW=0, FAST=1)
     target_type= dict(IMAGE=0, CIRCLE_TARGET=1, CIRCLE_TARGET_V2=2, CROSS=3)
-                        
+
     @classmethod
     def _createCalibrationStruct(cls,eyetracker, calibration_struct):
-        #method: Select Calibration Method (default: 5) 
-        #visualization: Set Visualization Status [0: visualization by external stimulus program 1: visualization by SDK (default)] 
-        #displayDevice: Set Display Device and resolution [0: primary device (default), 1: secondary device] 
-        #speed: Set Calibration/Validation Speed [0: slow (default), 1: fast] 
+        #method: Select Calibration Method (default: 5)
+        #visualization: Set Visualization Status [0: visualization by external stimulus program 1: visualization by SDK (default)]
+        #displayDevice: Set Display Device and resolution [0: primary device (default), 1: secondary device]
+        #speed: Set Calibration/Validation Speed [0: slow (default), 1: fast]
         #autoAccept: Set Calibration/Validation Point Acceptance [1: automatic (default) 0: manual]
-        #foregroundBrightness: Set Calibration/Validation Target Brightness [0..255] (default: 20) 
-        #backgroundBrightness: Set Calibration/Validation Background Brightness [0..255] (default: 239) 
-        #targetShape: Set Calibration/Validation Target Shape [IMAGE = 0, CIRCLE1 = 1 (default), CIRCLE2 = 2, CROSS = 3] 
-        #targetSize: Set Calibration/Validation Target Size (default: 10 pixels) 
+        #foregroundBrightness: Set Calibration/Validation Target Brightness [0..255] (default: 20)
+        #backgroundBrightness: Set Calibration/Validation Background Brightness [0..255] (default: 239)
+        #targetShape: Set Calibration/Validation Target Shape [IMAGE = 0, CIRCLE1 = 1 (default), CIRCLE2 = 2, CROSS = 3]
+        #targetSize: Set Calibration/Validation Target Size (default: 10 pixels)
         #targetFilename: Select Custom Calibration/Validation Target
         calibration_config=eyetracker.getConfiguration()['calibration']
 
@@ -1059,18 +1059,18 @@ class _iViewConfigMappings(object):
         calibration_struct.backgroundBrightness=c_int(calibration_config.get('screen_background_color',239))
         calibration_struct.targetShape=c_int(_iViewConfigMappings.target_type[calibration_config.get('target_type','CIRCLE_TARGET')])
         calibration_struct.targetFilename=b''
-        
+
         if calibration_config['target_type'] in ['CIRCLE_TARGET_V2', 'CIRCLE_TARGET']:
-            target_settings=calibration_config['target_attributes'] 
+            target_settings=calibration_config['target_attributes']
             calibration_struct.foregroundBrightness=c_int(target_settings.get('target_color',20))
             calibration_struct.targetSize=c_int(target_settings.get('target_size',30))
 
         elif calibration_config['target_type'] =='IMAGE_TARGET':
             calibration_struct.targetFilename=pyViewX.String(calibration_config['image_attributes'].get('file_name',b''))
             calibration_struct.targetSize=c_int(calibration_config['image_attributes'].get('target_size',30))
-        
+
         elif calibration_config['target_type'] == 'CROSSHAIR_TARGET':
-            target_settings=calibration_config['crosshair_attributes'] 
+            target_settings=calibration_config['crosshair_attributes']
             calibration_struct.foregroundBrightness=c_int(target_settings.get('target_color',20))
             calibration_struct.targetSize=c_int(target_settings.get('target_size',30))
         else:

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -1,5 +1,5 @@
 """
-ioHub Common Eye Tracker Interface for EyeLink(C) Systems.  
+ioHub Common Eye Tracker Interface for EyeLink(C) Systems.
 """
 # Part of the PsychoPy.iohub library
 # Copyright (C) 2012-2016 iSolver Software Solutionse
@@ -22,11 +22,11 @@ except Exception:
     pass
 
 class EyeTracker(EyeTrackerDevice):
-    """  
-    The SR Research EyeLink implementation of the Common Eye Tracker Interface 
+    """
+    The SR Research EyeLink implementation of the Common Eye Tracker Interface
     can be used by providing the following EyeTracker path as the device
     class in the iohub_config.yaml device settings file:
-        
+
         eyetracker.hw.sr_research.eyelink
     """
 
@@ -57,10 +57,10 @@ class EyeTracker(EyeTrackerDevice):
         """
 
         EyeTrackerDevice.__init__(self,*args,**kwargs)
-        
+
         EyeTracker._eyelink=None
-       
-        try:                
+
+        try:
             tracker_config=self.getConfiguration()
 
             # Connect to the eye tracker; setting the EyeTracker._eyelink class
@@ -70,7 +70,7 @@ class EyeTracker(EyeTrackerDevice):
                 print2err(" ** EyeLink Error: Could not connect to EyeLink Eye Tracker. EyeLink Eye tracker device will run in 'dummy' mode.")
                 tracker_config['enable_interface_without_connection']=True
                 self.setConnectionState(True)
-                
+
             self._addCommandFunctions()
 
             # Sets the physical ini settings, like default screen distance,
@@ -83,16 +83,16 @@ class EyeTracker(EyeTrackerDevice):
                 self._eyelink.sendCommand("aux_mouse_simulation = YES")
             else:
                 self._eyelink.sendCommand("aux_mouse_simulation = NO")
-                
+
             # set that the EyeLink connected button box, button 5
-            # (the big button on most of supported gamepads), will initiate 
+            # (the big button on most of supported gamepads), will initiate
             # an accept fixation command.
             self._eyelink.sendCommand("button_function 5 'accept_target_fixation'")
 
             # Sets up the file names / paths to be used for the native EyeLink EDF file.
             EyeTracker._local_edf_dir=os.path.abspath('.')
 
-            # Sets the 'runtime' configuration section of the eyetracker 
+            # Sets the 'runtime' configuration section of the eyetracker
             # settings, including eye to track, sample filtering level, etc.
             self._setRuntimeSettings(self._runtime_settings)
 
@@ -105,13 +105,13 @@ class EyeTracker(EyeTrackerDevice):
                         if cal_val is True:
                             eyelink.enableAutoCalibration()
                         elif cal_val is False:
-                            eyelink.disableAutoCalibration()        
+                            eyelink.disableAutoCalibration()
                     elif cal_key == 'pacing_speed': # in seconds.msec
-                        eyelink.setAutoCalibrationPacing(int(cal_val*1000))        
+                        eyelink.setAutoCalibrationPacing(int(cal_val*1000))
                     elif cal_key == 'type':
                         VALID_CALIBRATION_TYPES=dict(THREE_POINTS="HV3",FIVE_POINTS="HV5",NINE_POINTS="HV9",THIRTEEN_POINTS="HV13")
                         eyelink.setCalibrationType(VALID_CALIBRATION_TYPES[cal_val])
-                    elif cal_key == 'target_type': 
+                    elif cal_key == 'target_type':
                         pass
                     elif cal_key == 'screen_background_color':
                         pass
@@ -120,7 +120,7 @@ class EyeTracker(EyeTrackerDevice):
                     else:
                         print2err("WARNING: unhandled eye tracker calibration setting: {0}, value: {1}".format(cal_key,cal_val))
 
-            # native data recording file            
+            # native data recording file
             default_native_data_file_name=tracker_config.get('default_native_data_file_name',None)
             if default_native_data_file_name:
                 if isinstance(default_native_data_file_name,(str,unicode)):
@@ -140,9 +140,9 @@ class EyeTracker(EyeTrackerDevice):
                     print2err("ERROR: default_native_data_file_name must be a string or unicode value")
 
             if self._local_edf_dir and self._full_edf_name:
-                EyeTracker._active_edf_file=self._full_edf_name+'.EDF'    
+                EyeTracker._active_edf_file=self._full_edf_name+'.EDF'
             self._eyelink.openDataFile(self._host_edf_name+'.EDF')
-            
+
             # Creates a fileTransferDialog class that will be used when a connection is closed and
             # a native EDF file needs to be transfered from Host to Experiment PC.
             EyeTracker._eyelink.progressUpdate=self._fileTransferProgressUpdate
@@ -150,30 +150,30 @@ class EyeTracker(EyeTrackerDevice):
             print2err(" ---- Error during EyeLink EyeTracker Initialization ---- ")
             printExceptionDetailsToStdErr()
             print2err(" ---- Error during EyeLink EyeTracker Initialization ---- ")
-                    
+
     def trackerTime(self):
         """
-        trackerTime returns the current EyeLink Host Application time in 
-        msec format as a long integer.        
+        trackerTime returns the current EyeLink Host Application time in
+        msec format as a long integer.
         """
         return self._eyelink.trackerTime()
 
     def trackerSec(self):
         """
-        trackerSec returns the current EyeLink Host Application time in 
-        sec.msec format.        
+        trackerSec returns the current EyeLink Host Application time in
+        sec.msec format.
         """
         return self._eyelink.trackerTime()*self.DEVICE_TIMEBASE_TO_SEC
 
     def setConnectionState(self,enable):
         """
-        setConnectionState connects the ioHub Server to the EyeLink device if 
+        setConnectionState connects the ioHub Server to the EyeLink device if
         the enable arguement is True, otherwise an open connection is closed with
         the device. Calling this method multiple times with the same value has no effect.
-        
-        Note that when the ioHub EyeLink Device class is created when the ioHub server starts, 
+
+        Note that when the ioHub EyeLink Device class is created when the ioHub server starts,
         a connection is automatically created with the eye tracking device.
-        
+
         If the eye tracker is currently recording eye data and sending it to the
         ioHub server, the recording will be stopped prior to closing the connection.
 
@@ -185,7 +185,7 @@ class EyeTracker(EyeTrackerDevice):
         """
         try:
             tracker_config=self.getConfiguration()
-            dummyModeEnabled=tracker_config.get('enable_interface_without_connection',False)    
+            dummyModeEnabled=tracker_config.get('enable_interface_without_connection',False)
             host_pc_ip_address=tracker_config.get('network_settings','100.1.1.1')
 
             if EyeTracker._eyelink is None:
@@ -199,7 +199,7 @@ class EyeTracker(EyeTrackerDevice):
             if enable is True or enable is False:
                 if enable is True and not self._eyelink.isConnected():
                     if dummyModeEnabled:
-                        self._eyelink.dummy_open()     
+                        self._eyelink.dummy_open()
                     else:
                         self._eyelink.open(host_pc_ip_address)
 
@@ -208,7 +208,7 @@ class EyeTracker(EyeTrackerDevice):
                     return EyeTrackerConstants.EYETRACKER_OK
                 elif enable is False and self._eyelink.isConnected():
                     self._eyelink.setOfflineMode()
-    
+
                     if self._active_edf_file:
                         self._eyelink.closeDataFile()
                         # receive(scr,dest)
@@ -220,23 +220,23 @@ class EyeTracker(EyeTrackerDevice):
                 print2err('INVALID_METHOD_ARGUMENT_VALUE')
         except Exception, e:
             printExceptionDetailsToStdErr()
-            
-            
+
+
     def isConnected(self):
         """
         isConnected indicates if there is an active connection between the ioHub
         Server and the eye tracking device.
 
-        Note that when the ioHub EyeLink Device class is created when the ioHub server starts, 
+        Note that when the ioHub EyeLink Device class is created when the ioHub server starts,
         a connection is automatically created with the eye tracking device.
 
         The ioHub must be connected to the eye tracker device for it to be able to receive
-        events from the eye tracking system. Eye tracking events are received when 
+        events from the eye tracking system. Eye tracking events are received when
         isConnected() == True and when isRecordingEnabled() == True.
 
         Args:
             None
-            
+
         Return:
             bool:  True = the eye tracking hardware is connected. False otherwise.
         """
@@ -244,7 +244,7 @@ class EyeTracker(EyeTrackerDevice):
             return self._eyelink.isConnected() != 0
         except Exception, e:
             printExceptionDetailsToStdErr()
-            
+
     def sendCommand(self, key, value=None):
         """
         The sendCommand method sends an EyeLink command key and value to the EyeLink device.
@@ -252,16 +252,16 @@ class EyeTracker(EyeTrackerDevice):
         doing so is a device dependent operation, and will have no effect on other
         implementations of the Common EyeTracker Interface, unless the other eye tracking
         device happens to support the same command, value format.
-        
+
         If both key and value are provided, internally they are combined into a
         string of the form:
-            
-            "key = value" 
-            
-        and this is sent to the EyeLink device. If only key is provided, it is 
-        assumed to include both the command name and any value or arguements 
-        required by the EyeLink all in the one arguement, which is sent to the 
-        EyeLink device untouched. 
+
+            "key = value"
+
+        and this is sent to the EyeLink device. If only key is provided, it is
+        assumed to include both the command name and any value or arguements
+        required by the EyeLink all in the one arguement, which is sent to the
+        EyeLink device untouched.
         """
         try:
             if key in EyeTracker._COMMAND_TO_FUNCTION:
@@ -272,7 +272,7 @@ class EyeTracker(EyeTrackerDevice):
                     cmdstr="{0}".format(key)
                 else:
                     cmdstr="{0} = {1}".format(key,value)
-                self._eyelink.sendCommand(cmdstr)    
+                self._eyelink.sendCommand(cmdstr)
                 r= self._readResultFromTracker(cmdstr)
                 print2err("[%s] result: %s"%(cmdstr,r))
                 return EyeTrackerConstants.EYETRACKER_OK
@@ -283,15 +283,15 @@ class EyeTracker(EyeTrackerDevice):
         """
         The sendMessage method sends a string (max length 128 characters) to the
         EyeLink device. The message will be time stamped and inserted into the
-        native EDF file, if one is being recorded. If no native EyeLink data file 
+        native EDF file, if one is being recorded. If no native EyeLink data file
         is being recorded, this method is a no-op.
         """
-        try:        
-            if time_offset:            
+        try:
+            if time_offset:
                 r = self._eyelink.sendMessage("\t%d\t%s"%(time_offset,message_contents))
             else:
                 r = self._eyelink.sendMessage(message_contents)
-    
+
             if r == 0:
                 return EyeTrackerConstants.EYETRACKER_OK
             return EyeTrackerConstants.EYETRACKER_ERROR
@@ -299,16 +299,16 @@ class EyeTracker(EyeTrackerDevice):
             printExceptionDetailsToStdErr()
     def runSetupProcedure(self,starting_state=EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE):
         """
-        runSetupProcedure initiates the EyeLink Camera Setup and Calibration procedure. 
-        Currently, only the default starting_state value of 
-        EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE is supported. 
-        
+        runSetupProcedure initiates the EyeLink Camera Setup and Calibration procedure.
+        Currently, only the default starting_state value of
+        EyeTrackerConstants.DEFAULT_SETUP_PROCEDURE is supported.
+
         The current implemntation does not support displaying of the eye camera
-        images on the Camera Setup screen, the screen is blank. 
-        
+        images on the Camera Setup screen, the screen is blank.
+
         When runSetupProcedure is called, the following keys can be used on either the
         Host PC or Experiment PC to control the state of the setup procedure:
-            
+
             * C = Start Calibration
             * V = Start Validation
             * ENTER should be pressed at the end of a calibration or validation to accept the calibration, or in the case of validation, use the option drift correction that can be performed as part of the validation process in the EyeLink system.
@@ -321,7 +321,7 @@ class EyeTracker(EyeTrackerDevice):
         try:
             import eyeLinkCoreGraphicsIOHubPsychopy
             EyeLinkCoreGraphicsIOHubPsychopy = eyeLinkCoreGraphicsIOHubPsychopy.EyeLinkCoreGraphicsIOHubPsychopy
-            
+
             calibration_properties=self.getConfiguration().get('calibration')
             circle_attributes=calibration_properties.get('target_attributes')
             targetForegroundColor=circle_attributes.get('outer_color') # [r,g,b] of outer circle of targets
@@ -355,7 +355,7 @@ class EyeTracker(EyeTrackerDevice):
 
         Args:
            None
-  
+
         Return:
             bool: True == the device is recording data; False == Recording is not occurring
         """
@@ -369,7 +369,7 @@ class EyeTracker(EyeTrackerDevice):
         enableEventReporting is the device type independent method that is equivelent
         to the EyeTracker specific setRecordingState method.
         """
-        try:        
+        try:
             enabled=EyeTrackerDevice.enableEventReporting(self,enabled)
             return self.setRecordingState(enabled)
         except Exception, e:
@@ -377,31 +377,31 @@ class EyeTracker(EyeTrackerDevice):
     def setRecordingState(self,recording):
         """
         setRecordingState enables (recording=True) or disables (recording=False)
-        the recording of eye data by the eye tracker and the sending of any eye 
+        the recording of eye data by the eye tracker and the sending of any eye
         data to the ioHub Server. The eye tracker must be connected to the ioHub Server
         by using the setConnectionState(True) method for recording to be possible.
 
         Args:
             recording (bool): if True, the eye tracker will start recordng data.; false = stop recording data.
-           
+
         Return:
             bool: the current recording state of the eye tracking device
         """
         try:
             if not isinstance(recording,bool):
                 printExceptionDetailsToStdErr()
-             
-            if recording is True and not self.isRecordingEnabled():                
+
+            if recording is True and not self.isRecordingEnabled():
                 error = self._eyelink.startRecording(1,1,1,1)
                 if error:
                     print2err('Start Recording error : ',error)
-    
+
                 if not self._eyelink.waitForBlockStart(100, 1, 0):
                     print2err('EYETRACKER_START_RECORD_EXCEPTION ')
 
                 EyeTrackerDevice.enableEventReporting(self,True)
                 return self.isRecordingEnabled()
-            
+
             elif recording is False and self.isRecordingEnabled():
                 self._eyelink.stopRecording()
                 EyeTrackerDevice.enableEventReporting(self,False)
@@ -415,11 +415,11 @@ class EyeTracker(EyeTrackerDevice):
     def getLastSample(self):
         """
         getLastSample returns the most recent EyeSampleEvent received
-        from the iViewX system. Any position fields are in Display 
-        device coordinate space. If the eye tracker is not recording or is not 
-        connected, then None is returned.        
+        from the iViewX system. Any position fields are in Display
+        device coordinate space. If the eye tracker is not recording or is not
+        connected, then None is returned.
 
-        Args: 
+        Args:
             None
 
         Returns:
@@ -436,23 +436,23 @@ class EyeTracker(EyeTrackerDevice):
 
     def getLastGazePosition(self):
         """
-        getLastGazePosition returns the most recent x,y eye position, in Display 
+        getLastGazePosition returns the most recent x,y eye position, in Display
         device coordinate space, received by the ioHub server from the EyeLink device.
         In the case of binocular recording, and if both eyes are successfully being tracked,
         then the average of the two eye positions is returned.
         If the eye tracker is not recording or is not connected, then None is returned.
         The getLastGazePosition method returns the most recent eye gaze position
-        retieved from the eye tracker device. This is the position on the 
+        retieved from the eye tracker device. This is the position on the
         calibrated 2D surface that the eye tracker is reporting as the current
-        eye position. The units are in the units in use by the Display device. 
-        
+        eye position. The units are in the units in use by the Display device.
+
         If binocular recording is being performed, the average position of both
-        eyes is returned. 
-        
-        If no samples have been received from the eye tracker, or the 
+        eyes is returned.
+
+        If no samples have been received from the eye tracker, or the
         eye tracker is not currently recording data, None is returned.
 
-        Args: 
+        Args:
             None
 
         Returns:
@@ -464,7 +464,7 @@ class EyeTracker(EyeTrackerDevice):
             return self._latest_gaze_position
         except Exception, e:
             printExceptionDetailsToStdErr()
-    
+
     def _poll(self):
         try:
             if self._eyelink is None:
@@ -474,7 +474,7 @@ class EyeTracker(EyeTrackerDevice):
             poll_time=Computer.getTime()
             confidenceInterval=poll_time-self._last_poll_time
             self._last_poll_time=poll_time
-            
+
             #get native events queued up
             nEvents=[]
             while 1:
@@ -538,10 +538,10 @@ class EyeTracker(EyeTrackerDevice):
                         if gx == pylink.MISSING_DATA or gy == pylink.MISSING_DATA or leftPupilSize==0:
                             status=20
                             leftPupilSize=0
-                        else:    
+                        else:
                             leftGaze=self._eyeTrackerToDisplayCoords((gx,gy))
                             lastgaze = leftGaze
-                        
+
                         rightPupilSize=rightData.getPupilSize()
                         rightRawPupil=rightData.getRawPupil()
                         rightHref=rightData.getHREF()
@@ -554,14 +554,14 @@ class EyeTracker(EyeTrackerDevice):
                         if gx == pylink.MISSING_DATA or gy == pylink.MISSING_DATA or rightPupilSize==0:
                             status+=2
                             rightPupilSize=0
-                        else:    
+                        else:
                             rightGaze=self._eyeTrackerToDisplayCoords((gx,gy))
                             if lastgaze is None:
                                 lastgaze = rightGaze
                             else:
                                 lastgaze = [lastgaze[0]+rightGaze[0], lastgaze[1]+rightGaze[1]]
                                 lastgaze = lastgaze[0]/2.0, lastgaze[1]/2.0
-                                
+
                         self._latest_gaze_position=lastgaze
 
                         # TO DO: EyeLink pyLink does not expose sample velocity fields. Patch and fix.
@@ -653,7 +653,7 @@ class EyeTracker(EyeTrackerDevice):
                             gaze=EyeTrackerConstants.UNDEFINED,EyeTrackerConstants.UNDEFINED
                             status=2
                             self._latest_gaze_position=None
-                        else:    
+                        else:
                             gaze=self._eyeTrackerToDisplayCoords((gx,gy))
                             self._latest_gaze_position=(gaze[0],gaze[1])
 
@@ -1014,7 +1014,7 @@ class EyeTracker(EyeTrackerDevice):
         except Exception:
             print2err("ERROR occurred during poll:")
             printExceptionDetailsToStdErr()
-                
+
 
     def _eyeTrackerToDisplayCoords(self,eyetracker_point):
         """
@@ -1022,28 +1022,28 @@ class EyeTracker(EyeTrackerDevice):
         try:
             cl,ct,cr,cb=self._display_device.getCoordBounds()
             cw,ch=cr-cl,ct-cb
-            
+
             dl,dt,dr,db=self._display_device.getBounds()
             dw,dh=dr-dl,db-dt
 
-            gxn,gyn=eyetracker_point[0]/dw,eyetracker_point[1]/dh                        
-            return cl+cw*gxn,cb+ch*(1.0-gyn)   
+            gxn,gyn=eyetracker_point[0]/dw,eyetracker_point[1]/dh
+            return cl+cw*gxn,cb+ch*(1.0-gyn)
         except Exception,e:
             printExceptionDetailsToStdErr()
-        
+
     def _displayToEyeTrackerCoords(self,display_x,display_y):
         """
         """
-        try:                        
+        try:
             cl,ct,cr,cb=self._display_device.getCoordBounds()
             cw,ch=cr-cl,ct-cb
-            
+
             dl,dt,dr,db=self._display_device.getBounds()
             dw,dh=dr-dl,db-dt
-            
-            cxn,cyn=(display_x+cw/2)/cw , 1.0-(display_y-ch/2)/ch       
-            return cxn*dw,  cyn*dh          
-           
+
+            cxn,cyn=(display_x+cw/2)/cw , 1.0-(display_y-ch/2)/ch
+            return cxn*dw,  cyn*dh
+
         except Exception,e:
             printExceptionDetailsToStdErr()
 
@@ -1051,23 +1051,23 @@ class EyeTracker(EyeTrackerDevice):
         for pkey,v in runtimeSettings.iteritems():
 
             if pkey == 'sample_filtering':
-                all_filters={'FILTER_FILE': 'FILTER_LEVEL_2', 
-                             'FILTER_ONLINE': 'FILTER_LEVEL_OFF'}    
+                all_filters={'FILTER_FILE': 'FILTER_LEVEL_2',
+                             'FILTER_ONLINE': 'FILTER_LEVEL_OFF'}
                 #print2err("sample_filtering: {0}".format(v))
-            
+
                 if str(v) in ('FILTER_OFF','FILTER_LEVEL_OFF','FILTER_LEVEL_1','FILTER_LEVEL_2'):
-                    vd = {u'FILTER_ALL': str(v)}                    
+                    vd = {u'FILTER_ALL': str(v)}
                     v = vd
-                    
-                fkeys = [str(k) for k in v.keys()]                
+
+                fkeys = [str(k) for k in v.keys()]
                 if 'FILTER_ALL' in fkeys:
-                    for k in all_filters.keys():
+                    for k in all_filters:
                         all_filters[k] = str(v[u'FILTER_ALL'])
                 else:
                     for k in fkeys:
-                        if k in all_filters.keys():
+                        if k in all_filters:
                             all_filters[k]=str(v[k])
-                            
+
                 #print2err("processed sample_filtering: {0}".format(all_filters))
                 self._setSampleFilterLevel(all_filters)
             elif pkey == 'sampling_rate':
@@ -1112,7 +1112,7 @@ class EyeTracker(EyeTrackerDevice):
                 pass
             else:
                 track_eyes = EyeTrackerConstants.getName(track_eyes)
-    
+
             if track_eyes is None:
                 print2err("** Warning: UNKNOWN EYE CONSTANT, SETTING EYE TO TRACK TO RIGHT. UNKNOWN EYE CONSTANT: ",track_eyes)
                 track_eyes='RIGHT'
@@ -1125,9 +1125,9 @@ class EyeTracker(EyeTrackerDevice):
             else:
                 print2err("** Warning: UNKNOWN EYE CONSTANT, SETTING EYE TO TRACK TO RIGHT. UNKNOWN EYE CONSTANT: ",track_eyes)
                 track_eyes='RIGHT'
-    
+
             srate=self._getSamplingRate()
-    
+
             self._eyelink.sendCommand("lock_active_eye = NO")
             if track_eyes == "BOTH":
                 if self._eyelink.getTrackerVersion() == 3:
@@ -1179,7 +1179,7 @@ class EyeTracker(EyeTrackerDevice):
     def _setSamplingRate(self,sampling_rate):
         """
         """
-        try:        
+        try:
             if self.isConnected():
                 srate=sampling_rate
                 tracker_version=self._eyelink.getTrackerVersion()
@@ -1190,7 +1190,7 @@ class EyeTracker(EyeTrackerDevice):
                     trackerVersion =self._eyelink.getTrackerVersionString().strip()
                     trackerVersion = trackerVersion.split(' ')
                     tv = float(trackerVersion[len(trackerVersion)-1])
-    
+
                     if tv>3:
                         # EyeLink 2000
                         rts = []
@@ -1231,7 +1231,7 @@ class EyeTracker(EyeTrackerDevice):
             if ffilter is None:
                 ffilter = 0
             #print2err('lfilter, ffilter: {}, {}'.format(lfilter, ffilter))
-            self._eyelink.setHeuristicLinkAndFileFilter(lfilter, ffilter)            
+            self._eyelink.setHeuristicLinkAndFileFilter(lfilter, ffilter)
             return EyeTrackerConstants.EYETRACKER_OK
         except Exception:
             print2err("EYELINK Error during _setSampleFilterLevel: ", filter_settings_dict)
@@ -1239,9 +1239,9 @@ class EyeTracker(EyeTrackerDevice):
             return EyeTrackerConstants.EYETRACKER_ERROR
 
     def _eyelinkSetScreenPhysicalData(self):
-        try:        
+        try:
             eyelink=self._eyelink
-    
+
             # eye to screen distance
             sdist=self._display_device.getConfiguration().get('default_eye_distance',None)
             if sdist:
@@ -1250,7 +1250,7 @@ class EyeTracker(EyeTrackerDevice):
             else:
                 print2err('ERROR: "default_eye_distance":"surface_center" value could not be read from monitor settings')
                 return False
-    
+
             # screen_phys_coords
             sdim=self._display_device.getConfiguration().get('physical_dimensions',None)
             if sdim:
@@ -1259,22 +1259,22 @@ class EyeTracker(EyeTrackerDevice):
                     sh=sdim['height']
                     hsw=sw/2.0
                     hsh=sh/2.0
-    
+
                     eyelink.sendCommand("screen_phys_coords = -%.3f, %.3f, %.3f, -%.3f"%(hsw,hsh,hsw,hsh))
             else:
                 print2err('ERROR: "physical_stimudisplay_x,display_ylus_area":"width" or "height" value could not be read from monitor settings')
                 return False
-    
+
             # calibration coord space
             l,t,r,b=self._display_device.getBounds()
             w=r-l
             h=b-t
             eyelink.sendCommand("screen_pixel_coords %.2f %.2f %.2f %.2f" %(0,0,w,h))
             eyelink.sendMessage("DISPLAY_COORDS  %.2f %.2f %.2f %.2f" %(0,0,w,h))
-            
+
             #bug in pylink makes this not work; must use default setting of 10
             #eyelink.sendCommand("screen_write_prescale = 100")
-            
+
         except Exception:
             print2err("EYELINK Error during _eyelinkSetScreenPhysicalData:")
             printExceptionDetailsToStdErr()
@@ -1282,15 +1282,15 @@ class EyeTracker(EyeTrackerDevice):
 
 
     def _eyeLinkHardwareAndSoftwareVersion(self):
-        try:        
+        try:
             tracker_software_ver = 0
             eyelink_ver = self._eyelink.getTrackerVersion()
-    
+
             if eyelink_ver == 3:
                 tvstr = self._eyelink.getTrackerVersionString()
                 vindex = tvstr.find("EYELINK CL")
                 tracker_software_ver = int(float(tvstr[(vindex + len("EYELINK CL")):].strip()))
-    
+
             return eyelink_ver, tracker_software_ver
         except Exception:
             print2err("EYELINK Error during _eyeLinkHardwareAndSoftwareVersion:")
@@ -1300,22 +1300,22 @@ class EyeTracker(EyeTrackerDevice):
     def _eyelinkSetLinkAndFileContents(self):
         try:
             eyelink = self._eyelink
-    
+
             eyelink_hw_ver, eyelink_sw_ver = self._eyeLinkHardwareAndSoftwareVersion()
-    
+
             # set EDF file contents
             eyelink.sendCommand("file_event_filter = LEFT, RIGHT, FIXATION, SACCADE, BLINK, MESSAGE, BUTTON, INPUT")
             eyelink.sendCommand("file_event_data = GAZE , GAZERES , HREF , AREA  , VELOCITY , STATUS")
-    
+
             if eyelink_sw_ver>=4:
                 eyelink.sendCommand("file_sample_data = GAZE, GAZERES, HREF , PUPIL , AREA ,STATUS, BUTTON, INPUT, HTARGET")
             else:
                 eyelink.sendCommand("file_sample_data = GAZE, GAZERES, HREF , PUPIL , AREA ,STATUS, BUTTON, INPUT")
-    
+
             # set link data
             eyelink.sendCommand("link_event_filter = LEFT, RIGHT, FIXATION, SACCADE , BLINK, BUTTON, MESSAGE, INPUT")
             eyelink.sendCommand("link_event_data = GAZE, GAZERES, HREF , AREA, VELOCITY, STATUS")
-    
+
             if eyelink_sw_ver>=4:
                 eyelink.sendCommand("link_sample_data = GAZE, GAZERES, HREF , PUPIL , AREA ,STATUS, BUTTON, INPUT , HTARGET")
             else:
@@ -1344,7 +1344,7 @@ class EyeTracker(EyeTrackerDevice):
     def _readResultFromTracker(self,cmd,timeout=5):
         try:
             self._eyelink.readRequest(cmd)
-    
+
             t = pylink.currentTime()
             # Waits for a maximum of timeout msec
             while(pylink.currentTime()-t < timeout):
@@ -1367,12 +1367,12 @@ class EyeTracker(EyeTrackerDevice):
             else:
                 print2err("** EyeLink Warning: _setPupilDetection: Unrecofnized pupil fitting type: ",pmode)
                 return EyeTrackerConstants.EYETRACKER_ERROR
-            return EyeTrackerConstants.EYETRACKER_OK    
+            return EyeTrackerConstants.EYETRACKER_OK
         except Exception:
             print2err("EYELINK Error during _setPupilDetection:")
             printExceptionDetailsToStdErr()
             return EyeTrackerConstants.EYETRACKER_ERROR
-        
+
     def _getPupilDetectionModel(self):
         try:
             v = self._readResultFromTracker("use_ellipse_fitter")
@@ -1394,7 +1394,7 @@ class EyeTracker(EyeTrackerDevice):
             else:
                 print2err("EYELINK Error during _setEyeTrackingMode: Unknown Trackiong Mode: ",r)
                 return EyeTrackerConstants.EYETRACKER_ERROR
-            if r == 0:                
+            if r == 0:
                 self._eyelink.sendCommand("force_corneal_reflection = OFF")
             self._eyelink.sendCommand("corneal_mode %d"%(r))
             return EyeTrackerConstants.EYETRACKER_OK
@@ -1403,17 +1403,17 @@ class EyeTracker(EyeTrackerDevice):
             print2err("EYELINK Error during _setEyeTrackingMode:")
             printExceptionDetailsToStdErr()
             return EyeTrackerConstants.EYETRACKER_ERROR
-        
+
     def _getSamplingRate(self):
         """
         """
-        try:        
+        try:
             if self.isConnected():
                 srate = self._eyelink.getSampleRate()
                 if srate is None or srate < 0:
-                    srate = self._readResultFromTracker('sample_rate',5)    
+                    srate = self._readResultFromTracker('sample_rate',5)
                 #print2err('srate: ', srate," ", type(srate))
-                if srate:                
+                if srate:
                     return int(srate)
                 return self._eyelink.getSampleRate()
             else:
@@ -1423,23 +1423,23 @@ class EyeTracker(EyeTrackerDevice):
             print2err("EYELINK Error during _getSamplingRate:")
             printExceptionDetailsToStdErr()
             return EyeTrackerConstants.EYETRACKER_ERROR
-            
+
 #================= Command Functions ==========================================
 
 _EYELINK_HOST_MODES={
-    "EL_IDLE_MODE" : 1,  
-    "EL_IMAGE_MODE" : 2,  
-    "EL_SETUP_MENU_MODE" : 3,  
-    "EL_USER_MENU_1" : 5,  
-    "EL_USER_MENU_2" : 6,  
-    "EL_USER_MENU_3" : 7,  
-    "EL_OPTIONS_MENU_MODE" : 8,  
-    "EL_OUTPUT_MENU_MODE" : 9,  
-    "EL_DEMO_MENU_MODE" : 10,  
-    "EL_CALIBRATE_MODE" : 11,  
-    "EL_VALIDATE_MODE" : 12,  
-    "EL_DRIFT_CORR_MODE" : 13,  
-    "EL_RECORD_MODE" : 14,  
+    "EL_IDLE_MODE" : 1,
+    "EL_IMAGE_MODE" : 2,
+    "EL_SETUP_MENU_MODE" : 3,
+    "EL_USER_MENU_1" : 5,
+    "EL_USER_MENU_2" : 6,
+    "EL_USER_MENU_3" : 7,
+    "EL_OPTIONS_MENU_MODE" : 8,
+    "EL_OUTPUT_MENU_MODE" : 9,
+    "EL_DEMO_MENU_MODE" : 10,
+    "EL_CALIBRATE_MODE" : 11,
+    "EL_VALIDATE_MODE" : 12,
+    "EL_DRIFT_CORR_MODE" : 13,
+    "EL_RECORD_MODE" : 14,
     }
 
 _eyeLinkCalibrationResultDict = dict()
@@ -1464,7 +1464,7 @@ def _doDriftCorrect(*args,**kwargs):
     try:
         if len(args)==4:
             x,y,draw,allow_setup=args
-            r=pylink.getEyeLink().doDriftCorrect(x,y,draw,allow_setup) 
+            r=pylink.getEyeLink().doDriftCorrect(x,y,draw,allow_setup)
             return r
         else:
             print2err("doDriftCorrect requires 4 parameters, received: ", args)
@@ -1481,7 +1481,7 @@ def _applyDriftCorrect():
             return ['EYE_TRACKER_ERROR','applyDriftCorrect',r]
     except Exception,e:
         printExceptionDetailsToStdErr()
-        
+
 def _eyeAvailable(*args,**kwargs):
     try:
         r=pylink.getEyeLink().eyeAvailable()
@@ -1502,7 +1502,7 @@ def _dummyOpen(*args,**kwargs):
         return r
     except Exception,e:
         printExceptionDetailsToStdErr()
-    
+
 def _getCalibrationMessage(*args,**kwargs):
     try:
         m=pylink.getEyeLink().getCalibrationMessage()
@@ -1515,7 +1515,7 @@ def _getCalibrationMessage(*args,**kwargs):
         return rString
     except Exception,e:
         printExceptionDetailsToStdErr()
-        
+
 def _setIPAddress(*args, **kwargs):
     try:
         if len(args)==1:
@@ -1545,7 +1545,7 @@ def _setNativeRecordingFileSaveDir(*args):
             EyeTracker._local_edf_dir=edfpath
     except Exception,e:
         printExceptionDetailsToStdErr()
-                
+
 #    def drawToHostApplicationWindow(self,graphic_type,**graphic_attributes):
 #        """
 #        EyeLink supported:

--- a/psychopy/iohub/devices/mcu/iosync/__init__.py
+++ b/psychopy/iohub/devices/mcu/iosync/__init__.py
@@ -79,7 +79,7 @@ from ....constants import DeviceConstants, EventConstants
 import numpy as N
 import gevent
 getTime= Computer.getTime
-        
+
 class MCU(Device):
     """
     """
@@ -97,8 +97,8 @@ class MCU(Device):
                 ]
     __slots__=[e for e in _mcu_slots]
     def __init__(self, *args, **kwargs):
-        self.serial_port=None   
-        self.time_sync_interval=None   
+        self.serial_port=None
+        self.time_sync_interval=None
 
         Device.__init__(self,*args,**kwargs['dconfig'])
 
@@ -129,18 +129,18 @@ class MCU(Device):
                 self._mcu.resetState(blocking=True)
                 self._mcu.close()
                 self._mcu=None
-                
+
         return self.isConnected()
 
     def isConnected(self):
         return self._mcu != None
-           
+
     def getDeviceTime(self):
         return T3Request.sync_state.local2RemoteTime(getTime())
-        
+
     def getSecTime(self):
         """
-        Returns current device time in sec.msec format. 
+        Returns current device time in sec.msec format.
         Relies on a functioning getDeviceTime() method.
         """
         return self.getDeviceTime()#*self.DEVICE_TIMEBASE_TO_SEC
@@ -150,18 +150,18 @@ class MCU(Device):
         Specifies if the device should be reporting events to the ioHub Process
         (enabled=True) or whether the device should stop reporting events to the
         ioHub Process (enabled=False).
-        
-            
+
+
         Args:
             enabled (bool):  True (default) == Start to report device events to the ioHub Process. False == Stop Reporting Events to the ioHub Process. Most Device types automatically start sending events to the ioHUb Process, however some devices like the EyeTracker and AnlogInput device's do not. The setting to control this behavour is 'auto_report_events'
-        
+
         Returns:
-            bool: The current reporting state. 
+            bool: The current reporting state.
         """
         if enabled and not self.isReportingEvents():
             if not self.isConnected():
                 self.setConnectionState(True)
-            event_types=self.getConfiguration().get('monitor_event_types',[])    
+            event_types=self.getConfiguration().get('monitor_event_types',[])
             enable_analog = 'AnalogInputEvent' in event_types
             enable_digital = 'DigitalInputEvent' in event_types
             enable_threshold = 'ThresholdEvent' in event_types
@@ -169,15 +169,15 @@ class MCU(Device):
         elif enabled is False and self.isReportingEvents() is True:
             if self.isConnected():
                 self._enableInputEvents(False,False,False)
-                
+
         return Device.enableEventReporting(self,enabled)
 
     def isReportingEvents(self):
         """
         Returns whether a Device is currently reporting events to the ioHub Process.
-        
+
         Args: None
-        
+
         Returns:
             (bool): Current reporting state.
         """
@@ -189,7 +189,7 @@ class MCU(Device):
         request = self._mcu.requestTime()
         self._request_dict[request.getID()]=request
         return request.asdict()
- 
+
     def getDigitalInputs(self):
         request=self._mcu.getDigitalInputs()
         self._request_dict[request.getID()]=request
@@ -209,7 +209,7 @@ class MCU(Device):
         request=self._mcu.generateKeyboardEvent(use_char, press_duration)
         self._request_dict[request.getID()]=request
         return request.asdict()
-        
+
     def setDigitalOutputPin(self,dout_pin_index,new_pin_state):
         request=self._mcu.setDigitalOutputPin(dout_pin_index,new_pin_state)
         self._request_dict[request.getID()]=request
@@ -342,7 +342,7 @@ class MCU(Device):
         try:
             logged_time=getTime()
 
-            if self.isConnected():            
+            if self.isConnected():
                 self._mcu.getSerialRx()
                 if logged_time-self._last_sync_time>=self.time_sync_interval:
                     self._mcu._runTimeSync()
@@ -352,9 +352,9 @@ class MCU(Device):
                 return False
 
             confidence_interval=logged_time-self._last_callback_time
-    
+
             events = self._mcu.getRxEvents()
-            for event in events:             
+            for event in events:
                 current_MCU_time = event.device_time#self.getSecTime()
                 device_time = event.device_time
                 if event.local_time is None:
@@ -390,16 +390,16 @@ class MCU(Device):
                     elist[8] = confidence_interval
                     elist[9] = delay
                     elist[10] = 0
-                   
+
                     self._addNativeEventToBuffer(elist)
-                
+
             replies = self._mcu.getRequestReplies(True)
             for reply in replies:
                 rid=reply.getID()
-                if rid in self._request_dict.keys():
+                if rid in self._request_dict:
                     self._response_dict[rid]=reply
                     del self._request_dict[rid]
-            
+
             self._last_callback_time=logged_time
             return True
         except Exception, e:
@@ -407,16 +407,16 @@ class MCU(Device):
             print2err("ERROR in MCU._poll: ",e)
             printExceptionDetailsToStdErr()
             print2err("---------------------")
-            
+
     def _close(self):
         if self._mcu:
             self.resetState()
             self.setConnectionState(False)
-            
+
         Device._close(self)
-        
+
 class AnalogInputEvent(DeviceEvent):
-    _newDataTypes = [        
+    _newDataTypes = [
             ('AI_0',N.float32),
             ('AI_1',N.float32),
             ('AI_2',N.float32),
@@ -430,7 +430,7 @@ class AnalogInputEvent(DeviceEvent):
     EVENT_TYPE_STRING='ANALOG_INPUT'
     IOHUB_DATA_TABLE=EVENT_TYPE_STRING
     __slots__=[e[0] for e in _newDataTypes]
-    def __init__(self,*args,**kwargs):        
+    def __init__(self,*args,**kwargs):
         DeviceEvent.__init__(self,*args,**kwargs)
 
 class ThresholdEvent(DeviceEvent):
@@ -457,7 +457,7 @@ class DigitalInputEvent(DeviceEvent):
     EVENT_TYPE_ID=EventConstants.DIGITAL_INPUT
     EVENT_TYPE_STRING='DIGITAL_INPUT'
     IOHUB_DATA_TABLE=EVENT_TYPE_STRING
-    __slots__=[e[0] for e in _newDataTypes]    
-    def __init__(self,*args,**kwargs):        
+    __slots__=[e[0] for e in _newDataTypes]
+    def __init__(self,*args,**kwargs):
         self.state=0
         DeviceEvent.__init__(self,*args,**kwargs)

--- a/psychopy/iohub/devices/mcu/iosync/pysync.py
+++ b/psychopy/iohub/devices/mcu/iosync/pysync.py
@@ -15,14 +15,14 @@ outputs.
 Be sure to use Teensiduno to compile and upload the ioSync sketch to the Teensy 3
 which will be used. Otherwise the pySync interface will not fucntion.
 
-ioSync uses a majority of the Teensy 3 pins, including the ones on the bottom 
+ioSync uses a majority of the Teensy 3 pins, including the ones on the bottom
 of the Teensy 3 accessable via the solder pads.
 
 ioSync Teensy 3 Pin Assignment
 ===============================
 
 The ioSync uses the T3 pins as follows:
-    
+
 Teensy 3 board LED:
 ~~~~~~~~~~~~~~~~~~~
 
@@ -84,7 +84,7 @@ SPI Pins:
 ~~~~~~~~~~
 
     SPI_SS:     CS0     // digital pin 10 on T3, Device Select
-    SPI_MOSI:   DOUT    // digital pin 11 on T3, SPI Data Output 
+    SPI_MOSI:   DOUT    // digital pin 11 on T3, SPI Data Output
     SPI_MISO:   DIN     // digital pin 12 on T3, SPI Data Input
     SPI_SCK:    SCK     // digital pin 13 on 3, Clock
 
@@ -99,7 +99,7 @@ UART:
 
     RX: RX1         // digital pin 0 on T3
     TX: TX1         // digital pin 1 in T3
-    
+
 PWM Outputs:
 ~~~~~~~~~~~~
 
@@ -117,7 +117,7 @@ try:
 except Exception:
     from timeit import default_timer as getTime
     from collections import OrderedDict
-    
+
     def print2err(*args):
         print args
 
@@ -127,14 +127,14 @@ class T3Event(object):
     ANALOG_INPUT_EVENT = 2
     THRESHOLD_EVENT = 3
     def __init__(self,event_type,event_time_bytes,remaining_bytes):
-        self._type=event_type              
+        self._type=event_type
         self.usec_device_time = (event_time_bytes[4] << 40) + (event_time_bytes[5] << 32) \
         + (event_time_bytes[0] << 24) + (event_time_bytes[1] << 16) \
         + (event_time_bytes[2] << 8) + event_time_bytes[3]
         self.device_time = self.usec_device_time/1000000.0
         self.local_time=T3Request.sync_state.remote2LocalTime(self.device_time)
         self._parseRemainingBytes(remaining_bytes)
-        
+
     def getTypeInt(self):
         return self._type
 
@@ -146,17 +146,17 @@ class T3Event(object):
 
     def _parseRemainingBytes(self,remaining_bytes):
         raise AttributeError("T3Event._parseRemainingBytes must be extended")
-        
+
 class DigitalInputEvent(T3Event):
     def __init__(self,event_type,event_time_bytes,din_value):
         T3Event.__init__(self,event_type,event_time_bytes,din_value)
 
     def _parseRemainingBytes(self,din_value):
         self._value=din_value[0]
-        
+
     def getDigitalInputByte(self):
         return self._value
-        
+
     def asdict(self):
         rdict=T3Event.asdict(self)
         rdict['value']=self.getDigitalInputByte()
@@ -200,7 +200,7 @@ EVENT_TYPE_2_CLASS[T3Event.ANALOG_INPUT_EVENT] = AnalogInputEvent
 EVENT_TYPE_2_CLASS[T3Event.THRESHOLD_EVENT] = ThresholdEvent
 
 ################################
-     
+
 class T3Request(object):
     NULL_REQUEST =0
     GET_USEC_TIME =1
@@ -227,23 +227,23 @@ class T3Request(object):
         if user_byte_array:
             self._tx_data.extend(bytearray([i for i in user_byte_array]))
         self._tx_byte_count=len(self._tx_data)
-        self._tx_data[2]= self._tx_byte_count    
+        self._tx_data[2]= self._tx_byte_count
         self._rx_data=None
         self._rx_byte_count=0
 
         if T3Request.sync_state is None:
             T3Request.sync_state=TimeSyncState(5)
-            
+
         self.tx_time=None
         self.rx_time=None
         self.usec_device_time=None
         self.device_time=None
         self.iohub_time=None
 
-            
+
     def getTypeInt(self):
         return self._type
-        
+
     def getID(self):
         return self._id
 
@@ -258,7 +258,7 @@ class T3Request(object):
 
     def getRxByteCount(self):
         return self._rx_byte_count
-        
+
     def setRxByteArray(self,d):
         self._rx_data=d
         self._rx_byte_count=len(d)
@@ -315,7 +315,7 @@ class SyncTimebaseRequest(T3Request):
 
     def syncWithT3Time(self):
         if self.sync_point_counter == 3:
-            # calc sync run min, update state, and clear sync_run_data            
+            # calc sync run min, update state, and clear sync_run_data
             min_rtt_point_index=self.sync_run_data[:,2].argmin()
             L2,R2,RTT2=self.sync_run_data[min_rtt_point_index,:]
             if len(self.sync_state.RTTs)>0:
@@ -329,7 +329,7 @@ class SyncTimebaseRequest(T3Request):
             self.sync_run_data[i,1]=self.device_time # R
             self.sync_run_data[i,2]=(self.rx_time-self.tx_time) # rtt
 
-            SyncTimebaseRequest.sync_point_counter+=1                                
+            SyncTimebaseRequest.sync_point_counter+=1
 
 class GetT3DigitalInputStateRequest(T3Request):
     def __init__(self):
@@ -341,9 +341,9 @@ class GetT3AnalogInputStateRequest(T3Request):
 
 class GenerateKeyboardEventRequest(T3Request):
     """
-    Requests the Teensy to generate a key press event and then a release event 
+    Requests the Teensy to generate a key press event and then a release event
     press_duration*100 msec later.use_char is not actually used currently.
-    The 
+    The
     """
     def __init__(self,use_char='v', press_duration=15):
         T3Request.__init__(self,T3Request.GENERATE_KEYBOARD_EVENT,[use_char,press_duration])
@@ -370,13 +370,13 @@ class SetT3AnalogThresholdsRequest(T3Request):
 
 ####################
 
-class T3MC(object):    
+class T3MC(object):
 
     def __init__(self,port_num, baud=115200, timeout=0):
         self._port_num=port_num
         self._baud=baud
-        self._timeout=timeout       
-        self._active_requests=OrderedDict()  
+        self._timeout=timeout
+        self._active_requests=OrderedDict()
         self._serial_port=None
         self._rx_events=[]
         self._request_replies=[]
@@ -430,26 +430,26 @@ class T3MC(object):
         return iosync_ports
 
     def getSerialPort(self):
-          return self._serial_port 
-    
+          return self._serial_port
+
     def getActiveRequests(self,clear=False):
         r=self._active_requests
         if clear is True:
             self._active_requests=[]
         return r
-        
+
     def getRequestReplies(self,clear=False):
         r=self._request_replies
         if clear is True:
             self._request_replies=[]
         return r
-        
+
     def getRxEvents(self,clear=True):
         r=self._rx_events
         if clear is True:
             self._rx_events=[]
         return r
-        
+
     def connectSerial(self):
 
         self._serial_port = serial.Serial(self._port_num, self._baud, timeout=self._timeout)
@@ -485,7 +485,7 @@ class T3MC(object):
                     remaining_bytes = []
                     if remaining_byte_count > 0:
                         remaining_bytes = [ord(c) for c in self._serial_port.read(remaining_byte_count)]
-                    if request_id in EVENT_TYPE_2_CLASS.keys():
+                    if request_id in EVENT_TYPE_2_CLASS:
                         event = EVENT_TYPE_2_CLASS[request_id](request_id, time_bytes, remaining_bytes)
                         self._rx_events.append(event)
                 else:
@@ -507,22 +507,22 @@ class T3MC(object):
             self._serial_port=None
             return True
         return False
-        
+
     def close(self):
         try:
             self.enableInputEvents(False,False)
         except Exception:
-            pass        
+            pass
         try:
             self.flushSerialInput()
         except Exception:
-            pass        
+            pass
         try:
             self.closeSerial()
         except Exception:
             pass
         self._serial_port=None
-        
+
     def requestTime(self):
         r=GetT3UsecRequest()
         self._sendT3Request(r)
@@ -575,7 +575,7 @@ class T3MC(object):
         r=EnableT3InputStreaming(enable_digital,enable_analog, enable_thresh)
         self._sendT3Request(r)
         return r
-        
+
     def __del__(self):
         self.close()
 
@@ -584,43 +584,43 @@ class T3MC(object):
 
 class RingBuffer(object):
     """
-    NumPyRingBuffer is a circular buffer implemented using a one dimensional 
+    NumPyRingBuffer is a circular buffer implemented using a one dimensional
     numpy array on the backend. The algorithm used to implement the ring buffer
     behavour does not require any array copies to occur while the ring buffer is
-    maintained, while at the same time allowing sequential element access into the 
+    maintained, while at the same time allowing sequential element access into the
     numpy array using a subset of standard slice notation.
-    
+
     When the circular buffer is created, a maximum size , or maximum
-    number of elements,  that the buffer can hold *must* be specified. When 
+    number of elements,  that the buffer can hold *must* be specified. When
     the buffer becomes full, each element added to the buffer removes the oldest
-    element from the buffer so that max_size is never exceeded. 
- 
+    element from the buffer so that max_size is never exceeded.
+
     Items are added to the ring buffer using the classes append method.
-    
-    The current number of elements in the buffer can be retrieved using the 
-    getLength() method of the class. 
-    
+
+    The current number of elements in the buffer can be retrieved using the
+    getLength() method of the class.
+
     The isFull() method can be used to determine if
     the ring buffer has reached its maximum size, at which point each new element
     added will disregard the oldest element in the array.
-    
+
     The getElements() method is used to retrieve the actual numpy array containing
-    the elements in the ring buffer. The element in index 0 is the oldest remaining 
+    the elements in the ring buffer. The element in index 0 is the oldest remaining
     element added to the buffer, and index n (which can be up to max_size-1)
     is the the most recent element added to the buffer.
 
-    Methods that can be called from a standard numpy array can also be called using the 
+    Methods that can be called from a standard numpy array can also be called using the
     NumPyRingBuffer instance created. However Numpy module level functions will not accept
     a NumPyRingBuffer as a valid arguement.
-    
+
     To clear the ring buffer and start with no data in the buffer, without
     needing to create a new NumPyRingBuffer object, call the clear() method
     of the class.
-    
+
     Example::
-    
+
         ring_buffer=RingBuffer(10)
-        
+
         for i in xrange(25):
             ring_buffer.append(i)
             print '-------'
@@ -632,25 +632,25 @@ class RingBuffer(object):
             print '\tStandard Deviation: ',ring_buffer.std()
             print '\tFirst 3 Elements: ',ring_buffer[:3]
             print '\tLast 3 Elements: ',ring_buffer[-3:]
-        
-        
-        
+
+
+
     """
     def __init__(self, max_size, dtype=np.float32):
         self._dtype=dtype
         self._npa=np.empty(max_size*2,dtype=dtype)
         self.max_size=max_size
         self._index=0
-        
+
     def append(self, element):
         """
-        Add element e to the end of the RingBuffer. The element must match the 
+        Add element e to the end of the RingBuffer. The element must match the
         numpy data type specified when the NumPyRingBuffer was created. By default,
         the RingBuffer uses float32 values.
-        
-        If the Ring Buffer is full, adding the element to the end of the array 
+
+        If the Ring Buffer is full, adding the element to the end of the array
         removes the currently oldest element from the start of the array.
-        
+
         :param numpy.dtype element: An element to add to the RingBuffer.
         :returns None:
         """
@@ -661,11 +661,11 @@ class RingBuffer(object):
 
     def getElements(self):
         """
-        Return the numpy array being used by the RingBuffer, the length of 
+        Return the numpy array being used by the RingBuffer, the length of
         which will be equal to the number of elements added to the list, or
         the last max_size elements added to the list. Elements are in order
         of addition to the ring buffer.
-        
+
         :param None:
         :returns numpy.array: The array of data elements that make up the Ring Buffer.
         """
@@ -674,21 +674,21 @@ class RingBuffer(object):
     def isFull(self):
         """
         Indicates if the RingBuffer is at it's max_size yet.
-        
+
         :param None:
         :returns bool: True if max_size or more elements have been added to the RingBuffer; False otherwise.
         """
         return self._index >= self.max_size
-        
+
     def clear(self):
         """
         Clears the RingBuffer. The next time an element is added to the buffer, it will have a size of one.
-        
+
         :param None:
-        :returns None: 
+        :returns None:
         """
         self._index=0
-        
+
     def __setitem__(self, indexs,v):
         if isinstance(indexs,(list,tuple)):
             for i in indexs:
@@ -704,7 +704,7 @@ class RingBuffer(object):
                     if indexs.stop is None:
                         istop=0
                     start=istart+self._index
-                    stop=istop+self._index            
+                    stop=istop+self._index
                     self._npa[slice(start%self.max_size,stop%self.max_size,i.step)]=v
                     self._npa[slice((start%self.max_size)+self.max_size,(stop%self.max_size)+self.max_size,i.step)]=v
         elif isinstance(indexs, (int,long)):
@@ -719,7 +719,7 @@ class RingBuffer(object):
             if indexs.stop is None:
                 istop=0
             start=istart+self._index
-            stop=istop+self._index  
+            stop=istop+self._index
             self._npa[slice(start%self.max_size,stop%self.max_size,indexs.step)]=v
             self._npa[slice((start%self.max_size)+self.max_size,(stop%self.max_size)+self.max_size,indexs.step)]=v
         else:
@@ -732,19 +732,19 @@ class RingBuffer(object):
             for i in indexs:
                 if isinstance(i, (int,long)):
                     rarray.append(current_array[i])
-                elif isinstance(i,slice):          
+                elif isinstance(i,slice):
                     rarray.extend(current_array[i])
             return np.asarray(rarray,dtype=self._dtype)
         elif isinstance(indexs, (int,long,slice)):
             return current_array[indexs]
         else:
             raise TypeError()
-    
+
     def __getattr__(self,a):
         if self._index<self.max_size:
             return getattr(self._npa[:self._index],a)
         return getattr(self._npa[self._index%self.max_size:(self._index%self.max_size)+self.max_size],a)
-    
+
     def __len__(self):
         if self.isFull():
             return self.max_size
@@ -768,7 +768,7 @@ class TimeSyncState(object):
         Current drift between two time bases.
         """
         if len(self.R_times) <= 1:
-            return None          
+            return None
         return float((self.R_times[-1] - self.R_times[-2]) / \
                      (self.L_times[-1] - self.L_times[-2]))
 
@@ -779,7 +779,7 @@ class TimeSyncState(object):
 #        if r is np.nan:
 #            return None
 #        return float(r)
-        
+
     def getOffset(self):
         """
         Current offset between two time bases.
@@ -797,12 +797,12 @@ class TimeSyncState(object):
 
     def getAccuracy(self):
         """
-        Current accuracy of the time syncronization, as calculated as the 
+        Current accuracy of the time syncronization, as calculated as the
         average of the last 10 round trip time sync request - response delays
         divided by two.
         """
         if len(self.R_times) < 1:
-            return None 
+            return None
         return float(self.RTTs[-1]/2.0)
 #
 #        if len(self.RTTs) <= 1:
@@ -811,12 +811,12 @@ class TimeSyncState(object):
 #        if r is np.nan:
 #            return None
 #        return float(r)
-        
+
     def local2RemoteTime(self,local_time=None):
         """
         Converts a local time (sec.msec format) to the corresponding remote
         computer time, using the current offset and drift measures.
-        """        
+        """
         #drift=self.getDrift()
         offset=self.getOffset()
         if offset is None:
@@ -825,11 +825,11 @@ class TimeSyncState(object):
             local_time=getTime()
         #local_dt=0.0#local_time-self.L_times[-1]
         return (local_time+offset)#+local_dt#drift*local_time+offset
-          
+
     def remote2LocalTime(self,remote_time):
         """
         Converts a remote computer time (sec.msec format) to the corresponding local
-        time, using the current offset and drift measures.       
+        time, using the current offset and drift measures.
         """
         #drift=self.getDrift()
         offset=self.getOffset()

--- a/psychopy/iohub/devices/pyXHook.py
+++ b/psychopy/iohub/devices/pyXHook.py
@@ -416,7 +416,7 @@ class HookManager(threading.Thread):
             # numlock is active:
             modifier_key_state += ModifierKeyCodes.numlock
 
-        for pk in pressed_keys.keys():
+        for pk in pressed_keys:
             if pk not in ['capslock', 'numlock']:
                 is_mod_id = ModifierKeyCodes.getID(pk)
                 if is_mod_id:

--- a/psychopy/iohub/devices/touch/hw/elo/__init__.py
+++ b/psychopy/iohub/devices/touch/hw/elo/__init__.py
@@ -30,31 +30,31 @@ class Touch(TouchDevice):
     The Touch class represents a touch screen input device. The Elo implementation
     of the Touch Dveice uses a Serial interface for communication between
     the Host Computer running ioHub and the Elo Touch Controller. A Serial - USB
-    converter is generally also used so that any computer with a free USB 2.0 
+    converter is generally also used so that any computer with a free USB 2.0
     port, running an operating system supported by the Serial - USB
     converter and PsychoPy.iohub, can be used as the Host.
-    
-    Touch position data is mapped to the coordinate space defined in the ioHub 
-    configuration file for the Display index specified. If the touch device is 
-    on a display other than the PsychoPy full screen window Display, then 
-    positional data is returned using the OS desktop pixel bounds for the given 
+
+    Touch position data is mapped to the coordinate space defined in the ioHub
+    configuration file for the Display index specified. If the touch device is
+    on a display other than the PsychoPy full screen window Display, then
+    positional data is returned using the OS desktop pixel bounds for the given
     display.
 
-    Touch Events are generated independantly of other device events, including 
+    Touch Events are generated independantly of other device events, including
     a mouse device. Therefore touch data can be used in parallel to mouse data.
-    
+
     The Elo Touch Device does not require any external driver or native library
-    other than the pyserial Python package. Infact, unless you wish the 
+    other than the pyserial Python package. Infact, unless you wish the
     touch device to be registered as a Mouse Device, it is important **not**
-    to install any additional drivers or software for the Elo Screen. 
-    
-    When using a Serial - USB converter to connect the Elo Device to a Host 
+    to install any additional drivers or software for the Elo Screen.
+
+    When using a Serial - USB converter to connect the Elo Device to a Host
     Computer USB port, please ensure any required driver or software for
     the converter is installed on the Host PC. The converter should create an
     active Serial Port on the Host Computer.
-    
+
     Configure the serial port created by the Serial - USB converter as follows:
-    
+
          *. 9600 Baud
          *. 8 Data Bits
          *. 1 Stop Bit
@@ -62,15 +62,15 @@ class Touch(TouchDevice):
          *. Hardware Handshaking enabled
          *. Software Handshaking disabled
          *. Half Duplex
-      
+
     """
     LEAD_IN_BYTE='U'
 
-    EVENT_CLASS_NAMES=['TouchEvent','TouchMoveEvent','TouchPressEvent','TouchReleaseEvent']                       
+    EVENT_CLASS_NAMES=['TouchEvent','TouchMoveEvent','TouchPressEvent','TouchReleaseEvent']
     DEVICE_TYPE_ID=DeviceConstants.TOUCH
     DEVICE_TYPE_STRING='TOUCH'
     __slots__=['_elo_hw_config','_non_touch_events','_rx_data','_serial_port_hw','serial_port_num','_raw_positions']
-    def __init__(self,*args,**kwargs):   
+    def __init__(self,*args,**kwargs):
         TouchDevice.__init__(self,*args,**kwargs)
         self._non_touch_events=deque(maxlen=64)
         serial_config=self.getConfiguration().get('serial')
@@ -81,27 +81,27 @@ class Touch(TouchDevice):
             except Exception:
                 sport=sport
             self.serial_port_num=sport
-            
+
         self._raw_positions=False
         self._rx_data=''
         self._serial_port_hw=None
         self._connectSerial()
-        
-        self._elo_hw_config=dict(JUMPERS=self.queryDevice('Jumpers'))#_getJumpers())        
+
+        self._elo_hw_config=dict(JUMPERS=self.queryDevice('Jumpers'))#_getJumpers())
         self._elo_hw_config['OWNER']=self.queryDevice('Owner')
         self._elo_hw_config['ID']=self.queryDevice('ID')
         self._elo_hw_config['REPORT']=self.queryDevice('Report')
-        self._elo_hw_config['DIAGNOSTICS']=self.queryDevice('Diagnostics')        
-    
+        self._elo_hw_config['DIAGNOSTICS']=self.queryDevice('Diagnostics')
+
     def getHardwareConfiguration(self):
         return self._elo_hw_config
-        
+
     def queryDevice(self,query_type, *args,**kwargs):
         """
         Send the underlying touch screen device a query request and return the response.
         """
         self._query(query_type,*args,**kwargs)
-        if query_type in RESPONSE_PACKET_TYPES.keys():
+        if query_type in RESPONSE_PACKET_TYPES:
             stime=getTime()
             while getTime()-stime<0.10:
                 self._poll()
@@ -113,13 +113,13 @@ class Touch(TouchDevice):
 
 
         return None
-        
+
     def commandDevice(self,cmd_type, *args,**kwargs):
         """
         Send the underlying touch screen device a command and return the response.
         """
         self._command(cmd_type,*args,**kwargs)
-        if cmd_type in RESPONSE_PACKET_TYPES.keys():
+        if cmd_type in RESPONSE_PACKET_TYPES:
             stime=getTime()
             while getTime()-stime<0.010:
                 self._poll()
@@ -129,21 +129,21 @@ class Touch(TouchDevice):
                         return reply.asdict()
                 gevent.sleep(0)
         return None
-    
+
     def getPositionType(self):
         if self._raw_positions is True:
             return 'RAW'
         return 'CALIBRATED'
-        
+
     def _connectSerial(self):
         self._serial_port_hw = serial.Serial(self.serial_port_num, 9600, timeout=0)
         if self._serial_port_hw is None:
             raise ValueError("Error: Serial Port Connection Failed: %s"%(str(self.serial_port_num)))
         self._flushSerialInput()
-        
+
     def _readAnyRx(self,max_bytes=256):
         self._rx(num_bytes=max_bytes)
-        
+
     def _flushSerialInput(self):
         self._serial_port_hw.flushInput()
         self._readAnyRx(max_bytes=100)
@@ -161,20 +161,20 @@ class Touch(TouchDevice):
             qpkt=QUERY_PACKET_TYPES[query_type](*args,**kwargs)
         self._tx(qpkt._packet_bytes)
         return qpkt
-        
+
     def _command(self,cmd_type,*args,**kwargs):
         qpkt=cmd_type
         if isinstance(cmd_type,basestring):
             qpkt=COMMAND_PACKET_TYPES[cmd_type](*args,**kwargs)
         self._tx(qpkt._packet_bytes)
         return qpkt
-   
+
     def _rx(self,async=False,num_bytes=10):
         if async:
             while self._serial_port_hw.inWaiting()>0:
                 self._rx_data+=self._serial_port_hw.read(self._serial_port_hw.inWaiting())
         else:
-                self._rx_data+=self._serial_port_hw.read(num_bytes) 
+                self._rx_data+=self._serial_port_hw.read(num_bytes)
 
     def saveConfiguration(self):
         # Save elo device settings to NVRAM
@@ -185,46 +185,46 @@ class Touch(TouchDevice):
         # Save elo device settings to NVRAM
         pkt=self._command('N',*(0,7,0))
         reply_packets=self._poll()
-        
+
     def initCalibration(self):
         try:
-            # set flag indicating raw touch coords should be used in touch events, as 
+            # set flag indicating raw touch coords should be used in touch events, as
             # data is not calibrated
             self.clearEvents()
             self._raw_positions=True
-            
+
             # To acquire calibration points, controller must be in raw coordinate
             # mode. We use the point of untouch as our calibration point. */
-    
+
             # Get current Mode settings
             pkt=self._query('m')
             reply_packets=self._poll()
-            
+
             # Set Mode to utouch events only
             pkt=self._command('M',*(132,))
             reply_packets=self._poll()
-    
+
             # Get current swap-axis state
             pkt=self._query('c',*(0,True))
             reply_packets=self._poll()
-    
+
             # Disable swap-axis
             pkt=self._command('C',*(0,0,0,0,0,0,False))
             reply_packets=self._poll()
-            
+
             # Get current mode settings
             pkt=self._query('m')
             reply_packets=self._poll()
         except Exception, e:
             print2err("Exception During Touch.initCalibration: ",str(e))
-            
+
     def applyCalibrationData(self,xmin,xmax,ymin,ymax,x1,y1,x2,y2,sx,sy,leftx,uppery,rightx,lowery):
         # set calibration and scaling params on controller */
         try:
             # compute number of touch points per screen coordinate */
             xunit = (x2-x1) / (rightx-leftx)
             yunit = (y2-y1) / (lowery-uppery)
-    
+
             #/* extrapolate the calibration points to corner points of screen image */
             xhigh = x2 + (xunit * (xmax-rightx))
             xlow = x1 - (xunit * (leftx-xmin))
@@ -234,49 +234,49 @@ class Touch(TouchDevice):
                 xhigh = 1 # in case axis inverted */
             yhigh = y2 + (yunit * (ymax - lowery))
             ylow = y1 - (yunit * (uppery - ymin))
-            if ylow < 1: 
+            if ylow < 1:
                 ylow = 1
-            if yhigh < 1: 
+            if yhigh < 1:
                 yhigh = 1
-    
+
             # detect touchscreen orientation corrections */
             xyswap = math.fabs(sx-x1) < math.fabs(sy-y1)
-    
+
             #xinv = xhigh < xlow
             #yinv = yhigh < ylow
-    
-            # set calibration x, y data        
+
+            # set calibration x, y data
             pkt=self._command('C',*('X',xlow,xhigh,0,0,0,False))
             reply_packets=self._poll()
-    
+
             pkt=self._command('C',*('Y',ylow,yhigh,0,0,0,False))
             reply_packets=self._poll()
-            
-            # set swap_axis flag       
+
+            # set swap_axis flag
             pkt=self._command('C',*(0,0,0,0,0,0,xyswap))
             reply_packets=self._poll()
-        
+
             # set scaling .....
             pkt=self._command('S',*('X',xmin,xmax))
             reply_packets=self._poll()
-    
+
             # set scaling .....
             pkt=self._command('S',*('Y',ymin,ymax))
-            reply_packets=self._poll()       
-            
+            reply_packets=self._poll()
+
             # Change mode to send touch, untouch, and touch movement events
             pkt=self._command('M',*( 199,14))
             reply_packets=self._poll()
-    
+
             # Get current Mode settings
             pkt=self._query('m')
             reply_packets=self._poll()
-    
-            # set flag indicating calibrated touch coords should be 
+
+            # set flag indicating calibrated touch coords should be
             # used in touch events, as data is not calibrated
             self.clearEvents()
             self._raw_positions=False
-            
+
         except Exception, e:
             print2err("Exception During Touch.applyCalibrationData: ",str(e))
 
@@ -287,7 +287,7 @@ class Touch(TouchDevice):
             TouchDevice.clearEvents(self)
         except Exception, e:
             print2err("Exception During Touch.clearEvents: ",str(e))
-            
+
     def _poll(self):
         """
         Checks for any new Touch Response Packets...
@@ -302,14 +302,14 @@ class Touch(TouchDevice):
                         #print2err('Non LEAD_IN_BYTE: ',ord(self._rx_data[0]))
                         self._rx_data=self._rx_data[1:]
                     rx_size=len(self._rx_data)
-                    
+
                     if rx_size<10:
                         self._rx(num_bytes=10-len(self._rx_data))
                         if len(self._rx_data)<10:
                             self._last_poll_time=poll_time
                             #print2err('Poll < 10 bytes: ',currentSec()-poll_time)
                             return self._non_touch_events
-                            
+
                     if self._rx_data[0]=='U' and self._rx_data[1] == 'T':
                         response_class=RESPONSE_PACKET_TYPES.get('T')
                         touch_event=response_class(poll_time,bytearray(self._rx_data[:10]))
@@ -317,23 +317,23 @@ class Touch(TouchDevice):
                         self._rx_data=self._rx_data[10:]
                         if touch_event._valid_response is True:
                             etype=EventConstants.TOUCH_MOVE
-                            if touch_event.touch_type==touch_event.TOUCH_PRESS:                    
+                            if touch_event.touch_type==touch_event.TOUCH_PRESS:
                                 etype=EventConstants.TOUCH_PRESS
                             elif touch_event.touch_type==touch_event.TOUCH_RELEASE:
                                 etype=EventConstants.TOUCH_RELEASE
-                            confidence_interval=poll_time-self._last_poll_time # confidence interval                    
-                            # TODO: Calculate Delay more accurately if possible                    
-                            delay=poll_time-touch_event.time # delay   
-                            # TODO: Set Display ID correctly                    
+                            confidence_interval=poll_time-self._last_poll_time # confidence interval
+                            # TODO: Calculate Delay more accurately if possible
+                            delay=poll_time-touch_event.time # delay
+                            # TODO: Set Display ID correctly
                             display_id=0
-        
+
                             self._lastPosition=self._position
                             if self._raw_positions is True:
                                 self._position=touch_event.x,touch_event.y
                             else:
                                 self._position=self._pixelToDisplayCoords(touch_event.x,touch_event.y)
-                            
-                            event =[            
+
+                            event =[
                                     0, # exp id
                                     0, # session id
                                     0, #device id (not currently used)
@@ -350,10 +350,10 @@ class Touch(TouchDevice):
                                     self._position[1],
                                     touch_event.z
                                     ]
-        
+
                             #print2err('Poll TouchEvent: ',currentSec()-poll_time)
                             self._addNativeEventToBuffer(event)
-                    elif self._rx_data[0]=='U': 
+                    elif self._rx_data[0]=='U':
                         response_class=RESPONSE_PACKET_TYPES.get(self._rx_data[1])
                         # TODO: Checksum validation should be done here.
                         if response_class:
@@ -374,25 +374,25 @@ class Touch(TouchDevice):
             return self._non_touch_events
         except Exception:
             print2err("Exception During Touch._poll: ")
-            printExceptionDetailsToStdErr()            
-                
+            printExceptionDetailsToStdErr()
+
     def _pixelToDisplayCoords(self,px,py):
         """
-        Converts 0,0,pix_width,pix_height coord space to display device coord space.  
+        Converts 0,0,pix_width,pix_height coord space to display device coord space.
         """
         try:
             dw,dh=self._display_device.getPixelResolution()
             rx=px/float(dw)
             ry=py/float(dh)
             left,top,right,bottom=self._display_device.getCoordBounds()
-            w,h=right-left,top-bottom            
-            x,y=left+w*rx,bottom+h*(1.0-ry) 
+            w,h=right-left,top-bottom
+            x,y=left+w*rx,bottom+h*(1.0-ry)
             return x,y
         except Exception:
-            print2err("Error During EloDevice._pixelToDisplayCoords:") 
+            print2err("Error During EloDevice._pixelToDisplayCoords:")
             printExceptionDetailsToStdErr()
             return px,py
-                       
+
     def _closeSerial(self):
         """
         """

--- a/psychopy/iohub/util/variableProvider.py
+++ b/psychopy/iohub/util/variableProvider.py
@@ -8,7 +8,7 @@ from . import OrderedDict,  printExceptionDetailsToStdErr, print2err
 #### Experiment Variable (IV and DV) Condition Management
 #
 class ConditionSetProvider(object):
-    def __init__(self, conditionSetArray, randomize=False):        
+    def __init__(self, conditionSetArray, randomize=False):
         non_empty_count=0
         empty_sets=[]
         for i,c in enumerate(conditionSetArray):
@@ -16,7 +16,7 @@ class ConditionSetProvider(object):
                 non_empty_count+=1
             else:
                 empty_sets.append(i)
-        
+
         for i in empty_sets:
             conditionSetArray.pop(i)
 
@@ -109,7 +109,7 @@ class ExperimentVariableProvider(object):
         the second level within each block is a ndarray of trial condition variable. Each trial is an nd array
         of the condition variable values for that iteration.
         Supported variable types are:
-            
+
              * unicode
              * color ( a string in an xls file of format [r,g,b,a] or (r,g,b,a). a is optional. It is converted to a
              * ndarray for the cell [(r,'u8'),(g,'u8'),(b,'u8'),(a,'u8')]
@@ -196,7 +196,7 @@ class ExperimentVariableProvider(object):
                 max_str_lens[i]=max(max_str_lens[i],len(r[s]))
         for i,s in enumerate(string_column_indexes):
             np_dtype[s]=(np_dtype[s][0],np_dtype[s][1],max_str_lens[i])
-            
+
         self._numpyConditionVariableDescriptor=np_dtype
 
         self.data=np.asarray(temp_rows,dtype=np_dtype)
@@ -215,7 +215,7 @@ class ExperimentVariableProvider(object):
 
             blockList=[]
             for pbn in self.practiceBlockValues:
-                if pbn in tempBlockDict.keys():
+                if pbn in tempBlockDict:
                     blockList.append(TrialSetProvider(tempBlockDict[pbn],self.randomizeTrials))
                     del tempBlockDict[pbn]
             self.practiceBlocks=BlockSetProvider(blockList, False)

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -485,8 +485,7 @@ class Monitor(object):
         else:
             thisFile = open(thisFileName, 'r')
             self.calibs = cPickle.load(thisFile)
-            self.calibNames = self.calibs.keys()
-            self.calibNames.sort()
+            self.calibNames = sorted(self.calibs)
             thisFile.close()
 
     def newCalib(self, calibName=None, width=None,

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -192,7 +192,7 @@ class Preferences(object):
                                         preserve_errors=True)
         self.restoreBadPrefs(cfg, resultOfValidate)
         # force favComponent level values to be integers
-        if 'favComponents' in cfg['builder'].keys():
+        if 'favComponents' in cfg['builder']:
             for key in cfg['builder']['favComponents']:
                 _compKey = cfg['builder']['favComponents'][key]
                 cfg['builder']['favComponents'][key] = int(_compKey)

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -138,7 +138,7 @@ if hasattr(backend, 'defaultOutput'):
     if dev=='default' or travisCI:
         pass  # do nothing
     elif dev not in backend.getDevices(kind='output'):
-        devNames = backend.getDevices(kind='output').keys()
+        devNames = sorted(backend.getDevices(kind='output').keys())
         logging.error(u"Requested audio device '{}' that is not available on "
                         "this hardware. The 'audioDevice' preference should be one of "
                         "{}".format(dev, devNames))

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -89,7 +89,7 @@ class _StreamsDict(dict):
         label = getStreamLabel(sampleRate, channels, blockSize)
         # replace -1 with any regex integer
         simil = re.compile(label.replace("-1", r"[-+]?(\d+)"))  # I hate REGEX!
-        for thisFormat in self.keys():
+        for thisFormat in self:
             if simil.match(thisFormat):  # we found a close-enough match
                 return thisFormat, self[thisFormat]
         # if we've been given values in each place then create stream
@@ -103,7 +103,7 @@ class _StreamsDict(dict):
         """
         label = getStreamLabel(sampleRate, channels, blockSize)
         # try to retrieve existing stream of that name
-        if label in self.keys():
+        if label in self:
             pass
         # on some systems more than one stream isn't supported so check
         elif sys.platform == 'win32' and len(self):

--- a/psychopy/tests/test_app/test_builder/genComponsTemplate.py
+++ b/psychopy/tests/test_app/test_builder/genComponsTemplate.py
@@ -79,7 +79,7 @@ for compName in sorted(allComp):
             err = order + ' <==> NEW (no matching param in original)'
         print(err.encode('utf8'))
         mismatches.append(err)
-    for parName in comp.params.keys():
+    for parName in comp.params:
         # default is what you get from param.__str__, which returns its value
         default = '%s.%s.default:%s' % (compName, parName, comp.params[parName])
         out.append(default)

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -102,7 +102,7 @@ class TestComponents(object):
                 print(mismatch.encode('utf8'))
                 if not ignoreOrder:
                     err.append(mismatch)
-            for parName in comp.params.keys():
+            for parName in comp.params:
                 # default is what you get from param.__str__, which returns its value
                 default = '%s.%s.default:%s' % (compName, parName, comp.params[parName])
                 lineFields = []

--- a/psychopy/tests/test_data/test_Xlsx.py
+++ b/psychopy/tests/test_data/test_Xlsx.py
@@ -47,7 +47,7 @@ def test_TrialTypeImport():
         for trialN, trialCSV in enumerate(fromCSV):
             trialXLSX = fromXLSX[trialN]
             assert trialXLSX.keys() == trialCSV.keys()
-            for header in trialCSV.keys():
+            for header in trialCSV:
                 if trialXLSX[header] != trialCSV[header]:
                     print(header, trialCSV[header], trialXLSX[header])
                 assert trialXLSX[header] == trialCSV[header]

--- a/psychopy/tests/test_gui/test_DlgFromDictWx.py
+++ b/psychopy/tests/test_gui/test_DlgFromDictWx.py
@@ -27,13 +27,12 @@ class TestDlgFromDictWx():
 
     def test_sort_keys_true(self):
         dlg = DlgFromDict(self.d, sort_keys=True, show=False)
-        keys = self.d.copy().keys()
-        keys.sort()
+        keys = sorted(self.d)
         assert keys == dlg._keys
 
     def test_sort_keys_false(self):
         dlg = DlgFromDict(self.d, sort_keys=False, show=False)
-        keys = self.d.copy().keys()
+        keys = list(self.d)
         assert keys == dlg._keys
 
     def test_copy_dict_true(self):
@@ -48,7 +47,7 @@ class TestDlgFromDictWx():
         order = ['exp_type', 'participant', 'handedness', 'exp_version']
         # Be certain we will actually request a different order
         # further down.
-        assert order != self.od.keys()
+        assert order != list(self.od)
 
         dlg = DlgFromDict(self.od, order=order, show=False)
         assert dlg.inputFieldNames == order
@@ -57,7 +56,7 @@ class TestDlgFromDictWx():
         order = ('exp_type', 'participant', 'handedness', 'exp_version')
         # Be certain we will actually request a different order
         # further down.
-        assert list(order) != self.od.keys()
+        assert list(order) != list(self.od)
 
         dlg = DlgFromDict(self.od, order=order, show=False)
         assert dlg.inputFieldNames == list(order)

--- a/psychopy/tools/wizard.py
+++ b/psychopy/tools/wizard.py
@@ -362,7 +362,7 @@ class BaseWizard(object):
                       'no dropped frames', 'internet access')
         # ofInterest.append('background processes')
         for item in ofInterest:
-            if not item in config.keys():
+            if not item in config:
                 continue  # eg, microphone latency
             if config[item][2]:  # warn True
                 summary.append(("X   " + _translate(item), red))

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -164,7 +164,7 @@ def setColor(obj, color, colorSpace=None, operation='',
     if type(color) in [str, unicode, numpy.string_]:
         if operation not in ('', None):
             raise TypeError('Cannot do operations on named or hex color')
-        if color.lower() in colors.colors255.keys():
+        if color.lower() in colors.colors255:
             # set rgb, color and colorSpace
             setattr(obj, rgbAttrib,
                     numpy.array(colors.colors255[color.lower()], float))

--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -137,7 +137,7 @@ def _audioTimeCallback(event, movieInstanceRef, streamPlayer):
 def _setPluginPathEnviron():
     """Plugins aren't in the same path as the libvlc.dylib
     """
-    if 'VLC_PLUGIN_PATH' in os.environ.keys():
+    if 'VLC_PLUGIN_PATH' in os.environ:
         return
     dllPath = vlc.dll._name
     from os.path import split, join

--- a/psychopy/visual/textbox/__init__.py
+++ b/psychopy/visual/textbox/__init__.py
@@ -1269,7 +1269,7 @@ class TextBox(object):
         return te_x, te_y
 
     def __del__(self):
-        if hasattr(self, '_textbox_instance') and self.getName() in self._textbox_instance.keys():
+        if hasattr(self, '_textbox_instance') and self.getName() in self._textbox_instance:
             del self._textbox_instances[self.getName()]
         del self._current_glfont
         del self._text_grid

--- a/psychopy/visual/textbox/fontmanager.py
+++ b/psychopy/visual/textbox/fontmanager.py
@@ -102,7 +102,7 @@ class FontManager(object):
         style_dict = self._available_font_info.get(font_family_name)
         if style_dict is None:
             return None
-        if font_style and font_style in style_dict.keys():
+        if font_style and font_style in style_dict:
             return style_dict[font_style]
         for style, fonts in style_dict.iteritems():
             b, i = self.booleansFromStyleName(style)

--- a/psychopy/voicekey/vk_tools.py
+++ b/psychopy/voicekey/vk_tools.py
@@ -171,7 +171,7 @@ def _get_pyo_codes(fmt='', dtype='int16', file_out=''):
     if not fmt:
         dot_ext = os.path.splitext(file_out)[1]
         fmt = dot_ext.lower().strip('.')
-    if fmt in pyo_formats.keys():
+    if fmt in pyo_formats:
         file_fmt = pyo_formats[fmt]
     else:
         msg = 'format `{0}` not supported'.format(file_out)
@@ -182,7 +182,7 @@ def _get_pyo_codes(fmt='', dtype='int16', file_out=''):
     else:
         ok_dfmt = pyo_dtype
 
-    if dtype in ok_dfmt.keys():
+    if dtype in ok_dfmt:
         data_fmt = pyo_dtype[dtype]
     else:
         msg = 'data format `{0}` not supported for `{1}`'.format(

--- a/psychopy/web.py
+++ b/psychopy/web.py
@@ -143,7 +143,7 @@ def getPacFiles():
         # loop through each possible network (e.g. Ethernet, Airport...)
         for network in networks.items():
             netKey, network = network  # the first part is a long identifier
-            if 'ProxyAutoConfigURLString' in network['Proxies'].keys():
+            if 'ProxyAutoConfigURLString' in network['Proxies']:
                 pacFiles.append(network['Proxies']['ProxyAutoConfigURLString'])
     return list(set(pacFiles))  # remove redundant ones
 


### PR DESCRIPTION
Py2 returned a list from .keys() but py3 returns an iterator
This is slightly simpler than the list(dict.keys()) conversion
that is more widely recommended