### PR TITLE
Add == and != operators for DataHandler and _BaseTrialHandler, and JSON export for staircases

### DIFF
--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -17,6 +17,7 @@ import inspect
 import codecs
 import numpy as np
 import pandas as pd
+import json_tricks
 from distutils.version import StrictVersion
 
 import psychopy
@@ -361,6 +362,51 @@ class _BaseTrialHandler(_ComparisonMixin):
                 ws.cell(_cell).value = val
 
         wb.save(filename=fileName)
+
+    def saveAsJson(self,
+                   fileName=None,
+                   encoding='utf-8',
+                   fileCollisionMethod='rename'):
+        """
+        Serialize the object to the JSON format.
+
+        Parameters
+        ----------
+        fileName: string, or None
+            the name of the file to create or append. Can include a relative or
+            absolute path. If `None`, will not write to a file, but return an
+            in-memory JSON object.
+
+        encoding : string, optional
+            The encoding to use when writing the file. This parameter will be
+            ignored if `append` is `False` and `fileName` ends with `.psydat`
+            or `.npy` (i.e. if a binary file is to be written).
+
+        fileCollisionMethod : string
+            Collision method passed to
+            :func:`~psychopy.tools.fileerrortools.handleFileCollision`. Can be
+            either of `'rename'`, `'overwrite'`, or `'fail'`.
+
+        Notes
+        -----
+        Currently, a copy of the object is created, and the copy's .origin
+        attribute is set to an empty string before serializing
+        because loading the created JSON file would sometimes fail otherwise.
+
+        """
+        self_copy = copy.deepcopy(self)
+        self_copy.origin = ''
+        msg = ('Setting attribute .origin to empty string during JSON '
+               'serialization.')
+        logging.warn(msg)
+
+        if fileName is None:
+            return json_tricks.np.dumps(self_copy)
+        else:
+            f = openOutputFile(fileName,
+                               fileCollisionMethod=fileCollisionMethod,
+                               encoding=encoding)
+            json_tricks.np.dump(self_copy, f)
 
     def getOriginPathAndFile(self, originPath=None):
         """Attempts to determine the path of the script that created this

--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -408,6 +408,10 @@ class _BaseTrialHandler(_ComparisonMixin):
                                encoding=encoding)
             json_tricks.np.dump(self_copy, f)
 
+            if f != sys.stdout:
+                f.close()
+                logging.info('Saved JSON data to %s' % f.name)
+
     def getOriginPathAndFile(self, originPath=None):
         """Attempts to determine the path of the script that created this
         data file and returns both the path to that script and its contents.

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
-from builtins import object
 import sys
 import copy
 import pickle
@@ -14,9 +13,10 @@ import pickle
 from psychopy import logging
 from psychopy.tools.filetools import openOutputFile, genDelimiter
 from .utils import checkValidFilePath
+from .base import _ComparisonMixin
 
 
-class ExperimentHandler(object):
+class ExperimentHandler(_ComparisonMixin):
     """A container class for keeping track of multiple loops/handlers
 
     Useful for generating a single data file from an experiment with many

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -28,7 +28,7 @@ from psychopy.tools.filetools import openOutputFile, genDelimiter
 from psychopy.tools.fileerrortools import handleFileCollision
 from psychopy.contrib.quest import QuestObject
 from psychopy.contrib.psi import PsiObject
-from .base import _BaseTrialHandler
+from .base import _BaseTrialHandler, _ComparisonMixin
 from .utils import _getExcelCellName
 
 try:
@@ -669,6 +669,12 @@ class StairHandler(_BaseTrialHandler):
         logging.info('saved data to %s' % f.name)
 
 
+class QuestObject_(QuestObject, _ComparisonMixin):
+    """A QuestObject that implements the == and != operators.
+    """
+    pass
+
+
 class QuestHandler(StairHandler):
     """Class that implements the Quest algorithm for quick measurement of
     psychophysical thresholds.
