### PR TITLE
RF/BF/FF: Imports during installation, Windows requirements, and loading json calibration files

### DIFF
--- a/createInitFile.py
+++ b/createInitFile.py
@@ -83,16 +83,12 @@ if __git_sha__ == 'n/a':
         __git_sha__ = output.strip()  # remove final linefeed
 
 # update preferences and the user paths
-try:
+if 'installing' not in locals():
     from psychopy.preferences import prefs
     for pathName in prefs.general['paths']:
         sys.path.append(pathName)
-
+    
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
-except ImportError as e:
-    if not any(x in str(e) for x in ["configobj", "past", "builtins"]):
-        raise
-    pass
 """
 
 

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -39,13 +39,9 @@ if __git_sha__ == 'n/a':
         __git_sha__ = output.strip()  # remove final linefeed
 
 # update preferences and the user paths
-try:
+if 'installing' not in locals():
     from psychopy.preferences import prefs
     for pathName in prefs.general['paths']:
         sys.path.append(pathName)
     
-        from psychopy.tools.versionchooser import useVersion, ensureMinimal
-except ImportError as e:
-    if not any(x in str(e) for x in ["configobj", "past", "builtins"]):
-        raise
-    pass
+    from psychopy.tools.versionchooser import useVersion, ensureMinimal

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -500,7 +500,8 @@ class Monitor(object):
         else:
             if ext==".json":
                 with open(thisFileName, 'r') as thisFile:
-                    self.calibs = json_tricks.load(thisFile, ignore_comments=False)
+                    self.calibs = json_tricks.load(thisFile, ignore_comments=False,
+                                                   encoding='utf-8', preserve_order=False)
             else:
                 with open(thisFileName, 'rb') as thisFile:
                     self.calibs = pickle.load(thisFile)

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -499,13 +499,12 @@ class Monitor(object):
             self.calibNames = []
         else:
             if ext==".json":
-                thisFile = open(thisFileName, 'r')
-                self.calibs = json_tricks.load(thisFile, ignore_comments=False)
+                with open(thisFileName, 'r') as thisFile:
+                    self.calibs = json_tricks.load(thisFile, ignore_comments=False)
             else:
-                thisFile = open(thisFileName, 'rb')
-                self.calibs = pickle.load(thisFile)
+                with open(thisFileName, 'rb') as thisFile:
+                    self.calibs = pickle.load(thisFile)
             self.calibNames = sorted(self.calibs)
-            thisFile.close()
             
             if not constants.PY3:  # saving for future (not needed if we are IN future!)
                 # save JSON copies of our calibrations
@@ -591,9 +590,8 @@ class Monitor(object):
         """
         if not constants.PY3:  # don't ever save pickle files form PY3
             thisFileName = os.path.join(monitorFolder, self.name + ".calib")
-            thisFile = open(thisFileName, 'wb')
-            pickle.dump(self.calibs, thisFile)
-            thisFile.close()
+            with open(thisFileName, 'wb') as thisFile:
+                pickle.dump(self.calibs, thisFile)
         # also save as JSON (at the moment)
         # (When we're sure this works we should ONLY save as JSON)
         self._saveJSON()

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -498,10 +498,11 @@ class Monitor(object):
         if not os.path.exists(thisFileName):
             self.calibNames = []
         else:
-            thisFile = open(thisFileName, 'rb')
             if ext==".json":
+                thisFile = open(thisFileName, 'r')
                 self.calibs = json_tricks.load(thisFile, ignore_comments=False)
             else:
+                thisFile = open(thisFileName, 'rb')
                 self.calibs = pickle.load(thisFile)
             self.calibNames = sorted(self.calibs)
             thisFile.close()

--- a/psychopy/tests/test_monitors/test_monitors.py
+++ b/psychopy/tests/test_monitors/test_monitors.py
@@ -36,7 +36,7 @@ class TestMonitorCalibration(object):
             assert os.path.isfile(self.fullname + '.calib')
 
     def test_reload_monitor(self):
-        """Reload the monitor and verify that all """
+        """Reload the monitor and verify that all elements in each object match"""
         mon2 = Monitor(self.monitor_name)
         # test that all values in the reloaded monitor match the original instance
         for key1 in self.mon.calibs.keys():

--- a/psychopy/tests/test_monitors/test_monitors.py
+++ b/psychopy/tests/test_monitors/test_monitors.py
@@ -1,0 +1,30 @@
+from psychopy.monitors.calibTools import Monitor
+import pytest
+
+
+@pytest.mark.monitors
+class TestMonitorCalibration(object):
+    def setup(self):
+        pass
+
+    def teardown(self):
+        pass
+
+    def test_reload_monitor(self):
+        self.mon = Monitor('test',
+                           width=40,
+                           distance=57,
+                           gamma=1.0,
+                           notes='Here are notes')
+        self.mon.saveMon()
+        self.mon2 = Monitor('test')
+        assert all([[self.mon.calibs[key][key2] is self.mon2.calibs[key][key2]
+                     for key2 in self.mon.calibs[key]]
+                    for key in self.mon.calibs])
+
+
+if __name__ == '__main__':
+    cls = TestMonitorCalibration()
+    cls.setup()
+    cls.test_reload_monitor()
+    cls.teardown()

