### PR TITLE
BF: Fixed _selectWindow() ignoring 'win' argument

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1158,7 +1158,7 @@ class WindowMixin(object):
         """Switch drawing to the specified window. Calls the window's
         _setCurrent() method which handles the switch.
         """
-        self.win._setCurrent()
+        win._setCurrent()
 
     def _updateList(self):
         """The user shouldn't need this method since it gets called


### PR DESCRIPTION
Correcting an embarrassingly trivial bug in my last commit that was breaking drawing to multiple windows when passing a window other than its parent to draw(). 

Cause: _selectWindow() was ignoring its 'win' argument preventing stimuli from being drawn windows other than it's parent. This was due to self.win._setCurrent() being called rather than the _setCurrent() method of the 'win' passed to _selectWindow().

Fix: Changed self.win._setCurrent() -> win._setCurrent(), closes issue #1513