### PR TITLE
FF: Allow pass on missing configobj/future during install.

### DIFF
--- a/createInitFile.py
+++ b/createInitFile.py
@@ -83,11 +83,16 @@ if __git_sha__ == 'n/a':
         __git_sha__ = output.strip()  # remove final linefeed
 
 # update preferences and the user paths
-from psychopy.preferences import prefs
-for pathName in prefs.general['paths']:
-    sys.path.append(pathName)
+try:
+    from psychopy.preferences import prefs
+    for pathName in prefs.general['paths']:
+        sys.path.append(pathName)
 
-from psychopy.tools.versionchooser import useVersion, ensureMinimal
+        from psychopy.tools.versionchooser import useVersion, ensureMinimal
+except ImportError as e:
+    if not any(x in str(e) for x in ["configobj", "past", "builtins"]):
+        raise
+    pass
 """
 
 

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -39,8 +39,13 @@ if __git_sha__ == 'n/a':
         __git_sha__ = output.strip()  # remove final linefeed
 
 # update preferences and the user paths
-from psychopy.preferences import prefs
-for pathName in prefs.general['paths']:
-    sys.path.append(pathName)
-
-from psychopy.tools.versionchooser import useVersion, ensureMinimal
+try:
+    from psychopy.preferences import prefs
+    for pathName in prefs.general['paths']:
+        sys.path.append(pathName)
+    
+        from psychopy.tools.versionchooser import useVersion, ensureMinimal
+except ImportError as e:
+    if not any(x in str(e) for x in ["configobj", "past", "builtins"]):
+        raise
+    pass


### PR DESCRIPTION
I think future and configobj are imported pre-`setuptools.setup`, leading to `ImportError`s because they haven't yet been installed.

Example (applies to python 2 and 3, just switch `python=2.7` to `python=3.6`):

```shell
# create fresh env (I'm on Windows, so get numpy/scipy via conda)
conda create --name py27 python=2.7 numpy scipy -y
activate py27

# first try master (e58f828)
pip install git+https://github.com/psychopy/psychopy

#Collecting git+https://github.com/psychopy/psychopy
#  Cloning https://github.com/psychopy/psychopy to c:\users\aforre~1\appdata\local\temp\pip-efryur-build
#    Complete output from command python setup.py egg_info:
#    Traceback (most recent call last):
#      File "<string>", line 1, in <module>
#      File "c:\users\aforre~1\appdata\local\temp\pip-efryur-build\setup.py", line 62, in <module>
#        exec(vStr)
#      File "<string>", line 42, in <module>
#      File "psychopy\__init__.py", line 42, in <module>
#        from psychopy.preferences import prefs
#      File "psychopy\preferences\__init__.py", line 8, in <module>
#        from . import preferences as prefsLib
#      File "psychopy\preferences\preferences.py", line 4, in <module>
#        from builtins import object
#    ImportError: No module named builtins

# grab my fork (re-add the try/catch for configobj, also include future in the mix)
pip install git+https://github.com/aforren1/psychopy@preinstall
# (success)
```