### PR TITLE
Fixes for shellCall(), and  improvements to psychopyApp.py on macOS with Anaconda

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -8,14 +8,26 @@
 from __future__ import absolute_import, print_function
 
 import sys
-from psychopy.app._psychopyApp import PsychoPyApp, __version__
 
 # fix macOS locale-bug on startup: sets locale to LC_ALL (must be defined!)
 import psychopy.locale_setup  # noqa
 
+
 # NB the PsychoPyApp classes moved to _psychopyApp.py as of version 1.78.00
 # to allow for better upgrading possibilities from the mac app bundle. this
 # file now used solely as a launcher for the app, not as the app itself.
+
+
+def start_app():
+    from psychopy.app._psychopyApp import PsychoPyApp
+
+    showSplash = True
+    if '--no-splash' in sys.argv:
+        showSplash = False
+        del sys.argv[sys.argv.index('--no-splash')]
+    app = PsychoPyApp(0, showSplash=showSplash)
+    app.MainLoop()
+
 
 if __name__ == '__main__':
     if '-x' in sys.argv:
@@ -26,8 +38,10 @@ if __name__ == '__main__':
         core.shellCall([sys.executable, os.path.abspath(targetScript)])
         sys.exit()
     if '-v' in sys.argv or '--version' in sys.argv:
-        info = 'PsychoPy2, version %s (c)Jonathan Peirce 2015, GNU GPL license'
-        print(info % __version__)
+        from psychopy import __version__
+        msg = ('PsychoPy2, version %s (c)Jonathan Peirce 2015, GNU GPL license'
+               % __version__)
+        print(msg)
         sys.exit()
     if '-h' in sys.argv or '--help' in sys.argv:
         print("""Starts the PsychoPy2 application.
@@ -56,10 +70,24 @@ Options:
 """)
         sys.exit()
 
+    if (sys.platform == 'darwin' and
+            ('| packaged by conda-forge |' in sys.version or
+             '|Anaconda' in sys.version)):
+
+        # On macOS with Anaconda, GUI applications need to be run using
+        # `pythonw`. Since we have no way to determine whether this is currently
+        # the case, we run this script again -- ensuring we're definitely using
+        # pythonw.
+        import os
+        env = os.environ
+        PYTHONW = env.get('PYTHONW', 'False')
+
+        if PYTHONW != 'True':
+            from psychopy import core
+            core.shellCall([sys.executable + 'w', __file__],
+                           env=dict(env, PYTHONW='True'))
+            sys.exit()
+        else:
+            start_app()
     else:
-        showSplash = True
-        if '--no-splash' in sys.argv:
-            showSplash = False
-            del sys.argv[sys.argv.index('--no-splash')]
-        app = PsychoPyApp(0, showSplash=showSplash)
-        app.MainLoop()
+        start_app()

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -84,8 +84,11 @@ Options:
 
         if PYTHONW != 'True':
             from psychopy import core
-            core.shellCall([sys.executable + 'w', __file__],
-                           env=dict(env, PYTHONW='True'))
+            cmd = [sys.executable + 'w', __file__]
+            if '--no-splash' in sys.argv:
+                cmd.append('--no-splash')
+
+            core.shellCall(cmd, env=dict(env, PYTHONW='True'))
             sys.exit()
         else:
             start_app()

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -75,7 +75,7 @@ def quit():
     sys.exit(0)  # quits the python session entirely
 
 
-def shellCall(shellCmd, stdin='', stderr=False, encoding='utf-8'):
+def shellCall(shellCmd, stdin='', stderr=False, env=None, encoding='utf-8'):
     """Call a single system command with arguments, return its stdout.
     Returns stdout, stderr if stderr is True.
     Handles simple pipes, passing stdin to shellCmd (pipes are untested
@@ -91,6 +91,9 @@ def shellCall(shellCmd, stdin='', stderr=False, encoding='utf-8'):
 
     stderr : bool
         Whether to return the standard error output once execution is finished.
+
+    env : dict
+        The environment variables to set during execution.
 
     encoding : str
         The encoding to use for communication with the executed command.
@@ -109,6 +112,9 @@ def shellCall(shellCmd, stdin='', stderr=False, encoding='utf-8'):
     when running Python 2.7.
 
     """
+    if env is None:
+        env = dict()
+
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
         shellCmdList = shlex.split(shellCmd)
@@ -134,14 +140,14 @@ def shellCall(shellCmd, stdin='', stderr=False, encoding='utf-8'):
             proc = subprocess.Popen(bytesObjects, stdin=subprocess.PIPE,
                                     stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE,
-                                    encoding=encoding)
+                                    encoding=encoding, env=env)
         else:
             msg = 'shellCall() requires Python 2.7, or 3.6 and newer.'
             raise RuntimeError(msg)
     else:
         proc = subprocess.Popen(bytesObjects, stdin=subprocess.PIPE,
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+                                stderr=subprocess.PIPE, env=env)
 
     stdoutData, stderrData = proc.communicate(stdin)
 

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -75,11 +75,39 @@ def quit():
     sys.exit(0)  # quits the python session entirely
 
 
