### PR TITLE
BF: psychopy updates shouldn't suggest 'updating' to older version 

### DIFF
--- a/psychopy/app/connections.py
+++ b/psychopy/app/connections.py
@@ -347,6 +347,11 @@ class InstallUpdateDialog(wx.Dialog):
             msg += _translate("PsychoPy could not connect to the \n internet"
                               " to check for more recent versions.\n")
             msg += _translate("Check proxy settings in preferences.")
+        elif self.latest['version'] < self.runningVersion:
+            msg = _translate(
+                "You are running PsychoPy (%s), which is ahead of the latest"
+                " official version (%s)") % (self.runningVersion,
+                                             self.latest['version'])
         elif self.latest['version'] == self.runningVersion:
             msg = _translate(
                 "You are running the latest version of PsychoPy (%s)\n ") % self.runningVersion

--- a/psychopy/app/connections.py
+++ b/psychopy/app/connections.py
@@ -347,7 +347,7 @@ class InstallUpdateDialog(wx.Dialog):
             msg += _translate("PsychoPy could not connect to the \n internet"
                               " to check for more recent versions.\n")
             msg += _translate("Check proxy settings in preferences.")
-        elif self.latest == self.runningVersion:
+        elif self.latest['version'] == self.runningVersion:
             msg = _translate(
                 "You are running the latest version of PsychoPy (%s)\n ") % self.runningVersion
             msg += _translate("You can revert to a previous version by "


### PR DESCRIPTION
This addresses issue #1443 , which I think was a twofold issue. The first was a simple bug in connections.py, where the latest version isn't expanded properly when checking if the install is up-to-date.

The second is that self.latest is fetched from http://www.psychopy.org/version.txt, which at the moment is 1.85.3. There was no handling for when the running version is actually higher than this. I'm not sure if this is a situation that is intended to happen, or if the version.txt page is just out of date. The [intstallation instructions](http://www.psychopy.org/installation.html) recommend installing 1.85.4.

I've added some handling so that the message "You are running PsychoPy ([VERSION]), which is ahead of the latest official version ([VERSION])" is displayed when this occurs. It may be that the version.txt page should also be updated.