### PR TITLE
BF: Add status attribute in CedrusBox script generation

### DIFF
--- a/psychopy/app/builder/components/cedrusBox/__init__.py
+++ b/psychopy/app/builder/components/cedrusBox/__init__.py
@@ -118,7 +118,8 @@ class cedrusButtonBoxComponent(KeyboardComponent):
         if (self.params['store'].val != 'nothing' or
                 self.params['storeCorrect'].val):
             code = ("%(name)s.keys = []  # to store response values\n"
-                    "%(name)s.rt = []\n")
+                    "%(name)s.rt = []\n"
+			"%(name)s.status = None\n")
             buff.writeIndentedLines(code % self.params)
 
     def writeFrameCode(self, buff):


### PR DESCRIPTION
Attempting to utilize a cedrusButtonBox response in the Builder view results in the error:

**_AttributeError: 'ResponseDevice' object has no attribute 'status'_**

Unlike classes like KeyBoardComponent, cedrusButtonBoxComponent does not have a corresponding response class in which the status attribute is initialized. However, the status attribute is still necessary for the experiment script to run, hence the changes.