### PR TITLE
Update qtgui.py handleLineEditChange fxn

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -181,7 +181,7 @@ class Dlg(QtWidgets.QDialog):
                 thisType = self.inputFieldTypes[ix]
 
                 try:
-                    if isinstance(thisType, basestring):
+                    if issubclass(thisType, basestring):
                         self.data[ix] = str(new_text)
                     elif thisType == tuple:
                         jtext = "[" + str(new_text) + "]"


### PR DESCRIPTION
`isinstance` is used to check if `thisType` is an instance of `basestring` in this case, `thisType` is a class itself, not an instance of a class. If `thisType` is `<type 'unicode'>`, then using `isinstance(thisType, basestring) returns False- which appears to not be the intended function. However using `issubclass(thisType, basestring) returns True because `unicode` is a subclass (not an instance) of basestring.