### PR TITLE
ENH: Stimulus class for generating random noise stimuli

### DIFF
--- a/psychopy/visual/noise.py
+++ b/psychopy/visual/noise.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python2
+
+"""Stimulus object for drawing random noise stimuliof various kinds. """
+
+# Part of the PsychoPy library
+# Copyright (C) 2015 Jonathan Peirce
+# some code provided by Andrew Schofield
+# Distributed under the terms of the GNU General Public License (GPL).
+
+from __future__ import absolute_import
+
+import pyglet
+pyglet.options['debug_gl'] = False
+import ctypes
+GL = pyglet.gl
+try:
+    from PIL import Image
+except ImportError:
+    import Image
+import cmath
+import psychopy  # so we can get the __path__
+from psychopy import logging
+from psychopy.visual import filters
+from psychopy.tools.arraytools import val2array
+from psychopy.tools.attributetools import attributeSetter
+from .grating import GratingStim
+import numpy
+from numpy import exp, sin, cos
+from numpy.fft import fft2, ifft2, fftshift, ifftshift
+
+from . import shaders as _shaders
+
+
+class NoiseStim(GratingStim):
+    """A stimulus with 2 textures: a radom noise sample and a mask
+
+    **Example**::
+
+    noise1 = noise = visual.NoiseStim(
+                                    win=win, name='noise',units='pix', 
+                                    noiseImage='testImg.jpg', mask='circle',
+                                    ori=1.0, pos=(0, 0), size=(512, 512), sf=None, phase=0,
+                                    color=[1,1,1], colorSpace='rgb', opacity=1, blendmode='add', contrast=1.0,
+                                    texRes=512,
+                                    noiseType='Gabor', noiseElementSize=4, noiseBaseSf=32.0/512,
+                                    noiseBW=1.0, noiseBWO=30, noiseFractalPower=-1,noiseFilterLower=3/512, noiseFilterUpper=8.0/512.0, 
+                                    noiseFilterOrder=3.0, noiseClip=3.0, interpolate=False, depth=-1.0)
+                                    
+            # gives a circular patch of noise made up of scattered Gabor elements with peak frequency = 32.0/512 cycles per pixel, 
+            # orientation = 0 , frequency bandwidth = 1 octave and orientation bandwidth 30 degrees
+
+    **Types of noise available**
+    Binary, Normal, Uniform - pixel based noise samples drawn from a binary (blank and white), normal or uniform distribution respectively. Binary noise is always exactly zero mean, Normal and Uniform are approximately so.
+            Parameters -    noiseElementSize - (can be a tuple) defines the size of the noise elements in the components units.
+                            noiseClip the values in normally distributed noise are divided by noiseClip to limit excessively high or low values.
+    
+    Gabor, Isotropic - Effectively a dense scattering of Gabor elements with random amplitude and fixed orientation for Gabor or random orientation for Isotropic noise.
+            Parameters -    noiseBaseSf - centre spatial frequency in the component units. 
+                            noiseBW - spatial frequency bandwidth full width half hight in octaves.
+                            ori - centre orientation for Gabor noise (works as for gratingStim so twists the final image at render time).
+                            noiseBWO - orientation bandwidth for Gabor noise full width half height in degrees.
+
+            In practice the desired amplitude spectrum for the noise is built in Fourier space with a random phase spectrum. DC term is set to zero - ie zero mean.
+        
+    Filtered - Effectively a white noise sample that has been filtered with a low, high or bandpass Butterworth filter.
+            The contrast of the noise falls by half its maximum (3dB) at the cutoff frequencies.
+            Parameters -    noiseFilterUpper - upper cutoff frequency - if greater than texRes/2 cycles per image low pass filter used.
+                            noiseFilterLower - Lower cutoff frequency - if zero low pass filter used.
+                            noiseFilterOrder - The order of the filter controls the steepness of the falloff outside the passband.
+                            noiseClip - with 'contrast' determines clipping values and rescaling factor such that final rms contrast is close to that requested by contrast parameter while keeping pixel values in range -1, 1.  
+            
+            In practice the desired amplitude spectrum is built in the Fourier Domain with a random phase spectrum. DC term is set to zero - ie zero mean
+        
+    White, Coloured - A noise sample whose spatial frequency spectrum is biased towards low (pink, red noise) or high (purple, violet noise) spatial frequencies or completely flat for White noise.
+            Parameters -    noiseFractalPower - spectrum = f^noiseFractalPower  - determines the spatial frequency bias of the noise. 1 = white, negative = low prefered, postive = high preferred, -1 = fractal or brownian noise. This parameter is ignored for noise type = White.
+                            noiseClip - with 'contrast' determines clipping values and rescaling factor such that final rms contrast is close to that requested by contrast parameter while keeping pixel values in range -1, 1.  
+
+            In practice the desired amplitude spectrum is built in the Fourier Domain with a random phase spectrum. DC term is set to zero - ie zero mean
+            Note despite name the noise is always grey scale.
+
+    Image - A noise sample whose spatial frequency spectrum is taken from the supplied image.
+            Parameters -    noiseImage name of nparray or image file from which to take spectrum - should be same size as largest side requested for component if units is pix or texRes x texRes otherwise
+                            noiseClip - with 'contrast' determines clipping values and rescaling factor such that final rms contrast is close to that requested by contrast parameter while keeping pixel values in range -1, 1.  
+
+            In practice the desired amplitude spectrum is taken from the image and paired with a random phase spectrum. DC term is set to zero - ie zero mean
+            
+    **Updating noise samples and timing**
+    The noise is rebuilt at next call of the draw function whenever a paramter starting 'noise' is notionally changed even if the value does not actually change every time. eg. setting a paramter to update every frame will cause a new noise sample on every frame but see below.
+    A rebuild can also be forced at any time using the buildNoise() function.
+    The updateNoise() function can be used at any time to produce a new random saple of noise without doing a full build. ie it is quicker than a full build.
+    Both buildNoise and updateNoise can be slow for large samples. 
+    Samples of Binary, Normal or Uniform noise can usually be made at frame rate using noiseUpdate. 
+    Updating or building other noise types at frame rate may result in dropped frames. 
+    An alternative is to build a large sample of noise at the start of the routien and place it off the screen then cut a samples out of this at random locations and feed that as a numpy array into the texture of a visible gratingStim.
+
+    **Notes on size**
+    If units = pix and noiseType = Binary, Normal or Uniform will make noise sample of requested size.
+    If units = pix and noiseType is Gabor, Isotropic, Filtered, White, Coloured or Image will make sqaure noise sample with side length equal that of the largest dimetions requested.
+    if units is not pix will make sqaure noise sample with side length equal to texRes then rescale to present.
+    
+    **Notes on interpolation**
+    For pixel based noise interpolation = nearest is usually best.
+    For other noise types linear is better if the size of the noise sample does not match the final size of the image well.
+    
+    **Notes on frequency**
+    Frequencies for cutoffs etc are converted between units for you but can be counter intuitive. 1/size is always 1 cycle per image.
+    For the sf (final spatial frequency) parameter itself 1/size (or None for units pix) will faithfully represent the image without further scaling.
+    
+    **Notes on orientation and phase**
+    The ori parameter twists the final image so the samples in noiseType Binary, Normal or Uniform will no longer be alighned to the sides of the monitor if ori is not a multiple of 90.
+    Most other noise types look broadly the same for all values of ori but the specific sample shown can be made to rotate by changing ori.
+    The dominant orientation for Gabor noise is determined by ori at render time, not before.
+    
+    The phase parameter similarly shifts the sample around within the display window at render time and will not choose new random phases for the noise sample.
+    """
+
+    def __init__(self,
+                 win,
+                 mask="none",
+                 units="",
+                 pos=(0.0, 0.0),
+                 size=None,
+                 sf=None,
+                 ori=0.0,
+                 phase=(0.0, 0.0),
+                 noiseType='none',
+                 noiseElementSize='16',
+                 noiseBaseSf='1',
+                 noiseBW='1',
+                 noiseBWO='30',
+                 noiseFractalPower=-1,
+                 noiseFilterUpper='50',
+                 noiseFilterLower='0',
+                 noiseFilterOrder='1.0',
+                 noiseClip='1',
+                 noiseImage='None',
+                 texRes=128,
+                 rgb=None,
+                 dkl=None,
+                 lms=None,
+                 color=(1.0, 1.0, 1.0),
+                 colorSpace='rgb',
+                 contrast=0.5,  # see doc
+                 opacity=1.0,
+                 depth=0,
+                 rgbPedestal=(0.0, 0.0, 0.0),
+                 interpolate=False,
+                 blendmode='avg',
+                 name=None,
+                 autoLog=None,
+                 autoDraw=False,
+                 maskParams=None):
+        """ """  # Empty docstring. All doc is in attributes
+        # what local vars are defined (these are the init params) for use by
+        # __repr__
+
+        self._initParams = dir()
+        for unecess in ['self', 'rgb', 'dkl', 'lms']:
+            self._initParams.remove(unecess)
+        # initialise parent class
+        GratingStim.__init__(self, win, tex='sin',
+                             units=units, pos=pos, size=size, sf=sf,
+                             ori=ori, phase=phase,
+                             color=color, colorSpace=colorSpace,
+                             contrast=contrast, opacity=opacity,
+                             depth=depth, interpolate=interpolate,
+                             name=name, autoLog=autoLog, autoDraw=autoDraw,blendmode=blendmode,
+                             maskParams=None)
+        # use shaders if available by default, this is a good thing
+        self.__dict__['useShaders'] = win._haveShaders
+        # UGLY HACK: Some parameters depend on each other for processing.
+        # They are set "superficially" here.
+        # TO DO: postpone calls to _createTexture, setColor and
+        #self.__dict__['tex'] = tex
+        self.__dict__['mask'] = mask
+        self.__dict__['maskParams'] = maskParams
+
+        # initialise textures and masks for stimulus
+        #self._carrierID = GL.GLuint()
+        #GL.glGenTextures(1, ctypes.byref(self._carrierID))
+        #self._envelopeID = GL.GLuint()
+        #GL.glGenTextures(1, ctypes.byref(self._envelopeID))
+        #self.interpolate = interpolate
+        #del self._texID  # created by GratingStim.__init__
+
+        self.mask = mask
+        #self.tex = tex
+        self.texRes=int(texRes)
+        self.noiseType=noiseType
+        self.noiseImage=noiseImage
+        self.noiseElementSize=noiseElementSize
+        #print self.noiseElementSize,noiseElementSize, self.__dict__['noiseElementSize']
+        self.noiseBaseSf=float(noiseBaseSf)
+        self.noiseBW=float(noiseBW)
+        self.noiseBWO=float(noiseBWO)
+        self.noiseFractalPower=float(noiseFractalPower)
+        self.noiseFilterUpper=float(noiseFilterUpper)
+        self.noiseFilterLower=float(noiseFilterLower)
+        self.noiseFilterOrder=float(noiseFilterOrder)
+        if noiseClip != 'none':
+            self.noiseClip=float(noiseClip)
+        else:
+            self.noiseClip=noiseClip
+        self.blendmode=blendmode
+        
+        # print(self.CMphase)
+        #self._shaderProg = _shaders.compileProgram(
+         #   _shaders.vertSimple, carrierEnvelopeMaskFrag)
+
+        self.local = numpy.ones((texRes, texRes), dtype=numpy.ubyte)
+        self.local_p = self.local.ctypes
+        # self.local=GL.GL_UNSIGNED_BYTE(self.local)
+        # fix scaling to window coords
+        # self._calcCyclesPerStim()
+        #self._calcEnvCyclesPerStim()
+        self._sideLength=1.0   
+        self._size=512         # in unlikely case where it does not get set anywehre else before use.
+        self.buildNoise()
+        self._needBuild = False
+        #self._needNoiseUpdate = False
+        #print self.noiseElementSize
+
+    @attributeSetter
+    def noiseType(self, value):
+        """Type of noise to generate
+            'Binary, Normal and Uniform' produce pixel based random samples from the indicated distribitions. Binary has zero mean lumiannce, Normal and Uniform approximate this.
+            'Gabor and Isotropic' produce dense, random scatterd Gabor elements with fixed (Gabor) or randomn (Isotropic) orientations. Zero mean lumiannce.
+            'White' produces white noise with a flat amplitude spectrum. Zero mean lumiannce.
+            'Filtered' Produces white noise filtered by a low-, high- or band-pass filter. Zero mean lumiannce.
+            'Coloured' produces noise with a skewed applitude spectrum (note samples are grey scale not actually coloured). Zero mean lumiannce.
+            'Image' prodcues noise with the same spectrum as the supplied image but with mean lumiance set to zero.
+        
+        """
+        self.__dict__['noiseType'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseImage(self, value):
+        """Image from which to derive the amplitude spectrum of noise type Image 
+        """
+       
+        self.__dict__['noiseImage'] = value
+        self._needUpdate = True
+        self._needBuild = True
+
+    @attributeSetter
+    def noiseElementSize(self, value):
+        """noise element size for Binary, Normal or Uniform noise
+        """
+        
+        self.__dict__['noiseElementSize'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseBaseSf(self, value):
+        """Spatial frequency for Gabor or Isotropic noise
+        """
+        
+        self.__dict__['noiseBaseSf'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseBW(self, value):
+        """Spatial frequency bandwith for Gabor or Isotropic noise, full width at half height in octaves
+        """
+        
+        self.__dict__['noiseBW'] = value
+        self._needUpdate = True 
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseBWO(self, value):
+        """Orientaion bandwith for Gabor noise, full width at half height in degrees
+        """
+        
+        self.__dict__['noiseBWO'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseFractalPower(self, value):
+        """Exponent for 'coloured' noise. Amplitide spectrum = f^noiseFractalPower
+        """
+        
+        self.__dict__['noiseFractalPower'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseFilterUpper(self, value):
+        """Upper cuttoff for filtered noise. > size/2 creates high pass filter
+        """
+        
+        self.__dict__['noiseFilterUpper'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseFilterLower(self, value):
+        """Lower cuttoff for filtered noise. Zero creates low pass filter
+        """
+        
+        self.__dict__['noiseFilterLower'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseFilterOrder(self, value):
+        """Order of Butterworth filter for filtered noise. High = fast fall off withfrequency outside pass band.
+        """
+        
+        self.__dict__['noiseFilterOrder'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def noiseClip(self, value):
+        """Ignored for types 'Binary and Uniform'.
+            For 'Normal' noise pixel values are divided by noiseClip to limit the standard deviation of the noise values.
+            For all other noise types noiseClip determines the level at which pixel values are cliped and subsequently re-scaled so as to produce a final image appraching the desired RMS contrast.
+                High values will tend to reduce the ultimate RMS contrast but increase fidelity of appearance.
+                Low values prioritise accurate final contrast but result in a binarised or thresholded appearance.
+        """
+        
+        self.__dict__['noiseClip'] = value
+        self._needUpdate = True
+        self._needBuild = True
+        
+    @attributeSetter
+    def blendMode(self, value):
+        """Sets the openGL blend mode
+        """
+        
+        self.__dict__['blendMode'] = value
+        self._needUpdate = True
+    
+    @attributeSetter
+    def texRes(self, value):
+        """Power-of-two int. Sets the resolution of the mask and texture.
+        maybe used as the side length for generating the noise texture but is not used if units = pix.
+
+        :ref:`Operations <attrib-operations>` supported.
+        """
+        self.__dict__['texRes'] = value
+
+        # ... now rebuild textures (call attributeSetters without logging).
+        
+        self._needUpdate = True 
+        self._needBuild = True
+        
+        if hasattr(self, 'tex'):
+            self._set('tex', self.tex, log=False)
+        if hasattr(self, 'mask'):
+            self._set('mask', self.mask, log=False)
+
+    def setTexRes(self, value, log=None):
+        self._set('texRes', value, log=log)
+        
+    def setNoiseType(self, value, log=None):
+        self._set('noiseType', value, log=log)
+        
+    def setNoiseImage(self, value, log=None):
+        print value
+        self._set('noiseImage', value, log=log)
+        
+    def setNoiseClip(self, value, log=None):
+        self._set('noiseClip', value, log=log)
+        
+    def setNoiseElementSize(self, value, log=None):
+        self._set('noiseElementSize', value, log=log)
+        
+    def setNoiseBaseSf(self, value, log=None):
+        self._set('noiseBaseSf', value, log=log)
+        
+    def setNoiseBW(self, value, log=None):
+        self._set('noiseBW', value, log=log)
+        
+    def setNoiseBWO(self, value, log=None):
+        self._set('noiseBWO', value, log=log)
+       
+    def setNoiseFractalPower(self, value, log=None):
+        self._set('noiseFractalPower', value, log=log)
+       
+    def setNoiseFilterUpper(self, value, log=None):
+        self._set('noiseFilterUpper', value, log=log)
+        
+    def setNoiseFilterLower(self, value, log=None):
+        self._set('noiseFilterLower', value, log=log)
+        
+    def setNoiseFilterOrder(self, value, log=None):
+        self._set('noiseFilterOrder', value, log=log)
+
+    def setblendMode(self, value, log=None):
+        self._set('blendMode', value, log=log)
+
+    def draw(self, win=None):
+        """Draw the stimulus in its relevant window. You must call
+        this method after every MyWin.flip() if you want the
+        stimulus to appear on that frame and then update the screen
+        again.
+        """
+        #print 'draw noise'
+        if win is None:
+            win = self.win
+        saveBlendMode=win.blendMode
+        win.blendMode=self.blendMode
+        self._selectWindow(win)
+
+        #do scaling
+        GL.glPushMatrix()  # push before the list, pop after
+        win.setScale('pix')
+        #the list just does the texture mapping
+
+        desiredRGB = self._getDesiredRGB(self.rgb, self.colorSpace,
+                                         self.contrast)
+        GL.glColor4f(desiredRGB[0], desiredRGB[1], desiredRGB[2],
+                     self.opacity)
+
+        # re-build the noise if not done so since last parameter update
+        if self._needBuild:
+            self.buildNoise()
+        # remake textures if necessary
+        if self._needTextureUpdate:
+            self.setTex(value=self.tex, log=False)
+        if self._needUpdate:
+            self._updateList()
+        GL.glCallList(self._listID)
+
+        #return the view to previous state
+        GL.glPopMatrix()
+        win.blendMode=saveBlendMode
+
+            
+    def updateNoise(self):
+        """Updates the noise sample. Does not change any of the noise parameters but choses a new random sample given the previously set parameters.
+        """
+
+        if not(self.noiseType in ['binary','Binary','normal','Normal','uniform','Uniform']):
+            Ph=numpy.random.uniform(0,2*numpy.pi,int(self._size**2))
+            Ph=numpy.reshape(Ph,(int(self._size),int(self._size)))
+            In=self.noiseTex*exp(1j*Ph)
+            self.tex=numpy.real(ifft2(In))
+            self.tex=ifftshift(self.tex)
+            gsd=filters.getRMScontrast(self.tex)
+            factor=(gsd*self.noiseClip)/self.contrast
+            numpy.clip(self.tex,-factor,factor,self.tex)
+            self.tex=self.tex/factor
+        else:
+            numpy.random.shuffle(self.noiseTex)  # pick random noise sample by shuffleing values
+            self.tex=numpy.reshape(self.noiseTex,(int(self._sideLength[1]),int(self._sideLength[0]))) #reshape to sqaure
+            
+    def buildNoise(self):
+        """build a new noise sample. Required to act on chnages to any noise parameters or texRes.
+        """
+
+        if self.units=='pix':
+            if not (self.noiseType in ['Binary','binary','Normal','normal','uniform','Uniform']):
+                mysize=numpy.max(self.size)
+            else:
+                mysize=self.size
+            sampleSize=self.noiseElementSize
+            mysf=self.__dict__['noiseBaseSf']*mysize
+            lowsf=self.noiseFilterLower*mysize
+            upsf=self.noiseFilterUpper*mysize
+        else:
+            mysize=self.texRes
+            pixSize=self.size/self.texRes
+            sampleSize=self.noiseElementSize/pixSize
+            mysf=self.size[0]*self.noiseBaseSf
+            lowsf=self.size[0]*self.noiseFilterLower
+            upsf=self.size[0]*self.noiseFilterUpper
+       
+        self._size=mysize  # store for use by updateNoise()
+        self._sf=mysf
+        if self.noiseType in ['binary','Binary','normal','Normal','uniform','Uniform']:
+            self._sideLength=numpy.round(mysize/sampleSize)  # dummy side length for use when unpacking noise samples in updateNoise()
+            self._sideLength.astype(int)
+            totalSamples=self._sideLength[0]*self._sideLength[1]
+            if self.noiseType in ['binary','Binary']:
+                self.noiseTex=numpy.append(numpy.ones(int(numpy.round(totalSamples/2.0))),-1*numpy.ones(int(numpy.round(totalSamples/2.0))))
+            elif self.noiseType in ['normal', 'Normal']:
+                self.noiseTex=numpy.random.randn(int(totalSamples))/self.noiseClip
+            elif self.noiseType in ['uniform', 'Uniform']:
+                self.noiseTex=2.0*numpy.random.rand(int(totalSamples))-1.0
+        elif self.noiseType in ['White','white']:
+            self.noiseTex=numpy.ones((int(mysize),int(mysize)))
+            self.noiseTex[0][0]=0
+        elif self.noiseType in ['Coloured','coloured']:
+            pin=filters.makeRadialMatrix(matrixSize=mysize, center=(0,0), radius=1.0)
+            self.noiseTex=numpy.multiply(numpy.ones((int(mysize),int(mysize))),(pin)**self.noiseFractalPower) 
+            self.noiseTex=fftshift(self.noiseTex)
+            self.noiseTex[0][0]=0
+        elif self.noiseType in ['Isotropic','isotropic']:
+            localf=mysf/mysize
+            linbw=2**self.noiseBW
+            lowf=2.0*localf/(linbw+1.0)
+            highf=linbw*lowf
+            FWF=highf-lowf
+            sigmaF=FWF/(2*numpy.sqrt(2*numpy.log(2)))
+            self.noiseTex=numpy.zeros(int(mysize**2))
+            self.noiseTex=numpy.reshape(self.noiseTex,(int(mysize),int(mysize)))
+            pin=filters.makeRadialMatrix(matrixSize=mysize, center=(0,0), radius=2)
+            self.noiseTex=filters.makeGauss(pin, mean=localf, sd=sigmaF)
+            self.noiseTex=fftshift(self.noiseTex)
+            self.noiseTex[0][0]=0
+        elif self.noiseType in ['Gabor','gabor']:
+            localf=mysf/mysize
+            linbw=2**self.noiseBW
+            lowf=2.0*localf/(linbw+1.0)
+            highf=linbw*lowf
+            FWF=highf-lowf
+            sigmaF=FWF/(2*numpy.sqrt(2*numpy.log(2)))
+            FWO=2.0*localf*numpy.tan(numpy.pi*self.noiseBWO/360.0)
+            sigmaO=FWO/(2*numpy.sqrt(2*numpy.log(2)))
+            self.noiseTex=numpy.zeros(int(mysize**2))
+            self.noiseTex=numpy.reshape(self.noiseTex,(int(mysize),int(mysize)))
+            yy, xx = numpy.mgrid[0:mysize, 0:mysize]
+            xx = (0.5 - 1.0 / mysize * xx) 
+            yy = (0.5 - 1.0 / mysize * yy) 
+            self.noiseTex=filters.make2DGauss(xx,yy,mean=(localf,0), sd=(sigmaF,sigmaO))
+            self.noiseTex=self.noiseTex+filters.make2DGauss(xx,yy, mean=(-localf,0), sd=(sigmaF,sigmaO))
+            self.noiseTex=fftshift(self.noiseTex)
+            self.noiseTex[0][0]=0
+        elif self.noiseType in ['Image','image']:
+            if not(self.noiseImage in ['None','none']):  
+                im = Image.open(self.noiseImage)
+                im = im.transpose(Image.FLIP_TOP_BOTTOM)
+                im = im.convert("L")  # FORCE TO LUMINANCE
+                intensity = numpy.array(im).astype(
+                        numpy.float32) * 0.0078431372549019607 - 1.0
+                self.noiseTex=numpy.absolute(fft2(intensity))
+            else:
+                self.noiseTex=numpy.ones((int(mysize),int(mysize)))  # if image is 'None' will make white noise as tempary measure
+            self.noiseTex[0][0]=0
+        elif self.noiseType in ['filtered','Filtered']:
+            self.noiseTex=numpy.ones((int(mysize),int(mysize)))
+            if upsf<(mysize/2.0):
+                self.noiseTex=filters.butter2d_lp_elliptic(size=[mysize,mysize], cutoff_x=upsf/mysize, cutoff_y=upsf/mysize, n=self.noiseFilterOrder, alpha=0, offset_x=2/(mysize-1),offset_y=2/(mysize-1))
+            if lowsf>0:
+                self.noiseTex=self.noiseTex-filters.butter2d_lp_elliptic(size=[mysize,mysize], cutoff_x=lowsf/mysize, cutoff_y=lowsf/mysize, n=self.noiseFilterOrder, alpha=0, offset_x=2/(mysize-1),offset_y=2/(mysize-1))
+            self.noiseTex=fftshift(self.noiseTex)
+            self.noiseTex[0][0]=0
+        else:
+            assert False, "Noise type not recognised"
+        self._needBuild = False # prevent noise from being re-built at next draw() unless a parameter is chnaged in the mean time.
+        self.updateNoise()  # now choose the inital random sample.
+        
+ 
+
+


### PR DESCRIPTION
I offer this stimulus class for generating visual random noise stimuli of various kinds. There are 4 main classes. Pixel based, Gabor element based, Filtered noise, and Coloured noise. Pixel based can have grey levels distributed according to binary, normal of uniform distributions. Gabor based can be oriented or isotropic. Filter based used Butterworth filtered white noise. Coloured noise allows gives the noise a skewed spatial frequency spectrum and includes white noise and noise derived from the spectrum of an image - this tool randomises the phase spectrum of the image. I’m not 100% sure about using the term coloured noise. I’ve used it as the technical terms for not flat spectra mostly use colour names: pink-noise being the most common. But is might be confused with noise that actually has different hues. I am working on a builder component to go with this. That component will be quite complex with a lot of parameters. I would like it for my lab but wonder how it might be simplified eg different builder components for different classes of noise or different tabs for the parameter belonging to different classes of noise. Do you have a view about adding such a component? I’m happy to upload what I have for discussion at some point soon.