--- a/psychopy/tests/test_monitors/test_monitors.py
+++ b/psychopy/tests/test_monitors/test_monitors.py
@@ -1,30 +1,51 @@
+import os
+import sys
+import glob
+import uuid
 from psychopy.monitors.calibTools import Monitor
+import numpy as np
 import pytest
 
 
 @pytest.mark.monitors
 class TestMonitorCalibration(object):
-    def setup(self):
-        pass
-
-    def teardown(self):
-        pass
-
-    def test_reload_monitor(self):
-        self.mon = Monitor('test',
+    def setup_class(self):
+        self.monitor_name = str(uuid.uuid4().hex)  # generate a random monitor name
+        if sys.platform == 'win32':
+            self.monitor_folder = os.path.join(os.environ['APPDATA'], 'psychopy2', 'monitors')
+        else:
+            self.monitor_folder = os.path.join(os.environ['HOME'], '.psychopy2', 'monitors')
+        self.fullname = os.path.join(self.monitor_folder, self.monitor_name)
+        self.mon = Monitor(self.monitor_name,
                            width=40,
                            distance=57,
                            gamma=1.0,
                            notes='Here are notes')
+
+    def teardown_class(self):
+        """Remove leftover monitor calibration files (if they exist)"""
+        for f in glob.glob(self.fullname + '.*'):
+            os.remove(f)
+
+    def test_save_monitor(self):
+        """See if the monitor calibration file ended up in the correct location"""
         self.mon.saveMon()
-        self.mon2 = Monitor('test')
-        assert all([[self.mon.calibs[key][key2] is self.mon2.calibs[key][key2]
-                     for key2 in self.mon.calibs[key]]
-                    for key in self.mon.calibs])
+        assert os.path.isfile(self.fullname + '.json')
+        if sys.version_info[0] == 2:
+            #  additionally, we should have a .calib file in python 2
+            assert os.path.isfile(self.fullname + '.calib')
+
+    def test_reload_monitor(self):
+        """Reload the monitor and verify that all """
+        mon2 = Monitor(self.monitor_name)
+        # test that all values in the reloaded monitor match the original instance
+        for key1 in self.mon.calibs.keys():
+            for key2 in self.mon.calibs[key1].keys():
+                if isinstance(self.mon.calibs[key1][key2], (np.ndarray, np.generic)):
+                    assert (self.mon.calibs[key1][key2] == mon2.calibs[key1][key2]).all()
+                else:
+                    assert self.mon.calibs[key1][key2] == mon2.calibs[key1][key2]
 
 
 if __name__ == '__main__':
-    cls = TestMonitorCalibration()
-    cls.setup()
-    cls.test_reload_monitor()
-    cls.teardown()
+    pytest.main()

--- a/psychopy/tests/test_monitors/test_monitors.py
+++ b/psychopy/tests/test_monitors/test_monitors.py
@@ -3,6 +3,7 @@ import sys
 import glob
 import uuid
 from psychopy.monitors.calibTools import Monitor
+from psychopy.constants import PY3
 import numpy as np
 import pytest
 
@@ -31,7 +32,7 @@ class TestMonitorCalibration(object):
         """See if the monitor calibration file ended up in the correct location"""
         self.mon.saveMon()
         assert os.path.isfile(self.fullname + '.json')
-        if sys.version_info[0] == 2:
+        if not PY3:
             #  additionally, we should have a .calib file in python 2
             assert os.path.isfile(self.fullname + '.calib')
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ else:
     f = open('psychopy/__init__.py', 'r')
     vStr = f.read()
     f.close()
+installing = True
 exec(vStr)
 
 # define the extensions to compile if necess

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,8 @@ required = ['numpy', 'scipy', 'matplotlib', 'pandas', 'pillow',
             'moviepy',
             ]
 # some optional dependencies
+if platform == 'win32':
+    required.extend(['pypiwin32'])
 if platform == 'darwin':
     required.extend(['pyobjc-core', 'pyobjc-framework-Quartz'])
 if PY3:  # doesn't exist on py2


### PR DESCRIPTION
- Better handling of preferences import during installation.
    - Use install-only variable to determine whether or not to skip preferences import in `psychopy/__init__.py`. The previous way I tried (in #1480) wasn't ideal.
- Added `pypiwin32` as dependency on Windows.
- Open json monitor calibration file with 'r', rather than 'rb'.
    - I get a `TypeError: the JSON object must be str, not 'bytes'` on a Windows 10 machine, current psychopy master, python 3.5, when trying to load the default `testMonitor.json`. However, the problem was fixed in python 3.6 (I think https://bugs.python.org/issue10976?).


