### PR TITLE
FF: psychopy.tools.versionchooser in for loop

### DIFF
--- a/createInitFile.py
+++ b/createInitFile.py
@@ -88,7 +88,7 @@ try:
     for pathName in prefs.general['paths']:
         sys.path.append(pathName)
 
-        from psychopy.tools.versionchooser import useVersion, ensureMinimal
+    from psychopy.tools.versionchooser import useVersion, ensureMinimal
 except ImportError as e:
     if not any(x in str(e) for x in ["configobj", "past", "builtins"]):
         raise


### PR DESCRIPTION
In the template, `from psychopy.tools.versionchooser import useVersion, ensureMinimal` was inside of a for loop, which caused the statement `from psychopy import useVersion` to fail in a separate script. Fixing the indentation in the init template fixes this issue.