### PR TITLE
BF: Added 'sounddevice' to all audioLib vars in `.spec` files

### DIFF
--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -39,7 +39,7 @@
     # Add paths here to your custom Python modules
     paths=list(default=list())
     # choice of audio library
-    audioLib = list(default=list('pyo', 'pygame'))
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
     # audio driver to use
     audioDriver = list(default=list('coreaudio', 'portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -39,7 +39,7 @@
     # Add paths here to your custom Python modules
     paths=list(default=list())
     # choice of audio library
-    audioLib = list(default=list('pyo', 'pygame'))
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -39,7 +39,7 @@
     # Add paths here to your custom Python modules
     paths=list(default=list())
     # choice of audio library
-    audioLib = list(default=list('pyo', 'pygame'))
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -39,7 +39,7 @@
     # Add paths here to your custom Python modules
     paths=list(default=list())
     # choice of audio library
-    audioLib = list(default=list('pyo', 'pygame'))
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
     # audio driver to use
     audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -35,7 +35,7 @@
     # Add paths here to your custom Python modules
     paths=list(default=list())
     # choice of audio library
-    audioLib = list(default=list('pyo', 'pygame'))
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)


### PR DESCRIPTION
'sounddevice' was missing from `baseNoArch.spec`/`general`/`audioLib` list. I've added it in, and used generateSpec.py to update the rest of the `.spec` files.

See #1529 