### PR TITLE
FIX: gettext.install() needs unicode=True in Python2.

### DIFF
--- a/psychopy/app/localization/__init__.py
+++ b/psychopy/app/localization/__init__.py
@@ -20,6 +20,7 @@ from builtins import map
 from builtins import range
 import gettext
 import os
+import sys
 import glob
 import codecs
 from psychopy import logging, prefs
@@ -127,7 +128,12 @@ try:
 except IOError:
     logging.debug("Locale for '%s' not found. Using default." % lang)
     trans = gettext.NullTranslations()
-trans.install()
+
+# gettext.install() needs unicode=True to get unicode output in Python2.
+if sys.version_info[0] >= 3:
+    trans.install()
+else:
+    trans.install(unicode=True)
 
 # PsychoPy app uses a nonstandard name _translate (instead of _)
 # A dependency overwrites _ somewhere, clobbering use of _ as global:

--- a/psychopy/app/localization/__init__.py
+++ b/psychopy/app/localization/__init__.py
@@ -20,10 +20,10 @@ from builtins import map
 from builtins import range
 import gettext
 import os
-import sys
 import glob
 import codecs
 from psychopy import logging, prefs
+import psychopy.constants
 
 import wx
 
@@ -130,7 +130,7 @@ except IOError:
     trans = gettext.NullTranslations()
 
 # gettext.install() needs unicode=True to get unicode output in Python2.
-if sys.version_info[0] >= 3:
+if psychopy.constants.PY3:
     trans.install()
 else:
     trans.install(unicode=True)


### PR DESCRIPTION
PsychoPy application crashes on Python 2.7 because translated strings are not output in unicode.
unicode=True is necessary to output translated string in unicode in Python2.

See also [https://discourse.psychopy.org/t/code-name-window-size-on-mac/2939](url)
