### PR TITLE
RFpy2and3: several places where we need bytes instead of str

### DIFF
--- a/psychopy/app/stdOutRich.py
+++ b/psychopy/app/stdOutRich.py
@@ -37,6 +37,11 @@ class StdOutRich(wx.richtext.RichTextCtrl):
             class WordFetcher:
         File "C:\Program Files\wxPython2.8 Docs and Demos\samples\hangman\hangman.py", line 23, in WordFetcher
         """
+
+        # if it comes form a stdout in Py3 then convert to unicode
+        if type(inStr) == bytes:
+            inStr = inStr.decode()
+
         for thisLine in inStr.splitlines(True):
             if len(re.findall('".*", line.*', thisLine)) > 0:
                 # this line contains a file/line location so write as URL

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -905,7 +905,7 @@ class _GlobalEventKeys(MutableMapping):
 
     _IndexKey = namedtuple('_IndexKey', ['key', 'modifiers'])
 
-    _valid_keys = set(string.lowercase + string.digits
+    _valid_keys = set(string.ascii_lowercase + string.digits
                       + string.punctuation + ' \t')
     _valid_keys.update(['escape', 'left', 'right', 'up', 'down'])
 

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -54,7 +54,7 @@ else:
 # fix, since *everything* should be decoded to Unicode, and not just this
 # specific pathname. Right now, errors will still occur if `monitorFolder` is
 # combined with `str`-type objects that contain non-ASCII characters.
-if isinstance(monitorFolder, str):
+if isinstance(monitorFolder, bytes):
     monitorFolder = monitorFolder.decode(sys.getfilesystemencoding())
 
 if not os.path.isdir(monitorFolder):

--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -531,9 +531,9 @@ class ElementArrayStim(MinimalStim, TextureMixin):
         _prog = self.win._progSignedTexMask
         GL.glUseProgram(_prog)
         # set the texture to be texture unit 0
-        GL.glUniform1i(GL.glGetUniformLocation(_prog, "texture"), 0)
+        GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
         # mask is texture unit 1
-        GL.glUniform1i(GL.glGetUniformLocation(_prog, "mask"), 1)
+        GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
 
         # bind textures
         GL.glActiveTexture(GL.GL_TEXTURE1)

--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -331,9 +331,9 @@ class GratingStim(BaseVisualStim, TextureMixin, ColorMixin, ContainerMixin):
         _prog = self.win._progSignedTexMask
         GL.glUseProgram(_prog)
         # set the texture to be texture unit 0
-        GL.glUniform1i(GL.glGetUniformLocation(_prog, "texture"), 0)
+        GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
         # mask is texture unit 1
-        GL.glUniform1i(GL.glGetUniformLocation(_prog, "mask"), 1)
+        GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
         # mask
         GL.glActiveTexture(GL.GL_TEXTURE1)
         GL.glBindTexture(GL.GL_TEXTURE_2D, self._maskID)

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -125,17 +125,17 @@ class ImageStim(BaseVisualStim, ContainerMixin, ColorMixin, TextureMixin):
             _prog = self.win._progSignedTexMask
             GL.glUseProgram(_prog)
             # set the texture to be texture unit 0
-            GL.glUniform1i(GL.glGetUniformLocation(_prog, "texture"), 0)
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
             # mask is texture unit 1
-            GL.glUniform1i(GL.glGetUniformLocation(_prog, "mask"), 1)
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
         else:
             # for an rgb image there is no recoloring
             _prog = self.win._progImageStim
             GL.glUseProgram(_prog)
             # set the texture to be texture unit 0
-            GL.glUniform1i(GL.glGetUniformLocation(_prog, "texture"), 0)
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
             # mask is texture unit 1
-            GL.glUniform1i(GL.glGetUniformLocation(_prog, "mask"), 1)
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
 
         # mask
         GL.glActiveTexture(GL.GL_TEXTURE1)

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -408,9 +408,9 @@ class RadialStim(GratingStim):
             prog = self.win._progSignedTexMask1D
             GL.glUseProgram(prog)
             # set the texture to be texture unit 0
-            GL.glUniform1i(GL.glGetUniformLocation(prog, "texture"), 0)
+            GL.glUniform1i(GL.glGetUniformLocation(prog, b"texture"), 0)
             # mask is texture unit 1
-            GL.glUniform1i(GL.glGetUniformLocation(prog, "mask"), 1)
+            GL.glUniform1i(GL.glGetUniformLocation(prog, b"mask"), 1)
 
             # set pointers to visible textures
             GL.glClientActiveTexture(GL.GL_TEXTURE0)
@@ -528,9 +528,9 @@ class RadialStim(GratingStim):
         GL.glUseProgram(self.win._progSignedTexMask1D)
         # set the texture to be texture unit 0
         GL.glUniform1i(GL.glGetUniformLocation(
-            self.win._progSignedTexMask1D, "texture"), 0)
+            self.win._progSignedTexMask1D, b"texture"), 0)
         GL.glUniform1i(GL.glGetUniformLocation(
-            self.win._progSignedTexMask1D, "mask"), 1)  # mask is texture unit 1
+            self.win._progSignedTexMask1D, b"mask"), 1)  # mask is texture unit 1
 
         # set pointers to visible textures
         GL.glClientActiveTexture(GL.GL_TEXTURE0)

--- a/psychopy/visual/secondorder.py
+++ b/psychopy/visual/secondorder.py
@@ -461,28 +461,28 @@ class EnvelopeGrating(GratingStim):
         # setup the shaderprogram
         GL.glUseProgram(self._shaderProg)
         # set the carrier to be texture unit 0
-        GL.glUniform1i(GL.glGetUniformLocation(self._shaderProg, "carrier"),
+        GL.glUniform1i(GL.glGetUniformLocation(self._shaderProg, b"carrier"),
                        0)
         # set the envelope to be texture unit 1
         GL.glUniform1i(GL.glGetUniformLocation(
-            self._shaderProg, "envelope"), 1)
+            self._shaderProg, b"envelope"), 1)
         GL.glUniform1i(GL.glGetUniformLocation(
-            self._shaderProg, "mask"), 2)  # mask is texture unit 2
+            self._shaderProg, b"mask"), 2)  # mask is texture unit 2
         GL.glUniform1f(GL.glGetUniformLocation(
-            self._shaderProg, "moddepth"), self.moddepth)
+            self._shaderProg, b"moddepth"), self.moddepth)
         GL.glUniform1f(GL.glGetUniformLocation(
-            self._shaderProg, "ori"), envrad)
+            self._shaderProg, b"ori"), envrad)
         # CM envelopes use (modedepth*envelope+1.0)*carrier. If beat is True
         # this becomes (moddepth*envelope)*carrier thus maing a second order
         # 'beat' pattern.
         if self.beat:
             GL.glUniform1f(GL.glGetUniformLocation(
-                self._shaderProg, "offset"),0.0)
+                self._shaderProg, b"offset"),0.0)
         else:
             GL.glUniform1f(GL.glGetUniformLocation(
-                self._shaderProg, "offset"), 1.0)
+                self._shaderProg, b"offset"), 1.0)
         GL.glUniform1f(GL.glGetUniformLocation(
-            self._shaderProg, "add"), addvalue)
+            self._shaderProg, b"add"), addvalue)
 
         # mask
         GL.glActiveTexture(GL.GL_TEXTURE2)

--- a/psychopy/visual/shaders.py
+++ b/psychopy/visual/shaders.py
@@ -33,7 +33,9 @@ def compileProgram(vertexSource=None, fragmentSource=None):
         """Compile shader source of given type (only needed by compileProgram)
         """
         shader = GL.glCreateShaderObjectARB(shaderType)
-
+        # if Py3 then we need to convert our (unicode) str into bytes for C
+        if type(source) != bytes:
+            source = source.encode()
         prog = c_char_p(source)
         length = c_int(-1)
         GL.glShaderSourceARB(shader,

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -715,7 +715,7 @@ class TextStim(BaseVisualStim, ColorMixin):
             #       desiredRGB.ctypes.data_as(ctypes.POINTER(ctypes.c_float)))
             #  # set the texture to be texture unit 0
             GL.glUniform3f(
-                GL.glGetUniformLocation(self.win._progSignedTexFont, "rgb"),
+                GL.glGetUniformLocation(self.win._progSignedTexFont, b"rgb"),
                 desiredRGB[0], desiredRGB[1], desiredRGB[2])
 
         else:  # color is set in texture, so set glColor to white


### PR DESCRIPTION
Also, the string module in PY3 no longer has .lowercase attribute
but both PY2 and PY3 have .ascii_lowercase so we use that now