### PR TITLE
FF: atexit solution in favor for closing ExperimentHandlers

### DIFF
--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -21,7 +21,6 @@ from psychopy.clock import (MonotonicClock, Clock, CountdownTimer,
 from psychopy.platform_specific import rush  # pylint: disable=W0611
 from psychopy import logging
 from psychopy.constants import STARTED, NOT_STARTED, FINISHED, PY3
-from psychopy.data import experiment
 
 try:
     import pyglet
@@ -63,9 +62,6 @@ def quit():
     """
     # pygame.quit()  # safe even if pygame was never initialised
     logging.flush()
-    
-    for thisExp in experiment.ExperimentHandler._instances:
-        thisExp.close()
     
     for thisThread in threading.enumerate():
         if hasattr(thisThread, 'stop') and hasattr(thisThread, 'running'):

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -9,7 +9,7 @@ from builtins import str
 import sys
 import copy
 import pickle
-import weakref
+import atexit
 
 from psychopy import logging
 from psychopy.tools.filetools import openOutputFile, genDelimiter
@@ -28,8 +28,6 @@ class ExperimentHandler(_ComparisonMixin):
         exp = data.ExperimentHandler(name="Face Preference",version='0.1.0')
 
     """
-    
-    _instances = weakref.WeakSet()
     
     def __init__(self,
                  name='',
@@ -76,8 +74,6 @@ class ExperimentHandler(_ComparisonMixin):
 
             autoLog : True (default) or False
         """
-        ExperimentHandler._instances.add(self)
-        
         self.loops = []
         self.loopsUnfinished = []
         self.name = name
@@ -103,6 +99,7 @@ class ExperimentHandler(_ComparisonMixin):
         else:
             # fail now if we fail at all!
             checkValidFilePath(dataFileName, makeValid=True)
+        atexit.register(self.close)
 
     def __del__(self):
         self.close()
@@ -345,7 +342,7 @@ class ExperimentHandler(_ComparisonMixin):
             if self.saveWideText == True:
                 self.saveAsWideText(self.dataFileName + '.csv', delim=',')
         self.abort()
-        self.augoLog = False
+        self.autoLog = False
 
     def abort(self):
         """Inform the ExperimentHandler that the run was aborted.


### PR DESCRIPTION
In correspondence with #1497 I've replaced the old fix for this solution: keeping track of ExperimentHandlers manually with weakref, then manually calling the each instance's `.close()` method in `core.quit()` 

with a new, cleaner fix: use `atexit` to register each instances `self.close` method to be called on interpreter exit before garbage collection. This does fix the same issue that the original weakref patch was working towards.