### PR TITLE
Mouse from Builder supports "clickable" stimuli (virtual buttons)

### DIFF
--- a/psychopy/app/builder/components/keyboard/__init__.py
+++ b/psychopy/app/builder/components/keyboard/__init__.py
@@ -72,7 +72,7 @@ class KeyboardComponent(BaseComponent):
                          "before the onset of this component?")
         self.params['discard previous'] = Param(
             discardPrev, valType='bool', allowedTypes=[],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['discard previous'])
 
@@ -81,7 +81,7 @@ class KeyboardComponent(BaseComponent):
         self.params['store'] = Param(
             store, valType='str', allowedTypes=[],
             allowedVals=['last key', 'first key', 'all keys', 'nothing'],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['store'])
 
@@ -89,7 +89,7 @@ class KeyboardComponent(BaseComponent):
                          "(e.g end the trial)?")
         self.params['forceEndRoutine'] = Param(
             forceEndRoutine, valType='bool', allowedTypes=[],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['forceEndRoutine'])
 
@@ -97,7 +97,7 @@ class KeyboardComponent(BaseComponent):
                          "correct/incorrect?")
         self.params['storeCorrect'] = Param(
             storeCorrect, valType='bool', allowedTypes=[],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['storeCorrect'])
 
@@ -107,7 +107,7 @@ class KeyboardComponent(BaseComponent):
             "press.")
         self.params['correctAns'] = Param(
             correctAns, valType='str', allowedTypes=[],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['correctAns'])
 
@@ -116,7 +116,7 @@ class KeyboardComponent(BaseComponent):
             "the screen flipped")
         self.params['syncScreenRefresh'] = Param(
             syncScreenRefresh, valType='bool',
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['syncScreenRefresh'])
 

--- a/psychopy/app/builder/components/mouse/__init__.py
+++ b/psychopy/app/builder/components/mouse/__init__.py
@@ -4,6 +4,7 @@
 
 from os import path
 from .._base import BaseComponent, Param, _translate
+import re
 
 # the absolute path to the folder containing this path
 thisFolder = path.abspath(path.dirname(__file__))
@@ -13,7 +14,10 @@ tooltip = _translate('Mouse: query mouse position and buttons')
 # only use _localized values for label values, nothing functional:
 _localized = {'saveMouseState': _translate('Save mouse state'),
               'forceEndRoutineOnPress': _translate('End Routine on press'),
-              'timeRelativeTo': _translate('Time relative to')}
+              'timeRelativeTo': _translate('Time relative to'),
+              'Clickable stimuli': 'Clickable stimuli',
+              'Store params for clicked': 'Store params for clicked',
+              'New clicks only': 'New clicks only'}
 
 
 class MouseComponent(BaseComponent):