@@ -848,7 +854,7 @@ class QuestHandler(StairHandler):
         self._questNextIntensity = startVal
 
         # Create Quest object
-        self._quest = QuestObject(
+        self._quest = QuestObject_(
             startVal, startValSd, pThreshold, beta, delta, gamma,
             grain=grain, range=range)
 
@@ -1034,6 +1040,12 @@ class QuestHandler(StairHandler):
             self.finished = False
 
 
+class PsiObject_(PsiObject, _ComparisonMixin):
+    """A PsiObject that implements the == and != operators.
+    """
+    pass
+
+
 class PsiHandler(StairHandler):
     """Handler to implement the "Psi" adaptive psychophysical method
     (Kontsevich & Tyler, 1999).
@@ -1184,7 +1196,7 @@ class PsiHandler(StairHandler):
                 prior = None
 
         twoAFC = True if expectedMin == 0.5 else False
-        self._psi = PsiObject(
+        self._psi = PsiObject_(
             intensRange, alphaRange, betaRange, intensPrecision,
             alphaPrecision, betaPrecision, delta=delta,
             stepType=stepType, TwoAFC=twoAFC, prior=prior)

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -721,6 +721,12 @@ class TrialHandler(_BaseTrialHandler):
         df = df.convert_objects()
         return df
 
+    def saveAsJson(self,
+                   fileName=None,
+                   encoding='utf-8',
+                   fileCollisionMethod='rename'):
+        raise NotImplementedError('Not implemented for TrialHandler.')
+
     def addData(self, thisType, value, position=None):
         """Add data for the current trial
         """
@@ -1116,6 +1122,12 @@ class TrialHandler2(_BaseTrialHandler):
         if f != sys.stdout:
             f.close()
             logging.info('saved wide-format data to %s' % f.name)
+
+    def saveAsJson(self,
+                   fileName=None,
+                   encoding='utf-8',
+                   fileCollisionMethod='rename'):
+        raise NotImplementedError('Not implemented for TrialHandler2.')
 
     def addData(self, thisType, value):
         """Add a piece of data to the current trial
@@ -1838,3 +1850,9 @@ class TrialHandlerExt(TrialHandler):
         if f != sys.stdout:
             f.close()
             logging.info('saved wide-format data to %s' % f.name)
+
+    def saveAsJson(self,
+                   fileName=None,
+                   encoding='utf-8',
+                   fileCollisionMethod='rename'):
+        raise NotImplementedError('Not implemented for TrialHandlerExt.')

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -918,6 +918,15 @@ class TrialHandler2(_BaseTrialHandler):
         strRepres += ')'
         return strRepres
 
+    def __eq__(self, other):
+        # We want to ignore the RNG object when doing the comparison.
+        self_copy = copy.deepcopy(self)
+        other_copy = copy.deepcopy(other)
+        del self_copy._rng, other_copy._rng
+
+        result = super(TrialHandler2, self_copy).__eq__(other_copy)
+        return result
+
     @property
     def data(self):
         """Returns a pandas DataFrame of the trial data so far

--- a/psychopy/tests/test_data/test_ExperimentHandler.py
+++ b/psychopy/tests/test_data/test_ExperimentHandler.py
@@ -120,6 +120,26 @@ class TestExperimentHandler(object):
         exp.saveAsWideText(fileName)
         exp.saveAsPickle(fileName)
 
+    def test_comparison_equals(self):
+        e1 = data.ExperimentHandler()
+        e2 = data.ExperimentHandler()
+        assert e1 == e2
+
+    def test_comparison_not_equal(self):
+        e1 = data.ExperimentHandler()
+        e2 = data.ExperimentHandler(name='foo')
+        assert e1 != e2
+
+    def test_comparison_equals_with_same_TrialHandler_attached(self):
+        e1 = data.ExperimentHandler()
+        e2 = data.ExperimentHandler()
+        t = data.TrialHandler([dict(foo=1)], 2)
+
+        e1.addLoop(t)
+        e2.addLoop(t)
+
+        assert e1 == e2
+
 
 if __name__ == '__main__':
     import pytest

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -325,6 +325,30 @@ class TestStairHandler(_BaseTestStairHandler):
                                       nReversals=len(step_sizes) + 1)
         assert staircase.nReversals == len(step_sizes) + 1
 
+    def test_comparison_equals(self):
+        s1 = data.StairHandler(5)
+        s2 = data.StairHandler(5)
+        assert s1 == s2
+
+    def test_comparison_equals_after_iteration(self):
+        s1 = data.StairHandler(5)
+        s2 = data.StairHandler(5)
+        s1.__next__()
+        s2.__next__()
+        assert s1 == s2
+
+    def test_comparison_not_equal(self):
+        s1 = data.StairHandler(5)
+        s2 = data.StairHandler(6)
+        assert s1 != s2
+
+    def test_comparison_not_equal_after_iteration(self):
+        s1 = data.StairHandler(5)
+        s2 = data.StairHandler(6)
+        s1.__next__()
+        s2.__next__()
+        assert s1 != s2
+
 
 class TestQuestHandler(_BaseTestStairHandler):
     """
@@ -380,6 +404,96 @@ class TestQuestHandler(_BaseTestStairHandler):
         )
         assert self.stairs._quest.x[0] == -range/2
         assert self.stairs._quest.x[-1] == range/2
