### PR TITLE
BF: self._video_height/width should be int, not float

### DIFF
--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -334,10 +334,10 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
 
         self._total_frame_count = self._video_stream.get(
             cv2.CAP_PROP_FRAME_COUNT)
-        self._video_width = self._video_stream.get(
-            cv2.CAP_PROP_FRAME_WIDTH)
-        self._video_height = self._video_stream.get(
-            cv2.CAP_PROP_FRAME_HEIGHT)
+        self._video_width = int(self._video_stream.get(
+            cv2.CAP_PROP_FRAME_WIDTH))
+        self._video_height = int(self._video_stream.get(
+            cv2.CAP_PROP_FRAME_HEIGHT))
         self._format = self._video_stream.get(
             cv2.CAP_PROP_FORMAT)
         # TODO: Read depth from video source


### PR DESCRIPTION
opencv returns `self._video_stream.get(cv2.CAP_PROP_FRAME_WIDTH)` (and height) as a float. This causes an error a few lines down in
`self._numpy_frame = numpy.zeros((self._video_height, self._video_width, self._video_frame_depth),  dtype=numpy.uint8)`

By changing these variables to integers, this error does not occur.
See: #1509 