### PR TITLE
ENH: Catch AttributeError during avbin import

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -47,10 +47,6 @@ if sys.platform == 'win32':
         haveAvbin = False
         # either avbin isn't installed or scipy.stats has been imported
         # (prevents avbin loading)
-    except Exception as e:
-        # WindowsError on some systems
-        # AttributeError if using avbin5 from pyglet 1.2?
-        haveAvbin = False
     except AttributeError:
         # avbin is not found, causing exception in pyglet 1.2??
         # (running psychopy 1.81 standalone on windows 7):
@@ -61,6 +57,11 @@ if sys.platform == 'win32':
         # AttributeError: 'NoneType' object has no attribute
         # 'avbin_get_version'
         haveAvbin = False
+    except Exception:
+        # WindowsError on some systems
+        # AttributeError if using avbin5 from pyglet 1.2?
+        haveAvbin = False
+
 
 import psychopy  # so we can get the __path__
 from psychopy import core, platform_specific, logging, prefs, monitors, event


### PR DESCRIPTION
The `AttributeError` didn't get caught as it was superseded by the `Exception`, which was caught right before. Changed to order of `except` blocks to fix this.