@@ -26,7 +30,7 @@ class MouseComponent(BaseComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim='',
-                 save='final', forceEndRoutineOnPress=True,
+                 save='final', forceEndRoutineOnPress="any click",
                  timeRelativeTo='routine'):
         super(MouseComponent, self).__init__(
             exp, parentName, name=name,
@@ -38,6 +42,11 @@ class MouseComponent(BaseComponent):
         self.url = "http://www.psychopy.org/builder/components/mouse.html"
         self.exp.requirePsychopyLibs(['event'])
         self.categories = ['Inputs']
+
+        self.order += [
+            'forceEndRoutineOnPress',
+            'saveMouseState', 'timeRelativeTo',
+            'newClicksOnly', 'clickable', 'saveParamsClickable']
 
         # params
         msg = _translate(
@@ -52,9 +61,14 @@ class MouseComponent(BaseComponent):
 
         msg = _translate("Should a button press force the end of the routine"
                          " (e.g end the trial)?")
+        if forceEndRoutineOnPress is True:
+            forceEndRoutineOnPress = 'any click'
+        elif forceEndRoutineOnPress is False:
+            forceEndRoutineOnPress = 'never'
         self.params['forceEndRoutineOnPress'] = Param(
-            forceEndRoutineOnPress, valType='bool', allowedTypes=[],
-            updates='constant', allowedUpdates=[],
+            forceEndRoutineOnPress, valType='str',
+            allowedVals=['never', 'any click', 'valid click'],
+            updates='constant',
             hint=msg,
             label=_localized['forceEndRoutineOnPress'])
 
@@ -63,9 +77,65 @@ class MouseComponent(BaseComponent):
         self.params['timeRelativeTo'] = Param(
             timeRelativeTo, valType='str',
             allowedVals=['experiment', 'routine'],
-            updates='constant', allowedUpdates=[],
+            updates='constant',
             hint=msg,
             label=_localized['timeRelativeTo'])
+
+
+        msg = _translate('If the mouse button is already down when we start'
+                         'checking then wait for it to be released before'
+                         'recording as a new click.'
+                         )
+        self.params['newClicksOnly'] = Param(
+            True, valType='bool',
+            updates='constant',
+            hint=msg,
+            label=_localized['New clicks only'])
+        msg = _translate('A comma-separated list of your stimulus names that '
+                         'can be "clicked" by the participant. '
+                         'e.g. target, foil'
+                         )
+        self.params['clickable'] = Param(
+            '', valType='code',
+            updates='constant',
+            hint=msg,
+            label=_localized['Clickable stimuli'])
+
+        msg = _translate('The params (e.g. name, text), for which you want '
+                         'to store the current value, for the stimulus that was'
+                         '"clicked" by the mouse. Make sure that all the '
+                         'clickable objects have all these params.'
+                         )
+        self.params['saveParamsClickable'] = Param(
+            'name,', valType='code',
+            updates='constant', allowedUpdates=[],
+            hint=msg,
+            label=_localized['Store params for clicked'])
+
+
+    @property
+    def _clickableParamsList(self):
+        # convert clickableParams (str) to a list
+        params = self.params['saveParamsClickable'].val
+        paramsList = re.findall(r"[\w']+", params)
+        return paramsList or ['name']
+
+    def _writeClickableObjectsCode(self, buff):
+        # code to check if clickable objects were clicked
+        code = (
+            "# check if the mouse was inside our 'clickable' objects\n"
+            "for obj in [%(clickable)s]:\n"
+            "    if obj.contains(%(name)s):\n"
+            "        gotValidClick = True\n")
+        buff.writeIndentedLines(code % self.params)
+
+        buff.setIndentLevel(+2, relative=True)
+        code = ''
+        for paramName in self._clickableParamsList:
+            code += "%s.clicked_%s.append(obj.%s)\n" %(self.params['name'],
+                                                     paramName, paramName)
+        buff.writeIndentedLines(code % self.params)
+        buff.setIndentLevel(-2, relative=True)
 
     def writeInitCode(self, buff):
         code = ("%(name)s = event.Mouse(win=win)\n"
@@ -86,7 +156,11 @@ class MouseComponent(BaseComponent):
                      "%(name)s.leftButton = []\n"
                      "%(name)s.midButton = []\n"
                      "%(name)s.rightButton = []\n"
-                     "%(name)s.time = []\n")
+                     "%(name)s.time = []\n"
+                     "gotValidClick = False\n")
+        if self.params['clickable'].val:
+            for clickableObjParam in self._clickableParamsList:
+                code += "%(name)s.clicked_{} = []\n".format(clickableObjParam)
 
         buff.writeIndentedLines(code % self.params)
 
@@ -95,21 +169,35 @@ class MouseComponent(BaseComponent):
         """
         forceEnd = self.params['forceEndRoutineOnPress'].val
         routineClockName = self.exp.flow._currentRoutine._clockName
-
+        
+        # get a clock for timing
+        if self.params['timeRelativeTo'].val == 'experiment':
+            self.clockStr = 'globalClock'
+        elif self.params['timeRelativeTo'].val == 'routine':
+            self.clockStr = routineClockName
+        
         # only write code for cases where we are storing data as we go (each
         # frame or each click)
 
         # might not be saving clicks, but want it to force end of trial
         if (self.params['saveMouseState'].val not in
-                ['every frame', 'on click'] and not forceEnd):
+                ['every frame', 'on click'] and forceEnd=='never'):
             return
 
         buff.writeIndented("# *%s* updates\n" % self.params['name'])
 
         # writes an if statement to determine whether to draw etc
         self.writeStartTestCode(buff)
-        code = ("%(name)s.status = STARTED\n"
-                "event.mouseButtons = [0, 0, 0]  # reset mouse buttons to be 'up'\n")
+        code = "%(name)s.status = STARTED\n"
+
+        if self.params['newClicksOnly']:
+            code += (
+                "prevButtonState = %(name)s.getPressed()"
+                "  # if button is down already this ISN'T a new click\n")
+        else:
+            code += (
+                "prevButtonState = [0, 0, 0]"
+                "  # if now button is down we will treat as 'new' click\n")
         buff.writeIndentedLines(code % self.params)
 
         # to get out of the if statement
@@ -130,19 +218,21 @@ class MouseComponent(BaseComponent):
         buff.setIndentLevel(1, relative=True)  # to get out of if statement
         dedentAtEnd = 1  # keep track of how far to dedent later
 
-        # get a clock for timing
-        if self.params['timeRelativeTo'].val == 'experiment':
-            clockStr = 'globalClock'
-        elif self.params['timeRelativeTo'].val == 'routine':
-            clockStr = routineClockName
 
         # write param checking code
-        if self.params['saveMouseState'].val == 'on click' or forceEnd:
+        if (self.params['saveMouseState'].val == 'on click'
+            or forceEnd in ['any click', 'valid click']):
             code = ("buttons = %(name)s.getPressed()\n"
-                    "if sum(buttons) > 0:  # ie if any button is pressed\n")
+                    "if buttons != prevButtonState:  # button state changed?")
             buff.writeIndentedLines(code % self.params)
             buff.setIndentLevel(1, relative=True)
             dedentAtEnd += 1
+            buff.writeIndented("prevButtonState = buttons\n")
+            code = ("if sum(buttons) > 0:  # state changed to a new click\n")
+            buff.writeIndentedLines(code % self.params)
+            buff.setIndentLevel(1, relative=True)
+            dedentAtEnd += 1
+
         elif self.params['saveMouseState'].val == 'every frame':
             code = "buttons = %(name)s.getPressed()\n" % self.params
             buff.writeIndented(code)
@@ -154,19 +244,26 @@ class MouseComponent(BaseComponent):
                     "%(name)s.y.append(y)\n"
                     "%(name)s.leftButton.append(buttons[0])\n"
                     "%(name)s.midButton.append(buttons[1])\n"
-                    "%(name)s.rightButton.append(buttons[2])\n" %
+                    "%(name)s.rightButton.append(buttons[2])\n"%
                     self.params)
-
             code += ("%s.time.append(%s.getTime())\n" %
-                     (self.params['name'], clockStr))
-
+                     (self.params['name'], self.clockStr))
             buff.writeIndentedLines(code)
+            # also write code about clicked objects if needed.
+            if self.params['clickable'].val:
+                self._writeClickableObjectsCode(buff)
 
         # does the response end the trial?
-        if forceEnd is True:
+        if forceEnd == 'any click':
             code = ("# abort routine on response\n"
                     "continueRoutine = False\n")
-            buff.writeIndentedLines(code % self.params)
+            buff.writeIndentedLines(code)
+        elif forceEnd == 'valid click':
+            code = ("if gotValidClick:  # abort routine on response\n"
+                    "    continueRoutine = False\n")
+            buff.writeIndentedLines(code)
+        else:
+            print(forceEnd)
 
         # dedent
         # 'if' statement of the time test and button check
@@ -195,29 +292,54 @@ class MouseComponent(BaseComponent):
                     (currLoop.params['name'], currLoop.type))
 
         buff.writeIndentedLines(code)
-
-        if store == 'final':
+            
+        if store == 'final':  # for the o
             # buff.writeIndented("# get info about the %(name)s\n"
             # %(self.params))
             code = ("x, y = %(name)s.getPos()\n"
                     "buttons = %(name)s.getPressed()\n" %
                     self.params)
+            code += ("%s.time = %s.getTime()\n" %
+                     (self.params['name'], self.clockStr))
+            # also write code about clicked objects if needed.
+            if self.params['clickable'].val:
+                buff.writeIndented("if sum(buttons):\n")
+                buff.setIndentLevel(+1, relative=True)
+                self._writeClickableObjectsCode(buff)
+                buff.setIndentLevel(-1, relative=True)
 
             if currLoop.type != 'StairHandler':
-                vals = (currLoop.params['name'], name)
                 code += (
-                    "%s.addData('%s.x', x)\n" % vals +
-                    "%s.addData('%s.y', y)\n" % vals +
-                    "%s.addData('%s.leftButton', buttons[0])\n" % vals +
-                    "%s.addData('%s.midButton', buttons[1])\n" % vals +
-                    "%s.addData('%s.rightButton', buttons[2])\n" % vals)
+                    "{loopName}.addData('{mouseName}.x', x)\n" 
+                    "{loopName}.addData('{mouseName}.y', y)\n" 
+                    "{loopName}.addData('{mouseName}.leftButton', buttons[0])\n" 
+                    "{loopName}.addData('{mouseName}.midButton', buttons[1])\n" 
+                    "{loopName}.addData('{mouseName}.rightButton', buttons[2])\n"
+                )
 
-            buff.writeIndentedLines(code)
+                # then add `trials.addData('mouse.clicked_name',.....)`
+                for paramName in self._clickableParamsList:
+                    code += (
+                        "if len({mouseName}.clicked_{param}):\n"
+                        "    {loopName}.addData('{mouseName}.clicked_{param}', " 
+                        "{mouseName}.clicked_{param}[0])\n"
+                    )
+                buff.writeIndentedLines(
+                    code.format(loopName=currLoop.params['name'],
+                                mouseName=name,
+                                param=paramName))
+
         elif store != 'never':
             # buff.writeIndented("# save %(name)s data\n" %(self.params))
-            for property in ['x', 'y', 'leftButton', 'midButton',
-                             'rightButton', 'time']:
-                if store == 'every frame' or not forceEnd:
+            mouseDataProps = ['x', 'y', 'leftButton', 'midButton',
+                             'rightButton', 'time']
+            # possibly add clicked params if we have clickable objects
+            if self.params['clickable'].val:
+                for paramName in self._clickableParamsList:
+                    mouseDataProps.append("clicked_{}".format(paramName))
+            # use that set of properties to create set of addData commands
+            for property in mouseDataProps:
+                if store == 'every frame' or forceEnd == "never":
                     code = ("%s.addData('%s.%s', %s.%s)\n" %
                             (currLoop.params['name'], name,
                              property, name, property))

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -373,6 +373,13 @@ class Experiment(object):
         elif name == 'forceEndTrialOnPress':  # deprecated in v1.70.00
             params['forceEndRoutineOnPress'].val = bool(val)
             return  # forceEndTrial doesn't need to update  type or 'updates'
+        elif name == 'forceEndRoutineOnPress':
+            if val is True:
+                val = "any click"
+            elif val is False:
+                val = "never"
+            params['forceEndRoutineOnPress'].val = val
+            return
         elif name == 'trialList':  # deprecated in v1.70.00
             params['conditions'].val = eval(val)
             return  # forceEndTrial doesn't need to update  type or 'updates'

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -486,7 +486,7 @@ class TrialHandler(_BaseTrialHandler):
                 dataOutNew.append('ran_sum')
                 continue  # no need to do more with this one
             # then break into dataType and analysis
-            dataType, analType = string.rsplit(thisDataOut, '_', 1)
+            dataType, analType = thisDataOut.rsplit('_', 1)
             if dataType == 'all':
                 dataOutNew.extend(
                     [key + "_" + analType for key in allDataTypes])
@@ -514,7 +514,7 @@ class TrialHandler(_BaseTrialHandler):
             dataOut.append('order_raw')
         # do the necessary analysis on the data
         for thisDataOutN, thisDataOut in enumerate(dataOut):
-            dataType, analType = string.rsplit(thisDataOut, '_', 1)
+            dataType, analType = thisDataOut.rsplit('_', 1)
             if not dataType in self.data:
                 # that analysis can't be done
                 dataOutInvalid.append(thisDataOut)
@@ -1572,7 +1572,7 @@ class TrialHandlerExt(TrialHandler):
                 dataOutNew.append('ran_sum')
                 continue  # no need to do more with this one
             # then break into dataType and analysis
-            dataType, analType = string.rsplit(thisDataOut, '_', 1)
+            dataType, analType = thisDataOut.rsplit('_', 1)
             if dataType == 'all':
                 keyType = [key + "_" + analType for key in allDataTypes]
                 dataOutNew.extend(keyType)
@@ -1600,7 +1600,7 @@ class TrialHandlerExt(TrialHandler):
             dataOut.append('order_raw')
         # do the necessary analysis on the data
         for thisDataOutN, thisDataOut in enumerate(dataOut):
-            dataType, analType = string.rsplit(thisDataOut, '_', 1)
+            dataType, analType = thisDataOut.rsplit('_', 1)
             if not dataType in self.data:
                 # that analysis can't be done
                 dataOutInvalid.append(thisDataOut)

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -529,7 +529,7 @@ class Mouse(object):
             mouse.set_pos(newPosPix)
         else:
             if hasattr(self.win.winHandle, 'set_mouse_position'):
-                newPosPix = self.win.size / 2 + newPosPix
+                newPosPix = numpy.array(self.win.size) / 2 + newPosPix
                 x, y = int(newPosPix[0]), int(newPosPix[1])
                 self.win.winHandle.set_mouse_position(x, y)
             else:
@@ -555,7 +555,7 @@ class Mouse(object):
             # get position in window
             lastPosPix = numpy.array([w._mouse_x, w._mouse_y])
             # set (0,0) to centre
-            lastPosPix = lastPosPix - self.win.size / 2
+            lastPosPix = lastPosPix - numpy.array(self.win.size) / 2
         self.lastPos = self._pix2windowUnits(lastPosPix)
         return self.lastPos
 

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -557,7 +557,7 @@ class Mouse(object):
             # set (0,0) to centre
             lastPosPix = lastPosPix - numpy.array(self.win.size) / 2
         self.lastPos = self._pix2windowUnits(lastPosPix)
-        return self.lastPos
+        return copy.copy(self.lastPos)
 
     def mouseMoved(self, distance=None, reset=False):
         """Determine whether/how far the mouse has moved.
@@ -739,9 +739,9 @@ class Mouse(object):
 
             # else:
             if not getTime:
-                return mouseButtons
+                return copy.copy(mouseButtons)
             else:
-                return mouseButtons, mouseTimes
+                return copy.copy(mouseButtons), copy.copy(mouseTimes)
 
     def isPressedIn(self, shape, buttons=(0, 1, 2)):
         """Returns `True` if the mouse is currently inside the shape and

--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -632,7 +632,7 @@ def _getHashGitHead(gdir='.'):
         return None  # no git
     git_branches = subprocess.check_output('git branch', cwd=gdir, shell=True)
     git_branch = [line.split()[1] for line in git_branches.splitlines()
-                  if line.startswith('*')]
+                  if line.startswith(b'*')]
     if len(git_branch):
         return git_branch[0] + ' ' + git_hash.strip()
     else:

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -4,7 +4,7 @@ ApertureComponent.name.label:Name
 ApertureComponent.name.valType:code
 ApertureComponent.name.val:aperture
 ApertureComponent.name.allowedTypes:[]
-ApertureComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+ApertureComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 ApertureComponent.name.categ:Basic
 ApertureComponent.name.allowedVals:[]
 ApertureComponent.name.readOnly:False
@@ -16,7 +16,7 @@ ApertureComponent.stopVal.label:Stop
 ApertureComponent.stopVal.valType:code
 ApertureComponent.stopVal.val:1.0
 ApertureComponent.stopVal.allowedTypes:[]
-ApertureComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+ApertureComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 ApertureComponent.stopVal.categ:Basic
 ApertureComponent.stopVal.allowedVals:[]
 ApertureComponent.stopVal.readOnly:False
@@ -29,7 +29,7 @@ ApertureComponent.durationEstim.label:Expected duration (s)
 ApertureComponent.durationEstim.valType:code
 ApertureComponent.durationEstim.val:
 ApertureComponent.durationEstim.allowedTypes:[]
-ApertureComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+ApertureComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312ed0>>
 ApertureComponent.durationEstim.categ:Basic
 ApertureComponent.durationEstim.allowedVals:[]
 ApertureComponent.durationEstim.readOnly:False
@@ -42,7 +42,7 @@ ApertureComponent.pos.label:Position [x,y]
 ApertureComponent.pos.valType:code
 ApertureComponent.pos.val:(0, 0)
 ApertureComponent.pos.allowedTypes:[]
-ApertureComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+ApertureComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b050>>
 ApertureComponent.pos.categ:Basic
 ApertureComponent.pos.allowedVals:[]
 ApertureComponent.pos.readOnly:False
@@ -55,7 +55,7 @@ ApertureComponent.startEstim.label:Expected start (s)
 ApertureComponent.startEstim.valType:code
 ApertureComponent.startEstim.val:
 ApertureComponent.startEstim.allowedTypes:[]
-ApertureComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+ApertureComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 ApertureComponent.startEstim.categ:Basic
 ApertureComponent.startEstim.allowedVals:[]
 ApertureComponent.startEstim.readOnly:False
@@ -68,7 +68,7 @@ ApertureComponent.units.label:Units
 ApertureComponent.units.valType:str
 ApertureComponent.units.val:norm
 ApertureComponent.units.allowedTypes:[]
-ApertureComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c50>>
+ApertureComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 ApertureComponent.units.categ:Basic
 ApertureComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 ApertureComponent.units.readOnly:False
@@ -81,7 +81,7 @@ ApertureComponent.startType.label:start type
 ApertureComponent.startType.valType:str
 ApertureComponent.startType.val:time (s)
 ApertureComponent.startType.allowedTypes:[]
-ApertureComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+ApertureComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 ApertureComponent.startType.categ:Basic
 ApertureComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 ApertureComponent.startType.readOnly:False
@@ -94,7 +94,7 @@ ApertureComponent.stopType.label:stop type
 ApertureComponent.stopType.valType:str
 ApertureComponent.stopType.val:duration (s)
 ApertureComponent.stopType.allowedTypes:[]
-ApertureComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+ApertureComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 ApertureComponent.stopType.categ:Basic
 ApertureComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 ApertureComponent.stopType.readOnly:False
@@ -107,7 +107,7 @@ ApertureComponent.startVal.label:Start
 ApertureComponent.startVal.valType:code
 ApertureComponent.startVal.val:0.0
 ApertureComponent.startVal.allowedTypes:[]
-ApertureComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+ApertureComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 ApertureComponent.startVal.categ:Basic
 ApertureComponent.startVal.allowedVals:[]
 ApertureComponent.startVal.readOnly:False
@@ -120,7 +120,7 @@ ApertureComponent.size.label:Size
 ApertureComponent.size.valType:code
 ApertureComponent.size.val:1
 ApertureComponent.size.allowedTypes:[]
-ApertureComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+ApertureComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 ApertureComponent.size.categ:Basic
 ApertureComponent.size.allowedVals:[]
 ApertureComponent.size.readOnly:False
@@ -134,7 +134,7 @@ CodeComponent.Begin Experiment.label:Begin Experiment
 CodeComponent.Begin Experiment.valType:extendedCode
 CodeComponent.Begin Experiment.val:
 CodeComponent.Begin Experiment.allowedTypes:[]
-CodeComponent.Begin Experiment.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+CodeComponent.Begin Experiment.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 CodeComponent.Begin Experiment.categ:Basic
 CodeComponent.Begin Experiment.allowedVals:[]
 CodeComponent.Begin Experiment.readOnly:False
@@ -147,7 +147,7 @@ CodeComponent.name.label:Name
 CodeComponent.name.valType:code
 CodeComponent.name.val:code
 CodeComponent.name.allowedTypes:[]
-CodeComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+CodeComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 CodeComponent.name.categ:Basic
 CodeComponent.name.allowedVals:[]
 CodeComponent.name.readOnly:False
@@ -159,7 +159,7 @@ CodeComponent.Begin Routine.label:Begin Routine
 CodeComponent.Begin Routine.valType:extendedCode
 CodeComponent.Begin Routine.val:
 CodeComponent.Begin Routine.allowedTypes:[]
-CodeComponent.Begin Routine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+CodeComponent.Begin Routine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b250>>
 CodeComponent.Begin Routine.categ:Basic
 CodeComponent.Begin Routine.allowedVals:[]
 CodeComponent.Begin Routine.readOnly:False
@@ -172,7 +172,7 @@ CodeComponent.End Routine.label:End Routine
 CodeComponent.End Routine.valType:extendedCode
 CodeComponent.End Routine.val:
 CodeComponent.End Routine.allowedTypes:[]
-CodeComponent.End Routine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+CodeComponent.End Routine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b2d0>>
 CodeComponent.End Routine.categ:Basic
 CodeComponent.End Routine.allowedVals:[]
 CodeComponent.End Routine.readOnly:False
@@ -185,7 +185,7 @@ CodeComponent.End Experiment.label:End Experiment
 CodeComponent.End Experiment.valType:extendedCode
 CodeComponent.End Experiment.val:
 CodeComponent.End Experiment.allowedTypes:[]
-CodeComponent.End Experiment.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe050>>
+CodeComponent.End Experiment.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b310>>
 CodeComponent.End Experiment.categ:Basic
 CodeComponent.End Experiment.allowedVals:[]
 CodeComponent.End Experiment.readOnly:False
@@ -198,7 +198,7 @@ CodeComponent.Each Frame.label:Each Frame
 CodeComponent.Each Frame.valType:extendedCode
 CodeComponent.Each Frame.val:
 CodeComponent.Each Frame.allowedTypes:[]
-CodeComponent.Each Frame.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+CodeComponent.Each Frame.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b290>>
 CodeComponent.Each Frame.categ:Basic
 CodeComponent.Each Frame.allowedVals:[]
 CodeComponent.Each Frame.readOnly:False
@@ -212,7 +212,7 @@ DotsComponent.color.label:Color
 DotsComponent.color.valType:str
 DotsComponent.color.val:$[1.0,1.0,1.0]
 DotsComponent.color.allowedTypes:[]
-DotsComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+DotsComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 DotsComponent.color.categ:Basic
 DotsComponent.color.allowedVals:[]
 DotsComponent.color.readOnly:False
@@ -225,7 +225,7 @@ DotsComponent.colorSpace.label:Color space
 DotsComponent.colorSpace.valType:str
 DotsComponent.colorSpace.val:rgb
 DotsComponent.colorSpace.allowedTypes:[]
-DotsComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+DotsComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b050>>
 DotsComponent.colorSpace.categ:Basic
 DotsComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 DotsComponent.colorSpace.readOnly:False
@@ -238,7 +238,7 @@ DotsComponent.startVal.label:Start
 DotsComponent.startVal.valType:code
 DotsComponent.startVal.val:0.0
 DotsComponent.startVal.allowedTypes:[]
-DotsComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+DotsComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 DotsComponent.startVal.categ:Basic
 DotsComponent.startVal.allowedVals:[]
 DotsComponent.startVal.readOnly:False
@@ -251,7 +251,7 @@ DotsComponent.fieldPos.label:Field position
 DotsComponent.fieldPos.valType:code
 DotsComponent.fieldPos.val:(0.0, 0.0)
 DotsComponent.fieldPos.allowedTypes:[]
-DotsComponent.fieldPos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe2d0>>
+DotsComponent.fieldPos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b590>>
 DotsComponent.fieldPos.categ:Basic
 DotsComponent.fieldPos.allowedVals:[]
 DotsComponent.fieldPos.readOnly:False
@@ -264,7 +264,7 @@ DotsComponent.speed.label:Speed
 DotsComponent.speed.valType:code
 DotsComponent.speed.val:0.1
 DotsComponent.speed.allowedTypes:[]
-DotsComponent.speed.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe090>>
+DotsComponent.speed.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b110>>
 DotsComponent.speed.categ:Dots
 DotsComponent.speed.allowedVals:[]
 DotsComponent.speed.readOnly:False
@@ -277,7 +277,7 @@ DotsComponent.noiseDots.label:Noise dots
 DotsComponent.noiseDots.valType:str
 DotsComponent.noiseDots.val:direction
 DotsComponent.noiseDots.allowedTypes:[]
-DotsComponent.noiseDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe210>>
+DotsComponent.noiseDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b4d0>>
 DotsComponent.noiseDots.categ:Dots
 DotsComponent.noiseDots.allowedVals:['direction', 'position', 'walk']
 DotsComponent.noiseDots.readOnly:False
@@ -290,7 +290,7 @@ DotsComponent.dotLife.label:Dot life-time
 DotsComponent.dotLife.valType:code
 DotsComponent.dotLife.val:3
 DotsComponent.dotLife.allowedTypes:[]
-DotsComponent.dotLife.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe150>>
+DotsComponent.dotLife.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b410>>
 DotsComponent.dotLife.categ:Dots
 DotsComponent.dotLife.allowedVals:[]
 DotsComponent.dotLife.readOnly:False
@@ -303,7 +303,7 @@ DotsComponent.units.label:Units
 DotsComponent.units.valType:str
 DotsComponent.units.val:from exp settings
 DotsComponent.units.allowedTypes:[]
-DotsComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+DotsComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 DotsComponent.units.categ:Basic
 DotsComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 DotsComponent.units.readOnly:False
@@ -316,7 +316,7 @@ DotsComponent.refreshDots.label:Dot refresh rule
 DotsComponent.refreshDots.valType:str
 DotsComponent.refreshDots.val:repeat
 DotsComponent.refreshDots.allowedTypes:[]
-DotsComponent.refreshDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe1d0>>
+DotsComponent.refreshDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b490>>
 DotsComponent.refreshDots.categ:Dots
 DotsComponent.refreshDots.allowedVals:['none', 'repeat']
 DotsComponent.refreshDots.readOnly:False
@@ -329,7 +329,7 @@ DotsComponent.opacity.label:Opacity
 DotsComponent.opacity.valType:code
 DotsComponent.opacity.val:1
 DotsComponent.opacity.allowedTypes:[]
-DotsComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+DotsComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 DotsComponent.opacity.categ:Basic
 DotsComponent.opacity.allowedVals:[]
 DotsComponent.opacity.readOnly:False
@@ -342,7 +342,7 @@ DotsComponent.fieldShape.label:Field shape
 DotsComponent.fieldShape.valType:str
 DotsComponent.fieldShape.val:circle
 DotsComponent.fieldShape.allowedTypes:[]
-DotsComponent.fieldShape.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe250>>
+DotsComponent.fieldShape.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 DotsComponent.fieldShape.categ:Basic
 DotsComponent.fieldShape.allowedVals:['circle', 'square']
 DotsComponent.fieldShape.readOnly:False
@@ -355,7 +355,7 @@ DotsComponent.coherence.label:Coherence
 DotsComponent.coherence.valType:code
 DotsComponent.coherence.val:1.0
 DotsComponent.coherence.allowedTypes:[]
-DotsComponent.coherence.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe0d0>>
+DotsComponent.coherence.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b390>>
 DotsComponent.coherence.categ:Dots
 DotsComponent.coherence.allowedVals:[]
 DotsComponent.coherence.readOnly:False
@@ -368,7 +368,7 @@ DotsComponent.nDots.label:Number of dots
 DotsComponent.nDots.valType:code
 DotsComponent.nDots.val:100
 DotsComponent.nDots.allowedTypes:[]
-DotsComponent.nDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+DotsComponent.nDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b150>>
 DotsComponent.nDots.categ:Dots
 DotsComponent.nDots.allowedVals:[]
 DotsComponent.nDots.readOnly:False
@@ -381,7 +381,7 @@ DotsComponent.stopVal.label:Stop
 DotsComponent.stopVal.valType:code
 DotsComponent.stopVal.val:1.0
 DotsComponent.stopVal.allowedTypes:[]
-DotsComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c50>>
+DotsComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 DotsComponent.stopVal.categ:Basic
 DotsComponent.stopVal.allowedVals:[]
 DotsComponent.stopVal.readOnly:False
@@ -394,7 +394,7 @@ DotsComponent.durationEstim.label:Expected duration (s)
 DotsComponent.durationEstim.valType:code
 DotsComponent.durationEstim.val:
 DotsComponent.durationEstim.allowedTypes:[]
-DotsComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+DotsComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 DotsComponent.durationEstim.categ:Basic
 DotsComponent.durationEstim.allowedVals:[]
 DotsComponent.durationEstim.readOnly:False
@@ -407,7 +407,7 @@ DotsComponent.fieldSize.label:Field size
 DotsComponent.fieldSize.valType:code
 DotsComponent.fieldSize.val:1.0
 DotsComponent.fieldSize.allowedTypes:[]
-DotsComponent.fieldSize.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe290>>
+DotsComponent.fieldSize.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 DotsComponent.fieldSize.categ:Basic
 DotsComponent.fieldSize.allowedVals:[]
 DotsComponent.fieldSize.readOnly:False
@@ -420,7 +420,7 @@ DotsComponent.startEstim.label:Expected start (s)
 DotsComponent.startEstim.valType:code
 DotsComponent.startEstim.val:
 DotsComponent.startEstim.allowedTypes:[]
-DotsComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+DotsComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312ed0>>
 DotsComponent.startEstim.categ:Basic
 DotsComponent.startEstim.allowedVals:[]
 DotsComponent.startEstim.readOnly:False
@@ -433,7 +433,7 @@ DotsComponent.signalDots.label:Signal dots
 DotsComponent.signalDots.valType:str
 DotsComponent.signalDots.val:same
 DotsComponent.signalDots.allowedTypes:[]
-DotsComponent.signalDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe190>>
+DotsComponent.signalDots.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
 DotsComponent.signalDots.categ:Dots
 DotsComponent.signalDots.allowedVals:['same', 'different']
 DotsComponent.signalDots.readOnly:False
@@ -446,7 +446,7 @@ DotsComponent.startType.label:start type
 DotsComponent.startType.valType:str
 DotsComponent.startType.val:time (s)
 DotsComponent.startType.allowedTypes:[]
-DotsComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+DotsComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 DotsComponent.startType.categ:Basic
 DotsComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 DotsComponent.startType.readOnly:False
@@ -459,7 +459,7 @@ DotsComponent.stopType.label:stop type
 DotsComponent.stopType.valType:str
 DotsComponent.stopType.val:duration (s)
 DotsComponent.stopType.allowedTypes:[]
-DotsComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+DotsComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 DotsComponent.stopType.categ:Basic
 DotsComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 DotsComponent.stopType.readOnly:False
@@ -472,7 +472,7 @@ DotsComponent.name.label:Name
 DotsComponent.name.valType:code
 DotsComponent.name.val:dots
 DotsComponent.name.allowedTypes:[]
-DotsComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+DotsComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 DotsComponent.name.categ:Basic
 DotsComponent.name.allowedVals:[]
 DotsComponent.name.readOnly:False
@@ -484,7 +484,7 @@ DotsComponent.dotSize.label:Dot size
 DotsComponent.dotSize.valType:code
 DotsComponent.dotSize.val:2
 DotsComponent.dotSize.allowedTypes:[]
-DotsComponent.dotSize.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe110>>
+DotsComponent.dotSize.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b3d0>>
 DotsComponent.dotSize.categ:Dots
 DotsComponent.dotSize.allowedVals:[]
 DotsComponent.dotSize.readOnly:False
@@ -497,7 +497,7 @@ DotsComponent.dir.label:Direction
 DotsComponent.dir.valType:code
 DotsComponent.dir.val:0.0
 DotsComponent.dir.allowedTypes:[]
-DotsComponent.dir.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+DotsComponent.dir.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b190>>
 DotsComponent.dir.categ:Dots
 DotsComponent.dir.allowedVals:[]
 DotsComponent.dir.readOnly:False
@@ -511,7 +511,7 @@ EnvGratingComponent.color.label:Color
 EnvGratingComponent.color.valType:str
 EnvGratingComponent.color.val:$[1,1,1]
 EnvGratingComponent.color.allowedTypes:[]
-EnvGratingComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe310>>
+EnvGratingComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b5d0>>
 EnvGratingComponent.color.categ:Basic
 EnvGratingComponent.color.allowedVals:[]
 EnvGratingComponent.color.readOnly:False
@@ -524,7 +524,7 @@ EnvGratingComponent.colorSpace.label:Color space
 EnvGratingComponent.colorSpace.valType:str
 EnvGratingComponent.colorSpace.val:rgb
 EnvGratingComponent.colorSpace.allowedTypes:[]
-EnvGratingComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe390>>
+EnvGratingComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b650>>
 EnvGratingComponent.colorSpace.categ:Basic
 EnvGratingComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 EnvGratingComponent.colorSpace.readOnly:False
@@ -537,7 +537,7 @@ EnvGratingComponent.pos.label:Position [x,y]
 EnvGratingComponent.pos.valType:code
 EnvGratingComponent.pos.val:(0, 0)
 EnvGratingComponent.pos.allowedTypes:[]
-EnvGratingComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe3d0>>
+EnvGratingComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b690>>
 EnvGratingComponent.pos.categ:Basic
 EnvGratingComponent.pos.allowedVals:[]
 EnvGratingComponent.pos.readOnly:False
@@ -550,7 +550,7 @@ EnvGratingComponent.stopType.label:stop type
 EnvGratingComponent.stopType.valType:str
 EnvGratingComponent.stopType.val:duration (s)
 EnvGratingComponent.stopType.allowedTypes:[]
-EnvGratingComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+EnvGratingComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b2d0>>
 EnvGratingComponent.stopType.categ:Basic
 EnvGratingComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 EnvGratingComponent.stopType.readOnly:False
@@ -563,7 +563,7 @@ EnvGratingComponent.blendmode.label:OpenGL blend mode
 EnvGratingComponent.blendmode.valType:str
 EnvGratingComponent.blendmode.val:avg
 EnvGratingComponent.blendmode.allowedTypes:[]
-EnvGratingComponent.blendmode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe7d0>>
+EnvGratingComponent.blendmode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba90>>
 EnvGratingComponent.blendmode.categ:Basic
 EnvGratingComponent.blendmode.allowedVals:['avg', 'add']
 EnvGratingComponent.blendmode.readOnly:False
@@ -576,7 +576,7 @@ EnvGratingComponent.startVal.label:Start
 EnvGratingComponent.startVal.valType:code
 EnvGratingComponent.startVal.val:0.0
 EnvGratingComponent.startVal.allowedTypes:[]
-EnvGratingComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+EnvGratingComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b250>>
 EnvGratingComponent.startVal.categ:Basic
 EnvGratingComponent.startVal.allowedVals:[]
 EnvGratingComponent.startVal.readOnly:False
@@ -589,7 +589,7 @@ EnvGratingComponent.size.label:Size [w,h]
 EnvGratingComponent.size.valType:code
 EnvGratingComponent.size.val:(0.5, 0.5)
 EnvGratingComponent.size.allowedTypes:[]
-EnvGratingComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe410>>
+EnvGratingComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b6d0>>
 EnvGratingComponent.size.categ:Basic
 EnvGratingComponent.size.allowedVals:[]
 EnvGratingComponent.size.readOnly:False
@@ -602,7 +602,7 @@ EnvGratingComponent.units.label:Units
 EnvGratingComponent.units.valType:str
 EnvGratingComponent.units.val:from exp settings
 EnvGratingComponent.units.allowedTypes:[]
-EnvGratingComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe050>>
+EnvGratingComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b1d0>>
 EnvGratingComponent.units.categ:Basic
 EnvGratingComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 EnvGratingComponent.units.readOnly:False
@@ -615,7 +615,7 @@ EnvGratingComponent.contrast.label:Carrier contrast
 EnvGratingComponent.contrast.valType:code
 EnvGratingComponent.contrast.val:0.5
 EnvGratingComponent.contrast.allowedTypes:[]
-EnvGratingComponent.contrast.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe510>>
+EnvGratingComponent.contrast.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b7d0>>
 EnvGratingComponent.contrast.categ:Carrier
 EnvGratingComponent.contrast.allowedVals:[]
 EnvGratingComponent.contrast.readOnly:False
@@ -628,7 +628,7 @@ EnvGratingComponent.opacity.label:Opacity
 EnvGratingComponent.opacity.valType:code
 EnvGratingComponent.opacity.val:1
 EnvGratingComponent.opacity.allowedTypes:[]
-EnvGratingComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe350>>
+EnvGratingComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b610>>
 EnvGratingComponent.opacity.categ:Basic
 EnvGratingComponent.opacity.allowedVals:[]
 EnvGratingComponent.opacity.readOnly:False
@@ -641,7 +641,7 @@ EnvGratingComponent.moddepth.label:Envelope modulation depth
 EnvGratingComponent.moddepth.valType:code
 EnvGratingComponent.moddepth.val:1.0
 EnvGratingComponent.moddepth.allowedTypes:[]
-EnvGratingComponent.moddepth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe750>>
+EnvGratingComponent.moddepth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba10>>
 EnvGratingComponent.moddepth.categ:Envelope
 EnvGratingComponent.moddepth.allowedVals:[]
 EnvGratingComponent.moddepth.readOnly:False
@@ -654,7 +654,7 @@ EnvGratingComponent.beat.label:Is modulation a beat
 EnvGratingComponent.beat.valType:str
 EnvGratingComponent.beat.val:False
 EnvGratingComponent.beat.allowedTypes:[]
-EnvGratingComponent.beat.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe790>>
+EnvGratingComponent.beat.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba50>>
 EnvGratingComponent.beat.categ:Envelope
 EnvGratingComponent.beat.allowedVals:[]
 EnvGratingComponent.beat.readOnly:False
@@ -667,7 +667,7 @@ EnvGratingComponent.envori.label:Envelope orientation
 EnvGratingComponent.envori.valType:code
 EnvGratingComponent.envori.val:0.0
 EnvGratingComponent.envori.allowedTypes:[]
-EnvGratingComponent.envori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe710>>
+EnvGratingComponent.envori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 EnvGratingComponent.envori.categ:Envelope
 EnvGratingComponent.envori.allowedVals:[]
 EnvGratingComponent.envori.readOnly:False
@@ -680,7 +680,7 @@ EnvGratingComponent.stopVal.label:Stop
 EnvGratingComponent.stopVal.valType:code
 EnvGratingComponent.stopVal.val:1.0
 EnvGratingComponent.stopVal.allowedTypes:[]
-EnvGratingComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+EnvGratingComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 EnvGratingComponent.stopVal.categ:Basic
 EnvGratingComponent.stopVal.allowedVals:[]
 EnvGratingComponent.stopVal.readOnly:False
@@ -693,7 +693,7 @@ EnvGratingComponent.durationEstim.label:Expected duration (s)
 EnvGratingComponent.durationEstim.valType:code
 EnvGratingComponent.durationEstim.val:
 EnvGratingComponent.durationEstim.allowedTypes:[]
-EnvGratingComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+EnvGratingComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 EnvGratingComponent.durationEstim.categ:Basic
 EnvGratingComponent.durationEstim.allowedVals:[]
 EnvGratingComponent.durationEstim.readOnly:False
@@ -706,7 +706,7 @@ EnvGratingComponent.envelope.label:Envelope texture
 EnvGratingComponent.envelope.valType:str
 EnvGratingComponent.envelope.val:sin
 EnvGratingComponent.envelope.allowedTypes:[]
-EnvGratingComponent.envelope.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe650>>
+EnvGratingComponent.envelope.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b910>>
 EnvGratingComponent.envelope.categ:Envelope
 EnvGratingComponent.envelope.allowedVals:[]
 EnvGratingComponent.envelope.readOnly:False
@@ -719,7 +719,7 @@ EnvGratingComponent.interpolate.label:Interpolate
 EnvGratingComponent.interpolate.valType:str
 EnvGratingComponent.interpolate.val:linear
 EnvGratingComponent.interpolate.allowedTypes:[]
-EnvGratingComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe610>>
+EnvGratingComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b8d0>>
 EnvGratingComponent.interpolate.categ:Carrier
 EnvGratingComponent.interpolate.allowedVals:['linear', 'nearest']
 EnvGratingComponent.interpolate.readOnly:False
@@ -732,7 +732,7 @@ EnvGratingComponent.startEstim.label:Expected start (s)
 EnvGratingComponent.startEstim.valType:code
 EnvGratingComponent.startEstim.val:
 EnvGratingComponent.startEstim.allowedTypes:[]
-EnvGratingComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+EnvGratingComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b0d0>>
 EnvGratingComponent.startEstim.categ:Basic
 EnvGratingComponent.startEstim.allowedVals:[]
 EnvGratingComponent.startEstim.readOnly:False
@@ -745,7 +745,7 @@ EnvGratingComponent.startType.label:start type
 EnvGratingComponent.startType.valType:str
 EnvGratingComponent.startType.val:time (s)
 EnvGratingComponent.startType.allowedTypes:[]
-EnvGratingComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+EnvGratingComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b310>>
 EnvGratingComponent.startType.categ:Basic
 EnvGratingComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 EnvGratingComponent.startType.readOnly:False
@@ -758,7 +758,7 @@ EnvGratingComponent.ori.label:Carrier Orientation
 EnvGratingComponent.ori.valType:code
 EnvGratingComponent.ori.val:0
 EnvGratingComponent.ori.allowedTypes:[]
-EnvGratingComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe490>>
+EnvGratingComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 EnvGratingComponent.ori.categ:Carrier
 EnvGratingComponent.ori.allowedVals:[]
 EnvGratingComponent.ori.readOnly:False
@@ -771,7 +771,7 @@ EnvGratingComponent.phase.label:Carrier phase (in cycles)
 EnvGratingComponent.phase.valType:code
 EnvGratingComponent.phase.val:0.0
 EnvGratingComponent.phase.allowedTypes:[]
-EnvGratingComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe590>>
+EnvGratingComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 EnvGratingComponent.phase.categ:Carrier
 EnvGratingComponent.phase.allowedVals:[]
 EnvGratingComponent.phase.readOnly:False
@@ -784,7 +784,7 @@ EnvGratingComponent.texture resolution.label:Texture resolution
 EnvGratingComponent.texture resolution.valType:code
 EnvGratingComponent.texture resolution.val:128
 EnvGratingComponent.texture resolution.allowedTypes:[]
-EnvGratingComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe5d0>>
+EnvGratingComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 EnvGratingComponent.texture resolution.categ:Carrier
 EnvGratingComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 EnvGratingComponent.texture resolution.readOnly:False
@@ -797,7 +797,7 @@ EnvGratingComponent.name.label:Name
 EnvGratingComponent.name.valType:code
 EnvGratingComponent.name.val:env_grating
 EnvGratingComponent.name.allowedTypes:[]
-EnvGratingComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+EnvGratingComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b290>>
 EnvGratingComponent.name.categ:Basic
 EnvGratingComponent.name.allowedVals:[]
 EnvGratingComponent.name.readOnly:False
@@ -809,7 +809,7 @@ EnvGratingComponent.envphase.label:Envelope phase
 EnvGratingComponent.envphase.valType:code
 EnvGratingComponent.envphase.val:0.0
 EnvGratingComponent.envphase.allowedTypes:[]
-EnvGratingComponent.envphase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe6d0>>
+EnvGratingComponent.envphase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b990>>
 EnvGratingComponent.envphase.categ:Envelope
 EnvGratingComponent.envphase.allowedVals:[]
 EnvGratingComponent.envphase.readOnly:False
@@ -822,7 +822,7 @@ EnvGratingComponent.envsf.label:Envelope spatial frequency
 EnvGratingComponent.envsf.valType:code
 EnvGratingComponent.envsf.val:1.0
 EnvGratingComponent.envsf.allowedTypes:[]
-EnvGratingComponent.envsf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe690>>
+EnvGratingComponent.envsf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b950>>
 EnvGratingComponent.envsf.categ:Envelope
 EnvGratingComponent.envsf.allowedVals:[]
 EnvGratingComponent.envsf.readOnly:False
@@ -835,7 +835,7 @@ EnvGratingComponent.mask.label:Mask
 EnvGratingComponent.mask.valType:str
 EnvGratingComponent.mask.val:None
 EnvGratingComponent.mask.allowedTypes:[]
-EnvGratingComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe4d0>>
+EnvGratingComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 EnvGratingComponent.mask.categ:Carrier
 EnvGratingComponent.mask.allowedVals:[]
 EnvGratingComponent.mask.readOnly:False
@@ -848,7 +848,7 @@ EnvGratingComponent.carrier.label:Carrier texture
 EnvGratingComponent.carrier.valType:str
 EnvGratingComponent.carrier.val:sin
 EnvGratingComponent.carrier.allowedTypes:[]
-EnvGratingComponent.carrier.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe450>>
+EnvGratingComponent.carrier.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 EnvGratingComponent.carrier.categ:Carrier
 EnvGratingComponent.carrier.allowedVals:[]
 EnvGratingComponent.carrier.readOnly:False
@@ -861,7 +861,7 @@ EnvGratingComponent.sf.label:Carrier spatial frequency
 EnvGratingComponent.sf.valType:code
 EnvGratingComponent.sf.val:1.0
 EnvGratingComponent.sf.allowedTypes:[]
-EnvGratingComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe550>>
+EnvGratingComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 EnvGratingComponent.sf.categ:Carrier
 EnvGratingComponent.sf.allowedVals:[]
 EnvGratingComponent.sf.readOnly:False
@@ -875,7 +875,7 @@ GratingComponent.opacity.label:Opacity
 GratingComponent.opacity.valType:code
 GratingComponent.opacity.val:1
 GratingComponent.opacity.allowedTypes:[]
-GratingComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+GratingComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 GratingComponent.opacity.categ:Basic
 GratingComponent.opacity.allowedVals:[]
 GratingComponent.opacity.readOnly:False
@@ -888,7 +888,7 @@ GratingComponent.tex.label:Texture
 GratingComponent.tex.valType:str
 GratingComponent.tex.val:sin
 GratingComponent.tex.allowedTypes:[]
-GratingComponent.tex.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe110>>
+GratingComponent.tex.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b150>>
 GratingComponent.tex.categ:Advanced
 GratingComponent.tex.allowedVals:[]
 GratingComponent.tex.readOnly:False
@@ -901,7 +901,7 @@ GratingComponent.colorSpace.label:Color space
 GratingComponent.colorSpace.valType:str
 GratingComponent.colorSpace.val:rgb
 GratingComponent.colorSpace.allowedTypes:[]
-GratingComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+GratingComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b190>>
 GratingComponent.colorSpace.categ:Basic
 GratingComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 GratingComponent.colorSpace.readOnly:False
@@ -914,7 +914,7 @@ GratingComponent.blendmode.label:OpenGL blend mode
 GratingComponent.blendmode.valType:str
 GratingComponent.blendmode.val:avg
 GratingComponent.blendmode.allowedTypes:[]
-GratingComponent.blendmode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe150>>
+GratingComponent.blendmode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b4d0>>
 GratingComponent.blendmode.categ:Basic
 GratingComponent.blendmode.allowedVals:['avg', 'add']
 GratingComponent.blendmode.readOnly:False
@@ -927,7 +927,7 @@ GratingComponent.name.label:Name
 GratingComponent.name.valType:code
 GratingComponent.name.val:grating
 GratingComponent.name.allowedTypes:[]
-GratingComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+GratingComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 GratingComponent.name.categ:Basic
 GratingComponent.name.allowedVals:[]
 GratingComponent.name.readOnly:False
@@ -939,7 +939,7 @@ GratingComponent.color.label:Color
 GratingComponent.color.valType:str
 GratingComponent.color.val:$[1,1,1]
 GratingComponent.color.allowedTypes:[]
-GratingComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+GratingComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 GratingComponent.color.categ:Basic
 GratingComponent.color.allowedVals:[]
 GratingComponent.color.readOnly:False
@@ -952,7 +952,7 @@ GratingComponent.stopVal.label:Stop
 GratingComponent.stopVal.valType:code
 GratingComponent.stopVal.val:1.0
 GratingComponent.stopVal.allowedTypes:[]
-GratingComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+GratingComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312ed0>>
 GratingComponent.stopVal.categ:Basic
 GratingComponent.stopVal.allowedVals:[]
 GratingComponent.stopVal.readOnly:False
@@ -965,7 +965,7 @@ GratingComponent.durationEstim.label:Expected duration (s)
 GratingComponent.durationEstim.valType:code
 GratingComponent.durationEstim.val:
 GratingComponent.durationEstim.allowedTypes:[]
-GratingComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+GratingComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 GratingComponent.durationEstim.categ:Basic
 GratingComponent.durationEstim.allowedVals:[]
 GratingComponent.durationEstim.readOnly:False
@@ -978,7 +978,7 @@ GratingComponent.mask.label:Mask
 GratingComponent.mask.valType:str
 GratingComponent.mask.val:None
 GratingComponent.mask.allowedTypes:[]
-GratingComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe190>>
+GratingComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b390>>
 GratingComponent.mask.categ:Advanced
 GratingComponent.mask.allowedVals:[]
 GratingComponent.mask.readOnly:False
@@ -991,7 +991,7 @@ GratingComponent.pos.label:Position [x,y]
 GratingComponent.pos.valType:code
 GratingComponent.pos.val:(0, 0)
 GratingComponent.pos.allowedTypes:[]
-GratingComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+GratingComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b3d0>>
 GratingComponent.pos.categ:Basic
 GratingComponent.pos.allowedVals:[]
 GratingComponent.pos.readOnly:False
@@ -1004,7 +1004,7 @@ GratingComponent.interpolate.label:Interpolate
 GratingComponent.interpolate.valType:str
 GratingComponent.interpolate.val:linear
 GratingComponent.interpolate.allowedTypes:[]
-GratingComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe1d0>>
+GratingComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b410>>
 GratingComponent.interpolate.categ:Advanced
 GratingComponent.interpolate.allowedVals:['linear', 'nearest']
 GratingComponent.interpolate.readOnly:False
@@ -1017,7 +1017,7 @@ GratingComponent.startEstim.label:Expected start (s)
 GratingComponent.startEstim.valType:code
 GratingComponent.startEstim.val:
 GratingComponent.startEstim.allowedTypes:[]
-GratingComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+GratingComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 GratingComponent.startEstim.categ:Basic
 GratingComponent.startEstim.allowedVals:[]
 GratingComponent.startEstim.readOnly:False
@@ -1030,7 +1030,7 @@ GratingComponent.units.label:Units
 GratingComponent.units.valType:str
 GratingComponent.units.val:from exp settings
 GratingComponent.units.allowedTypes:[]
-GratingComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c50>>
+GratingComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 GratingComponent.units.categ:Basic
 GratingComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 GratingComponent.units.readOnly:False
@@ -1043,7 +1043,7 @@ GratingComponent.texture resolution.label:Texture resolution
 GratingComponent.texture resolution.valType:code
 GratingComponent.texture resolution.val:128
 GratingComponent.texture resolution.allowedTypes:[]
-GratingComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe250>>
+GratingComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b490>>
 GratingComponent.texture resolution.categ:Advanced
 GratingComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 GratingComponent.texture resolution.readOnly:False
@@ -1056,7 +1056,7 @@ GratingComponent.phase.label:Phase (in cycles)
 GratingComponent.phase.valType:code
 GratingComponent.phase.val:0.0
 GratingComponent.phase.allowedTypes:[]
-GratingComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe0d0>>
+GratingComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 GratingComponent.phase.categ:Advanced
 GratingComponent.phase.allowedVals:[]
 GratingComponent.phase.readOnly:False
@@ -1069,7 +1069,7 @@ GratingComponent.startType.label:start type
 GratingComponent.startType.valType:str
 GratingComponent.startType.val:time (s)
 GratingComponent.startType.allowedTypes:[]
-GratingComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+GratingComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 GratingComponent.startType.categ:Basic
 GratingComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 GratingComponent.startType.readOnly:False
@@ -1082,7 +1082,7 @@ GratingComponent.ori.label:Orientation
 GratingComponent.ori.valType:code
 GratingComponent.ori.val:0
 GratingComponent.ori.allowedTypes:[]
-GratingComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+GratingComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 GratingComponent.ori.categ:Basic
 GratingComponent.ori.allowedVals:[]
 GratingComponent.ori.readOnly:False
@@ -1095,7 +1095,7 @@ GratingComponent.stopType.label:stop type
 GratingComponent.stopType.valType:str
 GratingComponent.stopType.val:duration (s)
 GratingComponent.stopType.allowedTypes:[]
-GratingComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+GratingComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 GratingComponent.stopType.categ:Basic
 GratingComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 GratingComponent.stopType.readOnly:False
@@ -1108,7 +1108,7 @@ GratingComponent.startVal.label:Start
 GratingComponent.startVal.valType:code
 GratingComponent.startVal.val:0.0
 GratingComponent.startVal.allowedTypes:[]
-GratingComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+GratingComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 GratingComponent.startVal.categ:Basic
 GratingComponent.startVal.allowedVals:[]
 GratingComponent.startVal.readOnly:False
@@ -1121,7 +1121,7 @@ GratingComponent.sf.label:Spatial frequency
 GratingComponent.sf.valType:code
 GratingComponent.sf.val:None
 GratingComponent.sf.allowedTypes:[]
-GratingComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe290>>
+GratingComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 GratingComponent.sf.categ:Advanced
 GratingComponent.sf.allowedVals:[]
 GratingComponent.sf.readOnly:False
@@ -1134,7 +1134,7 @@ GratingComponent.size.label:Size [w,h]
 GratingComponent.size.valType:code
 GratingComponent.size.val:(0.5, 0.5)
 GratingComponent.size.allowedTypes:[]
-GratingComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+GratingComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
 GratingComponent.size.categ:Basic
 GratingComponent.size.allowedVals:[]
 GratingComponent.size.readOnly:False
@@ -1148,7 +1148,7 @@ ImageComponent.opacity.label:Opacity
 ImageComponent.opacity.valType:code
 ImageComponent.opacity.val:1
 ImageComponent.opacity.allowedTypes:[]
-ImageComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe4d0>>
+ImageComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b310>>
 ImageComponent.opacity.categ:Basic
 ImageComponent.opacity.allowedVals:[]
 ImageComponent.opacity.readOnly:False
@@ -1161,7 +1161,7 @@ ImageComponent.flipVert.label:Flip vertically
 ImageComponent.flipVert.valType:bool
 ImageComponent.flipVert.val:False
 ImageComponent.flipVert.allowedTypes:[]
-ImageComponent.flipVert.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe790>>
+ImageComponent.flipVert.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b610>>
 ImageComponent.flipVert.categ:Advanced
 ImageComponent.flipVert.allowedVals:[]
 ImageComponent.flipVert.readOnly:False
@@ -1174,7 +1174,7 @@ ImageComponent.colorSpace.label:Color space
 ImageComponent.colorSpace.valType:str
 ImageComponent.colorSpace.val:rgb
 ImageComponent.colorSpace.allowedTypes:[]
-ImageComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe690>>
+ImageComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b0d0>>
 ImageComponent.colorSpace.categ:Advanced
 ImageComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 ImageComponent.colorSpace.readOnly:False
@@ -1187,7 +1187,7 @@ ImageComponent.flipHoriz.label:Flip horizontally
 ImageComponent.flipHoriz.valType:bool
 ImageComponent.flipHoriz.val:False
 ImageComponent.flipHoriz.allowedTypes:[]
-ImageComponent.flipHoriz.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe750>>
+ImageComponent.flipHoriz.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b7d0>>
 ImageComponent.flipHoriz.categ:Advanced
 ImageComponent.flipHoriz.allowedVals:[]
 ImageComponent.flipHoriz.readOnly:False
@@ -1200,7 +1200,7 @@ ImageComponent.name.label:Name
 ImageComponent.name.valType:code
 ImageComponent.name.val:image
 ImageComponent.name.allowedTypes:[]
-ImageComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+ImageComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 ImageComponent.name.categ:Basic
 ImageComponent.name.allowedVals:[]
 ImageComponent.name.readOnly:False
@@ -1212,7 +1212,7 @@ ImageComponent.color.label:Color
 ImageComponent.color.valType:str
 ImageComponent.color.val:$[1,1,1]
 ImageComponent.color.allowedTypes:[]
-ImageComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe450>>
+ImageComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 ImageComponent.color.categ:Advanced
 ImageComponent.color.allowedVals:[]
 ImageComponent.color.readOnly:False
@@ -1225,7 +1225,7 @@ ImageComponent.stopVal.label:Stop
 ImageComponent.stopVal.valType:code
 ImageComponent.stopVal.val:1.0
 ImageComponent.stopVal.allowedTypes:[]
-ImageComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+ImageComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b990>>
 ImageComponent.stopVal.categ:Basic
 ImageComponent.stopVal.allowedVals:[]
 ImageComponent.stopVal.readOnly:False
@@ -1238,7 +1238,7 @@ ImageComponent.durationEstim.label:Expected duration (s)
 ImageComponent.durationEstim.valType:code
 ImageComponent.durationEstim.val:
 ImageComponent.durationEstim.allowedTypes:[]
-ImageComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+ImageComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 ImageComponent.durationEstim.categ:Basic
 ImageComponent.durationEstim.allowedVals:[]
 ImageComponent.durationEstim.readOnly:False
@@ -1251,7 +1251,7 @@ ImageComponent.mask.label:Mask
 ImageComponent.mask.valType:str
 ImageComponent.mask.val:None
 ImageComponent.mask.allowedTypes:[]
-ImageComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe610>>
+ImageComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 ImageComponent.mask.categ:Advanced
 ImageComponent.mask.allowedVals:[]
 ImageComponent.mask.readOnly:False
@@ -1264,7 +1264,7 @@ ImageComponent.pos.label:Position [x,y]
 ImageComponent.pos.valType:code
 ImageComponent.pos.val:(0, 0)
 ImageComponent.pos.allowedTypes:[]
-ImageComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe6d0>>
+ImageComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b8d0>>
 ImageComponent.pos.categ:Basic
 ImageComponent.pos.allowedVals:[]
 ImageComponent.pos.readOnly:False
@@ -1277,7 +1277,7 @@ ImageComponent.interpolate.label:Interpolate
 ImageComponent.interpolate.valType:str
 ImageComponent.interpolate.val:linear
 ImageComponent.interpolate.allowedTypes:[]
-ImageComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe710>>
+ImageComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba10>>
 ImageComponent.interpolate.categ:Advanced
 ImageComponent.interpolate.allowedVals:['linear', 'nearest']
 ImageComponent.interpolate.readOnly:False
@@ -1290,7 +1290,7 @@ ImageComponent.startEstim.label:Expected start (s)
 ImageComponent.startEstim.valType:code
 ImageComponent.startEstim.val:
 ImageComponent.startEstim.allowedTypes:[]
-ImageComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+ImageComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b290>>
 ImageComponent.startEstim.categ:Basic
 ImageComponent.startEstim.allowedVals:[]
 ImageComponent.startEstim.readOnly:False
@@ -1303,7 +1303,7 @@ ImageComponent.units.label:Units
 ImageComponent.units.valType:str
 ImageComponent.units.val:from exp settings
 ImageComponent.units.allowedTypes:[]
-ImageComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe550>>
+ImageComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 ImageComponent.units.categ:Basic
 ImageComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 ImageComponent.units.readOnly:False
@@ -1316,7 +1316,7 @@ ImageComponent.texture resolution.label:Texture resolution
 ImageComponent.texture resolution.valType:code
 ImageComponent.texture resolution.val:128
 ImageComponent.texture resolution.allowedTypes:[]
-ImageComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe650>>
+ImageComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba50>>
 ImageComponent.texture resolution.categ:Advanced
 ImageComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 ImageComponent.texture resolution.readOnly:False
@@ -1329,7 +1329,7 @@ ImageComponent.startType.label:start type
 ImageComponent.startType.valType:str
 ImageComponent.startType.val:time (s)
 ImageComponent.startType.allowedTypes:[]
-ImageComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+ImageComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 ImageComponent.startType.categ:Basic
 ImageComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 ImageComponent.startType.readOnly:False
@@ -1342,7 +1342,7 @@ ImageComponent.ori.label:Orientation
 ImageComponent.ori.valType:code
 ImageComponent.ori.val:0
 ImageComponent.ori.allowedTypes:[]
-ImageComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe590>>
+ImageComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 ImageComponent.ori.categ:Basic
 ImageComponent.ori.allowedVals:[]
 ImageComponent.ori.readOnly:False
@@ -1355,7 +1355,7 @@ ImageComponent.stopType.label:stop type
 ImageComponent.stopType.valType:str
 ImageComponent.stopType.val:duration (s)
 ImageComponent.stopType.allowedTypes:[]
-ImageComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+ImageComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 ImageComponent.stopType.categ:Basic
 ImageComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 ImageComponent.stopType.readOnly:False
@@ -1368,7 +1368,7 @@ ImageComponent.startVal.label:Start
 ImageComponent.startVal.valType:code
 ImageComponent.startVal.val:0.0
 ImageComponent.startVal.allowedTypes:[]
-ImageComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+ImageComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b950>>
 ImageComponent.startVal.categ:Basic
 ImageComponent.startVal.allowedVals:[]
 ImageComponent.startVal.readOnly:False
@@ -1381,7 +1381,7 @@ ImageComponent.image.label:Image
 ImageComponent.image.valType:str
 ImageComponent.image.val:
 ImageComponent.image.allowedTypes:[]
-ImageComponent.image.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe490>>
+ImageComponent.image.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 ImageComponent.image.categ:Basic
 ImageComponent.image.allowedVals:[]
 ImageComponent.image.readOnly:False
@@ -1394,7 +1394,7 @@ ImageComponent.size.label:Size [w,h]
 ImageComponent.size.valType:code
 ImageComponent.size.val:(0.5, 0.5)
 ImageComponent.size.allowedTypes:[]
-ImageComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe5d0>>
+ImageComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b910>>
 ImageComponent.size.categ:Basic
 ImageComponent.size.allowedVals:[]
 ImageComponent.size.readOnly:False
@@ -1408,33 +1408,33 @@ KeyboardComponent.correctAns.label:Correct answer
 KeyboardComponent.correctAns.valType:str
 KeyboardComponent.correctAns.val:
 KeyboardComponent.correctAns.allowedTypes:[]
-KeyboardComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+KeyboardComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 KeyboardComponent.correctAns.categ:Basic
 KeyboardComponent.correctAns.allowedVals:[]
 KeyboardComponent.correctAns.readOnly:False
 KeyboardComponent.correctAns.updates:constant
 KeyboardComponent.correctAns.staticUpdater:None
 KeyboardComponent.correctAns.hint:What is the 'correct' key? Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
-KeyboardComponent.correctAns.allowedUpdates:[]
+KeyboardComponent.correctAns.allowedUpdates:None
 KeyboardComponent.storeCorrect.default:False
 KeyboardComponent.storeCorrect.label:Store correct
 KeyboardComponent.storeCorrect.valType:bool
 KeyboardComponent.storeCorrect.val:False
 KeyboardComponent.storeCorrect.allowedTypes:[]
-KeyboardComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+KeyboardComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 KeyboardComponent.storeCorrect.categ:Basic
 KeyboardComponent.storeCorrect.allowedVals:[]
 KeyboardComponent.storeCorrect.readOnly:False
 KeyboardComponent.storeCorrect.updates:constant
 KeyboardComponent.storeCorrect.staticUpdater:None
 KeyboardComponent.storeCorrect.hint:Do you want to save the response as correct/incorrect?
-KeyboardComponent.storeCorrect.allowedUpdates:[]
+KeyboardComponent.storeCorrect.allowedUpdates:None
 KeyboardComponent.name.default:key_resp
 KeyboardComponent.name.label:Name
 KeyboardComponent.name.valType:code
 KeyboardComponent.name.val:key_resp
 KeyboardComponent.name.allowedTypes:[]
-KeyboardComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+KeyboardComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 KeyboardComponent.name.categ:Basic
 KeyboardComponent.name.allowedVals:[]
 KeyboardComponent.name.readOnly:False
@@ -1446,7 +1446,7 @@ KeyboardComponent.stopVal.label:Stop
 KeyboardComponent.stopVal.valType:code
 KeyboardComponent.stopVal.val:
 KeyboardComponent.stopVal.allowedTypes:[]
-KeyboardComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+KeyboardComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 KeyboardComponent.stopVal.categ:Basic
 KeyboardComponent.stopVal.allowedVals:[]
 KeyboardComponent.stopVal.readOnly:False
@@ -1459,7 +1459,7 @@ KeyboardComponent.durationEstim.label:Expected duration (s)
 KeyboardComponent.durationEstim.valType:code
 KeyboardComponent.durationEstim.val:
 KeyboardComponent.durationEstim.allowedTypes:[]
-KeyboardComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+KeyboardComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312ed0>>
 KeyboardComponent.durationEstim.categ:Basic
 KeyboardComponent.durationEstim.allowedVals:[]
 KeyboardComponent.durationEstim.readOnly:False
@@ -1472,20 +1472,20 @@ KeyboardComponent.forceEndRoutine.label:Force end of Routine
 KeyboardComponent.forceEndRoutine.valType:bool
 KeyboardComponent.forceEndRoutine.val:True
 KeyboardComponent.forceEndRoutine.allowedTypes:[]
-KeyboardComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+KeyboardComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
 KeyboardComponent.forceEndRoutine.categ:Basic
 KeyboardComponent.forceEndRoutine.allowedVals:[]
 KeyboardComponent.forceEndRoutine.readOnly:False
 KeyboardComponent.forceEndRoutine.updates:constant
 KeyboardComponent.forceEndRoutine.staticUpdater:None
 KeyboardComponent.forceEndRoutine.hint:Should a response force the end of the Routine (e.g end the trial)?
-KeyboardComponent.forceEndRoutine.allowedUpdates:[]
+KeyboardComponent.forceEndRoutine.allowedUpdates:None
 KeyboardComponent.startEstim.default:
 KeyboardComponent.startEstim.label:Expected start (s)
 KeyboardComponent.startEstim.valType:code
 KeyboardComponent.startEstim.val:
 KeyboardComponent.startEstim.allowedTypes:[]
-KeyboardComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c50>>
+KeyboardComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 KeyboardComponent.startEstim.categ:Basic
 KeyboardComponent.startEstim.allowedVals:[]
 KeyboardComponent.startEstim.readOnly:False
@@ -1498,20 +1498,20 @@ KeyboardComponent.discard previous.label:Discard previous
 KeyboardComponent.discard previous.valType:bool
 KeyboardComponent.discard previous.val:True
 KeyboardComponent.discard previous.allowedTypes:[]
-KeyboardComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+KeyboardComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 KeyboardComponent.discard previous.categ:Basic
 KeyboardComponent.discard previous.allowedVals:[]
 KeyboardComponent.discard previous.readOnly:False
 KeyboardComponent.discard previous.updates:constant
 KeyboardComponent.discard previous.staticUpdater:None
 KeyboardComponent.discard previous.hint:Do you want to discard all responses occuring before the onset of this component?
-KeyboardComponent.discard previous.allowedUpdates:[]
+KeyboardComponent.discard previous.allowedUpdates:None
 KeyboardComponent.startType.default:'time (s)'
 KeyboardComponent.startType.label:start type
 KeyboardComponent.startType.valType:str
 KeyboardComponent.startType.val:time (s)
 KeyboardComponent.startType.allowedTypes:[]
-KeyboardComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+KeyboardComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 KeyboardComponent.startType.categ:Basic
 KeyboardComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 KeyboardComponent.startType.readOnly:False
@@ -1524,7 +1524,7 @@ KeyboardComponent.allowedKeys.label:Allowed keys
 KeyboardComponent.allowedKeys.valType:code
 KeyboardComponent.allowedKeys.val:'y','n','left','right','space'
 KeyboardComponent.allowedKeys.allowedTypes:[]
-KeyboardComponent.allowedKeys.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+KeyboardComponent.allowedKeys.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 KeyboardComponent.allowedKeys.categ:Basic
 KeyboardComponent.allowedKeys.allowedVals:[]
 KeyboardComponent.allowedKeys.readOnly:False
@@ -1537,7 +1537,7 @@ KeyboardComponent.stopType.label:stop type
 KeyboardComponent.stopType.valType:str
 KeyboardComponent.stopType.val:duration (s)
 KeyboardComponent.stopType.allowedTypes:[]
-KeyboardComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+KeyboardComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 KeyboardComponent.stopType.categ:Basic
 KeyboardComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 KeyboardComponent.stopType.readOnly:False
@@ -1550,7 +1550,7 @@ KeyboardComponent.startVal.label:Start
 KeyboardComponent.startVal.valType:code
 KeyboardComponent.startVal.val:0.0
 KeyboardComponent.startVal.allowedTypes:[]
-KeyboardComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+KeyboardComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 KeyboardComponent.startVal.categ:Basic
 KeyboardComponent.startVal.allowedVals:[]
 KeyboardComponent.startVal.readOnly:False
@@ -1563,34 +1563,34 @@ KeyboardComponent.store.label:Store
 KeyboardComponent.store.valType:str
 KeyboardComponent.store.val:last key
 KeyboardComponent.store.allowedTypes:[]
-KeyboardComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+KeyboardComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 KeyboardComponent.store.categ:Basic
 KeyboardComponent.store.allowedVals:['last key', 'first key', 'all keys', 'nothing']
 KeyboardComponent.store.readOnly:False
 KeyboardComponent.store.updates:constant
 KeyboardComponent.store.staticUpdater:None
 KeyboardComponent.store.hint:Choose which (if any) responses to store at the end of a trial
-KeyboardComponent.store.allowedUpdates:[]
+KeyboardComponent.store.allowedUpdates:None
 KeyboardComponent.syncScreenRefresh.default:True
 KeyboardComponent.syncScreenRefresh.label:sync RT with screen
 KeyboardComponent.syncScreenRefresh.valType:bool
 KeyboardComponent.syncScreenRefresh.val:True
 KeyboardComponent.syncScreenRefresh.allowedTypes:[]
-KeyboardComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+KeyboardComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 KeyboardComponent.syncScreenRefresh.categ:Basic
 KeyboardComponent.syncScreenRefresh.allowedVals:[]
 KeyboardComponent.syncScreenRefresh.readOnly:False
 KeyboardComponent.syncScreenRefresh.updates:constant
 KeyboardComponent.syncScreenRefresh.staticUpdater:None
 KeyboardComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
-KeyboardComponent.syncScreenRefresh.allowedUpdates:[]
+KeyboardComponent.syncScreenRefresh.allowedUpdates:None
 MicrophoneComponent.order:['name']
 MicrophoneComponent.stereo.default:False
 MicrophoneComponent.stereo.label:Stereo
 MicrophoneComponent.stereo.valType:bool
 MicrophoneComponent.stereo.val:False
 MicrophoneComponent.stereo.allowedTypes:[]
-MicrophoneComponent.stereo.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd050>>
+MicrophoneComponent.stereo.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 MicrophoneComponent.stereo.categ:Basic
 MicrophoneComponent.stereo.allowedVals:[]
 MicrophoneComponent.stereo.readOnly:False
@@ -1603,7 +1603,7 @@ MicrophoneComponent.name.label:Name
 MicrophoneComponent.name.valType:code
 MicrophoneComponent.name.val:mic_1
 MicrophoneComponent.name.allowedTypes:[]
-MicrophoneComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+MicrophoneComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b910>>
 MicrophoneComponent.name.categ:Basic
 MicrophoneComponent.name.allowedVals:[]
 MicrophoneComponent.name.readOnly:False
@@ -1615,7 +1615,7 @@ MicrophoneComponent.stopVal.label:Stop
 MicrophoneComponent.stopVal.valType:code
 MicrophoneComponent.stopVal.val:2.0
 MicrophoneComponent.stopVal.allowedTypes:[]
-MicrophoneComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+MicrophoneComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 MicrophoneComponent.stopVal.categ:Basic
 MicrophoneComponent.stopVal.allowedVals:[]
 MicrophoneComponent.stopVal.readOnly:False
@@ -1628,7 +1628,7 @@ MicrophoneComponent.durationEstim.label:Expected duration (s)
 MicrophoneComponent.durationEstim.valType:code
 MicrophoneComponent.durationEstim.val:
 MicrophoneComponent.durationEstim.allowedTypes:[]
-MicrophoneComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+MicrophoneComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba50>>
 MicrophoneComponent.durationEstim.categ:Basic
 MicrophoneComponent.durationEstim.allowedVals:[]
 MicrophoneComponent.durationEstim.readOnly:False
@@ -1641,7 +1641,7 @@ MicrophoneComponent.startEstim.label:Expected start (s)
 MicrophoneComponent.startEstim.valType:code
 MicrophoneComponent.startEstim.val:
 MicrophoneComponent.startEstim.allowedTypes:[]
-MicrophoneComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+MicrophoneComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 MicrophoneComponent.startEstim.categ:Basic
 MicrophoneComponent.startEstim.allowedVals:[]
 MicrophoneComponent.startEstim.readOnly:False
@@ -1654,7 +1654,7 @@ MicrophoneComponent.startType.label:start type
 MicrophoneComponent.startType.valType:str
 MicrophoneComponent.startType.val:time (s)
 MicrophoneComponent.startType.allowedTypes:[]
-MicrophoneComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+MicrophoneComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 MicrophoneComponent.startType.categ:Basic
 MicrophoneComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 MicrophoneComponent.startType.readOnly:False
@@ -1667,7 +1667,7 @@ MicrophoneComponent.stopType.label:stop type
 MicrophoneComponent.stopType.valType:str
 MicrophoneComponent.stopType.val:duration (s)
 MicrophoneComponent.stopType.allowedTypes:[]
-MicrophoneComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+MicrophoneComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b950>>
 MicrophoneComponent.stopType.categ:Basic
 MicrophoneComponent.stopType.allowedVals:['duration (s)']
 MicrophoneComponent.stopType.readOnly:False
@@ -1680,7 +1680,7 @@ MicrophoneComponent.startVal.label:Start
 MicrophoneComponent.startVal.valType:code
 MicrophoneComponent.startVal.val:0.0
 MicrophoneComponent.startVal.allowedTypes:[]
-MicrophoneComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+MicrophoneComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 MicrophoneComponent.startVal.categ:Basic
 MicrophoneComponent.startVal.allowedVals:[]
 MicrophoneComponent.startVal.readOnly:False
@@ -1688,13 +1688,13 @@ MicrophoneComponent.startVal.updates:None
 MicrophoneComponent.startVal.staticUpdater:None
 MicrophoneComponent.startVal.hint:When does the component start?
 MicrophoneComponent.startVal.allowedUpdates:None
-MouseComponent.order:['name']
+MouseComponent.order:['name', 'forceEndRoutineOnPress', 'saveMouseState', 'timeRelativeTo', 'newClicksOnly', 'clickable', 'saveParamsClickable']
 MouseComponent.name.default:mouse
 MouseComponent.name.label:Name
 MouseComponent.name.valType:code
 MouseComponent.name.val:mouse
 MouseComponent.name.allowedTypes:[]
-MouseComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+MouseComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 MouseComponent.name.categ:Basic
 MouseComponent.name.allowedVals:[]
 MouseComponent.name.readOnly:False
@@ -1706,20 +1706,20 @@ MouseComponent.timeRelativeTo.label:Time relative to
 MouseComponent.timeRelativeTo.valType:str
 MouseComponent.timeRelativeTo.val:routine
 MouseComponent.timeRelativeTo.allowedTypes:[]
-MouseComponent.timeRelativeTo.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+MouseComponent.timeRelativeTo.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 MouseComponent.timeRelativeTo.categ:Basic
 MouseComponent.timeRelativeTo.allowedVals:['experiment', 'routine']
 MouseComponent.timeRelativeTo.readOnly:False
 MouseComponent.timeRelativeTo.updates:constant
 MouseComponent.timeRelativeTo.staticUpdater:None
 MouseComponent.timeRelativeTo.hint:What should the values of mouse.time should be relative to?
-MouseComponent.timeRelativeTo.allowedUpdates:[]
+MouseComponent.timeRelativeTo.allowedUpdates:None
 MouseComponent.stopVal.default:1.0
 MouseComponent.stopVal.label:Stop
 MouseComponent.stopVal.valType:code
 MouseComponent.stopVal.val:1.0
 MouseComponent.stopVal.allowedTypes:[]
-MouseComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+MouseComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 MouseComponent.stopVal.categ:Basic
 MouseComponent.stopVal.allowedVals:[]
 MouseComponent.stopVal.readOnly:False
@@ -1732,7 +1732,7 @@ MouseComponent.durationEstim.label:Expected duration (s)
 MouseComponent.durationEstim.valType:code
 MouseComponent.durationEstim.val:
 MouseComponent.durationEstim.allowedTypes:[]
-MouseComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+MouseComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 MouseComponent.durationEstim.categ:Basic
 MouseComponent.durationEstim.allowedVals:[]
 MouseComponent.durationEstim.readOnly:False
@@ -1740,25 +1740,38 @@ MouseComponent.durationEstim.updates:None
 MouseComponent.durationEstim.staticUpdater:None
 MouseComponent.durationEstim.hint:(Optional) expected duration (s), purely for representing in the timeline
 MouseComponent.durationEstim.allowedUpdates:None
-MouseComponent.forceEndRoutineOnPress.default:True
+MouseComponent.forceEndRoutineOnPress.default:'any click'
 MouseComponent.forceEndRoutineOnPress.label:End Routine on press
-MouseComponent.forceEndRoutineOnPress.valType:bool
-MouseComponent.forceEndRoutineOnPress.val:True
+MouseComponent.forceEndRoutineOnPress.valType:str
+MouseComponent.forceEndRoutineOnPress.val:any click
 MouseComponent.forceEndRoutineOnPress.allowedTypes:[]
-MouseComponent.forceEndRoutineOnPress.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+MouseComponent.forceEndRoutineOnPress.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 MouseComponent.forceEndRoutineOnPress.categ:Basic
-MouseComponent.forceEndRoutineOnPress.allowedVals:[]
+MouseComponent.forceEndRoutineOnPress.allowedVals:['never', 'any click', 'valid click']
 MouseComponent.forceEndRoutineOnPress.readOnly:False
 MouseComponent.forceEndRoutineOnPress.updates:constant
 MouseComponent.forceEndRoutineOnPress.staticUpdater:None
 MouseComponent.forceEndRoutineOnPress.hint:Should a button press force the end of the routine (e.g end the trial)?
-MouseComponent.forceEndRoutineOnPress.allowedUpdates:[]
+MouseComponent.forceEndRoutineOnPress.allowedUpdates:None
+MouseComponent.newClicksOnly.default:True
+MouseComponent.newClicksOnly.label:New clicks only
+MouseComponent.newClicksOnly.valType:bool
+MouseComponent.newClicksOnly.val:True
+MouseComponent.newClicksOnly.allowedTypes:[]
+MouseComponent.newClicksOnly.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
+MouseComponent.newClicksOnly.categ:Basic
+MouseComponent.newClicksOnly.allowedVals:[]
+MouseComponent.newClicksOnly.readOnly:False
+MouseComponent.newClicksOnly.updates:constant
+MouseComponent.newClicksOnly.staticUpdater:None
+MouseComponent.newClicksOnly.hint:If the mouse button is already down when we startchecking then wait for it to be released beforerecording as a new click.
+MouseComponent.newClicksOnly.allowedUpdates:None
 MouseComponent.startEstim.default:
 MouseComponent.startEstim.label:Expected start (s)
 MouseComponent.startEstim.valType:code
 MouseComponent.startEstim.val:
 MouseComponent.startEstim.allowedTypes:[]
-MouseComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+MouseComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 MouseComponent.startEstim.categ:Basic
 MouseComponent.startEstim.allowedVals:[]
 MouseComponent.startEstim.readOnly:False
@@ -1771,7 +1784,7 @@ MouseComponent.startType.label:start type
 MouseComponent.startType.valType:str
 MouseComponent.startType.val:time (s)
 MouseComponent.startType.allowedTypes:[]
-MouseComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+MouseComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 MouseComponent.startType.categ:Basic
 MouseComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 MouseComponent.startType.readOnly:False
@@ -1779,12 +1792,25 @@ MouseComponent.startType.updates:None
 MouseComponent.startType.staticUpdater:None
 MouseComponent.startType.hint:How do you want to define your start point?
 MouseComponent.startType.allowedUpdates:None
+MouseComponent.clickable.default:
+MouseComponent.clickable.label:Clickable stimuli
+MouseComponent.clickable.valType:code
+MouseComponent.clickable.val:
+MouseComponent.clickable.allowedTypes:[]
+MouseComponent.clickable.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
+MouseComponent.clickable.categ:Basic
+MouseComponent.clickable.allowedVals:[]
+MouseComponent.clickable.readOnly:False
+MouseComponent.clickable.updates:constant
+MouseComponent.clickable.staticUpdater:None
+MouseComponent.clickable.hint:A comma-separated list of your stimulus names that can be "clicked" by the participant. e.g. target, foil
+MouseComponent.clickable.allowedUpdates:None
 MouseComponent.stopType.default:'duration (s)'
 MouseComponent.stopType.label:stop type
 MouseComponent.stopType.valType:str
 MouseComponent.stopType.val:duration (s)
 MouseComponent.stopType.allowedTypes:[]
-MouseComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+MouseComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 MouseComponent.stopType.categ:Basic
 MouseComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 MouseComponent.stopType.readOnly:False
@@ -1797,7 +1823,7 @@ MouseComponent.startVal.label:Start
 MouseComponent.startVal.valType:code
 MouseComponent.startVal.val:0.0
 MouseComponent.startVal.allowedTypes:[]
-MouseComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+MouseComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 MouseComponent.startVal.categ:Basic
 MouseComponent.startVal.allowedVals:[]
 MouseComponent.startVal.readOnly:False
@@ -1805,12 +1831,25 @@ MouseComponent.startVal.updates:None
 MouseComponent.startVal.staticUpdater:None
 MouseComponent.startVal.hint:When does the component start?
 MouseComponent.startVal.allowedUpdates:None
+MouseComponent.saveParamsClickable.default:name,
+MouseComponent.saveParamsClickable.label:Store params for clicked
+MouseComponent.saveParamsClickable.valType:code
+MouseComponent.saveParamsClickable.val:name,
+MouseComponent.saveParamsClickable.allowedTypes:[]
+MouseComponent.saveParamsClickable.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
+MouseComponent.saveParamsClickable.categ:Basic
+MouseComponent.saveParamsClickable.allowedVals:[]
+MouseComponent.saveParamsClickable.readOnly:False
+MouseComponent.saveParamsClickable.updates:constant
+MouseComponent.saveParamsClickable.staticUpdater:None
+MouseComponent.saveParamsClickable.hint:The params (e.g. name, text), for which you want to store the current value, for the stimulus that was"clicked" by the mouse. Make sure that all the clickable objects have all these params.
+MouseComponent.saveParamsClickable.allowedUpdates:[]
 MouseComponent.saveMouseState.default:'final'
 MouseComponent.saveMouseState.label:Save mouse state
 MouseComponent.saveMouseState.valType:str
 MouseComponent.saveMouseState.val:final
 MouseComponent.saveMouseState.allowedTypes:[]
-MouseComponent.saveMouseState.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c50>>
+MouseComponent.saveMouseState.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312ed0>>
 MouseComponent.saveMouseState.categ:Basic
 MouseComponent.saveMouseState.allowedVals:['final', 'on click', 'every frame', 'never']
 MouseComponent.saveMouseState.readOnly:False
@@ -1824,7 +1863,7 @@ MovieComponent.opacity.label:Opacity
 MovieComponent.opacity.valType:code
 MovieComponent.opacity.val:1
 MovieComponent.opacity.allowedTypes:[]
-MovieComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+MovieComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b290>>
 MovieComponent.opacity.categ:Basic
 MovieComponent.opacity.allowedVals:[]
 MovieComponent.opacity.readOnly:False
@@ -1837,7 +1876,7 @@ MovieComponent.name.label:Name
 MovieComponent.name.valType:code
 MovieComponent.name.val:movie
 MovieComponent.name.allowedTypes:[]
-MovieComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+MovieComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b950>>
 MovieComponent.name.categ:Basic
 MovieComponent.name.allowedVals:[]
 MovieComponent.name.readOnly:False
@@ -1849,7 +1888,7 @@ MovieComponent.movie.label:Movie file
 MovieComponent.movie.valType:str
 MovieComponent.movie.val:
 MovieComponent.movie.allowedTypes:[]
-MovieComponent.movie.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe110>>
+MovieComponent.movie.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b990>>
 MovieComponent.movie.categ:Basic
 MovieComponent.movie.allowedVals:[]
 MovieComponent.movie.readOnly:False
@@ -1862,7 +1901,7 @@ MovieComponent.stopVal.label:Stop
 MovieComponent.stopVal.valType:code
 MovieComponent.stopVal.val:1.0
 MovieComponent.stopVal.allowedTypes:[]
-MovieComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+MovieComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba50>>
 MovieComponent.stopVal.categ:Basic
 MovieComponent.stopVal.allowedVals:[]
 MovieComponent.stopVal.readOnly:False
@@ -1875,7 +1914,7 @@ MovieComponent.durationEstim.label:Expected duration (s)
 MovieComponent.durationEstim.valType:code
 MovieComponent.durationEstim.val:
 MovieComponent.durationEstim.allowedTypes:[]
-MovieComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+MovieComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b910>>
 MovieComponent.durationEstim.categ:Basic
 MovieComponent.durationEstim.allowedVals:[]
 MovieComponent.durationEstim.readOnly:False
@@ -1888,7 +1927,7 @@ MovieComponent.pos.label:Position [x,y]
 MovieComponent.pos.valType:code
 MovieComponent.pos.val:(0, 0)
 MovieComponent.pos.allowedTypes:[]
-MovieComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe050>>
+MovieComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b8d0>>
 MovieComponent.pos.categ:Basic
 MovieComponent.pos.allowedVals:[]
 MovieComponent.pos.readOnly:False
@@ -1901,7 +1940,7 @@ MovieComponent.forceEndRoutine.label:Force end of Routine
 MovieComponent.forceEndRoutine.valType:bool
 MovieComponent.forceEndRoutine.val:False
 MovieComponent.forceEndRoutine.allowedTypes:[]
-MovieComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe1d0>>
+MovieComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b7d0>>
 MovieComponent.forceEndRoutine.categ:Basic
 MovieComponent.forceEndRoutine.allowedVals:[]
 MovieComponent.forceEndRoutine.readOnly:False
@@ -1914,7 +1953,7 @@ MovieComponent.startEstim.label:Expected start (s)
 MovieComponent.startEstim.valType:code
 MovieComponent.startEstim.val:
 MovieComponent.startEstim.allowedTypes:[]
-MovieComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+MovieComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 MovieComponent.startEstim.categ:Basic
 MovieComponent.startEstim.allowedVals:[]
 MovieComponent.startEstim.readOnly:False
@@ -1927,7 +1966,7 @@ MovieComponent.units.label:Units
 MovieComponent.units.valType:str
 MovieComponent.units.val:from exp settings
 MovieComponent.units.allowedTypes:[]
-MovieComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+MovieComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 MovieComponent.units.categ:Basic
 MovieComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 MovieComponent.units.readOnly:False
@@ -1940,7 +1979,7 @@ MovieComponent.No audio.label:No audio
 MovieComponent.No audio.valType:bool
 MovieComponent.No audio.val:False
 MovieComponent.No audio.allowedTypes:[]
-MovieComponent.No audio.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe190>>
+MovieComponent.No audio.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 MovieComponent.No audio.categ:Basic
 MovieComponent.No audio.allowedVals:[]
 MovieComponent.No audio.readOnly:False
@@ -1953,7 +1992,7 @@ MovieComponent.startType.label:start type
 MovieComponent.startType.valType:str
 MovieComponent.startType.val:time (s)
 MovieComponent.startType.allowedTypes:[]
-MovieComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+MovieComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 MovieComponent.startType.categ:Basic
 MovieComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 MovieComponent.startType.readOnly:False
@@ -1966,7 +2005,7 @@ MovieComponent.ori.label:Orientation
 MovieComponent.ori.valType:code
 MovieComponent.ori.val:0
 MovieComponent.ori.allowedTypes:[]
-MovieComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe0d0>>
+MovieComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 MovieComponent.ori.categ:Basic
 MovieComponent.ori.allowedVals:[]
 MovieComponent.ori.readOnly:False
@@ -1979,7 +2018,7 @@ MovieComponent.stopType.label:stop type
 MovieComponent.stopType.valType:str
 MovieComponent.stopType.val:duration (s)
 MovieComponent.stopType.allowedTypes:[]
-MovieComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+MovieComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 MovieComponent.stopType.categ:Basic
 MovieComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 MovieComponent.stopType.readOnly:False
@@ -1992,7 +2031,7 @@ MovieComponent.startVal.label:Start
 MovieComponent.startVal.valType:code
 MovieComponent.startVal.val:0.0
 MovieComponent.startVal.allowedTypes:[]
-MovieComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+MovieComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 MovieComponent.startVal.categ:Basic
 MovieComponent.startVal.allowedVals:[]
 MovieComponent.startVal.readOnly:False
@@ -2005,7 +2044,7 @@ MovieComponent.backend.label:backend
 MovieComponent.backend.valType:str
 MovieComponent.backend.val:moviepy
 MovieComponent.backend.allowedTypes:[]
-MovieComponent.backend.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe150>>
+MovieComponent.backend.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 MovieComponent.backend.categ:Basic
 MovieComponent.backend.allowedVals:['moviepy', 'avbin', 'opencv']
 MovieComponent.backend.readOnly:False
@@ -2018,7 +2057,7 @@ MovieComponent.size.label:Size [w,h]
 MovieComponent.size.valType:code
 MovieComponent.size.val:
 MovieComponent.size.allowedTypes:[]
-MovieComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe090>>
+MovieComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 MovieComponent.size.categ:Basic
 MovieComponent.size.allowedVals:[]
 MovieComponent.size.readOnly:False
@@ -2028,521 +2067,453 @@ MovieComponent.size.hint:Size of this stimulus (either a single value or x,y pai
 MovieComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
 NoiseStimComponent.order:['tex', 'mask']
 NoiseStimComponent.noiseFilterUpper.default:8.0
+NoiseStimComponent.noiseFilterUpper.label:Upper cut off frequency
+NoiseStimComponent.noiseFilterUpper.valType:code
+NoiseStimComponent.noiseFilterUpper.val:8.0
+NoiseStimComponent.noiseFilterUpper.allowedTypes:[]
+NoiseStimComponent.noiseFilterUpper.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b2d0>>
 NoiseStimComponent.noiseFilterUpper.categ:Filtered
 NoiseStimComponent.noiseFilterUpper.allowedVals:[]
 NoiseStimComponent.noiseFilterUpper.readOnly:False
 NoiseStimComponent.noiseFilterUpper.updates:constant
-NoiseStimComponent.noiseFilterUpper.__dict__:{'staticUpdater': None, 'categ': 'Filtered', 'val': 8.0, 'hint': u'Upper cutoff frequency', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Upper cut off frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseFilterUpper.__weakref__:None
-NoiseStimComponent.noiseFilterUpper.valType:code
 NoiseStimComponent.noiseFilterUpper.staticUpdater:None
-NoiseStimComponent.noiseFilterUpper.val:8.0
-NoiseStimComponent.noiseFilterUpper.allowedTypes:[]
 NoiseStimComponent.noiseFilterUpper.hint:Upper cutoff frequency
 NoiseStimComponent.noiseFilterUpper.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseFilterUpper.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseFilterUpper.label:Upper cut off frequency
 NoiseStimComponent.color.default:[1,1,1]
+NoiseStimComponent.color.label:Color
+NoiseStimComponent.color.valType:str
+NoiseStimComponent.color.val:$[1,1,1]
+NoiseStimComponent.color.allowedTypes:[]
+NoiseStimComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 NoiseStimComponent.color.categ:Basic
 NoiseStimComponent.color.allowedVals:[]
 NoiseStimComponent.color.readOnly:False
 NoiseStimComponent.color.updates:constant
-NoiseStimComponent.color.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': '$[1,1,1]', 'hint': u'Color of this stimulus (e.g. $[1,1,0], red ); Right-click to bring up a color-picker (rgb only)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Color', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.color.__weakref__:None
-NoiseStimComponent.color.valType:str
 NoiseStimComponent.color.staticUpdater:None
-NoiseStimComponent.color.val:$[1,1,1]
-NoiseStimComponent.color.allowedTypes:[]
 NoiseStimComponent.color.hint:Color of this stimulus (e.g. $[1,1,0], red ); Right-click to bring up a color-picker (rgb only)
 NoiseStimComponent.color.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.color.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.color.label:Color
 NoiseStimComponent.colorSpace.default:'rgb'
+NoiseStimComponent.colorSpace.label:Color space
+NoiseStimComponent.colorSpace.valType:str
+NoiseStimComponent.colorSpace.val:rgb
+NoiseStimComponent.colorSpace.allowedTypes:[]
+NoiseStimComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
 NoiseStimComponent.colorSpace.categ:Basic
 NoiseStimComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 NoiseStimComponent.colorSpace.readOnly:False
 NoiseStimComponent.colorSpace.updates:constant
-NoiseStimComponent.colorSpace.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'rgb', 'hint': u'Choice of color space for the color (rgb, dkl, lms, hsv)', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': ['rgb', 'dkl', 'lms', 'hsv'], 'label': u'Color space', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.colorSpace.__weakref__:None
-NoiseStimComponent.colorSpace.valType:str
 NoiseStimComponent.colorSpace.staticUpdater:None
-NoiseStimComponent.colorSpace.val:rgb
-NoiseStimComponent.colorSpace.allowedTypes:[]
 NoiseStimComponent.colorSpace.hint:Choice of color space for the color (rgb, dkl, lms, hsv)
 NoiseStimComponent.colorSpace.allowedUpdates:None
-NoiseStimComponent.colorSpace.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.colorSpace.label:Color space
 NoiseStimComponent.pos.default:(0, 0)
+NoiseStimComponent.pos.label:Position [x,y]
+NoiseStimComponent.pos.valType:code
+NoiseStimComponent.pos.val:(0, 0)
+NoiseStimComponent.pos.allowedTypes:[]
+NoiseStimComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 NoiseStimComponent.pos.categ:Basic
 NoiseStimComponent.pos.allowedVals:[]
 NoiseStimComponent.pos.readOnly:False
 NoiseStimComponent.pos.updates:constant
-NoiseStimComponent.pos.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': (0, 0), 'hint': u'Position of this stimulus (e.g. [1,2] )', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Position [x,y]', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.pos.__weakref__:None
-NoiseStimComponent.pos.valType:code
 NoiseStimComponent.pos.staticUpdater:None
-NoiseStimComponent.pos.val:(0, 0)
-NoiseStimComponent.pos.allowedTypes:[]
 NoiseStimComponent.pos.hint:Position of this stimulus (e.g. [1,2] )
 NoiseStimComponent.pos.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.pos.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.pos.label:Position [x,y]
 NoiseStimComponent.stopType.default:'duration (s)'
+NoiseStimComponent.stopType.label:stop type
+NoiseStimComponent.stopType.valType:str
+NoiseStimComponent.stopType.val:duration (s)
+NoiseStimComponent.stopType.allowedTypes:[]
+NoiseStimComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 NoiseStimComponent.stopType.categ:Basic
 NoiseStimComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 NoiseStimComponent.stopType.readOnly:False
 NoiseStimComponent.stopType.updates:None
-NoiseStimComponent.stopType.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'duration (s)', 'hint': u'How do you want to define your end point?', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': ['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition'], 'label': u'stop type', 'readOnly': False, 'updates': None, 'valType': 'str'}
-NoiseStimComponent.stopType.__weakref__:None
-NoiseStimComponent.stopType.valType:str
 NoiseStimComponent.stopType.staticUpdater:None
-NoiseStimComponent.stopType.val:duration (s)
-NoiseStimComponent.stopType.allowedTypes:[]
 NoiseStimComponent.stopType.hint:How do you want to define your end point?
 NoiseStimComponent.stopType.allowedUpdates:None
-NoiseStimComponent.stopType.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.stopType.label:stop type
 NoiseStimComponent.blendmode.default:'avg'
+NoiseStimComponent.blendmode.label:OpenGL blend mode
+NoiseStimComponent.blendmode.valType:str
+NoiseStimComponent.blendmode.val:avg
+NoiseStimComponent.blendmode.allowedTypes:[]
+NoiseStimComponent.blendmode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b590>>
 NoiseStimComponent.blendmode.categ:Basic
 NoiseStimComponent.blendmode.allowedVals:[]
 NoiseStimComponent.blendmode.readOnly:False
 NoiseStimComponent.blendmode.updates:constant
-NoiseStimComponent.blendmode.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'avg', 'hint': u'OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is used if you want to generate the sum of two components)]', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'OpenGL blend mode', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.blendmode.__weakref__:None
-NoiseStimComponent.blendmode.valType:str
 NoiseStimComponent.blendmode.staticUpdater:None
-NoiseStimComponent.blendmode.val:avg
-NoiseStimComponent.blendmode.allowedTypes:[]
 NoiseStimComponent.blendmode.hint:OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is used if you want to generate the sum of two components)]
 NoiseStimComponent.blendmode.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.blendmode.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.blendmode.label:OpenGL blend mode
 NoiseStimComponent.noiseBaseSf.default:8.0
+NoiseStimComponent.noiseBaseSf.label:Base spatial frequency
+NoiseStimComponent.noiseBaseSf.valType:code
+NoiseStimComponent.noiseBaseSf.val:8.0
+NoiseStimComponent.noiseBaseSf.allowedTypes:[]
+NoiseStimComponent.noiseBaseSf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b150>>
 NoiseStimComponent.noiseBaseSf.categ:Gabor/Isotropic
 NoiseStimComponent.noiseBaseSf.allowedVals:[]
 NoiseStimComponent.noiseBaseSf.readOnly:False
 NoiseStimComponent.noiseBaseSf.updates:constant
-NoiseStimComponent.noiseBaseSf.__dict__:{'staticUpdater': None, 'categ': 'Gabor/Isotropic', 'val': 8.0, 'hint': u'Base spatial frequency', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Base spatial frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseBaseSf.__weakref__:None
-NoiseStimComponent.noiseBaseSf.valType:code
 NoiseStimComponent.noiseBaseSf.staticUpdater:None
-NoiseStimComponent.noiseBaseSf.val:8.0
-NoiseStimComponent.noiseBaseSf.allowedTypes:[]
 NoiseStimComponent.noiseBaseSf.hint:Base spatial frequency
 NoiseStimComponent.noiseBaseSf.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseBaseSf.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseBaseSf.label:Base spatial frequency
 NoiseStimComponent.startVal.default:0.0
+NoiseStimComponent.startVal.label:Start
+NoiseStimComponent.startVal.valType:code
+NoiseStimComponent.startVal.val:0.0
+NoiseStimComponent.startVal.allowedTypes:[]
+NoiseStimComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 NoiseStimComponent.startVal.categ:Basic
 NoiseStimComponent.startVal.allowedVals:[]
 NoiseStimComponent.startVal.readOnly:False
 NoiseStimComponent.startVal.updates:None
-NoiseStimComponent.startVal.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 0.0, 'hint': u'When does the component start?', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': [], 'label': u'Start', 'readOnly': False, 'updates': None, 'valType': 'code'}
-NoiseStimComponent.startVal.__weakref__:None
-NoiseStimComponent.startVal.valType:code
 NoiseStimComponent.startVal.staticUpdater:None
-NoiseStimComponent.startVal.val:0.0
-NoiseStimComponent.startVal.allowedTypes:[]
 NoiseStimComponent.startVal.hint:When does the component start?
 NoiseStimComponent.startVal.allowedUpdates:None
-NoiseStimComponent.startVal.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.startVal.label:Start
 NoiseStimComponent.size.default:(0.5, 0.5)
+NoiseStimComponent.size.label:Size [w,h]
+NoiseStimComponent.size.valType:code
+NoiseStimComponent.size.val:(0.5, 0.5)
+NoiseStimComponent.size.allowedTypes:[]
+NoiseStimComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba10>>
 NoiseStimComponent.size.categ:Basic
 NoiseStimComponent.size.allowedVals:[]
 NoiseStimComponent.size.readOnly:False
 NoiseStimComponent.size.updates:constant
-NoiseStimComponent.size.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': (0.5, 0.5), 'hint': u'Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] ', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Size [w,h]', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.size.__weakref__:None
-NoiseStimComponent.size.valType:code
 NoiseStimComponent.size.staticUpdater:None
-NoiseStimComponent.size.val:(0.5, 0.5)
-NoiseStimComponent.size.allowedTypes:[]
 NoiseStimComponent.size.hint:Size of this stimulus (either a single value or x,y pair, e.g. 2.5, [1,2] 
 NoiseStimComponent.size.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.size.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.size.label:Size [w,h]
 NoiseStimComponent.noiseClip.default:3.0
+NoiseStimComponent.noiseClip.label:Number of standard deviations at which to clip noise
+NoiseStimComponent.noiseClip.valType:code
+NoiseStimComponent.noiseClip.val:3.0
+NoiseStimComponent.noiseClip.allowedTypes:[]
+NoiseStimComponent.noiseClip.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b650>>
 NoiseStimComponent.noiseClip.categ: Noise
 NoiseStimComponent.noiseClip.allowedVals:[]
 NoiseStimComponent.noiseClip.readOnly:False
 NoiseStimComponent.noiseClip.updates:constant
-NoiseStimComponent.noiseClip.__dict__:{'staticUpdater': None, 'categ': ' Noise', 'val': 3.0, 'hint': u'Truncate high and low values beyound stated standard deviations from mean (not used for binary or uniform noise; scales rather than clips normal noise). The higher this is the lower the final RMS contrast. If low noise may appear binary', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Number of standard deviations at which to clip noise', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseClip.__weakref__:None
-NoiseStimComponent.noiseClip.valType:code
 NoiseStimComponent.noiseClip.staticUpdater:None
-NoiseStimComponent.noiseClip.val:3.0
-NoiseStimComponent.noiseClip.allowedTypes:[]
 NoiseStimComponent.noiseClip.hint:Truncate high and low values beyound stated standard deviations from mean (not used for binary or uniform noise; scales rather than clips normal noise). The higher this is the lower the final RMS contrast. If low noise may appear binary
 NoiseStimComponent.noiseClip.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseClip.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseClip.label:Number of standard deviations at which to clip noise
 NoiseStimComponent.noiseImage.default:'None'
+NoiseStimComponent.noiseImage.label:Image from which to derive noise spectrum
+NoiseStimComponent.noiseImage.valType:str
+NoiseStimComponent.noiseImage.val:None
+NoiseStimComponent.noiseImage.allowedTypes:[]
+NoiseStimComponent.noiseImage.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b0d0>>
 NoiseStimComponent.noiseImage.categ:Image noise
 NoiseStimComponent.noiseImage.allowedVals:[]
 NoiseStimComponent.noiseImage.readOnly:False
 NoiseStimComponent.noiseImage.updates:constant
-NoiseStimComponent.noiseImage.__dict__:{'staticUpdater': None, 'categ': 'Image noise', 'val': 'None', 'hint': u'An image from which to derive the frequency spectrum for the noise. Give filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Image from which to derive noise spectrum', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.noiseImage.__weakref__:None
-NoiseStimComponent.noiseImage.valType:str
 NoiseStimComponent.noiseImage.staticUpdater:None
-NoiseStimComponent.noiseImage.val:None
-NoiseStimComponent.noiseImage.allowedTypes:[]
 NoiseStimComponent.noiseImage.hint:An image from which to derive the frequency spectrum for the noise. Give filename (including path)
 NoiseStimComponent.noiseImage.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseImage.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseImage.label:Image from which to derive noise spectrum
 NoiseStimComponent.noiseNewSample.default:'None'
+NoiseStimComponent.noiseNewSample.label:How to update noise sample
+NoiseStimComponent.noiseNewSample.valType:str
+NoiseStimComponent.noiseNewSample.val:None
+NoiseStimComponent.noiseNewSample.allowedTypes:[]
+NoiseStimComponent.noiseNewSample.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b5d0>>
 NoiseStimComponent.noiseNewSample.categ: Noise
 NoiseStimComponent.noiseNewSample.allowedVals:['None', 'Repeat', 'N-frames', 'Seconds']
 NoiseStimComponent.noiseNewSample.readOnly:False
 NoiseStimComponent.noiseNewSample.updates:constant
-NoiseStimComponent.noiseNewSample.__dict__:{'staticUpdater': None, 'categ': ' Noise', 'val': 'None', 'hint': u'How to update noise if not otherwise required by other changes (none, repeat, N-frames, Seconds)', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['None', 'Repeat', 'N-frames', 'Seconds'], 'label': u'How to update noise sample', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.noiseNewSample.__weakref__:None
-NoiseStimComponent.noiseNewSample.valType:str
 NoiseStimComponent.noiseNewSample.staticUpdater:None
-NoiseStimComponent.noiseNewSample.val:None
-NoiseStimComponent.noiseNewSample.allowedTypes:[]
 NoiseStimComponent.noiseNewSample.hint:How to update noise if not otherwise required by other changes (none, repeat, N-frames, Seconds)
 NoiseStimComponent.noiseNewSample.allowedUpdates:[]
-NoiseStimComponent.noiseNewSample.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseNewSample.label:How to update noise sample
 NoiseStimComponent.noiseNewSampleWhen.default:'1'
+NoiseStimComponent.noiseNewSampleWhen.label:When to update noise sample
+NoiseStimComponent.noiseNewSampleWhen.valType:str
+NoiseStimComponent.noiseNewSampleWhen.val:1
+NoiseStimComponent.noiseNewSampleWhen.allowedTypes:[]
+NoiseStimComponent.noiseNewSampleWhen.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b110>>
 NoiseStimComponent.noiseNewSampleWhen.categ: Noise
 NoiseStimComponent.noiseNewSampleWhen.allowedVals:[]
 NoiseStimComponent.noiseNewSampleWhen.readOnly:False
 NoiseStimComponent.noiseNewSampleWhen.updates:constant
-NoiseStimComponent.noiseNewSampleWhen.__dict__:{'staticUpdater': None, 'categ': ' Noise', 'val': '1', 'hint': u'How often to update noise (in frames or seconds) - can be a variable, ignored if any noise characteristic is updating on every frame', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': [], 'label': u'When to update noise sample', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.noiseNewSampleWhen.__weakref__:None
-NoiseStimComponent.noiseNewSampleWhen.valType:str
 NoiseStimComponent.noiseNewSampleWhen.staticUpdater:None
-NoiseStimComponent.noiseNewSampleWhen.val:1
-NoiseStimComponent.noiseNewSampleWhen.allowedTypes:[]
 NoiseStimComponent.noiseNewSampleWhen.hint:How often to update noise (in frames or seconds) - can be a variable, ignored if any noise characteristic is updating on every frame
 NoiseStimComponent.noiseNewSampleWhen.allowedUpdates:[]
-NoiseStimComponent.noiseNewSampleWhen.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseNewSampleWhen.label:When to update noise sample
 NoiseStimComponent.noiseBWO.default:1
+NoiseStimComponent.noiseBWO.label:Orientation bandwidth for Gabor noise
+NoiseStimComponent.noiseBWO.valType:code
+NoiseStimComponent.noiseBWO.val:1
+NoiseStimComponent.noiseBWO.allowedTypes:[]
+NoiseStimComponent.noiseBWO.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b6d0>>
 NoiseStimComponent.noiseBWO.categ:Gabor/Isotropic
 NoiseStimComponent.noiseBWO.allowedVals:[]
 NoiseStimComponent.noiseBWO.readOnly:False
 NoiseStimComponent.noiseBWO.updates:constant
-NoiseStimComponent.noiseBWO.__dict__:{'staticUpdater': None, 'categ': 'Gabor/Isotropic', 'val': 1, 'hint': u'Orientation bandwidth in degrees (Gabor only) - Full width half height', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Orientation bandwidth for Gabor noise', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseBWO.__weakref__:None
-NoiseStimComponent.noiseBWO.valType:code
 NoiseStimComponent.noiseBWO.staticUpdater:None
-NoiseStimComponent.noiseBWO.val:1
-NoiseStimComponent.noiseBWO.allowedTypes:[]
 NoiseStimComponent.noiseBWO.hint:Orientation bandwidth in degrees (Gabor only) - Full width half height
 NoiseStimComponent.noiseBWO.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseBWO.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseBWO.label:Orientation bandwidth for Gabor noise
 NoiseStimComponent.noiseFilterLower.default:1.0
+NoiseStimComponent.noiseFilterLower.label:Lower cut off frequency
+NoiseStimComponent.noiseFilterLower.valType:code
+NoiseStimComponent.noiseFilterLower.val:1.0
+NoiseStimComponent.noiseFilterLower.allowedTypes:[]
+NoiseStimComponent.noiseFilterLower.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b690>>
 NoiseStimComponent.noiseFilterLower.categ:Filtered
 NoiseStimComponent.noiseFilterLower.allowedVals:[]
 NoiseStimComponent.noiseFilterLower.readOnly:False
 NoiseStimComponent.noiseFilterLower.updates:constant
-NoiseStimComponent.noiseFilterLower.__dict__:{'staticUpdater': None, 'categ': 'Filtered', 'val': 1.0, 'hint': u'Lower cutoff frequency', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Lower cut off frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseFilterLower.__weakref__:None
-NoiseStimComponent.noiseFilterLower.valType:code
 NoiseStimComponent.noiseFilterLower.staticUpdater:None
-NoiseStimComponent.noiseFilterLower.val:1.0
-NoiseStimComponent.noiseFilterLower.allowedTypes:[]
 NoiseStimComponent.noiseFilterLower.hint:Lower cutoff frequency
 NoiseStimComponent.noiseFilterLower.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseFilterLower.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseFilterLower.label:Lower cut off frequency
 NoiseStimComponent.units.default:'from exp settings'
+NoiseStimComponent.units.label:Units
+NoiseStimComponent.units.valType:str
+NoiseStimComponent.units.val:from exp settings
+NoiseStimComponent.units.allowedTypes:[]
+NoiseStimComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 NoiseStimComponent.units.categ:Basic
 NoiseStimComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 NoiseStimComponent.units.readOnly:False
 NoiseStimComponent.units.updates:None
-NoiseStimComponent.units.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'from exp settings', 'hint': u'Units of dimensions for this stimulus', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': ['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat'], 'label': u'Units', 'readOnly': False, 'updates': None, 'valType': 'str'}
-NoiseStimComponent.units.__weakref__:None
-NoiseStimComponent.units.valType:str
 NoiseStimComponent.units.staticUpdater:None
-NoiseStimComponent.units.val:from exp settings
-NoiseStimComponent.units.allowedTypes:[]
 NoiseStimComponent.units.hint:Units of dimensions for this stimulus
 NoiseStimComponent.units.allowedUpdates:None
-NoiseStimComponent.units.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.units.label:Units
 NoiseStimComponent.contrast.default:1.0
+NoiseStimComponent.contrast.label:Contrast
+NoiseStimComponent.contrast.valType:code
+NoiseStimComponent.contrast.val:1.0
+NoiseStimComponent.contrast.allowedTypes:[]
+NoiseStimComponent.contrast.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b310>>
 NoiseStimComponent.contrast.categ:Advanced
 NoiseStimComponent.contrast.allowedVals:[]
 NoiseStimComponent.contrast.readOnly:False
 NoiseStimComponent.contrast.updates:constant
-NoiseStimComponent.contrast.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 1.0, 'hint': u'Michaelson contrast of the image', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Contrast', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.contrast.__weakref__:None
-NoiseStimComponent.contrast.valType:code
 NoiseStimComponent.contrast.staticUpdater:None
-NoiseStimComponent.contrast.val:1.0
-NoiseStimComponent.contrast.allowedTypes:[]
 NoiseStimComponent.contrast.hint:Michaelson contrast of the image
 NoiseStimComponent.contrast.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.contrast.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.contrast.label:Contrast
 NoiseStimComponent.opacity.default:1
+NoiseStimComponent.opacity.label:Opacity
+NoiseStimComponent.opacity.valType:code
+NoiseStimComponent.opacity.val:1
+NoiseStimComponent.opacity.allowedTypes:[]
+NoiseStimComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 NoiseStimComponent.opacity.categ:Basic
 NoiseStimComponent.opacity.allowedVals:[]
 NoiseStimComponent.opacity.readOnly:False
 NoiseStimComponent.opacity.updates:constant
-NoiseStimComponent.opacity.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 1, 'hint': u'Opacity of the stimulus (1=opaque, 0=fully transparent, 0.5=translucent)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Opacity', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.opacity.__weakref__:None
-NoiseStimComponent.opacity.valType:code
 NoiseStimComponent.opacity.staticUpdater:None
-NoiseStimComponent.opacity.val:1
-NoiseStimComponent.opacity.allowedTypes:[]
 NoiseStimComponent.opacity.hint:Opacity of the stimulus (1=opaque, 0=fully transparent, 0.5=translucent)
 NoiseStimComponent.opacity.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.opacity.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.opacity.label:Opacity
 NoiseStimComponent.stopVal.default:1.0
+NoiseStimComponent.stopVal.label:Stop
+NoiseStimComponent.stopVal.valType:code
+NoiseStimComponent.stopVal.val:1.0
+NoiseStimComponent.stopVal.allowedTypes:[]
+NoiseStimComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 NoiseStimComponent.stopVal.categ:Basic
 NoiseStimComponent.stopVal.allowedVals:[]
 NoiseStimComponent.stopVal.readOnly:False
 NoiseStimComponent.stopVal.updates:constant
-NoiseStimComponent.stopVal.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 1.0, 'hint': u'When does the component end? (blank is endless)', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': [], 'label': u'Stop', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.stopVal.__weakref__:None
-NoiseStimComponent.stopVal.valType:code
 NoiseStimComponent.stopVal.staticUpdater:None
-NoiseStimComponent.stopVal.val:1.0
-NoiseStimComponent.stopVal.allowedTypes:[]
 NoiseStimComponent.stopVal.hint:When does the component end? (blank is endless)
 NoiseStimComponent.stopVal.allowedUpdates:[]
-NoiseStimComponent.stopVal.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.stopVal.label:Stop
 NoiseStimComponent.durationEstim.default:
+NoiseStimComponent.durationEstim.label:Expected duration (s)
+NoiseStimComponent.durationEstim.valType:code
+NoiseStimComponent.durationEstim.val:
+NoiseStimComponent.durationEstim.allowedTypes:[]
+NoiseStimComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 NoiseStimComponent.durationEstim.categ:Basic
 NoiseStimComponent.durationEstim.allowedVals:[]
 NoiseStimComponent.durationEstim.readOnly:False
 NoiseStimComponent.durationEstim.updates:None
-NoiseStimComponent.durationEstim.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': '', 'hint': u'(Optional) expected duration (s), purely for representing in the timeline', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': [], 'label': u'Expected duration (s)', 'readOnly': False, 'updates': None, 'valType': 'code'}
-NoiseStimComponent.durationEstim.__weakref__:None
-NoiseStimComponent.durationEstim.valType:code
 NoiseStimComponent.durationEstim.staticUpdater:None
-NoiseStimComponent.durationEstim.val:
-NoiseStimComponent.durationEstim.allowedTypes:[]
 NoiseStimComponent.durationEstim.hint:(Optional) expected duration (s), purely for representing in the timeline
 NoiseStimComponent.durationEstim.allowedUpdates:None
-NoiseStimComponent.durationEstim.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.durationEstim.label:Expected duration (s)
 NoiseStimComponent.interpolate.default:'nearest'
+NoiseStimComponent.interpolate.label:Interpolate
+NoiseStimComponent.interpolate.valType:str
+NoiseStimComponent.interpolate.val:nearest
+NoiseStimComponent.interpolate.allowedTypes:[]
+NoiseStimComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b390>>
 NoiseStimComponent.interpolate.categ:Advanced
 NoiseStimComponent.interpolate.allowedVals:['linear', 'nearest']
 NoiseStimComponent.interpolate.readOnly:False
 NoiseStimComponent.interpolate.updates:constant
-NoiseStimComponent.interpolate.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'nearest', 'hint': u'How should the image be interpolated if/when rescaled', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['linear', 'nearest'], 'label': u'Interpolate', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.interpolate.__weakref__:None
-NoiseStimComponent.interpolate.valType:str
 NoiseStimComponent.interpolate.staticUpdater:None
-NoiseStimComponent.interpolate.val:nearest
-NoiseStimComponent.interpolate.allowedTypes:[]
 NoiseStimComponent.interpolate.hint:How should the image be interpolated if/when rescaled
 NoiseStimComponent.interpolate.allowedUpdates:[]
-NoiseStimComponent.interpolate.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.interpolate.label:Interpolate
 NoiseStimComponent.startEstim.default:
+NoiseStimComponent.startEstim.label:Expected start (s)
+NoiseStimComponent.startEstim.valType:code
+NoiseStimComponent.startEstim.val:
+NoiseStimComponent.startEstim.allowedTypes:[]
+NoiseStimComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 NoiseStimComponent.startEstim.categ:Basic
 NoiseStimComponent.startEstim.allowedVals:[]
 NoiseStimComponent.startEstim.readOnly:False
 NoiseStimComponent.startEstim.updates:None
-NoiseStimComponent.startEstim.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': '', 'hint': u'(Optional) expected start (s), purely for representing in the timeline', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': [], 'label': u'Expected start (s)', 'readOnly': False, 'updates': None, 'valType': 'code'}
-NoiseStimComponent.startEstim.__weakref__:None
-NoiseStimComponent.startEstim.valType:code
 NoiseStimComponent.startEstim.staticUpdater:None
-NoiseStimComponent.startEstim.val:
-NoiseStimComponent.startEstim.allowedTypes:[]
 NoiseStimComponent.startEstim.hint:(Optional) expected start (s), purely for representing in the timeline
 NoiseStimComponent.startEstim.allowedUpdates:None
-NoiseStimComponent.startEstim.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.startEstim.label:Expected start (s)
 NoiseStimComponent.startType.default:'time (s)'
+NoiseStimComponent.startType.label:start type
+NoiseStimComponent.startType.valType:str
+NoiseStimComponent.startType.val:time (s)
+NoiseStimComponent.startType.allowedTypes:[]
+NoiseStimComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 NoiseStimComponent.startType.categ:Basic
 NoiseStimComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 NoiseStimComponent.startType.readOnly:False
 NoiseStimComponent.startType.updates:None
-NoiseStimComponent.startType.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'time (s)', 'hint': u'How do you want to define your start point?', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': ['time (s)', 'frame N', 'condition'], 'label': u'start type', 'readOnly': False, 'updates': None, 'valType': 'str'}
-NoiseStimComponent.startType.__weakref__:None
-NoiseStimComponent.startType.valType:str
 NoiseStimComponent.startType.staticUpdater:None
-NoiseStimComponent.startType.val:time (s)
-NoiseStimComponent.startType.allowedTypes:[]
 NoiseStimComponent.startType.hint:How do you want to define your start point?
 NoiseStimComponent.startType.allowedUpdates:None
-NoiseStimComponent.startType.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.startType.label:start type
 NoiseStimComponent.ori.default:0
+NoiseStimComponent.ori.label:Orientation
+NoiseStimComponent.ori.valType:code
+NoiseStimComponent.ori.val:0
+NoiseStimComponent.ori.allowedTypes:[]
+NoiseStimComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b610>>
 NoiseStimComponent.ori.categ:Advanced
 NoiseStimComponent.ori.allowedVals:[]
 NoiseStimComponent.ori.readOnly:False
 NoiseStimComponent.ori.updates:constant
-NoiseStimComponent.ori.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 0, 'hint': u'Orientation of this stimulus (in deg)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Orientation', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.ori.__weakref__:None
-NoiseStimComponent.ori.valType:code
 NoiseStimComponent.ori.staticUpdater:None
-NoiseStimComponent.ori.val:0
-NoiseStimComponent.ori.allowedTypes:[]
 NoiseStimComponent.ori.hint:Orientation of this stimulus (in deg)
 NoiseStimComponent.ori.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.ori.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.ori.label:Orientation
 NoiseStimComponent.phase.default:0.0
+NoiseStimComponent.phase.label:Phase (in cycles)
+NoiseStimComponent.phase.valType:code
+NoiseStimComponent.phase.val:0.0
+NoiseStimComponent.phase.allowedTypes:[]
+NoiseStimComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b410>>
 NoiseStimComponent.phase.categ:Advanced
 NoiseStimComponent.phase.allowedVals:[]
 NoiseStimComponent.phase.readOnly:False
 NoiseStimComponent.phase.updates:constant
-NoiseStimComponent.phase.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 0.0, 'hint': u'Spatial positioning of the image  (wraps in range 0-1.0)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Phase (in cycles)', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.phase.__weakref__:None
-NoiseStimComponent.phase.valType:code
 NoiseStimComponent.phase.staticUpdater:None
-NoiseStimComponent.phase.val:0.0
-NoiseStimComponent.phase.allowedTypes:[]
 NoiseStimComponent.phase.hint:Spatial positioning of the image  (wraps in range 0-1.0)
 NoiseStimComponent.phase.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.phase.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.phase.label:Phase (in cycles)
 NoiseStimComponent.noiseFilterOrder.default:0.0
+NoiseStimComponent.noiseFilterOrder.label:Order of filter
+NoiseStimComponent.noiseFilterOrder.valType:code
+NoiseStimComponent.noiseFilterOrder.val:0.0
+NoiseStimComponent.noiseFilterOrder.allowedTypes:[]
+NoiseStimComponent.noiseFilterOrder.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba90>>
 NoiseStimComponent.noiseFilterOrder.categ:Filtered
 NoiseStimComponent.noiseFilterOrder.allowedVals:[]
 NoiseStimComponent.noiseFilterOrder.readOnly:False
 NoiseStimComponent.noiseFilterOrder.updates:constant
-NoiseStimComponent.noiseFilterOrder.__dict__:{'staticUpdater': None, 'categ': 'Filtered', 'val': 1.0, 'hint': u'Order of filter - higher = steeper fall off, zero = no filter', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Order of filter', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseFilterOrder.__weakref__:None
-NoiseStimComponent.noiseFilterOrder.valType:code
 NoiseStimComponent.noiseFilterOrder.staticUpdater:None
-NoiseStimComponent.noiseFilterOrder.val:1.0
-NoiseStimComponent.noiseFilterOrder.allowedTypes:[]
 NoiseStimComponent.noiseFilterOrder.hint:Order of filter - higher = steeper fall off, zero = no filter
 NoiseStimComponent.noiseFilterOrder.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseFilterOrder.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseFilterOrder.label:Order of filter
 NoiseStimComponent.noiseBW.default:1
+NoiseStimComponent.noiseBW.label:Spatial frequency bandwidth
+NoiseStimComponent.noiseBW.valType:code
+NoiseStimComponent.noiseBW.val:1
+NoiseStimComponent.noiseBW.allowedTypes:[]
+NoiseStimComponent.noiseBW.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b1d0>>
 NoiseStimComponent.noiseBW.categ:Gabor/Isotropic
 NoiseStimComponent.noiseBW.allowedVals:[]
 NoiseStimComponent.noiseBW.readOnly:False
 NoiseStimComponent.noiseBW.updates:constant
-NoiseStimComponent.noiseBW.__dict__:{'staticUpdater': None, 'categ': 'Gabor/Isotropic', 'val': 1, 'hint': u'Spatial frequency bandwidth in octaves - Full width half height', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Spatial frequency bandwidth', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseBW.__weakref__:None
-NoiseStimComponent.noiseBW.valType:code
 NoiseStimComponent.noiseBW.staticUpdater:None
-NoiseStimComponent.noiseBW.val:1
-NoiseStimComponent.noiseBW.allowedTypes:[]
 NoiseStimComponent.noiseBW.hint:Spatial frequency bandwidth in octaves - Full width half height
 NoiseStimComponent.noiseBW.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseBW.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseBW.label:Spatial frequency bandwidth
 NoiseStimComponent.texture resolution.default:128
+NoiseStimComponent.texture resolution.label:Texture resolution
+NoiseStimComponent.texture resolution.valType:code
+NoiseStimComponent.texture resolution.val:128
+NoiseStimComponent.texture resolution.allowedTypes:[]
+NoiseStimComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b3d0>>
 NoiseStimComponent.texture resolution.categ:Advanced
 NoiseStimComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 NoiseStimComponent.texture resolution.readOnly:False
 NoiseStimComponent.texture resolution.updates:constant
-NoiseStimComponent.texture resolution.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': '128', 'hint': u'Resolution of the texture for standard ones such as sin, sqr etc. For most cases a value of 256 pixels will suffice', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['32', '64', '128', '256', '512'], 'label': u'Texture resolution', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.texture resolution.__weakref__:None
-NoiseStimComponent.texture resolution.valType:code
 NoiseStimComponent.texture resolution.staticUpdater:None
-NoiseStimComponent.texture resolution.val:128
-NoiseStimComponent.texture resolution.allowedTypes:[]
 NoiseStimComponent.texture resolution.hint:Resolution of the texture for standard ones such as sin, sqr etc. For most cases a value of 256 pixels will suffice
 NoiseStimComponent.texture resolution.allowedUpdates:[]
-NoiseStimComponent.texture resolution.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.texture resolution.label:Texture resolution
 NoiseStimComponent.name.default:noise
+NoiseStimComponent.name.label:Name
+NoiseStimComponent.name.valType:code
+NoiseStimComponent.name.val:noise
+NoiseStimComponent.name.allowedTypes:[]
+NoiseStimComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 NoiseStimComponent.name.categ:Basic
 NoiseStimComponent.name.allowedVals:[]
 NoiseStimComponent.name.readOnly:False
-NoiseStimComponent.name.__dict__:{'staticUpdater': None, 'categ': 'Basic', 'val': 'noise', 'hint': u'Name of this component (alpha-numeric or _, no spaces)', 'allowedTypes': [], 'allowedUpdates': None, 'allowedVals': [], 'label': u'Name', 'readOnly': False, 'updates': None, 'valType': 'code'}
-NoiseStimComponent.name.__weakref__:None
-NoiseStimComponent.name.valType:code
 NoiseStimComponent.name.staticUpdater:None
-NoiseStimComponent.name.val:noise
-NoiseStimComponent.name.allowedTypes:[]
 NoiseStimComponent.name.hint:Name of this component (alpha-numeric or _, no spaces)
 NoiseStimComponent.name.allowedUpdates:None
-NoiseStimComponent.name.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.name.label:Name
-NoiseStimComponent.noiseElementSize.default:2
+NoiseStimComponent.noiseElementSize.default:0.0625
+NoiseStimComponent.noiseElementSize.label:Noise element size for pixelated noise
+NoiseStimComponent.noiseElementSize.valType:code
+NoiseStimComponent.noiseElementSize.val:0.0625
+NoiseStimComponent.noiseElementSize.allowedTypes:[]
+NoiseStimComponent.noiseElementSize.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b190>>
 NoiseStimComponent.noiseElementSize.categ:Binary/Normal/Uniform
 NoiseStimComponent.noiseElementSize.allowedVals:[]
 NoiseStimComponent.noiseElementSize.readOnly:False
 NoiseStimComponent.noiseElementSize.updates:constant
-NoiseStimComponent.noiseElementSize.__dict__:{'staticUpdater': None, 'categ': 'Binary/Normal/Uniform', 'val': 2, 'hint': u'(Binary, Normal an Uniform only) Size of noise elements', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Noise element size for pixelated noise', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseElementSize.__weakref__:None
-NoiseStimComponent.noiseElementSize.valType:code
 NoiseStimComponent.noiseElementSize.staticUpdater:None
-NoiseStimComponent.noiseElementSize.val:2
-NoiseStimComponent.noiseElementSize.allowedTypes:[]
 NoiseStimComponent.noiseElementSize.hint:(Binary, Normal an Uniform only) Size of noise elements
 NoiseStimComponent.noiseElementSize.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseElementSize.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseElementSize.label:Noise element size for pixelated noise
 NoiseStimComponent.mask.default:'None'
+NoiseStimComponent.mask.label:Mask
+NoiseStimComponent.mask.valType:str
+NoiseStimComponent.mask.val:None
+NoiseStimComponent.mask.allowedTypes:[]
+NoiseStimComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 NoiseStimComponent.mask.categ:Advanced
 NoiseStimComponent.mask.allowedVals:[]
 NoiseStimComponent.mask.readOnly:False
 NoiseStimComponent.mask.updates:constant
-NoiseStimComponent.mask.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'None', 'hint': u'An image to define the alpha mask (ie shape)- gauss, circle... or a filename (including path)', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Mask', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.mask.__weakref__:None
-NoiseStimComponent.mask.valType:str
 NoiseStimComponent.mask.staticUpdater:None
-NoiseStimComponent.mask.val:None
-NoiseStimComponent.mask.allowedTypes:[]
 NoiseStimComponent.mask.hint:An image to define the alpha mask (ie shape)- gauss, circle... or a filename (including path)
 NoiseStimComponent.mask.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.mask.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.mask.label:Mask
 NoiseStimComponent.noiseFractalPower.default:0.0
+NoiseStimComponent.noiseFractalPower.label:Skew in frequency spectrum
+NoiseStimComponent.noiseFractalPower.valType:code
+NoiseStimComponent.noiseFractalPower.val:0.0
+NoiseStimComponent.noiseFractalPower.allowedTypes:[]
+NoiseStimComponent.noiseFractalPower.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b250>>
 NoiseStimComponent.noiseFractalPower.categ:Filtered
 NoiseStimComponent.noiseFractalPower.allowedVals:[]
 NoiseStimComponent.noiseFractalPower.readOnly:False
 NoiseStimComponent.noiseFractalPower.updates:constant
-NoiseStimComponent.noiseFractalPower.__dict__:{'staticUpdater': None, 'categ': 'Filtered', 'val': -1, 'hint': u"Exponent for spectral slope (A=f^Exponent) of noise negative exponents look nice. -1='pink noise', 1='white noise' (changes the spatial frequency spectrum - does not make the noise colourful)", 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Skew in frequency spectrum', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.noiseFractalPower.__weakref__:None
-NoiseStimComponent.noiseFractalPower.valType:code
 NoiseStimComponent.noiseFractalPower.staticUpdater:None
-NoiseStimComponent.noiseFractalPower.val:-1
-NoiseStimComponent.noiseFractalPower.allowedTypes:[]
-NoiseStimComponent.noiseFractalPower.hint:Exponent for spectral slope (A=f^Exponent) of noise negative exponents look nice. -1='pink noise', 1='white noise' (changes the spatial frequency spectrum - does not make the noise colourful)
+NoiseStimComponent.noiseFractalPower.hint:Exponent for spectral slope (A=f^Exponent) of noise negative exponents look nice. -1='pink noise', 0='white noise' (changes the spatial frequency spectrum - does not make the noise colourful)
 NoiseStimComponent.noiseFractalPower.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.noiseFractalPower.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseFractalPower.label:Skew in frequency spectrum
 NoiseStimComponent.sf.default:None
+NoiseStimComponent.sf.label:Final spatial frequency
+NoiseStimComponent.sf.valType:code
+NoiseStimComponent.sf.val:None
+NoiseStimComponent.sf.allowedTypes:[]
+NoiseStimComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b490>>
 NoiseStimComponent.sf.categ:Advanced
 NoiseStimComponent.sf.allowedVals:[]
 NoiseStimComponent.sf.readOnly:False
 NoiseStimComponent.sf.updates:constant
-NoiseStimComponent.sf.__dict__:{'staticUpdater': None, 'categ': 'Advanced', 'val': 'None', 'hint': u'Final spatial frequency of image in 1 or 2 dimensions, e.g. 4 or [2,3] use None to set to 1 cycle per unit length or 1 cycle per image if units=pix', 'allowedTypes': [], 'allowedUpdates': ['constant', 'set every repeat', 'set every frame'], 'allowedVals': [], 'label': u'Final spatial frequency', 'readOnly': False, 'updates': 'constant', 'valType': 'code'}
-NoiseStimComponent.sf.__weakref__:None
-NoiseStimComponent.sf.valType:code
 NoiseStimComponent.sf.staticUpdater:None
-NoiseStimComponent.sf.val:None
-NoiseStimComponent.sf.allowedTypes:[]
 NoiseStimComponent.sf.hint:Final spatial frequency of image in 1 or 2 dimensions, e.g. 4 or [2,3] use None to set to 1 cycle per unit length or 1 cycle per image if units=pix
 NoiseStimComponent.sf.allowedUpdates:['constant', 'set every repeat', 'set every frame']
-NoiseStimComponent.sf.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.sf.label:Final spatial frequency
 NoiseStimComponent.noiseType.default:'Binary'
+NoiseStimComponent.noiseType.label:Type of noise
+NoiseStimComponent.noiseType.valType:str
+NoiseStimComponent.noiseType.val:Binary
+NoiseStimComponent.noiseType.allowedTypes:[]
+NoiseStimComponent.noiseType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b4d0>>
 NoiseStimComponent.noiseType.categ: Noise
 NoiseStimComponent.noiseType.allowedVals:['Binary', 'Normal', 'Uniform', 'Gabor', 'Isotropic', 'White', 'Filtered', 'Image']
 NoiseStimComponent.noiseType.readOnly:False
 NoiseStimComponent.noiseType.updates:constant
-NoiseStimComponent.noiseType.__dict__:{'staticUpdater': None, 'categ': ' Noise', 'val': 'Binary', 'hint': u'Type of noise (Binary, Normal, Gabor, Isotropic, White, Coloured, Filtered, Image)', 'allowedTypes': [], 'allowedUpdates': [], 'allowedVals': ['Binary', 'Normal', 'Uniform', 'Gabor', 'Isotropic', 'White', 'Filtered', 'Image'], 'label': u'Type of noise', 'readOnly': False, 'updates': 'constant', 'valType': 'str'}
-NoiseStimComponent.noiseType.__weakref__:None
-NoiseStimComponent.noiseType.valType:str
 NoiseStimComponent.noiseType.staticUpdater:None
-NoiseStimComponent.noiseType.val:Binary
-NoiseStimComponent.noiseType.allowedTypes:[]
 NoiseStimComponent.noiseType.hint:Type of noise (Binary, Normal, Gabor, Isotropic, White, Coloured, Filtered, Image)
 NoiseStimComponent.noiseType.allowedUpdates:[]
-NoiseStimComponent.noiseType.__class__:<class 'psychopy.app.builder.experiment.Param'>
-NoiseStimComponent.noiseType.label:Type of noise
 ParallelOutComponent.order:['address', 'startData', 'stopData']
 ParallelOutComponent.name.default:p_port
 ParallelOutComponent.name.label:Name
 ParallelOutComponent.name.valType:code
 ParallelOutComponent.name.val:p_port
 ParallelOutComponent.name.allowedTypes:[]
-ParallelOutComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+ParallelOutComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 ParallelOutComponent.name.categ:Basic
 ParallelOutComponent.name.allowedVals:[]
 ParallelOutComponent.name.readOnly:False
@@ -2554,7 +2525,7 @@ ParallelOutComponent.syncScreen.label:Sync to screen
 ParallelOutComponent.syncScreen.valType:bool
 ParallelOutComponent.syncScreen.val:True
 ParallelOutComponent.syncScreen.allowedTypes:[]
-ParallelOutComponent.syncScreen.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+ParallelOutComponent.syncScreen.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b7d0>>
 ParallelOutComponent.syncScreen.categ:Basic
 ParallelOutComponent.syncScreen.allowedVals:[True, False]
 ParallelOutComponent.syncScreen.readOnly:False
@@ -2567,7 +2538,7 @@ ParallelOutComponent.stopData.label:Stop data
 ParallelOutComponent.stopData.valType:code
 ParallelOutComponent.stopData.val:0
 ParallelOutComponent.stopData.allowedTypes:[]
-ParallelOutComponent.stopData.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+ParallelOutComponent.stopData.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 ParallelOutComponent.stopData.categ:Basic
 ParallelOutComponent.stopData.allowedVals:[]
 ParallelOutComponent.stopData.readOnly:False
@@ -2580,7 +2551,7 @@ ParallelOutComponent.stopVal.label:Stop
 ParallelOutComponent.stopVal.valType:code
 ParallelOutComponent.stopVal.val:1.0
 ParallelOutComponent.stopVal.allowedTypes:[]
-ParallelOutComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+ParallelOutComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 ParallelOutComponent.stopVal.categ:Basic
 ParallelOutComponent.stopVal.allowedVals:[]
 ParallelOutComponent.stopVal.readOnly:False
@@ -2593,7 +2564,7 @@ ParallelOutComponent.durationEstim.label:Expected duration (s)
 ParallelOutComponent.durationEstim.valType:code
 ParallelOutComponent.durationEstim.val:
 ParallelOutComponent.durationEstim.allowedTypes:[]
-ParallelOutComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+ParallelOutComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 ParallelOutComponent.durationEstim.categ:Basic
 ParallelOutComponent.durationEstim.allowedVals:[]
 ParallelOutComponent.durationEstim.readOnly:False
@@ -2606,7 +2577,7 @@ ParallelOutComponent.startEstim.label:Expected start (s)
 ParallelOutComponent.startEstim.valType:code
 ParallelOutComponent.startEstim.val:
 ParallelOutComponent.startEstim.allowedTypes:[]
-ParallelOutComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+ParallelOutComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 ParallelOutComponent.startEstim.categ:Basic
 ParallelOutComponent.startEstim.allowedVals:[]
 ParallelOutComponent.startEstim.readOnly:False
@@ -2619,7 +2590,7 @@ ParallelOutComponent.startType.label:start type
 ParallelOutComponent.startType.valType:str
 ParallelOutComponent.startType.val:time (s)
 ParallelOutComponent.startType.allowedTypes:[]
-ParallelOutComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+ParallelOutComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 ParallelOutComponent.startType.categ:Basic
 ParallelOutComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 ParallelOutComponent.startType.readOnly:False
@@ -2632,7 +2603,7 @@ ParallelOutComponent.address.label:Port address
 ParallelOutComponent.address.valType:str
 ParallelOutComponent.address.val:0x0378
 ParallelOutComponent.address.allowedTypes:[]
-ParallelOutComponent.address.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+ParallelOutComponent.address.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 ParallelOutComponent.address.categ:Basic
 ParallelOutComponent.address.allowedVals:[u'0x0378', u'0x03BC', u'/dev/parport0', u'/dev/parport1', u'LabJack U3']
 ParallelOutComponent.address.readOnly:False
@@ -2645,7 +2616,7 @@ ParallelOutComponent.stopType.label:stop type
 ParallelOutComponent.stopType.valType:str
 ParallelOutComponent.stopType.val:duration (s)
 ParallelOutComponent.stopType.allowedTypes:[]
-ParallelOutComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+ParallelOutComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 ParallelOutComponent.stopType.categ:Basic
 ParallelOutComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 ParallelOutComponent.stopType.readOnly:False
@@ -2658,7 +2629,7 @@ ParallelOutComponent.startVal.label:Start
 ParallelOutComponent.startVal.valType:code
 ParallelOutComponent.startVal.val:0.0
 ParallelOutComponent.startVal.allowedTypes:[]
-ParallelOutComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+ParallelOutComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 ParallelOutComponent.startVal.categ:Basic
 ParallelOutComponent.startVal.allowedVals:[]
 ParallelOutComponent.startVal.readOnly:False
@@ -2671,7 +2642,7 @@ ParallelOutComponent.startData.label:Start data
 ParallelOutComponent.startData.valType:code
 ParallelOutComponent.startData.val:1
 ParallelOutComponent.startData.allowedTypes:[]
-ParallelOutComponent.startData.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+ParallelOutComponent.startData.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 ParallelOutComponent.startData.categ:Basic
 ParallelOutComponent.startData.allowedVals:[]
 ParallelOutComponent.startData.readOnly:False
@@ -2685,7 +2656,7 @@ PatchComponent.opacity.label:Opacity
 PatchComponent.opacity.valType:code
 PatchComponent.opacity.val:1
 PatchComponent.opacity.allowedTypes:[]
-PatchComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+PatchComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b4d0>>
 PatchComponent.opacity.categ:Basic
 PatchComponent.opacity.allowedVals:[]
 PatchComponent.opacity.readOnly:False
@@ -2698,7 +2669,7 @@ PatchComponent.colorSpace.label:Color space
 PatchComponent.colorSpace.valType:str
 PatchComponent.colorSpace.val:rgb
 PatchComponent.colorSpace.allowedTypes:[]
-PatchComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe050>>
+PatchComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b490>>
 PatchComponent.colorSpace.categ:Advanced
 PatchComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 PatchComponent.colorSpace.readOnly:False
@@ -2711,7 +2682,7 @@ PatchComponent.name.label:Name
 PatchComponent.name.valType:code
 PatchComponent.name.val:patch
 PatchComponent.name.allowedTypes:[]
-PatchComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+PatchComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 PatchComponent.name.categ:Basic
 PatchComponent.name.allowedVals:[]
 PatchComponent.name.readOnly:False
@@ -2723,7 +2694,7 @@ PatchComponent.color.label:Color
 PatchComponent.color.valType:str
 PatchComponent.color.val:$[1,1,1]
 PatchComponent.color.allowedTypes:[]
-PatchComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+PatchComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 PatchComponent.color.categ:Advanced
 PatchComponent.color.allowedVals:[]
 PatchComponent.color.readOnly:False
@@ -2736,7 +2707,7 @@ PatchComponent.stopVal.label:Stop
 PatchComponent.stopVal.valType:code
 PatchComponent.stopVal.val:1.0
 PatchComponent.stopVal.allowedTypes:[]
-PatchComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+PatchComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 PatchComponent.stopVal.categ:Basic
 PatchComponent.stopVal.allowedVals:[]
 PatchComponent.stopVal.readOnly:False
@@ -2749,7 +2720,7 @@ PatchComponent.durationEstim.label:Expected duration (s)
 PatchComponent.durationEstim.valType:code
 PatchComponent.durationEstim.val:
 PatchComponent.durationEstim.allowedTypes:[]
-PatchComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+PatchComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 PatchComponent.durationEstim.categ:Basic
 PatchComponent.durationEstim.allowedVals:[]
 PatchComponent.durationEstim.readOnly:False
@@ -2762,7 +2733,7 @@ PatchComponent.mask.label:Mask
 PatchComponent.mask.valType:str
 PatchComponent.mask.val:None
 PatchComponent.mask.allowedTypes:[]
-PatchComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe190>>
+PatchComponent.mask.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b1d0>>
 PatchComponent.mask.categ:Basic
 PatchComponent.mask.allowedVals:[]
 PatchComponent.mask.readOnly:False
@@ -2775,7 +2746,7 @@ PatchComponent.pos.label:Position [x,y]
 PatchComponent.pos.valType:code
 PatchComponent.pos.val:(0, 0)
 PatchComponent.pos.allowedTypes:[]
-PatchComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe090>>
+PatchComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b250>>
 PatchComponent.pos.categ:Basic
 PatchComponent.pos.allowedVals:[]
 PatchComponent.pos.readOnly:False
@@ -2788,7 +2759,7 @@ PatchComponent.interpolate.label:Interpolate
 PatchComponent.interpolate.valType:str
 PatchComponent.interpolate.val:linear
 PatchComponent.interpolate.allowedTypes:[]
-PatchComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe290>>
+PatchComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b390>>
 PatchComponent.interpolate.categ:Advanced
 PatchComponent.interpolate.allowedVals:['linear', 'nearest']
 PatchComponent.interpolate.readOnly:False
@@ -2801,7 +2772,7 @@ PatchComponent.sf.label:Spatial frequency
 PatchComponent.sf.valType:code
 PatchComponent.sf.val:None
 PatchComponent.sf.allowedTypes:[]
-PatchComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe1d0>>
+PatchComponent.sf.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba90>>
 PatchComponent.sf.categ:Advanced
 PatchComponent.sf.allowedVals:[]
 PatchComponent.sf.readOnly:False
@@ -2814,7 +2785,7 @@ PatchComponent.startEstim.label:Expected start (s)
 PatchComponent.startEstim.valType:code
 PatchComponent.startEstim.val:
 PatchComponent.startEstim.allowedTypes:[]
-PatchComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+PatchComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 PatchComponent.startEstim.categ:Basic
 PatchComponent.startEstim.allowedVals:[]
 PatchComponent.startEstim.readOnly:False
@@ -2827,7 +2798,7 @@ PatchComponent.units.label:Units
 PatchComponent.units.valType:str
 PatchComponent.units.val:from exp settings
 PatchComponent.units.allowedTypes:[]
-PatchComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+PatchComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 PatchComponent.units.categ:Basic
 PatchComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 PatchComponent.units.readOnly:False
@@ -2840,7 +2811,7 @@ PatchComponent.texture resolution.label:Texture resolution
 PatchComponent.texture resolution.valType:code
 PatchComponent.texture resolution.val:128
 PatchComponent.texture resolution.allowedTypes:[]
-PatchComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe250>>
+PatchComponent.texture resolution.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b610>>
 PatchComponent.texture resolution.categ:Advanced
 PatchComponent.texture resolution.allowedVals:['32', '64', '128', '256', '512']
 PatchComponent.texture resolution.readOnly:False
@@ -2853,7 +2824,7 @@ PatchComponent.phase.label:Phase (in cycles)
 PatchComponent.phase.valType:code
 PatchComponent.phase.val:0.0
 PatchComponent.phase.allowedTypes:[]
-PatchComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe210>>
+PatchComponent.phase.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b410>>
 PatchComponent.phase.categ:Advanced
 PatchComponent.phase.allowedVals:[]
 PatchComponent.phase.readOnly:False
@@ -2866,7 +2837,7 @@ PatchComponent.startType.label:start type
 PatchComponent.startType.valType:str
 PatchComponent.startType.val:time (s)
 PatchComponent.startType.allowedTypes:[]
-PatchComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+PatchComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 PatchComponent.startType.categ:Basic
 PatchComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 PatchComponent.startType.readOnly:False
@@ -2879,7 +2850,7 @@ PatchComponent.ori.label:Orientation
 PatchComponent.ori.valType:code
 PatchComponent.ori.val:0
 PatchComponent.ori.allowedTypes:[]
-PatchComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe110>>
+PatchComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b190>>
 PatchComponent.ori.categ:Basic
 PatchComponent.ori.allowedVals:[]
 PatchComponent.ori.readOnly:False
@@ -2892,7 +2863,7 @@ PatchComponent.stopType.label:stop type
 PatchComponent.stopType.valType:str
 PatchComponent.stopType.val:duration (s)
 PatchComponent.stopType.allowedTypes:[]
-PatchComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+PatchComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 PatchComponent.stopType.categ:Basic
 PatchComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 PatchComponent.stopType.readOnly:False
@@ -2905,7 +2876,7 @@ PatchComponent.startVal.label:Start
 PatchComponent.startVal.valType:code
 PatchComponent.startVal.val:0.0
 PatchComponent.startVal.allowedTypes:[]
-PatchComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+PatchComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 PatchComponent.startVal.categ:Basic
 PatchComponent.startVal.allowedVals:[]
 PatchComponent.startVal.readOnly:False
@@ -2918,7 +2889,7 @@ PatchComponent.image.label:Image/tex
 PatchComponent.image.valType:str
 PatchComponent.image.val:sin
 PatchComponent.image.allowedTypes:[]
-PatchComponent.image.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe150>>
+PatchComponent.image.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b3d0>>
 PatchComponent.image.categ:Basic
 PatchComponent.image.allowedVals:[]
 PatchComponent.image.readOnly:False
@@ -2931,7 +2902,7 @@ PatchComponent.size.label:Size [w,h]
 PatchComponent.size.valType:code
 PatchComponent.size.val:(0.5, 0.5)
 PatchComponent.size.allowedTypes:[]
-PatchComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe0d0>>
+PatchComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 PatchComponent.size.categ:Basic
 PatchComponent.size.allowedVals:[]
 PatchComponent.size.readOnly:False
@@ -2945,7 +2916,7 @@ PolygonComponent.opacity.label:Opacity
 PolygonComponent.opacity.valType:code
 PolygonComponent.opacity.val:1
 PolygonComponent.opacity.allowedTypes:[]
-PolygonComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+PolygonComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 PolygonComponent.opacity.categ:Basic
 PolygonComponent.opacity.allowedVals:[]
 PolygonComponent.opacity.readOnly:False
@@ -2958,7 +2929,7 @@ PolygonComponent.fillColorSpace.label:Fill color-space
 PolygonComponent.fillColorSpace.valType:str
 PolygonComponent.fillColorSpace.val:rgb
 PolygonComponent.fillColorSpace.allowedTypes:[]
-PolygonComponent.fillColorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe3d0>>
+PolygonComponent.fillColorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b110>>
 PolygonComponent.fillColorSpace.categ:Advanced
 PolygonComponent.fillColorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 PolygonComponent.fillColorSpace.readOnly:False
@@ -2971,7 +2942,7 @@ PolygonComponent.name.label:Name
 PolygonComponent.name.valType:code
 PolygonComponent.name.val:polygon
 PolygonComponent.name.allowedTypes:[]
-PolygonComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+PolygonComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 PolygonComponent.name.categ:Basic
 PolygonComponent.name.allowedVals:[]
 PolygonComponent.name.readOnly:False
@@ -2983,7 +2954,7 @@ PolygonComponent.fillColor.label:Fill color
 PolygonComponent.fillColor.valType:str
 PolygonComponent.fillColor.val:$[1,1,1]
 PolygonComponent.fillColor.allowedTypes:[]
-PolygonComponent.fillColor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe410>>
+PolygonComponent.fillColor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b5d0>>
 PolygonComponent.fillColor.categ:Advanced
 PolygonComponent.fillColor.allowedVals:[]
 PolygonComponent.fillColor.readOnly:False
@@ -2996,7 +2967,7 @@ PolygonComponent.stopVal.label:Stop
 PolygonComponent.stopVal.valType:code
 PolygonComponent.stopVal.val:1.0
 PolygonComponent.stopVal.allowedTypes:[]
-PolygonComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+PolygonComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 PolygonComponent.stopVal.categ:Basic
 PolygonComponent.stopVal.allowedVals:[]
 PolygonComponent.stopVal.readOnly:False
@@ -3009,7 +2980,7 @@ PolygonComponent.durationEstim.label:Expected duration (s)
 PolygonComponent.durationEstim.valType:code
 PolygonComponent.durationEstim.val:
 PolygonComponent.durationEstim.allowedTypes:[]
-PolygonComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+PolygonComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 PolygonComponent.durationEstim.categ:Basic
 PolygonComponent.durationEstim.allowedVals:[]
 PolygonComponent.durationEstim.readOnly:False
@@ -3022,7 +2993,7 @@ PolygonComponent.pos.label:Position [x,y]
 PolygonComponent.pos.valType:code
 PolygonComponent.pos.val:(0, 0)
 PolygonComponent.pos.allowedTypes:[]
-PolygonComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe2d0>>
+PolygonComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 PolygonComponent.pos.categ:Basic
 PolygonComponent.pos.allowedVals:[]
 PolygonComponent.pos.readOnly:False
@@ -3035,7 +3006,7 @@ PolygonComponent.interpolate.label:Interpolate
 PolygonComponent.interpolate.valType:str
 PolygonComponent.interpolate.val:linear
 PolygonComponent.interpolate.allowedTypes:[]
-PolygonComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe510>>
+PolygonComponent.interpolate.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b150>>
 PolygonComponent.interpolate.categ:Advanced
 PolygonComponent.interpolate.allowedVals:['linear', 'nearest']
 PolygonComponent.interpolate.readOnly:False
@@ -3048,7 +3019,7 @@ PolygonComponent.lineWidth.label:Line width
 PolygonComponent.lineWidth.valType:code
 PolygonComponent.lineWidth.val:1
 PolygonComponent.lineWidth.allowedTypes:[]
-PolygonComponent.lineWidth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe4d0>>
+PolygonComponent.lineWidth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba10>>
 PolygonComponent.lineWidth.categ:Basic
 PolygonComponent.lineWidth.allowedVals:[]
 PolygonComponent.lineWidth.readOnly:False
@@ -3061,7 +3032,7 @@ PolygonComponent.startEstim.label:Expected start (s)
 PolygonComponent.startEstim.valType:code
 PolygonComponent.startEstim.val:
 PolygonComponent.startEstim.allowedTypes:[]
-PolygonComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+PolygonComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 PolygonComponent.startEstim.categ:Basic
 PolygonComponent.startEstim.allowedVals:[]
 PolygonComponent.startEstim.readOnly:False
@@ -3074,7 +3045,7 @@ PolygonComponent.units.label:Units
 PolygonComponent.units.valType:str
 PolygonComponent.units.val:from exp settings
 PolygonComponent.units.allowedTypes:[]
-PolygonComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+PolygonComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 PolygonComponent.units.categ:Basic
 PolygonComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 PolygonComponent.units.readOnly:False
@@ -3087,7 +3058,7 @@ PolygonComponent.startType.label:start type
 PolygonComponent.startType.valType:str
 PolygonComponent.startType.val:time (s)
 PolygonComponent.startType.allowedTypes:[]
-PolygonComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+PolygonComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 PolygonComponent.startType.categ:Basic
 PolygonComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 PolygonComponent.startType.readOnly:False
@@ -3100,7 +3071,7 @@ PolygonComponent.lineColor.label:Line color
 PolygonComponent.lineColor.valType:str
 PolygonComponent.lineColor.val:$[1,1,1]
 PolygonComponent.lineColor.allowedTypes:[]
-PolygonComponent.lineColor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe490>>
+PolygonComponent.lineColor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b650>>
 PolygonComponent.lineColor.categ:Advanced
 PolygonComponent.lineColor.allowedVals:[]
 PolygonComponent.lineColor.readOnly:False
@@ -3113,7 +3084,7 @@ PolygonComponent.ori.label:Orientation
 PolygonComponent.ori.valType:code
 PolygonComponent.ori.val:0
 PolygonComponent.ori.allowedTypes:[]
-PolygonComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe350>>
+PolygonComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b690>>
 PolygonComponent.ori.categ:Basic
 PolygonComponent.ori.allowedVals:[]
 PolygonComponent.ori.readOnly:False
@@ -3126,7 +3097,7 @@ PolygonComponent.stopType.label:stop type
 PolygonComponent.stopType.valType:str
 PolygonComponent.stopType.val:duration (s)
 PolygonComponent.stopType.allowedTypes:[]
-PolygonComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+PolygonComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 PolygonComponent.stopType.categ:Basic
 PolygonComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 PolygonComponent.stopType.readOnly:False
@@ -3139,7 +3110,7 @@ PolygonComponent.startVal.label:Start
 PolygonComponent.startVal.valType:code
 PolygonComponent.startVal.val:0.0
 PolygonComponent.startVal.allowedTypes:[]
-PolygonComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+PolygonComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 PolygonComponent.startVal.categ:Basic
 PolygonComponent.startVal.allowedVals:[]
 PolygonComponent.startVal.readOnly:False
@@ -3152,7 +3123,7 @@ PolygonComponent.lineColorSpace.label:Line color-space
 PolygonComponent.lineColorSpace.valType:str
 PolygonComponent.lineColorSpace.val:rgb
 PolygonComponent.lineColorSpace.allowedTypes:[]
-PolygonComponent.lineColorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe450>>
+PolygonComponent.lineColorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b0d0>>
 PolygonComponent.lineColorSpace.categ:Advanced
 PolygonComponent.lineColorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 PolygonComponent.lineColorSpace.readOnly:False
@@ -3165,7 +3136,7 @@ PolygonComponent.nVertices.label:Num. vertices
 PolygonComponent.nVertices.valType:int
 PolygonComponent.nVertices.val:4
 PolygonComponent.nVertices.allowedTypes:[]
-PolygonComponent.nVertices.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe390>>
+PolygonComponent.nVertices.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b6d0>>
 PolygonComponent.nVertices.categ:Basic
 PolygonComponent.nVertices.allowedVals:[]
 PolygonComponent.nVertices.readOnly:False
@@ -3178,7 +3149,7 @@ PolygonComponent.size.label:Size [w,h]
 PolygonComponent.size.valType:code
 PolygonComponent.size.val:(0.5, 0.5)
 PolygonComponent.size.allowedTypes:[]
-PolygonComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe550>>
+PolygonComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b590>>
 PolygonComponent.size.categ:Basic
 PolygonComponent.size.allowedVals:[]
 PolygonComponent.size.readOnly:False
@@ -3193,7 +3164,7 @@ RatingScaleComponent.labels.label:Labels
 RatingScaleComponent.labels.valType:str
 RatingScaleComponent.labels.val:
 RatingScaleComponent.labels.allowedTypes:[]
-RatingScaleComponent.labels.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe0d0>>
+RatingScaleComponent.labels.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b410>>
 RatingScaleComponent.labels.categ:Basic
 RatingScaleComponent.labels.allowedVals:[]
 RatingScaleComponent.labels.readOnly:False
@@ -3206,7 +3177,7 @@ RatingScaleComponent.pos.label:Position [x,y]
 RatingScaleComponent.pos.valType:str
 RatingScaleComponent.pos.val:0, -0.4
 RatingScaleComponent.pos.allowedTypes:[]
-RatingScaleComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe5d0>>
+RatingScaleComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b450>>
 RatingScaleComponent.pos.categ:Advanced
 RatingScaleComponent.pos.allowedVals:[]
 RatingScaleComponent.pos.readOnly:False
@@ -3219,7 +3190,7 @@ RatingScaleComponent.high.label:Highest value
 RatingScaleComponent.high.valType:code
 RatingScaleComponent.high.val:7
 RatingScaleComponent.high.allowedTypes:[]
-RatingScaleComponent.high.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+RatingScaleComponent.high.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b190>>
 RatingScaleComponent.high.categ:Basic
 RatingScaleComponent.high.allowedVals:[]
 RatingScaleComponent.high.readOnly:False
@@ -3232,7 +3203,7 @@ RatingScaleComponent.storeRating.label:Store rating
 RatingScaleComponent.storeRating.valType:bool
 RatingScaleComponent.storeRating.val:True
 RatingScaleComponent.storeRating.allowedTypes:[]
-RatingScaleComponent.storeRating.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe290>>
+RatingScaleComponent.storeRating.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b490>>
 RatingScaleComponent.storeRating.categ:Advanced
 RatingScaleComponent.storeRating.allowedVals:[]
 RatingScaleComponent.storeRating.readOnly:False
@@ -3245,7 +3216,7 @@ RatingScaleComponent.marker.label:Marker type
 RatingScaleComponent.marker.valType:str
 RatingScaleComponent.marker.val:triangle
 RatingScaleComponent.marker.allowedTypes:[]
-RatingScaleComponent.marker.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe150>>
+RatingScaleComponent.marker.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b610>>
 RatingScaleComponent.marker.categ:Basic
 RatingScaleComponent.marker.allowedVals:[]
 RatingScaleComponent.marker.readOnly:False
@@ -3258,7 +3229,7 @@ RatingScaleComponent.startVal.label:Start
 RatingScaleComponent.startVal.valType:code
 RatingScaleComponent.startVal.val:0.0
 RatingScaleComponent.startVal.allowedTypes:[]
-RatingScaleComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+RatingScaleComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 RatingScaleComponent.startVal.categ:Basic
 RatingScaleComponent.startVal.allowedVals:[]
 RatingScaleComponent.startVal.readOnly:False
@@ -3271,7 +3242,7 @@ RatingScaleComponent.markerStart.label:Marker start
 RatingScaleComponent.markerStart.valType:str
 RatingScaleComponent.markerStart.val:
 RatingScaleComponent.markerStart.allowedTypes:[]
-RatingScaleComponent.markerStart.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe110>>
+RatingScaleComponent.markerStart.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba90>>
 RatingScaleComponent.markerStart.categ:Basic
 RatingScaleComponent.markerStart.allowedVals:[]
 RatingScaleComponent.markerStart.readOnly:False
@@ -3284,7 +3255,7 @@ RatingScaleComponent.disappear.label:Disappear
 RatingScaleComponent.disappear.valType:bool
 RatingScaleComponent.disappear.val:False
 RatingScaleComponent.disappear.allowedTypes:[]
-RatingScaleComponent.disappear.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe250>>
+RatingScaleComponent.disappear.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b250>>
 RatingScaleComponent.disappear.categ:Advanced
 RatingScaleComponent.disappear.allowedVals:[]
 RatingScaleComponent.disappear.readOnly:False
@@ -3297,7 +3268,7 @@ RatingScaleComponent.size.label:Size
 RatingScaleComponent.size.valType:code
 RatingScaleComponent.size.val:1.0
 RatingScaleComponent.size.allowedTypes:[]
-RatingScaleComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe310>>
+RatingScaleComponent.size.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b310>>
 RatingScaleComponent.size.categ:Advanced
 RatingScaleComponent.size.allowedVals:[]
 RatingScaleComponent.size.readOnly:False
@@ -3310,7 +3281,7 @@ RatingScaleComponent.tickHeight.label:Tick height
 RatingScaleComponent.tickHeight.valType:str
 RatingScaleComponent.tickHeight.val:
 RatingScaleComponent.tickHeight.allowedTypes:[]
-RatingScaleComponent.tickHeight.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe590>>
+RatingScaleComponent.tickHeight.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b090>>
 RatingScaleComponent.tickHeight.categ:Advanced
 RatingScaleComponent.tickHeight.allowedVals:[]
 RatingScaleComponent.tickHeight.readOnly:False
@@ -3323,7 +3294,7 @@ RatingScaleComponent.showAccept.label:Show accept
 RatingScaleComponent.showAccept.valType:bool
 RatingScaleComponent.showAccept.val:True
 RatingScaleComponent.showAccept.allowedTypes:[]
-RatingScaleComponent.showAccept.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe1d0>>
+RatingScaleComponent.showAccept.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b1d0>>
 RatingScaleComponent.showAccept.categ:Advanced
 RatingScaleComponent.showAccept.allowedVals:[]
 RatingScaleComponent.showAccept.readOnly:False
@@ -3336,7 +3307,7 @@ RatingScaleComponent.storeRatingTime.label:Store rating time
 RatingScaleComponent.storeRatingTime.valType:bool
 RatingScaleComponent.storeRatingTime.val:True
 RatingScaleComponent.storeRatingTime.allowedTypes:[]
-RatingScaleComponent.storeRatingTime.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe090>>
+RatingScaleComponent.storeRatingTime.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b4d0>>
 RatingScaleComponent.storeRatingTime.categ:Advanced
 RatingScaleComponent.storeRatingTime.allowedVals:[]
 RatingScaleComponent.storeRatingTime.readOnly:False
@@ -3349,7 +3320,7 @@ RatingScaleComponent.forceEndRoutine.label:Force end of Routine
 RatingScaleComponent.forceEndRoutine.valType:bool
 RatingScaleComponent.forceEndRoutine.val:True
 RatingScaleComponent.forceEndRoutine.allowedTypes:[]
-RatingScaleComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe050>>
+RatingScaleComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b210>>
 RatingScaleComponent.forceEndRoutine.categ:Advanced
 RatingScaleComponent.forceEndRoutine.allowedVals:[]
 RatingScaleComponent.forceEndRoutine.readOnly:False
@@ -3362,7 +3333,7 @@ RatingScaleComponent.low.label:Lowest value
 RatingScaleComponent.low.valType:code
 RatingScaleComponent.low.val:1
 RatingScaleComponent.low.allowedTypes:[]
-RatingScaleComponent.low.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+RatingScaleComponent.low.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b3d0>>
 RatingScaleComponent.low.categ:Basic
 RatingScaleComponent.low.allowedVals:[]
 RatingScaleComponent.low.readOnly:False
@@ -3375,7 +3346,7 @@ RatingScaleComponent.durationEstim.label:Expected duration (s)
 RatingScaleComponent.durationEstim.valType:code
 RatingScaleComponent.durationEstim.val:
 RatingScaleComponent.durationEstim.allowedTypes:[]
-RatingScaleComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+RatingScaleComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 RatingScaleComponent.durationEstim.categ:Basic
 RatingScaleComponent.durationEstim.allowedVals:[]
 RatingScaleComponent.durationEstim.readOnly:False
@@ -3388,7 +3359,7 @@ RatingScaleComponent.stopVal.label:Stop
 RatingScaleComponent.stopVal.valType:code
 RatingScaleComponent.stopVal.val:
 RatingScaleComponent.stopVal.allowedTypes:[]
-RatingScaleComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+RatingScaleComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 RatingScaleComponent.stopVal.categ:Basic
 RatingScaleComponent.stopVal.allowedVals:[]
 RatingScaleComponent.stopVal.readOnly:False
@@ -3401,7 +3372,7 @@ RatingScaleComponent.visualAnalogScale.label:Visual analog scale
 RatingScaleComponent.visualAnalogScale.valType:bool
 RatingScaleComponent.visualAnalogScale.val:False
 RatingScaleComponent.visualAnalogScale.allowedTypes:[]
-RatingScaleComponent.visualAnalogScale.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+RatingScaleComponent.visualAnalogScale.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 RatingScaleComponent.visualAnalogScale.categ:Basic
 RatingScaleComponent.visualAnalogScale.allowedVals:[]
 RatingScaleComponent.visualAnalogScale.readOnly:False
@@ -3414,7 +3385,7 @@ RatingScaleComponent.startEstim.label:Expected start (s)
 RatingScaleComponent.startEstim.valType:code
 RatingScaleComponent.startEstim.val:
 RatingScaleComponent.startEstim.allowedTypes:[]
-RatingScaleComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+RatingScaleComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 RatingScaleComponent.startEstim.categ:Basic
 RatingScaleComponent.startEstim.allowedVals:[]
 RatingScaleComponent.startEstim.readOnly:False
@@ -3427,7 +3398,7 @@ RatingScaleComponent.startType.label:start type
 RatingScaleComponent.startType.valType:str
 RatingScaleComponent.startType.val:time (s)
 RatingScaleComponent.startType.allowedTypes:[]
-RatingScaleComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+RatingScaleComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 RatingScaleComponent.startType.categ:Basic
 RatingScaleComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 RatingScaleComponent.startType.readOnly:False
@@ -3440,7 +3411,7 @@ RatingScaleComponent.stopType.label:stop type
 RatingScaleComponent.stopType.valType:str
 RatingScaleComponent.stopType.val:condition
 RatingScaleComponent.stopType.allowedTypes:[]
-RatingScaleComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+RatingScaleComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 RatingScaleComponent.stopType.categ:Basic
 RatingScaleComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 RatingScaleComponent.stopType.readOnly:False
@@ -3453,7 +3424,7 @@ RatingScaleComponent.scaleDescription.label:Scale description
 RatingScaleComponent.scaleDescription.valType:str
 RatingScaleComponent.scaleDescription.val:
 RatingScaleComponent.scaleDescription.allowedTypes:[]
-RatingScaleComponent.scaleDescription.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+RatingScaleComponent.scaleDescription.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b550>>
 RatingScaleComponent.scaleDescription.categ:Basic
 RatingScaleComponent.scaleDescription.allowedVals:[]
 RatingScaleComponent.scaleDescription.readOnly:False
@@ -3466,7 +3437,7 @@ RatingScaleComponent.storeHistory.label:Store history
 RatingScaleComponent.storeHistory.valType:bool
 RatingScaleComponent.storeHistory.val:False
 RatingScaleComponent.storeHistory.allowedTypes:[]
-RatingScaleComponent.storeHistory.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe190>>
+RatingScaleComponent.storeHistory.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b7d0>>
 RatingScaleComponent.storeHistory.categ:Advanced
 RatingScaleComponent.storeHistory.allowedVals:[]
 RatingScaleComponent.storeHistory.readOnly:False
@@ -3479,7 +3450,7 @@ RatingScaleComponent.categoryChoices.label:Category choices
 RatingScaleComponent.categoryChoices.valType:str
 RatingScaleComponent.categoryChoices.val:
 RatingScaleComponent.categoryChoices.allowedTypes:[]
-RatingScaleComponent.categoryChoices.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+RatingScaleComponent.categoryChoices.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 RatingScaleComponent.categoryChoices.categ:Basic
 RatingScaleComponent.categoryChoices.allowedVals:[]
 RatingScaleComponent.categoryChoices.readOnly:False
@@ -3492,7 +3463,7 @@ RatingScaleComponent.customize_everything.label:Customize everything :
 RatingScaleComponent.customize_everything.valType:str
 RatingScaleComponent.customize_everything.val:
 RatingScaleComponent.customize_everything.allowedTypes:[]
-RatingScaleComponent.customize_everything.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe610>>
+RatingScaleComponent.customize_everything.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b2d0>>
 RatingScaleComponent.customize_everything.categ:Custom
 RatingScaleComponent.customize_everything.allowedVals:[]
 RatingScaleComponent.customize_everything.readOnly:False
@@ -3505,7 +3476,7 @@ RatingScaleComponent.name.label:Name
 RatingScaleComponent.name.valType:code
 RatingScaleComponent.name.val:rating
 RatingScaleComponent.name.allowedTypes:[]
-RatingScaleComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+RatingScaleComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 RatingScaleComponent.name.categ:Basic
 RatingScaleComponent.name.allowedVals:[]
 RatingScaleComponent.name.readOnly:False
@@ -3517,7 +3488,7 @@ RatingScaleComponent.singleClick.label:Single click
 RatingScaleComponent.singleClick.valType:bool
 RatingScaleComponent.singleClick.val:False
 RatingScaleComponent.singleClick.allowedTypes:[]
-RatingScaleComponent.singleClick.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe210>>
+RatingScaleComponent.singleClick.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b390>>
 RatingScaleComponent.singleClick.categ:Advanced
 RatingScaleComponent.singleClick.allowedVals:[]
 RatingScaleComponent.singleClick.readOnly:False
@@ -3531,7 +3502,7 @@ SettingsComponent.Monitor.label:Monitor
 SettingsComponent.Monitor.valType:str
 SettingsComponent.Monitor.val:testMonitor
 SettingsComponent.Monitor.allowedTypes:[]
-SettingsComponent.Monitor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+SettingsComponent.Monitor.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b850>>
 SettingsComponent.Monitor.categ:Screen
 SettingsComponent.Monitor.allowedVals:[]
 SettingsComponent.Monitor.readOnly:False
@@ -3544,7 +3515,7 @@ SettingsComponent.color.label:Color
 SettingsComponent.color.valType:str
 SettingsComponent.color.val:$[0,0,0]
 SettingsComponent.color.allowedTypes:[]
-SettingsComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe550>>
+SettingsComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b790>>
 SettingsComponent.color.categ:Screen
 SettingsComponent.color.allowedVals:[]
 SettingsComponent.color.readOnly:False
@@ -3557,7 +3528,7 @@ SettingsComponent.colorSpace.label:Color space
 SettingsComponent.colorSpace.valType:str
 SettingsComponent.colorSpace.val:rgb
 SettingsComponent.colorSpace.allowedTypes:[]
-SettingsComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe390>>
+SettingsComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b9d0>>
 SettingsComponent.colorSpace.categ:Screen
 SettingsComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 SettingsComponent.colorSpace.readOnly:False
@@ -3570,7 +3541,7 @@ SettingsComponent.Experiment info.label:Experiment info
 SettingsComponent.Experiment info.valType:code
 SettingsComponent.Experiment info.val:{'participant':'', 'session':'001'}
 SettingsComponent.Experiment info.allowedTypes:[]
-SettingsComponent.Experiment info.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+SettingsComponent.Experiment info.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b0d0>>
 SettingsComponent.Experiment info.categ:Basic
 SettingsComponent.Experiment info.allowedVals:[]
 SettingsComponent.Experiment info.readOnly:False
@@ -3583,7 +3554,7 @@ SettingsComponent.JS libs.label:JS libs
 SettingsComponent.JS libs.valType:str
 SettingsComponent.JS libs.val:packaged
 SettingsComponent.JS libs.allowedTypes:[]
-SettingsComponent.JS libs.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe750>>
+SettingsComponent.JS libs.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b950>>
 SettingsComponent.JS libs.categ:Online
 SettingsComponent.JS libs.allowedVals:['packaged']
 SettingsComponent.JS libs.readOnly:False
@@ -3596,7 +3567,7 @@ SettingsComponent.Units.label:Units
 SettingsComponent.Units.valType:str
 SettingsComponent.Units.val:use prefs
 SettingsComponent.Units.allowedTypes:[]
-SettingsComponent.Units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe450>>
+SettingsComponent.Units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131ba10>>
 SettingsComponent.Units.categ:Screen
 SettingsComponent.Units.allowedVals:['use prefs', 'deg', 'pix', 'cm', 'norm', 'height', 'degFlatPos', 'degFlat']
 SettingsComponent.Units.readOnly:False
@@ -3609,7 +3580,7 @@ SettingsComponent.Save excel file.label:Save excel file
 SettingsComponent.Save excel file.valType:bool
 SettingsComponent.Save excel file.val:False
 SettingsComponent.Save excel file.allowedTypes:[]
-SettingsComponent.Save excel file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe3d0>>
+SettingsComponent.Save excel file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b350>>
 SettingsComponent.Save excel file.categ:Data
 SettingsComponent.Save excel file.allowedVals:[]
 SettingsComponent.Save excel file.readOnly:False
@@ -3622,7 +3593,7 @@ SettingsComponent.Enable Escape.label:Enable Escape key
 SettingsComponent.Enable Escape.valType:bool
 SettingsComponent.Enable Escape.val:True
 SettingsComponent.Enable Escape.allowedTypes:[]
-SettingsComponent.Enable Escape.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+SettingsComponent.Enable Escape.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b6d0>>
 SettingsComponent.Enable Escape.categ:Basic
 SettingsComponent.Enable Escape.allowedVals:[]
 SettingsComponent.Enable Escape.readOnly:False
@@ -3635,7 +3606,7 @@ SettingsComponent.Save psydat file.label:Save psydat file
 SettingsComponent.Save psydat file.valType:bool
 SettingsComponent.Save psydat file.val:True
 SettingsComponent.Save psydat file.allowedTypes:[]
-SettingsComponent.Save psydat file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe650>>
+SettingsComponent.Save psydat file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b8d0>>
 SettingsComponent.Save psydat file.categ:Data
 SettingsComponent.Save psydat file.allowedVals:[True]
 SettingsComponent.Save psydat file.readOnly:False
@@ -3648,7 +3619,7 @@ SettingsComponent.Window size (pixels).label:Window size (pixels)
 SettingsComponent.Window size (pixels).valType:code
 SettingsComponent.Window size (pixels).val:(1024, 768)
 SettingsComponent.Window size (pixels).allowedTypes:[]
-SettingsComponent.Window size (pixels).next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+SettingsComponent.Window size (pixels).next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b690>>
 SettingsComponent.Window size (pixels).categ:Screen
 SettingsComponent.Window size (pixels).allowedVals:[]
 SettingsComponent.Window size (pixels).readOnly:False
@@ -3661,7 +3632,7 @@ SettingsComponent.Full-screen window.label:Full-screen window
 SettingsComponent.Full-screen window.valType:bool
 SettingsComponent.Full-screen window.val:True
 SettingsComponent.Full-screen window.allowedTypes:[]
-SettingsComponent.Full-screen window.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+SettingsComponent.Full-screen window.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b710>>
 SettingsComponent.Full-screen window.categ:Screen
 SettingsComponent.Full-screen window.allowedVals:[]
 SettingsComponent.Full-screen window.readOnly:False
@@ -3674,7 +3645,7 @@ SettingsComponent.blendMode.label:Blend mode
 SettingsComponent.blendMode.valType:str
 SettingsComponent.blendMode.val:avg
 SettingsComponent.blendMode.allowedTypes:[]
-SettingsComponent.blendMode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe350>>
+SettingsComponent.blendMode.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b150>>
 SettingsComponent.blendMode.categ:Screen
 SettingsComponent.blendMode.allowedVals:['add', 'avg']
 SettingsComponent.blendMode.readOnly:False
@@ -3687,9 +3658,9 @@ SettingsComponent.Use version.label:Use PsychoPy version
 SettingsComponent.Use version.valType:str
 SettingsComponent.Use version.val:
 SettingsComponent.Use version.allowedTypes:[]
-SettingsComponent.Use version.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+SettingsComponent.Use version.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b750>>
 SettingsComponent.Use version.categ:Basic
-SettingsComponent.Use version.allowedVals:['latest', '1', '1.85', '', '1.85.1']
+SettingsComponent.Use version.allowedVals:['latest', '1', '1.85', '', '1.85.3']
 SettingsComponent.Use version.readOnly:False
 SettingsComponent.Use version.updates:None
 SettingsComponent.Use version.staticUpdater:None
@@ -3700,7 +3671,7 @@ SettingsComponent.HTML path.label:Output path
 SettingsComponent.HTML path.valType:str
 SettingsComponent.HTML path.val:html
 SettingsComponent.HTML path.allowedTypes:[]
-SettingsComponent.HTML path.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe710>>
+SettingsComponent.HTML path.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b990>>
 SettingsComponent.HTML path.categ:Online
 SettingsComponent.HTML path.allowedVals:[]
 SettingsComponent.HTML path.readOnly:False
@@ -3713,7 +3684,7 @@ SettingsComponent.Save csv file.label:Save csv file (summaries)
 SettingsComponent.Save csv file.valType:bool
 SettingsComponent.Save csv file.val:False
 SettingsComponent.Save csv file.allowedTypes:[]
-SettingsComponent.Save csv file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe410>>
+SettingsComponent.Save csv file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b110>>
 SettingsComponent.Save csv file.categ:Data
 SettingsComponent.Save csv file.allowedVals:[]
 SettingsComponent.Save csv file.readOnly:False
@@ -3726,7 +3697,7 @@ SettingsComponent.OSF Project ID.label:OSF Project ID
 SettingsComponent.OSF Project ID.valType:str
 SettingsComponent.OSF Project ID.val:
 SettingsComponent.OSF Project ID.allowedTypes:[]
-SettingsComponent.OSF Project ID.next:<bound method ProjIDParam.next of <psychopy.app.builder.components.settings.ProjIDParam object at 0x10e1fe6d0>>
+SettingsComponent.OSF Project ID.next:<bound method ProjIDParam.next of <psychopy.app.builder.components.settings.ProjIDParam object at 0x11131ba50>>
 SettingsComponent.OSF Project ID.categ:Online
 SettingsComponent.OSF Project ID.allowedVals:['']
 SettingsComponent.OSF Project ID.readOnly:False
@@ -3739,7 +3710,7 @@ SettingsComponent.Save log file.label:Save log file
 SettingsComponent.Save log file.valType:bool
 SettingsComponent.Save log file.val:True
 SettingsComponent.Save log file.allowedTypes:[]
-SettingsComponent.Save log file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe510>>
+SettingsComponent.Save log file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b810>>
 SettingsComponent.Save log file.categ:Data
 SettingsComponent.Save log file.allowedVals:[]
 SettingsComponent.Save log file.readOnly:False
@@ -3752,7 +3723,7 @@ SettingsComponent.Save wide csv file.label:Save csv file (trial-by-trial)
 SettingsComponent.Save wide csv file.valType:bool
 SettingsComponent.Save wide csv file.val:True
 SettingsComponent.Save wide csv file.allowedTypes:[]
-SettingsComponent.Save wide csv file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe2d0>>
+SettingsComponent.Save wide csv file.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b5d0>>
 SettingsComponent.Save wide csv file.categ:Data
 SettingsComponent.Save wide csv file.allowedVals:[]
 SettingsComponent.Save wide csv file.readOnly:False
@@ -3765,7 +3736,7 @@ SettingsComponent.Show mouse.label:Show mouse
 SettingsComponent.Show mouse.valType:bool
 SettingsComponent.Show mouse.val:False
 SettingsComponent.Show mouse.allowedTypes:[]
-SettingsComponent.Show mouse.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe490>>
+SettingsComponent.Show mouse.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b510>>
 SettingsComponent.Show mouse.categ:Screen
 SettingsComponent.Show mouse.allowedVals:[]
 SettingsComponent.Show mouse.readOnly:False
@@ -3778,7 +3749,7 @@ SettingsComponent.Data filename.label:Data filename
 SettingsComponent.Data filename.valType:code
 SettingsComponent.Data filename.val:u'data/%s_%s_%s' % (expInfo['participant'], expName, expInfo['date'])
 SettingsComponent.Data filename.allowedTypes:[]
-SettingsComponent.Data filename.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe4d0>>
+SettingsComponent.Data filename.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b890>>
 SettingsComponent.Data filename.categ:Data
 SettingsComponent.Data filename.allowedVals:[]
 SettingsComponent.Data filename.readOnly:False
@@ -3791,7 +3762,7 @@ SettingsComponent.Show info dlg.label:Show info dialog
 SettingsComponent.Show info dlg.valType:bool
 SettingsComponent.Show info dlg.val:True
 SettingsComponent.Show info dlg.allowedTypes:[]
-SettingsComponent.Show info dlg.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+SettingsComponent.Show info dlg.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b590>>
 SettingsComponent.Show info dlg.categ:Basic
 SettingsComponent.Show info dlg.allowedVals:[]
 SettingsComponent.Show info dlg.readOnly:False
@@ -3804,7 +3775,7 @@ SettingsComponent.expName.label:Experiment name
 SettingsComponent.expName.valType:str
 SettingsComponent.expName.val:
 SettingsComponent.expName.allowedTypes:[]
-SettingsComponent.expName.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+SettingsComponent.expName.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 SettingsComponent.expName.categ:Basic
 SettingsComponent.expName.allowedVals:[]
 SettingsComponent.expName.readOnly:False
@@ -3817,7 +3788,7 @@ SettingsComponent.logging level.label:Logging level
 SettingsComponent.logging level.valType:code
 SettingsComponent.logging level.val:exp
 SettingsComponent.logging level.allowedTypes:[]
-SettingsComponent.logging level.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe690>>
+SettingsComponent.logging level.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b910>>
 SettingsComponent.logging level.categ:Data
 SettingsComponent.logging level.allowedVals:['error', 'warning', 'data', 'exp', 'info', 'debug']
 SettingsComponent.logging level.readOnly:False
@@ -3830,7 +3801,7 @@ SettingsComponent.Screen.label:Screen
 SettingsComponent.Screen.valType:num
 SettingsComponent.Screen.val:1
 SettingsComponent.Screen.allowedTypes:[]
-SettingsComponent.Screen.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+SettingsComponent.Screen.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x11131b650>>
 SettingsComponent.Screen.categ:Screen
 SettingsComponent.Screen.allowedVals:[]
 SettingsComponent.Screen.readOnly:False
@@ -3844,7 +3815,7 @@ SoundComponent.sound.label:Sound
 SoundComponent.sound.valType:str
 SoundComponent.sound.val:A
 SoundComponent.sound.allowedTypes:[]
-SoundComponent.sound.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+SoundComponent.sound.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 SoundComponent.sound.categ:Basic
 SoundComponent.sound.allowedVals:[]
 SoundComponent.sound.readOnly:False
@@ -3857,7 +3828,7 @@ SoundComponent.volume.label:Volume
 SoundComponent.volume.valType:code
 SoundComponent.volume.val:1
 SoundComponent.volume.allowedTypes:[]
-SoundComponent.volume.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+SoundComponent.volume.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 SoundComponent.volume.categ:Basic
 SoundComponent.volume.allowedVals:[]
 SoundComponent.volume.readOnly:False
@@ -3870,7 +3841,7 @@ SoundComponent.name.label:Name
 SoundComponent.name.valType:code
 SoundComponent.name.val:sound_1
 SoundComponent.name.allowedTypes:[]
-SoundComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+SoundComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 SoundComponent.name.categ:Basic
 SoundComponent.name.allowedVals:[]
 SoundComponent.name.readOnly:False
@@ -3882,7 +3853,7 @@ SoundComponent.stopVal.label:Stop
 SoundComponent.stopVal.valType:code
 SoundComponent.stopVal.val:1.0
 SoundComponent.stopVal.allowedTypes:[]
-SoundComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+SoundComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 SoundComponent.stopVal.categ:Basic
 SoundComponent.stopVal.allowedVals:[]
 SoundComponent.stopVal.readOnly:False
@@ -3895,7 +3866,7 @@ SoundComponent.durationEstim.label:Expected duration (s)
 SoundComponent.durationEstim.valType:code
 SoundComponent.durationEstim.val:
 SoundComponent.durationEstim.allowedTypes:[]
-SoundComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+SoundComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 SoundComponent.durationEstim.categ:Basic
 SoundComponent.durationEstim.allowedVals:[]
 SoundComponent.durationEstim.readOnly:False
@@ -3908,7 +3879,7 @@ SoundComponent.startEstim.label:Expected start (s)
 SoundComponent.startEstim.valType:code
 SoundComponent.startEstim.val:
 SoundComponent.startEstim.allowedTypes:[]
-SoundComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+SoundComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 SoundComponent.startEstim.categ:Basic
 SoundComponent.startEstim.allowedVals:[]
 SoundComponent.startEstim.readOnly:False
@@ -3921,7 +3892,7 @@ SoundComponent.startType.label:start type
 SoundComponent.startType.valType:str
 SoundComponent.startType.val:time (s)
 SoundComponent.startType.allowedTypes:[]
-SoundComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+SoundComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 SoundComponent.startType.categ:Basic
 SoundComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 SoundComponent.startType.readOnly:False
@@ -3934,7 +3905,7 @@ SoundComponent.stopType.label:stop type
 SoundComponent.stopType.valType:str
 SoundComponent.stopType.val:duration (s)
 SoundComponent.stopType.allowedTypes:[]
-SoundComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+SoundComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 SoundComponent.stopType.categ:Basic
 SoundComponent.stopType.allowedVals:['duration (s)']
 SoundComponent.stopType.readOnly:False
@@ -3947,7 +3918,7 @@ SoundComponent.startVal.label:Start
 SoundComponent.startVal.valType:code
 SoundComponent.startVal.val:0.0
 SoundComponent.startVal.allowedTypes:[]
-SoundComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+SoundComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 SoundComponent.startVal.categ:Basic
 SoundComponent.startVal.allowedVals:[]
 SoundComponent.startVal.readOnly:False
@@ -3961,7 +3932,7 @@ StaticComponent.code.label:Custom code
 StaticComponent.code.valType:code
 StaticComponent.code.val:
 StaticComponent.code.allowedTypes:[]
-StaticComponent.code.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+StaticComponent.code.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113211d0>>
 StaticComponent.code.categ:Basic
 StaticComponent.code.allowedVals:[]
 StaticComponent.code.readOnly:False
@@ -3974,7 +3945,7 @@ StaticComponent.name.label:Name
 StaticComponent.name.valType:code
 StaticComponent.name.val:ISI
 StaticComponent.name.allowedTypes:[]
-StaticComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+StaticComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 StaticComponent.name.categ:Basic
 StaticComponent.name.allowedVals:[]
 StaticComponent.name.readOnly:False
@@ -3986,7 +3957,7 @@ StaticComponent.stopVal.label:
 StaticComponent.stopVal.valType:code
 StaticComponent.stopVal.val:0.5
 StaticComponent.stopVal.allowedTypes:[]
-StaticComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+StaticComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113210d0>>
 StaticComponent.stopVal.categ:Basic
 StaticComponent.stopVal.allowedVals:[]
 StaticComponent.stopVal.readOnly:False
@@ -3999,7 +3970,7 @@ StaticComponent.durationEstim.label:
 StaticComponent.durationEstim.valType:code
 StaticComponent.durationEstim.val:
 StaticComponent.durationEstim.allowedTypes:[]
-StaticComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+StaticComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321150>>
 StaticComponent.durationEstim.categ:Basic
 StaticComponent.durationEstim.allowedVals:[]
 StaticComponent.durationEstim.readOnly:False
@@ -4012,7 +3983,7 @@ StaticComponent.startEstim.label:
 StaticComponent.startEstim.valType:code
 StaticComponent.startEstim.val:
 StaticComponent.startEstim.allowedTypes:[]
-StaticComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+StaticComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321110>>
 StaticComponent.startEstim.categ:Basic
 StaticComponent.startEstim.allowedVals:[]
 StaticComponent.startEstim.readOnly:False
@@ -4025,7 +3996,7 @@ StaticComponent.startType.label:
 StaticComponent.startType.valType:str
 StaticComponent.startType.val:time (s)
 StaticComponent.startType.allowedTypes:[]
-StaticComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+StaticComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321210>>
 StaticComponent.startType.categ:Basic
 StaticComponent.startType.allowedVals:['time (s)', 'frame N']
 StaticComponent.startType.readOnly:False
@@ -4038,7 +4009,7 @@ StaticComponent.stopType.label:
 StaticComponent.stopType.valType:str
 StaticComponent.stopType.val:duration (s)
 StaticComponent.stopType.allowedTypes:[]
-StaticComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+StaticComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321050>>
 StaticComponent.stopType.categ:Basic
 StaticComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N']
 StaticComponent.stopType.readOnly:False
@@ -4051,7 +4022,7 @@ StaticComponent.startVal.label:
 StaticComponent.startVal.valType:code
 StaticComponent.startVal.val:0.0
 StaticComponent.startVal.allowedTypes:[]
-StaticComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+StaticComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321090>>
 StaticComponent.startVal.categ:Basic
 StaticComponent.startVal.allowedVals:[]
 StaticComponent.startVal.readOnly:False
@@ -4065,7 +4036,7 @@ TextComponent.opacity.label:Opacity
 TextComponent.opacity.valType:code
 TextComponent.opacity.val:1
 TextComponent.opacity.allowedTypes:[]
-TextComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+TextComponent.opacity.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321190>>
 TextComponent.opacity.categ:Advanced
 TextComponent.opacity.allowedVals:[]
 TextComponent.opacity.readOnly:False
@@ -4078,7 +4049,7 @@ TextComponent.colorSpace.label:Color space
 TextComponent.colorSpace.valType:str
 TextComponent.colorSpace.val:rgb
 TextComponent.colorSpace.allowedTypes:[]
-TextComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+TextComponent.colorSpace.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321250>>
 TextComponent.colorSpace.categ:Advanced
 TextComponent.colorSpace.allowedVals:['rgb', 'dkl', 'lms', 'hsv']
 TextComponent.colorSpace.readOnly:False
@@ -4091,7 +4062,7 @@ TextComponent.name.label:Name
 TextComponent.name.valType:code
 TextComponent.name.val:text
 TextComponent.name.allowedTypes:[]
-TextComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+TextComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 TextComponent.name.categ:Basic
 TextComponent.name.allowedVals:[]
 TextComponent.name.readOnly:False
@@ -4103,7 +4074,7 @@ TextComponent.wrapWidth.label:Wrap width
 TextComponent.wrapWidth.valType:code
 TextComponent.wrapWidth.val:
 TextComponent.wrapWidth.allowedTypes:[]
-TextComponent.wrapWidth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe2d0>>
+TextComponent.wrapWidth.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113213d0>>
 TextComponent.wrapWidth.categ:Advanced
 TextComponent.wrapWidth.allowedVals:[]
 TextComponent.wrapWidth.readOnly:False
@@ -4116,7 +4087,7 @@ TextComponent.color.label:Color
 TextComponent.color.valType:str
 TextComponent.color.val:white
 TextComponent.color.allowedTypes:[]
-TextComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+TextComponent.color.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 TextComponent.color.categ:Basic
 TextComponent.color.allowedVals:[]
 TextComponent.color.readOnly:False
@@ -4131,7 +4102,7 @@ TextComponent.text.val:Any text
 
 including line breaks
 TextComponent.text.allowedTypes:[]
-TextComponent.text.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe4d0>>
+TextComponent.text.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321350>>
 TextComponent.text.categ:Basic
 TextComponent.text.allowedVals:[]
 TextComponent.text.readOnly:False
@@ -4144,7 +4115,7 @@ TextComponent.stopVal.label:Stop
 TextComponent.stopVal.valType:code
 TextComponent.stopVal.val:1.0
 TextComponent.stopVal.allowedTypes:[]
-TextComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+TextComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 TextComponent.stopVal.categ:Basic
 TextComponent.stopVal.allowedVals:[]
 TextComponent.stopVal.readOnly:False
@@ -4157,7 +4128,7 @@ TextComponent.durationEstim.label:Expected duration (s)
 TextComponent.durationEstim.valType:code
 TextComponent.durationEstim.val:
 TextComponent.durationEstim.allowedTypes:[]
-TextComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+TextComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 TextComponent.durationEstim.categ:Basic
 TextComponent.durationEstim.allowedVals:[]
 TextComponent.durationEstim.readOnly:False
@@ -4170,7 +4141,7 @@ TextComponent.pos.label:Position [x,y]
 TextComponent.pos.valType:code
 TextComponent.pos.val:(0, 0)
 TextComponent.pos.allowedTypes:[]
-TextComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+TextComponent.pos.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321290>>
 TextComponent.pos.categ:Basic
 TextComponent.pos.allowedVals:[]
 TextComponent.pos.readOnly:False
@@ -4183,7 +4154,7 @@ TextComponent.flip.label:Flip (mirror)
 TextComponent.flip.valType:str
 TextComponent.flip.val:
 TextComponent.flip.allowedTypes:[]
-TextComponent.flip.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe510>>
+TextComponent.flip.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321410>>
 TextComponent.flip.categ:Advanced
 TextComponent.flip.allowedVals:[]
 TextComponent.flip.readOnly:False
@@ -4196,7 +4167,7 @@ TextComponent.startEstim.label:Expected start (s)
 TextComponent.startEstim.valType:code
 TextComponent.startEstim.val:
 TextComponent.startEstim.allowedTypes:[]
-TextComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+TextComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 TextComponent.startEstim.categ:Basic
 TextComponent.startEstim.allowedVals:[]
 TextComponent.startEstim.readOnly:False
@@ -4209,7 +4180,7 @@ TextComponent.units.label:Units
 TextComponent.units.valType:str
 TextComponent.units.val:from exp settings
 TextComponent.units.allowedTypes:[]
-TextComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+TextComponent.units.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 TextComponent.units.categ:Advanced
 TextComponent.units.allowedVals:['from exp settings', 'deg', 'cm', 'pix', 'norm', 'height', 'degFlatPos', 'degFlat']
 TextComponent.units.readOnly:False
@@ -4222,7 +4193,7 @@ TextComponent.startType.label:start type
 TextComponent.startType.valType:str
 TextComponent.startType.val:time (s)
 TextComponent.startType.allowedTypes:[]
-TextComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+TextComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 TextComponent.startType.categ:Basic
 TextComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 TextComponent.startType.readOnly:False
@@ -4235,7 +4206,7 @@ TextComponent.ori.label:Orientation
 TextComponent.ori.valType:code
 TextComponent.ori.val:0
 TextComponent.ori.allowedTypes:[]
-TextComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe690>>
+TextComponent.ori.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321310>>
 TextComponent.ori.categ:Advanced
 TextComponent.ori.allowedVals:[]
 TextComponent.ori.readOnly:False
@@ -4248,7 +4219,7 @@ TextComponent.stopType.label:stop type
 TextComponent.stopType.valType:str
 TextComponent.stopType.val:duration (s)
 TextComponent.stopType.allowedTypes:[]
-TextComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+TextComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 TextComponent.stopType.categ:Basic
 TextComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 TextComponent.stopType.readOnly:False
@@ -4261,7 +4232,7 @@ TextComponent.startVal.label:Start
 TextComponent.startVal.valType:code
 TextComponent.startVal.val:0.0
 TextComponent.startVal.allowedTypes:[]
-TextComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+TextComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 TextComponent.startVal.categ:Basic
 TextComponent.startVal.allowedVals:[]
 TextComponent.startVal.readOnly:False
@@ -4274,7 +4245,7 @@ TextComponent.font.label:Font
 TextComponent.font.valType:str
 TextComponent.font.val:Arial
 TextComponent.font.allowedTypes:[]
-TextComponent.font.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fe490>>
+TextComponent.font.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321390>>
 TextComponent.font.categ:Basic
 TextComponent.font.allowedVals:[]
 TextComponent.font.readOnly:False
@@ -4287,7 +4258,7 @@ TextComponent.letterHeight.label:Letter height
 TextComponent.letterHeight.valType:code
 TextComponent.letterHeight.val:0.1
 TextComponent.letterHeight.allowedTypes:[]
-TextComponent.letterHeight.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+TextComponent.letterHeight.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113212d0>>
 TextComponent.letterHeight.categ:Basic
 TextComponent.letterHeight.allowedVals:[]
 TextComponent.letterHeight.readOnly:False
@@ -4301,7 +4272,7 @@ UnknownComponent.name.label:Name
 UnknownComponent.name.valType:code
 UnknownComponent.name.val:
 UnknownComponent.name.allowedTypes:[]
-UnknownComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+UnknownComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321090>>
 UnknownComponent.name.categ:Basic
 UnknownComponent.name.allowedVals:[]
 UnknownComponent.name.readOnly:False
@@ -4314,33 +4285,33 @@ cedrusButtonBoxComponent.correctAns.label:Correct answer
 cedrusButtonBoxComponent.correctAns.valType:code
 cedrusButtonBoxComponent.correctAns.val:
 cedrusButtonBoxComponent.correctAns.allowedTypes:[]
-cedrusButtonBoxComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b10>>
+cedrusButtonBoxComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321410>>
 cedrusButtonBoxComponent.correctAns.categ:Basic
 cedrusButtonBoxComponent.correctAns.allowedVals:[]
 cedrusButtonBoxComponent.correctAns.readOnly:False
 cedrusButtonBoxComponent.correctAns.updates:constant
 cedrusButtonBoxComponent.correctAns.staticUpdater:None
 cedrusButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 6 on a 7-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
-cedrusButtonBoxComponent.correctAns.allowedUpdates:[]
+cedrusButtonBoxComponent.correctAns.allowedUpdates:None
 cedrusButtonBoxComponent.storeCorrect.default:False
 cedrusButtonBoxComponent.storeCorrect.label:Store correct
 cedrusButtonBoxComponent.storeCorrect.valType:bool
 cedrusButtonBoxComponent.storeCorrect.val:False
 cedrusButtonBoxComponent.storeCorrect.allowedTypes:[]
-cedrusButtonBoxComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d90>>
+cedrusButtonBoxComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321310>>
 cedrusButtonBoxComponent.storeCorrect.categ:Basic
 cedrusButtonBoxComponent.storeCorrect.allowedVals:[]
 cedrusButtonBoxComponent.storeCorrect.readOnly:False
 cedrusButtonBoxComponent.storeCorrect.updates:constant
 cedrusButtonBoxComponent.storeCorrect.staticUpdater:None
 cedrusButtonBoxComponent.storeCorrect.hint:Do you want to save the response as correct/incorrect?
-cedrusButtonBoxComponent.storeCorrect.allowedUpdates:[]
+cedrusButtonBoxComponent.storeCorrect.allowedUpdates:None
 cedrusButtonBoxComponent.name.default:buttonBox
 cedrusButtonBoxComponent.name.label:Name
 cedrusButtonBoxComponent.name.valType:code
 cedrusButtonBoxComponent.name.val:buttonBox
 cedrusButtonBoxComponent.name.allowedTypes:[]
-cedrusButtonBoxComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c10>>
+cedrusButtonBoxComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f50>>
 cedrusButtonBoxComponent.name.categ:Basic
 cedrusButtonBoxComponent.name.allowedVals:[]
 cedrusButtonBoxComponent.name.readOnly:False
@@ -4352,7 +4323,7 @@ cedrusButtonBoxComponent.deviceNumber.label:Device number
 cedrusButtonBoxComponent.deviceNumber.valType:code
 cedrusButtonBoxComponent.deviceNumber.val:0
 cedrusButtonBoxComponent.deviceNumber.allowedTypes:[]
-cedrusButtonBoxComponent.deviceNumber.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ad0>>
+cedrusButtonBoxComponent.deviceNumber.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321350>>
 cedrusButtonBoxComponent.deviceNumber.categ:Advanced
 cedrusButtonBoxComponent.deviceNumber.allowedVals:[]
 cedrusButtonBoxComponent.deviceNumber.readOnly:False
@@ -4365,7 +4336,7 @@ cedrusButtonBoxComponent.stopVal.label:Stop
 cedrusButtonBoxComponent.stopVal.valType:code
 cedrusButtonBoxComponent.stopVal.val:1.0
 cedrusButtonBoxComponent.stopVal.allowedTypes:[]
-cedrusButtonBoxComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3c90>>
+cedrusButtonBoxComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d10>>
 cedrusButtonBoxComponent.stopVal.categ:Basic
 cedrusButtonBoxComponent.stopVal.allowedVals:[]
 cedrusButtonBoxComponent.stopVal.readOnly:False
@@ -4378,7 +4349,7 @@ cedrusButtonBoxComponent.durationEstim.label:Expected duration (s)
 cedrusButtonBoxComponent.durationEstim.valType:code
 cedrusButtonBoxComponent.durationEstim.val:
 cedrusButtonBoxComponent.durationEstim.allowedTypes:[]
-cedrusButtonBoxComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3fd0>>
+cedrusButtonBoxComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312dd0>>
 cedrusButtonBoxComponent.durationEstim.categ:Basic
 cedrusButtonBoxComponent.durationEstim.allowedVals:[]
 cedrusButtonBoxComponent.durationEstim.readOnly:False
@@ -4391,7 +4362,7 @@ cedrusButtonBoxComponent.useBoxTimer.label:Use box timer
 cedrusButtonBoxComponent.useBoxTimer.valType:bool
 cedrusButtonBoxComponent.useBoxTimer.val:False
 cedrusButtonBoxComponent.useBoxTimer.allowedTypes:[]
-cedrusButtonBoxComponent.useBoxTimer.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b90>>
+cedrusButtonBoxComponent.useBoxTimer.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113213d0>>
 cedrusButtonBoxComponent.useBoxTimer.categ:Advanced
 cedrusButtonBoxComponent.useBoxTimer.allowedVals:[True, False]
 cedrusButtonBoxComponent.useBoxTimer.readOnly:False
@@ -4404,20 +4375,20 @@ cedrusButtonBoxComponent.forceEndRoutine.label:Force end of Routine
 cedrusButtonBoxComponent.forceEndRoutine.valType:bool
 cedrusButtonBoxComponent.forceEndRoutine.val:True
 cedrusButtonBoxComponent.forceEndRoutine.allowedTypes:[]
-cedrusButtonBoxComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e90>>
+cedrusButtonBoxComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321390>>
 cedrusButtonBoxComponent.forceEndRoutine.categ:Basic
 cedrusButtonBoxComponent.forceEndRoutine.allowedVals:[]
 cedrusButtonBoxComponent.forceEndRoutine.readOnly:False
 cedrusButtonBoxComponent.forceEndRoutine.updates:constant
 cedrusButtonBoxComponent.forceEndRoutine.staticUpdater:None
 cedrusButtonBoxComponent.forceEndRoutine.hint:Should a response force the end of the Routine (e.g end the trial)?
-cedrusButtonBoxComponent.forceEndRoutine.allowedUpdates:[]
+cedrusButtonBoxComponent.forceEndRoutine.allowedUpdates:None
 cedrusButtonBoxComponent.startEstim.default:
 cedrusButtonBoxComponent.startEstim.label:Expected start (s)
 cedrusButtonBoxComponent.startEstim.valType:code
 cedrusButtonBoxComponent.startEstim.val:
 cedrusButtonBoxComponent.startEstim.allowedTypes:[]
-cedrusButtonBoxComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3dd0>>
+cedrusButtonBoxComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d90>>
 cedrusButtonBoxComponent.startEstim.categ:Basic
 cedrusButtonBoxComponent.startEstim.allowedVals:[]
 cedrusButtonBoxComponent.startEstim.readOnly:False
@@ -4430,20 +4401,20 @@ cedrusButtonBoxComponent.discard previous.label:Discard previous
 cedrusButtonBoxComponent.discard previous.valType:bool
 cedrusButtonBoxComponent.discard previous.val:True
 cedrusButtonBoxComponent.discard previous.allowedTypes:[]
-cedrusButtonBoxComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f10>>
+cedrusButtonBoxComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e90>>
 cedrusButtonBoxComponent.discard previous.categ:Basic
 cedrusButtonBoxComponent.discard previous.allowedVals:[]
 cedrusButtonBoxComponent.discard previous.readOnly:False
 cedrusButtonBoxComponent.discard previous.updates:constant
 cedrusButtonBoxComponent.discard previous.staticUpdater:None
 cedrusButtonBoxComponent.discard previous.hint:Do you want to discard all responses occuring before the onset of this component?
-cedrusButtonBoxComponent.discard previous.allowedUpdates:[]
+cedrusButtonBoxComponent.discard previous.allowedUpdates:None
 cedrusButtonBoxComponent.startType.default:'time (s)'
 cedrusButtonBoxComponent.startType.label:start type
 cedrusButtonBoxComponent.startType.valType:str
 cedrusButtonBoxComponent.startType.val:time (s)
 cedrusButtonBoxComponent.startType.allowedTypes:[]
-cedrusButtonBoxComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e50>>
+cedrusButtonBoxComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312f10>>
 cedrusButtonBoxComponent.startType.categ:Basic
 cedrusButtonBoxComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 cedrusButtonBoxComponent.startType.readOnly:False
@@ -4456,7 +4427,7 @@ cedrusButtonBoxComponent.allowedKeys.label:Allowed keys
 cedrusButtonBoxComponent.allowedKeys.valType:code
 cedrusButtonBoxComponent.allowedKeys.val:
 cedrusButtonBoxComponent.allowedKeys.allowedTypes:[]
-cedrusButtonBoxComponent.allowedKeys.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f50>>
+cedrusButtonBoxComponent.allowedKeys.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e50>>
 cedrusButtonBoxComponent.allowedKeys.categ:Basic
 cedrusButtonBoxComponent.allowedKeys.allowedVals:[]
 cedrusButtonBoxComponent.allowedKeys.readOnly:False
@@ -4469,7 +4440,7 @@ cedrusButtonBoxComponent.stopType.label:stop type
 cedrusButtonBoxComponent.stopType.valType:str
 cedrusButtonBoxComponent.stopType.val:duration (s)
 cedrusButtonBoxComponent.stopType.allowedTypes:[]
-cedrusButtonBoxComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3f90>>
+cedrusButtonBoxComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312e10>>
 cedrusButtonBoxComponent.stopType.categ:Basic
 cedrusButtonBoxComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 cedrusButtonBoxComponent.stopType.readOnly:False
@@ -4482,7 +4453,7 @@ cedrusButtonBoxComponent.startVal.label:Start
 cedrusButtonBoxComponent.startVal.valType:code
 cedrusButtonBoxComponent.startVal.val:0.0
 cedrusButtonBoxComponent.startVal.allowedTypes:[]
-cedrusButtonBoxComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a50>>
+cedrusButtonBoxComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312d50>>
 cedrusButtonBoxComponent.startVal.categ:Basic
 cedrusButtonBoxComponent.startVal.allowedVals:[]
 cedrusButtonBoxComponent.startVal.readOnly:False
@@ -4495,60 +4466,60 @@ cedrusButtonBoxComponent.store.label:Store
 cedrusButtonBoxComponent.store.valType:str
 cedrusButtonBoxComponent.store.val:first key
 cedrusButtonBoxComponent.store.allowedTypes:[]
-cedrusButtonBoxComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d10>>
+cedrusButtonBoxComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113212d0>>
 cedrusButtonBoxComponent.store.categ:Basic
 cedrusButtonBoxComponent.store.allowedVals:['last key', 'first key', 'all keys', 'nothing']
 cedrusButtonBoxComponent.store.readOnly:False
 cedrusButtonBoxComponent.store.updates:constant
 cedrusButtonBoxComponent.store.staticUpdater:None
 cedrusButtonBoxComponent.store.hint:Choose which (if any) responses to store at the end of a trial
-cedrusButtonBoxComponent.store.allowedUpdates:[]
+cedrusButtonBoxComponent.store.allowedUpdates:None
 cedrusButtonBoxComponent.syncScreenRefresh.default:True
 cedrusButtonBoxComponent.syncScreenRefresh.label:sync RT with screen
 cedrusButtonBoxComponent.syncScreenRefresh.valType:bool
 cedrusButtonBoxComponent.syncScreenRefresh.val:True
 cedrusButtonBoxComponent.syncScreenRefresh.allowedTypes:[]
-cedrusButtonBoxComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3ed0>>
+cedrusButtonBoxComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321290>>
 cedrusButtonBoxComponent.syncScreenRefresh.categ:Basic
 cedrusButtonBoxComponent.syncScreenRefresh.allowedVals:[]
 cedrusButtonBoxComponent.syncScreenRefresh.readOnly:False
 cedrusButtonBoxComponent.syncScreenRefresh.updates:constant
 cedrusButtonBoxComponent.syncScreenRefresh.staticUpdater:None
 cedrusButtonBoxComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
-cedrusButtonBoxComponent.syncScreenRefresh.allowedUpdates:[]
+cedrusButtonBoxComponent.syncScreenRefresh.allowedUpdates:None
 ioLabsButtonBoxComponent.order:['forceEndRoutine', 'active', 'lights', 'store', 'storeCorrect', 'correctAns']
 ioLabsButtonBoxComponent.correctAns.default:'0'
 ioLabsButtonBoxComponent.correctAns.label:Correct answer
 ioLabsButtonBoxComponent.correctAns.valType:str
 ioLabsButtonBoxComponent.correctAns.val:0
 ioLabsButtonBoxComponent.correctAns.allowedTypes:[]
-ioLabsButtonBoxComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd210>>
+ioLabsButtonBoxComponent.correctAns.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113214d0>>
 ioLabsButtonBoxComponent.correctAns.categ:Basic
 ioLabsButtonBoxComponent.correctAns.allowedVals:[]
 ioLabsButtonBoxComponent.correctAns.readOnly:False
 ioLabsButtonBoxComponent.correctAns.updates:constant
 ioLabsButtonBoxComponent.correctAns.staticUpdater:None
 ioLabsButtonBoxComponent.correctAns.hint:What is the 'correct' response? NB, buttons are labelled 0 to 7 on a 8-button box. Enter 'None' (no quotes) if withholding a response is correct. Might be helpful to add a correctAns column and use $correctAns to compare to the key press.
-ioLabsButtonBoxComponent.correctAns.allowedUpdates:[]
+ioLabsButtonBoxComponent.correctAns.allowedUpdates:None
 ioLabsButtonBoxComponent.storeCorrect.default:False
 ioLabsButtonBoxComponent.storeCorrect.label:Store correct
 ioLabsButtonBoxComponent.storeCorrect.valType:bool
 ioLabsButtonBoxComponent.storeCorrect.val:False
 ioLabsButtonBoxComponent.storeCorrect.allowedTypes:[]
-ioLabsButtonBoxComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd1d0>>
+ioLabsButtonBoxComponent.storeCorrect.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321490>>
 ioLabsButtonBoxComponent.storeCorrect.categ:Basic
 ioLabsButtonBoxComponent.storeCorrect.allowedVals:[]
 ioLabsButtonBoxComponent.storeCorrect.readOnly:False
 ioLabsButtonBoxComponent.storeCorrect.updates:constant
 ioLabsButtonBoxComponent.storeCorrect.staticUpdater:None
 ioLabsButtonBoxComponent.storeCorrect.hint:Do you want to save the response as correct/incorrect?
-ioLabsButtonBoxComponent.storeCorrect.allowedUpdates:[]
+ioLabsButtonBoxComponent.storeCorrect.allowedUpdates:None
 ioLabsButtonBoxComponent.name.default:bbox
 ioLabsButtonBoxComponent.name.label:Name
 ioLabsButtonBoxComponent.name.valType:code
 ioLabsButtonBoxComponent.name.val:bbox
 ioLabsButtonBoxComponent.name.allowedTypes:[]
-ioLabsButtonBoxComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3b50>>
+ioLabsButtonBoxComponent.name.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111312fd0>>
 ioLabsButtonBoxComponent.name.categ:Basic
 ioLabsButtonBoxComponent.name.allowedVals:[]
 ioLabsButtonBoxComponent.name.readOnly:False
@@ -4560,7 +4531,7 @@ ioLabsButtonBoxComponent.lights.label:Lights
 ioLabsButtonBoxComponent.lights.valType:bool
 ioLabsButtonBoxComponent.lights.val:True
 ioLabsButtonBoxComponent.lights.allowedTypes:[]
-ioLabsButtonBoxComponent.lights.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd290>>
+ioLabsButtonBoxComponent.lights.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321550>>
 ioLabsButtonBoxComponent.lights.categ:Basic
 ioLabsButtonBoxComponent.lights.allowedVals:[]
 ioLabsButtonBoxComponent.lights.readOnly:False
@@ -4573,7 +4544,7 @@ ioLabsButtonBoxComponent.stopVal.label:Stop
 ioLabsButtonBoxComponent.stopVal.valType:code
 ioLabsButtonBoxComponent.stopVal.val:1.0
 ioLabsButtonBoxComponent.stopVal.allowedTypes:[]
-ioLabsButtonBoxComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3e10>>
+ioLabsButtonBoxComponent.stopVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321050>>
 ioLabsButtonBoxComponent.stopVal.categ:Basic
 ioLabsButtonBoxComponent.stopVal.allowedVals:[]
 ioLabsButtonBoxComponent.stopVal.readOnly:False
@@ -4586,7 +4557,7 @@ ioLabsButtonBoxComponent.durationEstim.label:Expected duration (s)
 ioLabsButtonBoxComponent.durationEstim.valType:code
 ioLabsButtonBoxComponent.durationEstim.val:
 ioLabsButtonBoxComponent.durationEstim.allowedTypes:[]
-ioLabsButtonBoxComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd090>>
+ioLabsButtonBoxComponent.durationEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321110>>
 ioLabsButtonBoxComponent.durationEstim.categ:Basic
 ioLabsButtonBoxComponent.durationEstim.allowedVals:[]
 ioLabsButtonBoxComponent.durationEstim.readOnly:False
@@ -4599,20 +4570,20 @@ ioLabsButtonBoxComponent.forceEndRoutine.label:Force end of Routine
 ioLabsButtonBoxComponent.forceEndRoutine.valType:bool
 ioLabsButtonBoxComponent.forceEndRoutine.val:True
 ioLabsButtonBoxComponent.forceEndRoutine.allowedTypes:[]
-ioLabsButtonBoxComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd190>>
+ioLabsButtonBoxComponent.forceEndRoutine.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321450>>
 ioLabsButtonBoxComponent.forceEndRoutine.categ:Basic
 ioLabsButtonBoxComponent.forceEndRoutine.allowedVals:[]
 ioLabsButtonBoxComponent.forceEndRoutine.readOnly:False
 ioLabsButtonBoxComponent.forceEndRoutine.updates:constant
 ioLabsButtonBoxComponent.forceEndRoutine.staticUpdater:None
 ioLabsButtonBoxComponent.forceEndRoutine.hint:Should a response force the end of the Routine (e.g end the trial)?
-ioLabsButtonBoxComponent.forceEndRoutine.allowedUpdates:[]
+ioLabsButtonBoxComponent.forceEndRoutine.allowedUpdates:None
 ioLabsButtonBoxComponent.startEstim.default:
 ioLabsButtonBoxComponent.startEstim.label:Expected start (s)
 ioLabsButtonBoxComponent.startEstim.valType:code
 ioLabsButtonBoxComponent.startEstim.val:
 ioLabsButtonBoxComponent.startEstim.allowedTypes:[]
-ioLabsButtonBoxComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd050>>
+ioLabsButtonBoxComponent.startEstim.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321210>>
 ioLabsButtonBoxComponent.startEstim.categ:Basic
 ioLabsButtonBoxComponent.startEstim.allowedVals:[]
 ioLabsButtonBoxComponent.startEstim.readOnly:False
@@ -4625,20 +4596,20 @@ ioLabsButtonBoxComponent.discard previous.label:Discard previous
 ioLabsButtonBoxComponent.discard previous.valType:bool
 ioLabsButtonBoxComponent.discard previous.val:True
 ioLabsButtonBoxComponent.discard previous.allowedTypes:[]
-ioLabsButtonBoxComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd110>>
+ioLabsButtonBoxComponent.discard previous.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113210d0>>
 ioLabsButtonBoxComponent.discard previous.categ:Basic
 ioLabsButtonBoxComponent.discard previous.allowedVals:[]
 ioLabsButtonBoxComponent.discard previous.readOnly:False
 ioLabsButtonBoxComponent.discard previous.updates:constant
 ioLabsButtonBoxComponent.discard previous.staticUpdater:None
 ioLabsButtonBoxComponent.discard previous.hint:Do you want to discard all responses occuring before the onset of this component?
-ioLabsButtonBoxComponent.discard previous.allowedUpdates:[]
+ioLabsButtonBoxComponent.discard previous.allowedUpdates:None
 ioLabsButtonBoxComponent.startType.default:'time (s)'
 ioLabsButtonBoxComponent.startType.label:start type
 ioLabsButtonBoxComponent.startType.valType:str
 ioLabsButtonBoxComponent.startType.val:time (s)
 ioLabsButtonBoxComponent.startType.allowedTypes:[]
-ioLabsButtonBoxComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3bd0>>
+ioLabsButtonBoxComponent.startType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321090>>
 ioLabsButtonBoxComponent.startType.categ:Basic
 ioLabsButtonBoxComponent.startType.allowedVals:['time (s)', 'frame N', 'condition']
 ioLabsButtonBoxComponent.startType.readOnly:False
@@ -4651,7 +4622,7 @@ ioLabsButtonBoxComponent.lights off.label:Lights off
 ioLabsButtonBoxComponent.lights off.valType:bool
 ioLabsButtonBoxComponent.lights off.val:False
 ioLabsButtonBoxComponent.lights off.allowedTypes:[]
-ioLabsButtonBoxComponent.lights off.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd2d0>>
+ioLabsButtonBoxComponent.lights off.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321590>>
 ioLabsButtonBoxComponent.lights off.categ:Basic
 ioLabsButtonBoxComponent.lights off.allowedVals:[]
 ioLabsButtonBoxComponent.lights off.readOnly:False
@@ -4664,7 +4635,7 @@ ioLabsButtonBoxComponent.stopType.label:stop type
 ioLabsButtonBoxComponent.stopType.valType:str
 ioLabsButtonBoxComponent.stopType.val:duration (s)
 ioLabsButtonBoxComponent.stopType.allowedTypes:[]
-ioLabsButtonBoxComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3d50>>
+ioLabsButtonBoxComponent.stopType.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321250>>
 ioLabsButtonBoxComponent.stopType.categ:Basic
 ioLabsButtonBoxComponent.stopType.allowedVals:['duration (s)', 'duration (frames)', 'time (s)', 'frame N', 'condition']
 ioLabsButtonBoxComponent.stopType.readOnly:False
@@ -4677,7 +4648,7 @@ ioLabsButtonBoxComponent.startVal.label:Start
 ioLabsButtonBoxComponent.startVal.valType:code
 ioLabsButtonBoxComponent.startVal.val:0.0
 ioLabsButtonBoxComponent.startVal.allowedTypes:[]
-ioLabsButtonBoxComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1f3a90>>
+ioLabsButtonBoxComponent.startVal.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321190>>
 ioLabsButtonBoxComponent.startVal.categ:Basic
 ioLabsButtonBoxComponent.startVal.allowedVals:[]
 ioLabsButtonBoxComponent.startVal.readOnly:False
@@ -4690,7 +4661,7 @@ ioLabsButtonBoxComponent.active.label:Active buttons
 ioLabsButtonBoxComponent.active.valType:code
 ioLabsButtonBoxComponent.active.val:(0,1,2,3,4,5,6,7)
 ioLabsButtonBoxComponent.active.allowedTypes:[]
-ioLabsButtonBoxComponent.active.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd0d0>>
+ioLabsButtonBoxComponent.active.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321150>>
 ioLabsButtonBoxComponent.active.categ:Basic
 ioLabsButtonBoxComponent.active.allowedVals:[]
 ioLabsButtonBoxComponent.active.readOnly:False
@@ -4703,24 +4674,24 @@ ioLabsButtonBoxComponent.store.label:Store
 ioLabsButtonBoxComponent.store.valType:str
 ioLabsButtonBoxComponent.store.val:first button
 ioLabsButtonBoxComponent.store.allowedTypes:[]
-ioLabsButtonBoxComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd150>>
+ioLabsButtonBoxComponent.store.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x1113211d0>>
 ioLabsButtonBoxComponent.store.categ:Basic
 ioLabsButtonBoxComponent.store.allowedVals:['last button', 'first button', 'all buttons', 'nothing']
 ioLabsButtonBoxComponent.store.readOnly:False
 ioLabsButtonBoxComponent.store.updates:constant
 ioLabsButtonBoxComponent.store.staticUpdater:None
 ioLabsButtonBoxComponent.store.hint:Choose which (if any) responses to store at end of a trial
-ioLabsButtonBoxComponent.store.allowedUpdates:[]
+ioLabsButtonBoxComponent.store.allowedUpdates:None
 ioLabsButtonBoxComponent.syncScreenRefresh.default:True
 ioLabsButtonBoxComponent.syncScreenRefresh.label:sync RT with screen
 ioLabsButtonBoxComponent.syncScreenRefresh.valType:bool
 ioLabsButtonBoxComponent.syncScreenRefresh.val:True
 ioLabsButtonBoxComponent.syncScreenRefresh.allowedTypes:[]
-ioLabsButtonBoxComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x10e1fd250>>
+ioLabsButtonBoxComponent.syncScreenRefresh.next:<bound method Param.next of <psychopy.app.builder.experiment.Param object at 0x111321510>>
 ioLabsButtonBoxComponent.syncScreenRefresh.categ:Basic
 ioLabsButtonBoxComponent.syncScreenRefresh.allowedVals:[]
 ioLabsButtonBoxComponent.syncScreenRefresh.readOnly:False
 ioLabsButtonBoxComponent.syncScreenRefresh.updates:constant
 ioLabsButtonBoxComponent.syncScreenRefresh.staticUpdater:None
 ioLabsButtonBoxComponent.syncScreenRefresh.hint:A reaction time to a visual stimulus should be based on when the screen flipped
-ioLabsButtonBoxComponent.syncScreenRefresh.allowedUpdates:[]
+ioLabsButtonBoxComponent.syncScreenRefresh.allowedUpdates:None

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -99,23 +99,26 @@ class TestTrialHandler2(object):
                 trials.saveAsPickle(base_data_filename, fileCollisionMethod='fail')
 
     def test_psydat_filename_collision_output2(self):
-        #create conditions
+        # create conditions
         conditions=[]
         for trialType in range(5):
             conditions.append({'trialType':trialType})
-            #create trials
+            # create trials
         trials= data.TrialHandler2(trialList=conditions, seed=100, nReps=3,
                                   method='fullRandom', autoLog=False)
-        #simulate trials
+        # simulate trials
         for thisTrial in trials:
             resp = 'resp'+str(thisTrial['trialType'])
-            randResp=random()#a unique number so we can see which track orders
+            randResp=random()  # a unique number so we can see which track orders
             trials.addData('resp', resp)
-            trials.addData('rand',randResp)
-        #test wide data outputs
-        trials.saveAsWideText(pjoin(self.temp_dir, 'testFullRandom.csv'), delim=',', appendFile=False)
-        # not currently testing this as column order won't match (and we've removed the columns "ran" and "order")
-        utils.compareTextFiles(pjoin(self.temp_dir, 'testFullRandom.csv'), pjoin(fixturesPath,'corrFullRandomTH2.csv'))
+            trials.addData('rand', randResp)
+        # test wide data outputs
+        trials.saveAsWideText(pjoin(self.temp_dir, 'testFullRandom.csv'),
+                              delim=',', appendFile=False)
+        # not currently testing this as column order won't match
+        # (and we've removed the columns "ran" and "order")
+        utils.compareTextFiles(pjoin(self.temp_dir, 'testFullRandom.csv'),
+                               pjoin(fixturesPath,'corrFullRandomTH2.csv'))
 
     def test_random_data_output2(self):
         #create conditions

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -237,7 +237,7 @@ class ImageStim(BaseVisualStim, ContainerMixin, ColorMixin, TextureMixin):
     def draw(self, win=None):
         """Draw.
         """
-        if self.image in (None, "None", "none"):
+        if self.image is None or self.image == "None" or self.image == "none":
             return
 
         if win is None:
@@ -272,7 +272,7 @@ class ImageStim(BaseVisualStim, ContainerMixin, ColorMixin, TextureMixin):
             datatype = GL.GL_FLOAT
         else:
             datatype = GL.GL_UNSIGNED_BYTE
-        if value in (None,  "None", "none"):
+        if value is None or value == "None" or value == "none":
             self.isLumImage = True
         else:
             self.isLumImage = self._createTexture(value, id=self._texID,

--- a/setup.py
+++ b/setup.py
@@ -18,20 +18,26 @@ PY3 = version_info>=(3,0)
 
 # use pip module to parse the
 required = ['numpy', 'scipy', 'matplotlib', 'pandas', 'pillow',
-            'wxPython', 'pyglet','pygame', 'configobj',
+            'wxPython', 'pyglet', 'pygame', 'configobj',
             'soundfile', 'sounddevice',
-            'python-bidi', 'cffi', 'future', 'json_tricks',
+            'python-bidi', 'cffi',
+            'future', 'json_tricks',
             'pyosf', 'requests[security]',
-            'xlrd', 'openpyxl',
+            'xlrd', 'openpyxl',  # MS Excel
             'pyserial','pyparallel',
             'pyyaml', 'gevent', 'msgpack-python', 'psutil', 'tables',
             'opencv-python',
+            'moviepy',
             ]
 # some optional dependencies
 if platform == 'darwin':
     required.extend(['pyobjc-core', 'pyobjc-framework-Quartz'])
 if PY3:  # doesn't exist on py2
     required.append('pyqt5')
+# for dev you also want:
+# 'sphinx','pytest'
+# 'lxml', 'pyopengl'
+
 
 # compress psychojs to a zip file for packaging
 if '-noJS' in argv:  # only takes 0.5s but could skip if you prefer


### PR DESCRIPTION
Mouse component now has new params:
   - "clickable stimuli": a list of stimuli that we can register as clicked
   - "store params for clicked": e.g. store the name, and the stimulus text/image/color etc
   - "new clicks only": checks if button is down *and wasn't on previous frame*

and some changed params:
   - "End routine on press" now supports choice options "never" (equivalent to previous False), "any click" (equivalent to previous True) and "valid click" (new option, only finish if they clicked one of the listed stimuli)