### PR TITLE
NF: Add JSON serialization for TrialHandler2

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -1127,7 +1127,47 @@ class TrialHandler2(_BaseTrialHandler):
                    fileName=None,
                    encoding='utf-8',
                    fileCollisionMethod='rename'):
-        raise NotImplementedError('Not implemented for TrialHandler2.')
+        """
+        Serialize the object to the JSON format.
+
+        Parameters
+        ----------
+        fileName: string, or None
+            the name of the file to create or append. Can include a relative or
+            absolute path. If `None`, will not write to a file, but return an
+            in-memory JSON object.
+
+        encoding : string, optional
+            The encoding to use when writing the file. This parameter will be
+            ignored if `append` is `False` and `fileName` ends with `.psydat`
+            or `.npy` (i.e. if a binary file is to be written).
+
+        fileCollisionMethod : string
+            Collision method passed to
+            :func:`~psychopy.tools.fileerrortools.handleFileCollision`. Can be
+            either of `'rename'`, `'overwrite'`, or `'fail'`.
+
+        Notes
+        -----
+        Currently, a copy of the object is created, and the copy's .origin
+        attribute is set to an empty string before serializing
+        because loading the created JSON file would sometimes fail otherwise.
+
+        The RNG self._rng cannot be serialized as-is, so we store its state in
+        self._rng_state so we can restore it when loading.
+
+        """
+        self_copy = copy.deepcopy(self)
+        self_copy._rng_state = self_copy._rng.get_state()
+        del self_copy._rng
+
+        r = (super(TrialHandler2, self_copy)
+             .saveAsJson(fileName=fileName,
+                         encoding=encoding,
+                         fileCollisionMethod=fileCollisionMethod))
+
+        if fileName is None:
+            return r
 
     def addData(self, thisType, value):
         """Add a piece of data to the current trial

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -175,12 +175,12 @@ class TestTrialHandler2(object):
 
         t.origin = ''
 
-        dump_loaded = json_tricks.np.loads(dump)
-        dump_loaded._rng = np.random.RandomState()
-        dump_loaded._rng.set_state(dump_loaded._rng_state)
-        del dump_loaded._rng_state
+        t_loaded = json_tricks.np.loads(dump)
+        t_loaded._rng = np.random.RandomState()
+        t_loaded._rng.set_state(t_loaded._rng_state)
+        del t_loaded._rng_state
 
-        assert t == dump_loaded
+        assert t == t_loaded
 
     def test_json_dump_with_data(self):
         t = data.TrialHandler2(self.conditions, nReps=5)
@@ -189,12 +189,12 @@ class TestTrialHandler2(object):
 
         t.origin = ''
 
-        dump_loaded = json_tricks.np.loads(dump)
-        dump_loaded._rng = np.random.RandomState()
-        dump_loaded._rng.set_state(dump_loaded._rng_state)
-        del dump_loaded._rng_state
+        t_loaded = json_tricks.np.loads(dump)
+        t_loaded._rng = np.random.RandomState()
+        t_loaded._rng.set_state(t_loaded._rng_state)
+        del t_loaded._rng_state
 
-        assert t == dump_loaded
+        assert t == t_loaded
 
     def test_json_dump_after_iteration(self):
         t = data.TrialHandler2(self.conditions, nReps=5)
@@ -203,12 +203,12 @@ class TestTrialHandler2(object):
 
         t.origin = ''
 
-        dump_loaded = json_tricks.np.loads(dump)
-        dump_loaded._rng = np.random.RandomState()
-        dump_loaded._rng.set_state(dump_loaded._rng_state)
-        del dump_loaded._rng_state
+        t_loaded = json_tricks.np.loads(dump)
+        t_loaded._rng = np.random.RandomState()
+        t_loaded._rng.set_state(t_loaded._rng_state)
+        del t_loaded._rng_state
 
-        assert t == dump_loaded
+        assert t == t_loaded
 
     def test_json_dump_with_data_after_iteration(self):
         t = data.TrialHandler2(self.conditions, nReps=5)
@@ -218,12 +218,12 @@ class TestTrialHandler2(object):
 
         t.origin = ''
 
-        dump_loaded = json_tricks.np.loads(dump)
-        dump_loaded._rng = np.random.RandomState()
-        dump_loaded._rng.set_state(dump_loaded._rng_state)
-        del dump_loaded._rng_state
+        t_loaded = json_tricks.np.loads(dump)
+        t_loaded._rng = np.random.RandomState()
+        t_loaded._rng.set_state(t_loaded._rng_state)
+        del t_loaded._rng_state
 
-        assert t == dump_loaded
+        assert t == t_loaded
 
     def test_json_dump_to_file(self):
         t = data.TrialHandler2(self.conditions, nReps=5)

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -7,21 +7,27 @@ import os, glob
 from os.path import join as pjoin
 import shutil
 from pytest import raises
-from tempfile import mkdtemp
+from tempfile import mkdtemp, mkstemp
+import numpy as np
 from numpy.random import random
+import json_tricks
+import pytest
 
 from psychopy import data
 from psychopy.tools.filetools import fromFile
 from psychopy.tests import utils
-import pytest
 
 thisPath = os.path.split(__file__)[0]
 fixturesPath = os.path.join(thisPath,'..','data')
+
 
 class TestTrialHandler2(object):
     def setup_class(self):
         self.temp_dir = mkdtemp(prefix='psychopy-tests-testdata')
         self.rootName = 'test_data_file'
+        self.conditions = [dict(foo=1, bar=2),
+                           dict(foo=2, bar=3),
+                           dict(foo=3, bar=4)]
 
     def teardown_class(self):
         shutil.rmtree(self.temp_dir)
@@ -66,6 +72,7 @@ class TestTrialHandler2(object):
             # Make sure the correct number of files for the loop are there. (No overwriting by default).
             matches = len(glob.glob(os.path.join(self.temp_dir, self.rootName + "*.psydat")))
             assert matches==count, "Found %d matching files, should be %d" % (matches, count)
+
     def test_psydat_filename_collision_overwriting2(self):
         for count in [1, 10, 20]:
             trials = data.TrialHandler2([], 1, autoLog=False)
@@ -161,6 +168,78 @@ class TestTrialHandler2(object):
         t1.__next__()
         t2.__next__()
         assert t1 != t2
+
+    def test_json_dump(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        dump = t.saveAsJson()
+
+        t.origin = ''
+
+        dump_loaded = json_tricks.np.loads(dump)
+        dump_loaded._rng = np.random.RandomState()
+        dump_loaded._rng.set_state(dump_loaded._rng_state)
+        del dump_loaded._rng_state
+
+        assert t == dump_loaded
+
+    def test_json_dump_with_data(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        t.addData('foo', 'bar')
+        dump = t.saveAsJson()
+
+        t.origin = ''
+
+        dump_loaded = json_tricks.np.loads(dump)
+        dump_loaded._rng = np.random.RandomState()
+        dump_loaded._rng.set_state(dump_loaded._rng_state)
+        del dump_loaded._rng_state
+
+        assert t == dump_loaded
+
+    def test_json_dump_after_iteration(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        t.__next__()
+        dump = t.saveAsJson()
+
+        t.origin = ''
+
+        dump_loaded = json_tricks.np.loads(dump)
+        dump_loaded._rng = np.random.RandomState()
+        dump_loaded._rng.set_state(dump_loaded._rng_state)
+        del dump_loaded._rng_state
+
+        assert t == dump_loaded
+
+    def test_json_dump_with_data_after_iteration(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        t.addData('foo', 'bar')
+        t.__next__()
+        dump = t.saveAsJson()
+
+        t.origin = ''
+
+        dump_loaded = json_tricks.np.loads(dump)
+        dump_loaded._rng = np.random.RandomState()
+        dump_loaded._rng.set_state(dump_loaded._rng_state)
+        del dump_loaded._rng_state
+
+        assert t == dump_loaded
+
+    def test_json_dump_to_file(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        t.saveAsJson(fileName=self.temp_dir, fileCollisionMethod='overwrite')
+
+    def test_json_dump_and_reopen_file(self):
+        t = data.TrialHandler2(self.conditions, nReps=5)
+        t.addData('foo', 'bar')
+        t.__next__()
+
+        _, path = mkstemp(dir=self.temp_dir, suffix='.json')
+        t.saveAsJson(fileName=path, fileCollisionMethod='overwrite')
+        t.origin = ''
+
+        t_loaded = fromFile(path)
+        assert t == t_loaded
 
 
 if __name__ == '__main__':

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -16,6 +16,7 @@ import shutil
 import pickle
 import sys
 import codecs
+import numpy as np
 import json_tricks
 
 from psychopy import logging
@@ -45,10 +46,17 @@ def fromFile(filename):
                 contents.abort()
         elif filename.endswith('json'):
             contents = json_tricks.np.load(f)
-            # if isinstance(contents, data.TrialHandler):
-            #     contents.data.trials = contents
+
+            # Restore RNG if we load a TrialHandler2 object.
+            # We also need to remove the 'temporary' ._rng_state attribute that
+            # was saved with it.
+            from psychopy.data import TrialHandler2
+            if isinstance(contents, TrialHandler2):
+                contents._rng = np.random.RandomState(seed=contents.seed)
+                contents._rng.set_state(contents._rng_state)
+                del contents._rng_state
         else:
-            msg = ("Don't know how to handle this file type, aborting.")
+            msg = "Don't know how to handle this file type, aborting."
             raise ValueError(msg)
 
     return contents


### PR DESCRIPTION
We now support JSON export of `TrialHandler2` and all staircase procedures.

`TrialHandler` and `TrialHandlerExt` are not supported because their required `DataHandler` proves to be difficult to serialize.