+
+    def test_comparison_equals(self):
+        q1 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        q2 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        assert q1 == q2
+
+    def test_comparison_equals_after_iteration(self):
+        q1 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        q2 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        q1.__next__()
+        q2.__next__()
+        assert q1 == q2
+
+    def test_comparison_not_equal(self):
+        q1 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        q2 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=2)
+        assert q1 != q2
+
+    def test_comparison_not_equal_after_iteration(self):
+        q1 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=1)
+        q2 = data.QuestHandler(0.5, 0.2, pThreshold=0.63, gamma=0.01,
+                               nTrials=20, minVal=0, maxVal=2)
+        q1.__next__()
+        q2.__next__()
+        assert q1 != q2
+
+
+class TestPsiHandler(_BaseTestStairHandler):
+    def test_comparison_equals(self):
+        p1 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        p2 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        assert p1 == p2
+
+    def test_comparison_equals_after_iteration(self):
+        p1 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        p2 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        p1.__next__()
+        p2.__next__()
+        assert p1 == p2
+
+    def test_comparison_not_equal(self):
+        p1 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        p2 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.001)
+
+        assert p1 != p2
+
+    def test_comparison_not_equal_after_iteration(self):
+        p1 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.01)
+
+        p2 = data.PsiHandler(nTrials=10, intensRange=[0.1, 10],
+                             alphaRange=[0.1, 10], betaRange=[0.1, 3],
+                             intensPrecision=0.1, alphaPrecision=0.1,
+                             betaPrecision=0.1, delta=0.001)
+
+        p1.__next__()
+        p2.__next__()
+        assert p1 != p2
 
 
 class TestMultiStairHandler(_BaseTestMultiStairHandler):

--- a/psychopy/tests/test_data/test_TrialHandler.py
+++ b/psychopy/tests/test_data/test_TrialHandler.py
@@ -18,6 +18,7 @@ import pytest
 thisPath = os.path.split(__file__)[0]
 fixturesPath = os.path.join(thisPath,'..','data')
 
+
 class TestTrialHandler(object):
     def setup_class(self):
         self.temp_dir = mkdtemp(prefix='psychopy-tests-testdata')
@@ -29,7 +30,7 @@ class TestTrialHandler(object):
     def test_underscores_in_datatype_names(self):
         trials = data.TrialHandler([], 1, autoLog=False)
         trials.data.addDataType('with_underscore')
-        for trial in trials:#need to run trials or file won't be saved
+        for trial in trials:  # need to run trials or file won't be saved
             trials.addData('with_underscore', 0)
         base_data_filename = pjoin(self.temp_dir, self.rootName)
         trials.saveAsExcel(base_data_filename)
