### PR TITLE
BF: Line.{contains,overlaps}

### DIFF
--- a/psychopy/tests/test_all_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_all_visual/test_all_stimuli.py
@@ -19,14 +19,17 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 """
 _travisTesting = bool("{}".format(os.environ.get('TRAVIS')).lower() == 'true')
 
+
 class Test_Window(object):
     """Some tests just for the window - we don't really care about what's drawn inside it
     """
     def setup_class(self):
         self.temp_dir = mkdtemp(prefix='psychopy-tests-test_window')
         self.win = visual.Window([128,128], pos=[50,50], allowGUI=False, autoLog=False)
+
     def teardown_class(self):
         shutil.rmtree(self.temp_dir)
+
     def test_captureMovieFrames(self):
         stim = visual.GratingStim(self.win, dkl=[0,0,1])
         stim.autoDraw = True
@@ -37,6 +40,7 @@ class Test_Window(object):
         self.win.saveMovieFrames(os.path.join(self.temp_dir, 'junkFrames.png'))
         self.win.saveMovieFrames(os.path.join(self.temp_dir, 'junkFrames.gif'))
         region = self.win._getRegionOfFrame()
+
     def test_multiFlip(self):
         self.win.recordFrameIntervals = False #does a reset
         self.win.recordFrameIntervals = True
@@ -44,6 +48,7 @@ class Test_Window(object):
         self.win.multiFlip(3,clearBuffer=False)
         self.win.saveFrameIntervals(os.path.join(self.temp_dir, 'junkFrameInts'))
         fps = self.win.fps()
+
     def test_callonFlip(self):
         def assertThisIs2(val):
             assert val==2
@@ -58,12 +63,15 @@ class _baseVisualTest(object):
         self.win=None
         self.contextName
         raise NotImplementedError
+
     @classmethod
     def teardown_class(self):#run once for each test class (window)
         self.win.close()#shutil.rmtree(self.temp_dir)
+
     def setup(self):#this is run for each test individually
         #make sure we start with a clean window
         self.win.flip()
+
     def test_auto_draw(self):
         win = self.win
         stims=[]
@@ -78,6 +86,7 @@ class _baseVisualTest(object):
             assert stim.status==visual.FINISHED
             assert stim.status==visual.STOPPED
             "{}".format(stim) #check that str(xxx) is working
+
     def test_imageAndGauss(self):
         win = self.win
         fileName = os.path.join(utils.TESTS_DATA_PATH, 'testimage.jpg')
@@ -88,6 +97,7 @@ class _baseVisualTest(object):
         image.draw()
         utils.compareScreenshot('imageAndGauss_%s.png' %(self.contextName), win)
         win.flip()
+
     def test_gratingImageAndGauss(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -101,6 +111,7 @@ class _baseVisualTest(object):
         image.draw()
         utils.compareScreenshot('imageAndGauss_%s.png' %(self.contextName), win)
         win.flip()
+
     def test_envelopeGratingAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -118,6 +129,7 @@ class _baseVisualTest(object):
             utils.compareScreenshot('envelopeandrcos_%s.png' %(self.contextName), win)
             win.flip()
             "{}".format(image)
+
     def test_noiseAndRaisedCos(self):
         numpy.random.seed(1)
         win = self.win
@@ -159,7 +171,8 @@ class _baseVisualTest(object):
         image.draw()
         utils.compareScreenshot('noiseAndRcos_%s.png' %(self.contextName), win)
         win.flip()
-        str(image)        
+        str(image)
+
     def test_envelopeBeatAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -177,6 +190,7 @@ class _baseVisualTest(object):
             utils.compareScreenshot('beatandrcos_%s.png' %(self.contextName), win)
             win.flip()
             "{}".format(image)
+
     def test_numpyFilterMask(self):
         """if the mask is passed in as a numpy array it goes through a different
         set of rules when turned into a texture. But the outcome should be as above
@@ -191,6 +205,7 @@ class _baseVisualTest(object):
         image.draw()
         utils.compareScreenshot('imageAndGauss_%s.png' %(self.contextName), win)
         win.flip()
