### PR TITLE
Update .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,9 +1,71 @@
-Jonathan Peirce <jon@peirce.org.uk>
-Jonathan Peirce <jwp@kea.local>
-Jonathan Peirce <jon@peirce.org.uk>
-Jonathan Peirce <jwp@jwpiimac.home>
-Jonathan Peirce <lpzjwp@plpgrebe.psychology.nottingham.ac.uk>
-Jonathan Peirce <jon.peirce@gmail.com>
-Jeremy R Gray <jrgray@gmail.com>
-Jonas Lindeløv <jonas@lindeloev-desktop.(none)>
-Jonas Lindeløv <jonas@cnru.dk>
+Adam Kimbler <akimbler@fiu.edu>  adamkimbler <akimb009@fiu.edu>
+Andy Schofield <a.j.schofield@bham.ac.uk>  schofiaj <a.j.schofield@bham.ac.uk>
+Ariel Rokem <arokem@gmail.com>  arokem <arokem@berkeley.edu>
+Ariel Rokem <arokem@gmail.com>  arokem <arokem@gmail.com>
+Axel Kohler <axelkohler@web.de>  kohlman <axelkohler@web.de>
+Ayse Ilkay Isik <ilkayisik@gmail.com>  ilkayisik <ilkayisik@gmail.com>
+Cameron Riddell <31414128+CRiddler@users.noreply.github.com> CRiddler <31414128+CRiddler@users.noreply.github.com>
+Damien Mannion <d.mannion@unsw.edu.au>  Damien Mannion <dmannion@umn.edu>
+Dan McCloy <dan.mccloy@gmail.com>  drammock <dan.mccloy@gmail.com>
+Daniel Riggs <daniel.riggs1@gmail.com>  daniel <daniel.riggs1@gmail.com>
+Daniel Riggs <daniel.riggs1@gmail.com>  dantheman39 <daniel.riggs1@gmail.com>
+Eric Larson <larson.eric.d@gmail.com>  Eric89GXL <larson.eric.d@gmail.com>
+Falmo R. Kaule <fkaule@cogito.apsy.gse.uni-magdeburg.de>  fkaule <fkaule@cogito.apsy.gse.uni-magdeburg.de>
+Faruk Gulban <farukgulban@gmail.com>  ofgulban <farukgulban@gmail.com>
+Francois Morvillier <francois.morvillier@ilixa.com>  francois <francois.morvillier@ilixa.com>
+Frank Papenmeier <frank.papenmeier@uni-tuebingen.de>  frankpapenmeier <frank.papenmeier@uni-tuebingen.de>
+Gary Lupyan <glupyan@gmail.com>  glupyan <glupyan@gmail.com>
+Gavin Cooper <gjcooper@gmail.com>  gjcooper <gjcooper@gmail.com>
+Hiroyuki Sogo <hsogo12600@gmail.com>  Hiroyuki Sogo <hsogo515@gmail.com>
+Horea Christian <h.chr@mail.ru>  Horea Christian <horea.christ@yandex.com>
+Ian Hussey <Ian@Ians-MacBook-Air.local>  ianhussey <Ian@Ians-MacBook-Air.local>
+Jakub Kaczmarzyk <jakubk@mit.edu>  jakubk <jakubk@mit.edu>
+Jan Freyberg <jan.freyberg@gmail.com>  Jan Freyberg <janfreyberg@users.noreply.github.com>
+Jason Gors <jason.gors.work@gmail.com>  jason gors <jason.gors.work@gmail.com>
+Jay Borseth <jayb@alleninstitute.org>  Jay Borseth <jaybo@nomadelectronics.com>
+Jen Evans <jwe080@gmail.com>  jwe080 <jwe080@gmail.com>
+Jeremy Gray <jrgray@gmail.com>  Jeremy R. Gray <jrgray@gmail.com>
+Jeremy Gray <jrgray@gmail.com>  jeremygray <jrgray@gmail.com>
+Jonas Lindeløv <jonas@cnru.dk>  Jonas Kristoffer Lindeløv <jonas@cnru.dk>
+Jonas Lindeløv <jonas@cnru.dk>  Jonas Lindeløv <jonas@lindeloev-desktop.(none)>
+Jonas Lindeløv <jonas@cnru.dk>  lindeloev <jonas@cnru.dk>
+Jonathan Kominsky <jonk@Jonathan-Kominskys-MacBook-2.local>  jfkominsky <jonk@Jonathan-Kominskys-MacBook-2.local>
+Jonathan Peirce <jon.peirce@gmail.com>  Jon Peirce <jon.peirce@gmail.com>
+Jonathan Peirce <jon.peirce@gmail.com>  Jon Peirce <jon@peirce.org.uk>
+Jonathan Peirce <jon.peirce@gmail.com>  Jon Peirce <lpzjwp@budgie.home>
+Jonathan Peirce <jon.peirce@gmail.com>  Jonathan Peirce <jon@peirce.org.uk>
+Jonathan Peirce <jon.peirce@gmail.com>  Jonathan Peirce <jwp@jwpiimac.home>
+Jonathan Peirce <jon.peirce@gmail.com>  Jonathan Peirce <jwp@kea.local>
+Jonathan Peirce <jon.peirce@gmail.com>  Jonathan Peirce <lpzjwp@plpgrebe.psychology.nottingham.ac.uk>
+Jonathan Peirce <jon.peirce@gmail.com>  unknown <jwp@.(none)>
+Jonathan Peirce <jon.peirce@gmail.com>  unknown <lpzjwp@.ad.nottingham.ac.uk>
+Joseph Glavan <j.glavan4@gmail.com>  JosephGlavan <JosephGlavan@users.noreply.github.com>
+Josh Doe <josh@joshdoe.com>  joshdoe <josh@joshdoe.com>
+Marian Dowgialo <marian.dowgialo@braintech.pl>  mdovgialo <marian.dowgialo@braintech.pl>
+Marius Mather <onesandzeroes@github.com>  onesandzeroes <onesandzeroes@github.com>
+Matthew Cutone <cutonem@yorku.ca>  ghcmat <cutonem@yorku.ca>
+Matthew Cutone <cutonem@yorku.ca>  mdc <cutonem@yorku.ca>
+Matthew Cutone <cutonem@yorku.ca>  mdcutone <cutonem@yorku.ca>
+Michael MacAskill <michael.macaskill@nzbri.org>  Michael MacAskill <michael.macaskill@vanderveer.org.nz>
+Oliver Clark <o.clark@mmu.ac.uk>  OliJimbo <o.clark@mmu.ac.uk>
+Pablo Prietz <pprietz@uos.de>  Pablo Prietz <pabloprietz@83adb9ab.funky.uni-osnabrueck.de>
+Pieter Moors <pieter.moors@ppw.kuleuven.be>  PieterMoors <pieter.moors@ppw.kuleuven.be>
+Piotr Iwaniuk <piotr.iwaniuk@titanis.pl>  Piotr Iwaniuk <piwaniuk@poczta.onet.pl>
+Rebecca Sharman <lpxrs@nottingham.ac.uk>  lpxrs <lpxrs@.ad.nottingham.ac.uk>
+Rebecca Sharman <lpxrs@nottingham.ac.uk>  <lpxrs@.ad.nottingham.ac.uk>
+Rebecca Sharman <lpxrs@nottingham.ac.uk>  Becky Sharman <lpxrs@nottingham.ac.uk>
+Sol Simpson <sol@isolver-software.com>   Sol Simpson <sds-git@isolver-software.com>
+Sol Simpson <sol@isolver-software.com>  Sol Simpson <isolver@Sols-Mac-mini.local>
+Sol Simpson <sol@isolver-software.com>  isolver <sol@isolver-software.com>
+Suddha Sourav <suddha.sourav@gmail.com>  Suddha Sourav <suddhasourav@users.noreply.github.com>
+Suddha Sourav <suddha.sourav@gmail.com>  suddhasourav <suddha.sourav@gmail.com>
+Suddha Sourav <suddha.sourav@gmail.com>  suddhasourav <suddhasourav@users.noreply.github.com>
+Suddha Sourav <suddha.sourav@gmail.com>  unknown <suddha.sourav@gmail.com>
+Thomas Emmerling <git@thomasemmerling.de>  Thomas Emmerling <git@thomasemmerling.de>
+Thomas Scope <thomascope@gmail.com>  thomascope <thomascope@gmail.com>
+Todd Jennings <toddrjen@gmail.com>  Todd <toddrjen@gmail.com>
+Tristan Stenner <ttstenner@gmail.com>  Tristan Stenner <ttstenner@gmail.com> 
+Wilbert van Ham <W.vanHam@socsci.ru.nl>  wilberth <W.vanHam@socsci.ru.nl>
+William Högman <william@hogman.me>  William Hogman <me@whn.se>
+Yaroslav Halchenko <debian@onerussian.com>  Yaroslav Halchenko <debian@onerussian.com>
+Zhili Zheng <ypigzz@gmail.com>  zhili zheng <ypigzz@gmail.com>


### PR DESCRIPTION
`git shortlog -sne` now produces reasonable output without duplicate entries.

I used Google to find out the real names of contributors that had not specified them at commit time. The identities/names of the following contributors are still unknown:

- agrant@sastrugi.cmrr.umn.edu
- ramvs@ramvs-acer.staff.smu.edu.sg
- nwokedi@gmail.com