### PR TITLE
BF & ENH Corrects error in butter2d_lp_elliptic and adds 2d Guassian

### DIFF
--- a/psychopy/visual/filters.py
+++ b/psychopy/visual/filters.py
@@ -220,6 +220,30 @@ def makeGauss(x, mean=0.0, sd=1.0, gain=1.0, base=0.0):
     simpleGauss = numpy.exp((-numpy.power(mean - x, 2) / (2 * sd**2)))
     return base + gain * (simpleGauss)
 
+def make2DGauss(x,y, mean=0.0, sd=1.0, gain=1.0, base=0.0):
+    """
+    Return the gaussian distribution for a given set of x-vals
+
+   :Parameters:
+        x,y should be x and y indexes  as might be created by numpy.mgrid
+        mean: float
+            the centre of the distribution - may be a tuple
+        sd: float
+            the width of the distribution - may be a tuple
+        gain: float
+            the height of the distribution
+        base: float
+            an offset added to the result
+
+    """
+    
+    if numpy.size(sd)==1:
+        sd = [sd, sd]
+    if numpy.size(mean)==1:
+        mean = [mean, mean]
+        
+    simpleGauss = numpy.exp((-numpy.power(x - mean[0], 2) / (2 * sd[0]**2))-(numpy.power(y - mean[1], 2) / (2 * sd[1]**2)))
+    return base + gain * (simpleGauss)
 
 def getRMScontrast(matrix):
     """Returns the RMS contrast (the sample standard deviation) of a array
@@ -370,6 +394,6 @@ def butter2d_lp_elliptic(size, cutoff_x, cutoff_y, n=3,
     x2 = (x * numpy.cos(alpha) - y * numpy.sin(-alpha))
     y2 = (x * numpy.sin(-alpha) + y * numpy.cos(alpha))
 
-    f = 1 / (1 + ((2 * x2 / cutoff_x)**2 + (2 * y2 / cutoff_y)**2)**n)
+    f = 1 / (1+((x2/(cutoff_x))**2+(y2/(cutoff_y))**2)**n)
 
     return f


### PR DESCRIPTION
Corrects an error in butter2d_lp_elliptic where x and y co-oridinates were inappropriately multipled by 2. 
Adds a function to make 2D Gaussian profiles given a grid, 2 means and 2 standard deviations. Will cope with just one mean or SD.