-def shellCall(shellCmd, stdin='', stderr=False):
+def shellCall(shellCmd, stdin='', stderr=False, encoding='utf-8'):
     """Call a single system command with arguments, return its stdout.
     Returns stdout, stderr if stderr is True.
     Handles simple pipes, passing stdin to shellCmd (pipes are untested
     on windows) can accept string or list as the first argument
+
+    Parameters
+    ----------
+    shellCmd : str, or iterable
+        The command to execute, and its respective arguments.
+
+    stdin : str, or None
+        Input to pass to the command.
+
+    stderr : bool
+        Whether to return the standard error output once execution is finished.
+
+    encoding : str
+        The encoding to use for communication with the executed command.
+        This argument will be ignored on Python 2.7.
+
+    Notes
+    -----
+    We use ``subprocess.Popen`` to execute the command and establish
+    `stdin` and `stdout` pipes.
+    Python 2.7 always opens the pipes in text mode; however,
+    Python 3 defaults to binary mode, unless an encoding is specified.
+    To unify pipe communication across Python 2 and 3, we now provide an
+    `encoding` parameter, enforcing `utf-8` text mode by default.
+    This parameter is present from Python 3.6 onwards; using an older
+    Python 3 version will raise an exception. The parameter will be ignored
+    when running Python 2.7.
+
     """
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
@@ -90,16 +118,33 @@ def shellCall(shellCmd, stdin='', stderr=False):
     elif type(shellCmd) in (list, tuple):  # handles whitespace in filenames
         shellCmdList = shellCmd
     else:
-        return None, 'shellCmd requires a list or string'
+        msg = 'shellCmd requires a string or iterable.'
+        raise TypeError(msg)
+
     bytesObjects = []
     for obj in shellCmdList:
         if type(obj) != bytes:
             bytesObjects.append(obj.encode('utf-8'))
         else:
             bytesObjects.append(obj)
-    proc = subprocess.Popen(bytesObjects, stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    # Since Python 3.6, we can use the `encoding` parameter.
+    if PY3:
+        if sys.version_info.minor >= 6:
+            proc = subprocess.Popen(bytesObjects, stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    encoding=encoding)
+        else:
+            msg = 'shellCall() requires Python 2.7, or 3.6 and newer.'
+            raise RuntimeError(msg)
+    else:
+        proc = subprocess.Popen(bytesObjects, stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE)
+
     stdoutData, stderrData = proc.communicate(stdin)
+
     del proc
     if stderr:
         return stdoutData.strip(), stderrData.strip()

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -407,8 +407,7 @@ class Test_shellCall(object):
 
         self.msg = 'echo'
 
-    @staticmethod
-    def test_invalid_argument():
+    def test_invalid_argument(self):
         with pytest.raises(TypeError):
             shellCall(12345)
 

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -396,22 +396,51 @@ def test_quit():
 
 
 @pytest.mark.shellCall
-def test_shellCall():
-    if PY3:
-        # This call to shellCall from tests is failing from Python3
-        # but maybe it just isn't a great test anyway?!
-        # shellCall is used by PsychoPy Tools>Run and works on Py3 there!
-        pytest.xfail(reason="Failing on Py3")
-    msg = 'echo'
-    cmd = ('grep', 'findstr')[sys.platform == 'win32']
+class Test_shellCall(object):
+    def setup_class(self):
+        if sys.platform == 'win32':
+            self.cmd = 'findstr'
+        else:
+            self.cmd = 'grep'
 
-    for arg1 in [[cmd, msg],  cmd+' '+msg]:
-        echo = shellCall(arg1, stdin=msg)
-        assert echo == msg
-        echo, se = shellCall(arg1, stdin=msg, stderr=True)
-        assert echo == msg
-    echo, se = shellCall(12, stdin=msg)
-    assert echo is None
+        self.msg = 'echo'
+
+    @staticmethod
+    def test_invalid_argument():
+        with pytest.raises(TypeError):
+            shellCall(12345)
+
+    def test_stdin(self):
+        echo = shellCall([self.cmd, self.msg], stdin=self.msg)
+        assert echo == self.msg
+
+        echo = shellCall(self.cmd + ' ' + self.msg, stdin=self.msg)
+        assert echo == self.msg
+
+    def test_stderr(self):
+        _, se = shellCall([self.cmd, self.msg], stderr=True)
+        assert se == ''
+
+        _, se = shellCall(self.cmd + ' ' + self.msg, stderr=True)
+        assert se == ''
+
+    def test_stdin_and_stderr(self):
+        echo, se = shellCall([self.cmd, self.msg], stdin='echo', stderr=True)
+        assert echo == self.msg
+        assert se == ''
+
+        echo, se = shellCall(self.cmd + ' ' + self.msg, stdin='echo',
+                             stderr=True)
+        assert echo == self.msg
+        assert se == ''
+
+    def test_encoding(self):
+        shellCall([self.cmd, self.msg], stdin=self.msg, encoding='utf-8')
+
+        if PY3:
+            with pytest.raises(TypeError):
+                shellCall([self.cmd, self.msg], stdin=self.msg, encoding=None)
+
 
 
 if __name__ == '__main__':

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -400,8 +400,10 @@ class Test_shellCall(object):
     def setup_class(self):
         if sys.platform == 'win32':
             self.cmd = 'findstr'
+            self.env_cmd = 'set'
         else:
             self.cmd = 'grep'
+            self.env_cmd = 'env'
 
         self.msg = 'echo'
 
@@ -440,6 +442,13 @@ class Test_shellCall(object):
         if PY3:
             with pytest.raises(TypeError):
                 shellCall([self.cmd, self.msg], stdin=self.msg, encoding=None)
+
+    def test_env(self):
+        echo = shellCall(self.env_cmd)
+        assert echo == ''
+
+        echo = shellCall(self.env_cmd, env=dict(FOO='1'))
+        assert echo == 'FOO=1'
 
 
 


### PR DESCRIPTION
This PR
- fixes `core.shellCall()` for Python 3, which did not work before (NB: min. required version: 3.6 – allows to re-use most of the existing Python 2 code unchanged, which is not the case for earlier Python 3 releases)
- allows users to pass environment variables to programs executed via `shellCall()`
- ensures `psychopyApp.py` is run through `pythonw` on macOS with Anaconda (closes #1326)