@@ -148,6 +149,31 @@ class TestTrialHandler(object):
         trials.saveAsWideText(pjoin(self.temp_dir, 'testRandom.csv'), delim=',', appendFile=False)#this omits values
         utils.compareTextFiles(pjoin(self.temp_dir, 'testRandom.csv'), pjoin(fixturesPath,'corrRandom.csv'))
 
+    def test_comparison_equals(self):
+        t1 = data.TrialHandler([dict(foo=1)], 2)
+        t2 = data.TrialHandler([dict(foo=1)], 2)
+        assert t1 == t2
+
+    def test_comparison_equals_after_iteration(self):
+        t1 = data.TrialHandler([dict(foo=1)], 2)
+        t2 = data.TrialHandler([dict(foo=1)], 2)
+        t1.__next__()
+        t2.__next__()
+        assert t1 == t2
+
+    def test_comparison_not_equal(self):
+        t1 = data.TrialHandler([dict(foo=1)], 2)
+        t2 = data.TrialHandler([dict(foo=1)], 3)
+        assert t1 != t2
+
+    def test_comparison_not_equal_after_iteration(self):
+        t1 = data.TrialHandler([dict(foo=1)], 2)
+        t2 = data.TrialHandler([dict(foo=1)], 3)
+        t1.__next__()
+        t2.__next__()
+        assert t1 != t2
+
+
 class TestMultiStairs(object):
     def setup_class(self):
         self.temp_dir = mkdtemp(prefix='psychopy-tests-testdata')
@@ -185,14 +211,15 @@ class TestMultiStairs(object):
                     dataFileName=pjoin(self.temp_dir, 'multiQuestExperiment'), autoLog=False)
         exp.addLoop(stairs)
         for intensity,condition in stairs:
-            #make data that will cause different stairs to finish different times
+            # make data that will cause different stairs to finish different times
             if random()>condition['startVal']:
                 corr=1
             else:corr=0
             stairs.addData(corr)
         stairs.saveAsExcel(pjoin(self.temp_dir, 'multiQuestOut'))
-        stairs.saveAsPickle(pjoin(self.temp_dir, 'multiQuestOut'))#contains more info
+        stairs.saveAsPickle(pjoin(self.temp_dir, 'multiQuestOut'))# contains more info
 
-if __name__=='__main__':
+
+if __name__ == '__main__':
     import pytest
     pytest.main()

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -135,21 +135,31 @@ class TestTrialHandler2(object):
         # not currently testing this as column order won't match (and we've removed the columns "ran" and "order")
         utils.compareTextFiles(pjoin(self.temp_dir, 'testRandom.csv'), pjoin(fixturesPath,'corrRandomTH2.csv'))
 
-if __name__=='__main__':
+    def test_comparison_equals(self):
+        t1 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        t2 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        assert t1 == t2
 
-    import sys
+    def test_comparison_equals_after_iteration(self):
+        t1 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        t2 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        t1.__next__()
+        t2.__next__()
+        assert t1 == t2
 
-#    trials = data.TrialHandler2(trialList=[
-#        {'aParam':1},
-#        {'aParam':2},
-#        {'aParam':3},
-#        {'aParam':4, 'zParam':'extraValHere'}], seed=200, nReps=3, method='random')
-#    print('running:')
-#    for n, trial in enumerate(trials):
-#        print(trial)
-#    print('trials.data:')
-#    print(trials.data)
-#    trials.saveAsWideText(fileName = 'stdout')
-#
+    def test_comparison_not_equal(self):
+        t1 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        t2 = data.TrialHandler2([dict(foo=1)], 3, seed=1)
+        assert t1 != t2
+
+    def test_comparison_not_equal_after_iteration(self):
+        t1 = data.TrialHandler2([dict(foo=1)], 2, seed=1)
+        t2 = data.TrialHandler2([dict(foo=1)], 3, seed=1)
+        t1.__next__()
+        t2.__next__()
+        assert t1 != t2
+
+
+if __name__ == '__main__':
     import pytest
     pytest.main()

