### PR TITLE
BF: Supported light and voice keys by increasing hardware button limit

### DIFF
--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -496,9 +496,12 @@ class Pstbox(Serial):
     def __init__(self, *args, **kwargs):
         Serial.__init__(self, *args, **kwargs)
 
-        self._nbuttons = 5
+        self._nbuttons = 7
         # Buttons 0--4, from left to right:
         # [1, 2, 4, 8, 16]
+        # Buttons 5--6 are connected devices which generate button presses 
+        # (e.g. a refresh detector which responds when a certain luminance is 
+        # exceeded)
         self._button_bytes = 2**N.arange(self._nbuttons, dtype='uint8')
 
         self._nlamps = 5


### PR DESCRIPTION
Attempts to resolve issue #1309 by increasing the number of hardcoded hardware buttons from 5 to 7. 