### PR TITLE
BF: an attempt to fix further unicode issues with audioLibs

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -66,7 +66,10 @@ def getDevices(kind=None):
     devs = {}
     for ii in allDevs:  # in pyo this is a dict but keys are ii ! :-/
         dev = allDevs[ii]
-        devName = dev['name'].decode(osEncoding) # convert to unicode
+        try:  # convert to unicode
+            devName = dev['name'].decode(osEncoding)
+        except UnicodeEncodeError:  # if that fails try the current encoding
+            devName = dev['name']
         devs[devName] = dev
         dev['id'] = ii
     return devs


### PR DESCRIPTION
For some users it seems that
```
           devName = dev['name'].decode(osEncoding)
```
Spits a decode error and `dev['name']` claims already to be a unicode
object (so shouldn't need decoding). It isn't clear why, but it looks
like portaudio on some systems returns a bytes string and on some
returns a unicode object!?