### PR TITLE
FF: fixes needed as result of OrderedDict change

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -20,6 +20,7 @@ standard_library.install_aliases()
 from builtins import str
 from past.builtins import basestring
 from builtins import object
+from collections import OrderedDict
 import re
 import os
 import xml.etree.ElementTree as xml
@@ -1076,7 +1077,7 @@ class TrialHandler(object):
             code = ("# abbreviate parameter names if possible (e.g. rgb = %(name)s.rgb)\n"
                     "if %(name)s != None:\n"
                     "    for paramName in %(name)s:\n"
-                    "        exec(paramName + '= %(name)s.' + paramName)\n")
+                    "        exec('{} = %(name)s[paramName]'.format(paramName))\n")
             buff.writeIndentedLines(code % {'name': self.thisName})
 
         # then run the trials loop
@@ -1090,7 +1091,7 @@ class TrialHandler(object):
             code = ("# abbreviate parameter names if possible (e.g. rgb = %(name)s.rgb)\n"
                     "if %(name)s != None:\n"
                     "    for paramName in %(name)s:\n"
-                    "        exec(paramName + '= %(name)s.' + paramName)\n")
+                    "        exec('{} = %(name)s[paramName]'.format(paramName))\n")
             buff.writeIndentedLines(code % {'name': self.thisName})
 
     def writeLoopStartCodeJS(self, buff):


### PR DESCRIPTION
7d499265bca introduced some bugs:

  - experiment.py now needs to import OrderedDict to load variables of that
  - we can't do `word = thisTrial.word` any more
    we need `word = thistrial['word']` now