+
     def test_greyscaleImage(self):
         win = self.win
         fileName = os.path.join(utils.TESTS_DATA_PATH, 'greyscale.jpg')
@@ -215,6 +230,7 @@ class _baseVisualTest(object):
         imageStim.draw()
         utils.compareScreenshot('greyscale2_%s.png' %(self.contextName), win)
         win.flip()
+
     def test_numpyTexture(self):
         win = self.win
         grating = filters.makeGrating(res=64, ori=20.0,
@@ -299,6 +315,7 @@ class _baseVisualTest(object):
     #        interpolate=True)
     #    stim.draw()
     #    utils.compareScreenshot('gabor1_%s.png' %(contextName), win)
+
     def test_text(self):
         win = self.win
         if self.win.winType=='pygame':
@@ -370,6 +387,7 @@ class _baseVisualTest(object):
                 utils.compareScreenshot('movFrame1_%s.png' %(self.contextName), win)
             win.flip()
         "{}".format(mov) #check that str(xxx) is working
+
     def test_rect(self):
         win = self.win
         rect = visual.Rect(win)
@@ -382,6 +400,7 @@ class _baseVisualTest(object):
         "{}".format(rect) #check that str(xxx) is working
         rect.width = 1
         rect.height = 1
+
     def test_circle(self):
         win = self.win
         circle = visual.Circle(win)
@@ -393,16 +412,20 @@ class _baseVisualTest(object):
         circle.ori = 30
         circle.draw()
         "{}".format(circle) #check that str(xxx) is working
+
     def test_line(self):
         win = self.win
         line = visual.Line(win)
         line.start = (0, 0)
         line.end = (0.1, 0.1)
-        line.contains()  # pass
-        line.overlaps()  # pass
+        assert line.contains() is False
+        assert line.overlaps() is False
+        assert line.contains(0) is False
+        assert line.overlaps(line) is False
         line.draw()
         win.flip()
-        "{}".format(line) #check that str(xxx) is working
+        "{}".format(line)  # check that str(xxx) is working
+
     def test_Polygon(self):
         win = self.win
         cols = ['red','green','purple','orange','blue']
@@ -413,6 +436,7 @@ class _baseVisualTest(object):
         "{}".format(poly) #check that str(xxx) is working
         poly.edges = 3
         poly.radius = 1
+
     @pytest.mark.shape2
     def test_shape(self):
         win = self.win
@@ -432,6 +456,7 @@ class _baseVisualTest(object):
         shape.draw()
         assert 'Shape' in "{}".format(shape)  # check that str(xxx) is working
         utils.compareScreenshot('shape2_2_%s.png' %(self.contextName), win, crit=12.5)
+
     def test_radial(self):
         if self.win.winType=='pygame':
             pytest.skip("RadialStim dodgy on pygame")
@@ -457,6 +482,7 @@ class _baseVisualTest(object):
         wedge.draw()
         "{}".format(wedge) #check that str(xxx) is working
         utils.compareScreenshot('wedge2_%s.png' %(self.contextName), win, crit=10.0)
+
     def test_simpleimage(self):
         win = self.win
         fileName = os.path.join(utils.TESTS_DATA_PATH, 'testimage.jpg')
@@ -466,6 +492,7 @@ class _baseVisualTest(object):
         "{}".format(image) #check that str(xxx) is working
         image.draw()
         utils.compareScreenshot('simpleimage1_%s.png' %(self.contextName), win, crit=5.0) # Should be exact replication
+
     def test_dotsUnits(self):
         #to test this create a small dense circle of dots and check the circle
         #has correct dimensions
@@ -476,6 +503,7 @@ class _baseVisualTest(object):
         dots.draw()
         utils.compareScreenshot('dots_%s.png' %(self.contextName), self.win, crit=20)
         self.win.flip()
+
     def test_dots(self):
         #NB we can't use screenshots here - just check that no errors are raised
         win = self.win
@@ -508,6 +536,7 @@ class _baseVisualTest(object):
             "dots._signalDots failed to change after dots.setCoherence()"
         assert not numpy.alltrue(prevVerticesPix==dots.verticesPix), \
             "dots.verticesPix failed to change after dots.setPos()"
+
     def test_element_array(self):
         win = self.win
         if not win._haveShaders:
@@ -531,6 +560,7 @@ class _baseVisualTest(object):
         spiral.draw()
         utils.compareScreenshot('elarray1_%s.png' %(self.contextName), win)
         win.flip()
+
     def test_aperture(self):
         win = self.win
         if not win.allowStencil:
@@ -551,6 +581,7 @@ class _baseVisualTest(object):
             aperture = visual.Aperture(win, pos=pos, shape=shape, nVert=nVert)
             assert len(aperture.vertices) == nVert  # true for BaseShapeStim; expect (nVert-2)*3 if tesselated
             assert aperture.contains(pos)
+
     def test_aperture_image(self):
         win = self.win
         fileName = os.path.join(utils.TESTS_DATA_PATH, 'testwedges.png')
@@ -567,6 +598,7 @@ class _baseVisualTest(object):
         grating.draw()
         utils.compareScreenshot('aperture2_%s.png' %(self.contextName), win, crit=30)
         #aperture should automatically disable on exit
+
     def test_rating_scale(self):
         if self.win.winType=='pygame':
             pytest.skip("RatingScale not available on pygame")
@@ -580,6 +612,7 @@ class _baseVisualTest(object):
         rs.draw()
         utils.compareScreenshot('ratingscale1_%s.png' %(self.contextName), win, crit=40.0)
         win.flip()#AFTER compare screenshot
+
     def test_refresh_rate(self):
         if self.win.winType=='pygame':
             pytest.skip("getMsPerFrame seems to crash the testing of pygame")
@@ -589,6 +622,7 @@ class _baseVisualTest(object):
         assert (1000/150.0) < msPFavg < (1000/40.0), \
             "Your frame period is %.1fms which suggests you aren't syncing to the frame" %msPFavg
 
+
 #create different subclasses for each context/backend
 class TestPygletNorm(_baseVisualTest):
     @classmethod
@@ -596,6 +630,8 @@ class TestPygletNorm(_baseVisualTest):
         self.win = visual.Window([128,128], winType='pyglet', pos=[50,50], allowStencil=True, autoLog=False)
         self.contextName='norm'
         self.scaleFactor=1#applied to size/pos values
+
+
 if not _travisTesting:
     class TestPygletBlendAdd(_baseVisualTest):
         @classmethod
@@ -603,18 +639,24 @@ if not _travisTesting:
             self.win = visual.Window([128,128], winType='pyglet', pos=[50,50], blendMode='add', useFBO=True)
             self.contextName='normAddBlend'
             self.scaleFactor=1#applied to size/pos values
+
+
 class TestPygletNormFBO(_baseVisualTest):
     @classmethod
     def setup_class(self):
         self.win = visual.Window([128,128], winType='pyglet', pos=[50,50], allowStencil=True, autoLog=False, useFBO=True)
         self.contextName='norm'
         self.scaleFactor=1#applied to size/pos values
+
+
 class TestPygletHeight(_baseVisualTest):
     @classmethod
     def setup_class(self):
         self.win = visual.Window([128,64], winType='pyglet', pos=[50,50], allowStencil=False, autoLog=False)
         self.contextName='height'
         self.scaleFactor=1#applied to size/pos values
+
+
 class TestPygletNormNoShaders(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -622,12 +664,16 @@ class TestPygletNormNoShaders(_baseVisualTest):
         self.win._haveShaders=False
         self.contextName='normNoShade'
         self.scaleFactor=1#applied to size/pos values
+
+
 class TestPygletNormStencil(_baseVisualTest):
     @classmethod
     def setup_class(self):
         self.win = visual.Window([128,128], monitor='testMonitor', winType='pyglet', pos=[50,50], allowStencil=True, autoLog=False)
         self.contextName='stencil'
         self.scaleFactor=1#applied to size/pos values
+
+
 class TestPygletPix(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -639,6 +685,8 @@ class TestPygletPix(_baseVisualTest):
             units='pix', autoLog=False)
         self.contextName='pix'
         self.scaleFactor=60#applied to size/pos values
+
+
 class TestPygletCm(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -650,6 +698,8 @@ class TestPygletCm(_baseVisualTest):
             units='cm', autoLog=False)
         self.contextName='cm'
         self.scaleFactor=2#applied to size/pos values
+
+
 class TestPygletDeg(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -661,6 +711,8 @@ class TestPygletDeg(_baseVisualTest):
             units='deg', autoLog=False)
         self.contextName='deg'
         self.scaleFactor=2#applied to size/pos values
+
+
 class TestPygletDegFlat(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -672,6 +724,8 @@ class TestPygletDegFlat(_baseVisualTest):
             units='degFlat', autoLog=False)
         self.contextName='degFlat'
         self.scaleFactor=4#applied to size/pos values
+
+
 class TestPygletDegFlatPos(_baseVisualTest):
     @classmethod
     def setup_class(self):
@@ -683,6 +737,8 @@ class TestPygletDegFlatPos(_baseVisualTest):
             units='degFlatPos', autoLog=False)
         self.contextName='degFlatPos'
         self.scaleFactor=4#applied to size/pos values
+
+
 #class TestPygameNorm(_baseVisualTest):
 #    @classmethod
 #    def setup_class(self):
@@ -723,6 +779,7 @@ class TestPygletDegFlatPos(_baseVisualTest):
 #        self.contextName='deg'
 #        self.scaleFactor=2#applied to size/pos values
 #
+
 
 if __name__ == '__main__':
     cls = TestPygletDegFlatPos()

--- a/psychopy/tests/test_all_visual/test_contains_overlaps.py
+++ b/psychopy/tests/test_all_visual/test_contains_overlaps.py
@@ -6,12 +6,12 @@ from __future__ import division
 
 from builtins import range
 from past.utils import old_div
-from psychopy import visual, monitors, core
+from psychopy import visual, monitors
 from psychopy.visual import helpers
-from numpy import sqrt, cos, sin, radians, array
-from numpy.linalg import norm
+from numpy import sqrt, array
 import pytest
 import matplotlib
+
 
 params = [
     {'units':'pix',   'scaleFactor':500.0},
@@ -56,8 +56,10 @@ mon.setDistance(57)
 mon.setWidth(40.0)
 mon.setSizePix([1024,768])
 
-dbgStr = '"%s" returns wrong value: unit=%s, ori=%.1f, size=%s, pos=%s, testpoint=%s, expected=%s'
+dbgStr = ('"%s" returns wrong value: unit=%s, ori=%.1f, size=%s, pos=%s, '
+          'testpoint=%s, expected=%s')
 win = visual.Window([512,512], monitor=mon, winType='pyglet', autoLog=False)
+
 
 def contains_overlaps(testType):
     for param in params:
@@ -106,27 +108,30 @@ try:
 except Exception:
     have_nxutils = False
 
+
 # if matplotlib.__version__ > '1.2': try to use matplotlib Path objects
 # else: try to use nxutils
 # else: fall through to pure python
+
 
 @pytest.mark.polygon
 def test_point():
     poly1 = [(1,1), (1,-1), (-1,-1), (-1,1)]
     poly2 = [(2,2), (1,-1), (-1,-1), (-1,1)]
     assert helpers.pointInPolygon(0, 0, poly1)
-    assert helpers.pointInPolygon(12, 12, poly1) == False
-    assert helpers.pointInPolygon(0, 0, [(0,0), (1,1)]) == False
+    assert helpers.pointInPolygon(12, 12, poly1) is False
+    assert helpers.pointInPolygon(0, 0, [(0,0), (1,1)]) is False
 
     if have_nxutils:
         helpers.nxutils = nxutils
         matplotlib.__version__ = '1.1'  # matplotlib.nxutils
         assert helpers.polygonsOverlap(poly1, poly2)
-        del(helpers.nxutils)
+        del helpers.nxutils
 
-    matplotlib.__version__ = '0.0'    # pure python
+    matplotlib.__version__ = '0.0'  # pure python
     assert helpers.polygonsOverlap(poly1, poly2)
     matplotlib.__version__ = mpl_version
+
 
 @pytest.mark.polygon
 def test_contains():
@@ -135,10 +140,11 @@ def test_contains():
         helpers.nxutils = nxutils
         matplotlib.__version__ = '1.1'  # matplotlib.nxutils
         contains_overlaps('contains')
-        del(helpers.nxutils)
+        del helpers.nxutils
     matplotlib.__version__ = '0.0'  # pure python
     contains_overlaps('contains')
     matplotlib.__version__ = mpl_version
+
 
 @pytest.mark.polygon
 def test_overlaps():
@@ -147,25 +153,27 @@ def test_overlaps():
         helpers.nxutils = nxutils
         matplotlib.__version__ = '1.1'  # matplotlib.nxutils
         contains_overlaps('overlaps')
-        del(helpers.nxutils)
+        del helpers.nxutils
     matplotlib.__version__ = '0.0'  # pure python
     contains_overlaps('overlaps')
     matplotlib.__version__ = mpl_version
+
 
 @pytest.mark.polygon
 def test_border_contains():
     # tests that the .border of ShapeStim is detected and used by .contains()
     win.units = 'height'
     # `thing` has a fake hole and discontinuity (as the border will reveal):
-    thingVert = [(0,0),(0,.4),(.4,.4),(.4,0),(.1,0),(.1,.1),(.3,.1),(.3,.3),(.1,.3),(.1,0),
-        (0,0),(.1,-.1),(.3,-.1),(.3,-.3),(.1,-.3),(.1,-.1)]
+    thingVert = [(0,0),(0,.4),(.4,.4),(.4,0),(.1,0),(.1,.1),(.3,.1),(.3,.3),
+                 (.1,.3),(.1,0),(0,0),(.1,-.1),(.3,-.1),(.3,-.3),(.1,-.3),
+                 (.1,-.1)]
 
     inside_pts = [(.05,.05), (.15,-.15)]
     outside_pts = [(-.2,0)]
     hole_pts = [(.2,.2)]
 
     s = visual.ShapeStim(win, vertices=thingVert, fillColor='blue',
-                          lineWidth=1, lineColor='white')
+                         lineWidth=1, lineColor='white')
     s.draw()
     win.flip()
     for p in inside_pts:
@@ -185,6 +193,7 @@ def test_border_contains():
     for p in hole_pts:
         assert not s.contains(p)
 
+
 if __name__=='__main__':
-    test_contains_overlaps('contains')
-    test_contains_overlaps('overlaps')
+    contains_overlaps('contains')
+    contains_overlaps('overlaps')

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -28,8 +28,9 @@ class Line(ShapeStim):
         :class:`~psychopy.visual.ShapeStim` accepts, except
         for vertices, closeShape and fillColor.
 
-        The methods `contains` and `overlaps` are inherited from
-        `~psychopy.visual.ShapeStim`, but always return False
+        :Notes:
+
+        The methods `contains` and `overlaps` always return False
         (because a line is not a proper (2D) polygon).
         """
         # what local vars are defined (these are the init params) for use by
@@ -79,9 +80,8 @@ class Line(ShapeStim):
         """
         setAttribute(self, 'end', end, log)
 
-    # Not meaningful for a line, thus deleted
-    def contains(self):
-        pass
+    def contains(self, *args, **kwargs):
+        return False
 
-    def overlaps(self):
-        pass
+    def overlaps(self, *args):
+        return False


### PR DESCRIPTION
The `contains()` and `overlaps()` methods of `visual.Line` had a different signature than their parent (accepting no arguments), essentially being useless and violating [LSP](https://en.wikipedia.org/wiki/Liskov_substitution_principle). We now consume all passed (keyword) arguments, fixing this problem. We also explicitly return `False` now, as has always been indicated by the docstrings. Added tests for this behavior. While at it, I additionally cleaned up the test scripts a little bit to improve readability.