--- a/psychopy/tests/test_data/test_TrialHandlerExt.py
+++ b/psychopy/tests/test_data/test_TrialHandlerExt.py
@@ -168,6 +168,31 @@ class TestTrialHandlerExt(object):
         utils.compareTextFiles(pjoin(self.temp_dir, 'testRandom.csv'),
                                pjoin(fixturesPath,'corrRandom.csv'))
 
-if __name__=='__main__':
+    def test_comparison_equals(self):
+        t1 = data.TrialHandlerExt([dict(foo=1)], 2)
+        t2 = data.TrialHandlerExt([dict(foo=1)], 2)
+        assert t1 == t2
+
+    def test_comparison_equals_after_iteration(self):
+        t1 = data.TrialHandlerExt([dict(foo=1)], 2)
+        t2 = data.TrialHandlerExt([dict(foo=1)], 2)
+        t1.__next__()
+        t2.__next__()
+        assert t1 == t2
+
+    def test_comparison_not_equal(self):
+        t1 = data.TrialHandlerExt([dict(foo=1)], 2)
+        t2 = data.TrialHandlerExt([dict(foo=1)], 3)
+        assert t1 != t2
+
+    def test_comparison_not_equal_after_iteration(self):
+        t1 = data.TrialHandlerExt([dict(foo=1)], 2)
+        t2 = data.TrialHandlerExt([dict(foo=1)], 3)
+        t1.__next__()
+        t2.__next__()
+        assert t1 != t2
+
+
+if __name__ == '__main__':
     import pytest
     pytest.main()


### PR DESCRIPTION
This PR consists of two improvements:

1. it  implements the `__eq__()` and `__ne__` (`==` and `!=`) methods for `DataHandler` and `_BaseTrialHandler`(and derived classes)
2. it adds JSON serialization for StairHandler and derived classes

### `__eq__()` and `__ne__()` for `DataHandler` and `_BaseTrialHandler`

Example:
```python
In [1]: from psychopy.data import TrialHandler
   ...:
   ...: t1 = TrialHandler([dict(foo=1)], 2)
   ...: t2 = TrialHandler([dict(foo=1)], 2)
   ...:
   ...: print(t1 == t2)
   ...:
True
```
Specializations were required for

- `TrialHandler2`: ignore RNG object
- `QuestHandler` and `PsiHandler`, as they use contrib classes (see below).

`QuestHandle`r and `PsiHandler` rely on classes implemented in contrib modules; these should be left unchanged. Because an `==` or `!=` comparison on two `QuestHandler` / `PsiHandler` instances will eventually descent into their accompanying `QuestObject` / `PsiObject`, `__eq__()` and `__ne__()` have to be implemented for these objects as well. However, I did not want to
modify the contrib code, so I first tried an approach with monkey-patching, but this was ugly and not very intuitive. I now subclass `QuestObject` (as `QuestObject_`) and `PsiObject` (as` PsiObject_`),
respectively, and add the required `__eq__()` and `__ne__()` methods there. Accordingly, `QuestHandler` and `PsiHandler` will now instantiate `QuestObject_` and `PsiObject_`, respectively.

Why all this? Mostly because it will ease writing tests and debugging. For example, when saving a `StairHandler` object to disk and later reading it back in, it can now be compared to an existing in-memory object very easily -- which paves the way for a better testing infrastructure and makes it easier (and safer) to add new serialization implementations, such as JSON export.

### JSON serialization for StairHandler and derived classes

StairHandler and derived objects can now be serialized as JSON. Serialization of TrialHandler* is currently not supported, as json-tricks cannot properly handle the required DataHandler, [because
it is derived from a dict.](https://github.com/mverleg/pyjson_tricks/issues/30)

This is a first step in allowing us and our users to move away from pickle for long-term storage, and makes it easier to interface e.g. with REST APIs.
