### PR TITLE
TESTS: Add Anaconda builds & tests for Python 2.7 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   - echo "Installing PsychoPy dependencies via apt..."
   - travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl
   - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
-  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj python-openpyxl
+  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj
   - travis_retry sudo apt-get install -qq python-imaging python-mock
   - travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8
   - travis_retry sudo apt-get install -qq python-pyo python-opencv

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,7 @@ before_script:
        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset;
     fi
 
-# This might come in handy once we switch to Trusty, as Xvfb on precise
-# doesn't properly support the RANDR extension
+# This might come in handy once we switch to Trusty
 #  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 #      xpra --xvfb="Xorg +extension GLX +extension RANDR +extension RENDER -config `pwd`/dummy_xorg.conf -logfile ${HOME}/.xpra/xorg.log"  start :99;
 #    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,24 +42,10 @@ before_install:
 
   # PIP depdendencies
   - echo "\nNow installing dependencies via pip...\n"
-  - travis_retry sudo pip install --upgrade -qq cryptography
-  - travis_retry sudo pip install --upgrade -qq pip
-  - travis_retry sudo pip install --upgrade -qq soundfile
-  - travis_retry sudo pip install --upgrade -qq sounddevice
-  - travis_retry sudo pip install --upgrade -qq pyglet==1.3.0b1
+  - travis_retry sudo pip install --upgrade -force-reinstall -qq cryptography
+  - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
+  - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt
   - python -c 'import pyglet; print pyglet.version'
-  - travis_retry sudo pip install --upgrade -qq pillow
-  #  - python -c 'import Image; print Image.PILLOW_VERSION'
-  - travis_retry sudo pip install --upgrade -qq pyosf
-  - travis_retry sudo pip install --upgrade -qq xlrd
-  - travis_retry sudo pip install --upgrade -qq gevent # Don't use apt-get (too old version of gevent)
-  - travis_retry sudo pip install --upgrade -qq psutil # Don't use apt-get (too old version of psutil)
-  - travis_retry sudo pip install --upgrade -qq msgpack-python #n ot apt-get (no permissions for universe)
-  - travis_retry sudo pip install --upgrade -qq pyserial pycrsltd
-  - travis_retry sudo pip install --upgrade -qq future
-  - travis_retry sudo pip install --upgrade -qq json_tricks
-  - travis_retry sudo pip install --upgrade -qq codecov pytest pytest-cov
-  - travis_retry sudo pip install --upgrade -qq coveralls
 
 install: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,24 +5,24 @@ sudo: true
 
 language: python
 
-env:
-  global:
-    - DISPLAY=:99.0
-    - AUDIODEV=null
-
 matrix:
   include:
     - os: linux
       python: "2.7_with_system_site_packages"
-      env: USE_ANACONDA=false
+      env: USE_ANACONDA=false DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
       python: 2.7
-      env: USE_ANACONDA=true
+      env: USE_ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
       python: 3.6
-      env: USE_ANACONDA=true
+      env: USE_ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
+
+  allow_failures:
+    - os: linux
+      python: 3.6
+      env: USE_ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
 
 before_install:
   # System setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ before_install:
   - travis_retry sudo apt-get update -qq
   - sudo apt-cache policy  # What is actually available?
 
+  # This might come in handy once we switch to Trusty, as Xvfb on precise
+  # doesn't properly support the RANDR extension
+  # - travis_retry sudo apt-get install -qq xpra xserver-xorg-video-dummy
+
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri libavbin0
   - travis_retry sudo apt-get install -qq flac
   - flac -version
@@ -50,6 +54,8 @@ before_install:
   - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
   - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt
   - python -c 'import pyglet; print pyglet.version'
+  - python -c 'import matplotlib; print matplotlib.__version__'
+  - python -c 'import PIL; print PIL.__version__'
 
 install:
   - python setup.py build
@@ -57,8 +63,14 @@ install:
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset;
+       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset;
     fi;
+
+# This might come in handy once we switch to Trusty, as Xvfb on precise
+# doesn't properly support the RANDR extension
+#  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+#      xpra --xvfb="Xorg +extension GLX +extension RANDR +extension RENDER -config `pwd`/dummy_xorg.conf -logfile ${HOME}/.xpra/xorg.log"  start :99;
+#    fi;
 
 script:
   - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,7 @@ before_install:
 
   - if [ $USE_ANACONDA == "true" ]; then conda update -q conda; fi
   - if [ $USE_ANACONDA == "true" ]; then conda info -a; fi
-  # - if [ $USE_ANACONDA == "true" ]; then conda create -q -n psychopy-conda python=$TRAVIS_PYTHON_VERSION; fi
-  - ls -la ./conda/environment-$TRAVIS_PYTHON_VERSION.yml
+  - if [ $USE_ANACONDA == "true" ]; then ls -la ./conda/environment-$TRAVIS_PYTHON_VERSION.yml; fi
   - if [ $USE_ANACONDA == "true" ]; then conda env create -n psychopy-conda -f ./conda/environment-$TRAVIS_PYTHON_VERSION.yml; fi
   - if [ $USE_ANACONDA == "true" ]; then conda env list; fi
   - if [ $USE_ANACONDA == "true" ]; then source activate psychopy-conda; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: true
 
 language: python
 
-python:
-  - "2.7"
-
 env:
   global:
     - DISPLAY=:99.0
@@ -16,13 +13,16 @@ env:
 matrix:
   include:
     - os: linux
+      python: "2.7_with_system_site_packages"
       env: USE_ANACONDA=false
 
     - os: linux
+      python: 2.7
       env: USE_ANACONDA=true
 
-virtualenv:
-  system_site_packages: true
+    - os: linux
+      python: 3.6
+      env: USE_ANACONDA=true
 
 before_install:
   # System setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ virtualenv:
   system_site_packages: true
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq lsb-release
+  # System setup
+  - travis_retry sudo apt-get update -qq
+  - travis_retry sudo apt-get install -qq lsb-release
   - source /etc/lsb-release
   - echo ${DISTRIB_CODENAME}
   - wget -O- http://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
@@ -24,29 +25,35 @@ before_install:
   - travis_retry sudo apt-get update -qq
   - sudo apt-cache policy  # What is actually available?
 
-  # APT dependencies
-  - echo "Installing dependencies via apt..."
-  - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri python-xlib
-  - travis_retry sudo apt-get install -qq python-pygame python-opengl
-  - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
-  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj python-openpyxl
-  - travis_retry sudo apt-get install -qq python-imaging python-mock
-  - travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8
-  - travis_retry sudo apt-get install -qq python-pyo libavbin0
+  - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri libavbin0
   - travis_retry sudo apt-get install -qq flac
   - flac -version
-  - travis_retry sudo apt-get install -qq python-mock
+
+  # Locales
   # - travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
   - travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
   # - sudo dpkg-reconfigure locales
   # - locale -a  # list available locales
 
-  # PIP dependencies
-  - echo "Installing dependencies via pip..."
+  # APT Python dependencies for PsychoPy
+  - echo "Installing PsychoPy dependencies via apt..."
+  - travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl
+  - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
+  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj python-openpyxl
+  - travis_retry sudo apt-get install -qq python-imaging python-mock
+  - travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8
+  - travis_retry sudo apt-get install -qq python-pyo python-opencv
+  - travis_retry sudo apt-get install -qq python-mock
+
+  # PIP dependencies for PsychoPy
+  - echo "Installing PsychoPy dependencies via pip..."
+  - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
   - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt
   - python -c 'import pyglet; print pyglet.version'
 
-install: true
+install:
+  - python setup.py build
+  - python setup.py install
 
 before_script:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
@@ -54,7 +61,7 @@ before_script:
     fi;
 
 script:
-  -  pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy;
+  - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,10 +86,11 @@ before_install:
   - echo $PATH
   - which python
   - python --version
-  - python -c 'import pyglet; print pyglet.version'
-  - python -c 'import matplotlib; print matplotlib.__version__'
-  - python -c 'import PIL; print PIL.__version__'
-  - python -c 'import openpyxl; print openpyxl.__version__'
+  - python -c 'import pyglet; print(pyglet.version)'
+  - python -c 'import matplotlib; print(matplotlib.__version__)'
+  - python -c 'import PIL; print(PIL.__version__)'
+  - python -c 'import wx; print(wx.__version__)'
+  - python -c 'import openpyxl; print(openpyxl.__version__)'
 
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,34 +16,33 @@ virtualenv:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install lsb-release
+  - sudo apt-get install -qq lsb-release
   - source /etc/lsb-release
   - echo ${DISTRIB_CODENAME}
   - wget -O- http://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
   - wget -q -O- http://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
   - travis_retry sudo apt-get update -qq
-  - sudo apt-cache policy           # What is actually available?
+  - sudo apt-cache policy  # What is actually available?
 
   # APT dependencies
   - echo "Installing dependencies via apt..."
-  - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
+  - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri python-xlib
   - travis_retry sudo apt-get install -qq python-pygame python-opengl
-  - travis_retry sudo apt-get install -qq python-yaml python-xlib
-  - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-lxml
-  - travis_retry sudo apt-get install -qq python-configobj python-imaging python-openpyxl python-mock python-wxgtk2.8 libavbin0 python-pyo
-  - travis_retry sudo apt-get install -qq python-pandas
-  - travis_retry sudo apt-get install -qq python-qt4
+  - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
+  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj python-openpyxl
+  - travis_retry sudo apt-get install -qq python-imaging python-mock
+  - travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8
+  - travis_retry sudo apt-get install -qq python-pyo libavbin0
   - travis_retry sudo apt-get install -qq flac
   - flac -version
+  - travis_retry sudo apt-get install -qq python-mock
   # - travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
   - travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
   # - sudo dpkg-reconfigure locales
-  # - locale -a       # list available locales
+  # - locale -a  # list available locales
 
-  # PIP depdendencies
+  # PIP dependencies
   - echo "Installing dependencies via pip..."
-  - travis_retry sudo pip install --upgrade -force-reinstall -qq cryptography
-  - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
   - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt
   - python -c 'import pyglet; print pyglet.version'
 
@@ -55,10 +54,8 @@ before_script:
     fi;
 
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
-      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy;
-    fi
+  -  pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy;
 
 after_success:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
+  - coveralls
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ python:
   - "2.7"
 
 env:
-  global: DISPLAY=:99.0
+  global:
+    - DISPLAY=:99.0
+    - AUDIODEV=null
 
 virtualenv:
   system_site_packages: true
@@ -38,6 +40,10 @@ before_install:
   - travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
   # - sudo dpkg-reconfigure locales
   # - locale -a  # list available locales
+
+  - travis_retry sudo apt-get install -qq libasound2-dev alsa-utils alsa-oss
+  - sudo modprobe snd-dummy
+  - sudo lsmod
 
   # APT Python dependencies for PsychoPy
   - echo "Installing PsychoPy dependencies via apt..."
@@ -74,6 +80,9 @@ before_script:
 
 script:
   - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
+
+  # This does not work on Precise, probably because ffmpeg is outdated
+  # - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s psychopy
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ before_install:
   - python -c 'import PIL; print(PIL.__version__)'
   - python -c 'import wx; print(wx.__version__)'
   - python -c 'import openpyxl; print(openpyxl.__version__)'
+  - python -c 'import tables; print(tables.__version__)'
 
 install:
   - python setup.py build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 # vim ft=yaml
 # travis-ci.org and coveralls definition for PsychoPy tests
 dist: precise  # the default (trusty) causing problem with SSL as of Aug 2017
+sudo: true
+
 language: python
+
 python:
   - "2.7"
+
+env:
+  global: DISPLAY=:99.0
+
 virtualenv:
   system_site_packages: true
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install lsb-release
@@ -15,39 +23,56 @@ before_install:
   - wget -q -O- http://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
   - travis_retry sudo apt-get update -qq
   - sudo apt-cache policy           # What is actually available?
+
+  # APT dependencies
+  - echo "\nNow installing dependencies via apt...\n"
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
   - travis_retry sudo apt-get install -qq python-pygame python-opengl
-  - travis_retry sudo -H pip install --upgrade -qq cryptography
-  - travis_retry sudo -H pip install --upgrade -qq pip
-  - travis_retry sudo -H pip install --upgrade -qq soundfile
-  - travis_retry sudo -H pip install --upgrade -qq sounddevice
-  - travis_retry sudo -H pip install -qq pyglet==1.3.0b1
-  - python -c 'import pyglet; print pyglet.version'
-  - travis_retry sudo -H pip install -q pillow
-  - travis_retry sudo -H pip install -q pyosf
-  - travis_retry sudo -H pip install -q xlrd
-#  - python -c 'import Image; print Image.PILLOW_VERSION'
-  - travis_retry sudo -H pip install -qq gevent # Don't use apt-get (too old version of gevent)
   - travis_retry sudo apt-get install -qq python-yaml python-xlib
-  - travis_retry sudo -H pip install -qq psutil # Don't use apt-get (too old version of psutil)
-  - travis_retry sudo -H pip install -qq msgpack-python #not apt-get (no permissions for universe)
   - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-lxml
   - travis_retry sudo apt-get install -qq python-configobj python-imaging python-openpyxl python-mock python-wxgtk2.8 libavbin0 python-pyo
   - travis_retry sudo apt-get install -qq python-pandas
   - travis_retry sudo apt-get install -qq python-qt4
-  - travis_retry sudo pip install -qq codecov
-  - travis_retry sudo pip install -qq future json_tricks
-install:
   - travis_retry sudo apt-get install -qq flac
   - flac -version
-  #- travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
+  # - travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
   - travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
-  #- sudo dpkg-reconfigure locales
-  #- locale -a       # list available locales
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install -q coveralls; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install -q pyserial pycrsltd; fi
+  # - sudo dpkg-reconfigure locales
+  # - locale -a       # list available locales
+
+  # PIP depdendencies
+  - echo "\nNow installing dependencies via pip...\n"
+  - travis_retry sudo pip install --upgrade -qq cryptography
+  - travis_retry sudo pip install --upgrade -qq pip
+  - travis_retry sudo pip install --upgrade -qq soundfile
+  - travis_retry sudo pip install --upgrade -qq sounddevice
+  - travis_retry sudo pip install --upgrade -qq pyglet==1.3.0b1
+  - python -c 'import pyglet; print pyglet.version'
+  - travis_retry sudo pip install --upgrade -qq pillow
+  #  - python -c 'import Image; print Image.PILLOW_VERSION'
+  - travis_retry sudo pip install --upgrade -qq pyosf
+  - travis_retry sudo pip install --upgrade -qq xlrd
+  - travis_retry sudo pip install --upgrade -qq gevent # Don't use apt-get (too old version of gevent)
+  - travis_retry sudo pip install --upgrade -qq psutil # Don't use apt-get (too old version of psutil)
+  - travis_retry sudo pip install --upgrade -qq msgpack-python #n ot apt-get (no permissions for universe)
+  - travis_retry sudo pip install --upgrade -qq pyserial pycrsltd
+  - travis_retry sudo pip install --upgrade -qq future
+  - travis_retry sudo pip install --upgrade -qq json_tricks
+  - travis_retry sudo pip install --upgrade -qq codecov pytest pytest-cov
+  - travis_retry sudo pip install --upgrade -qq coveralls
+
+install: true
+
+before_script:
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +render -noreset;
+    fi;
+
 script:
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then xvfb-run -s "-screen 0 1024x768x24 -ac +extension GLX +render -noreset" coverage run --rcfile=.travis_coveragerc psychopy/tests/runPytest.py -v -s -m "not needs_sound"; else { echo "TODO while avoiding duplication"; exit 1; } fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then
+      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy;
+    fi
+
 after_success:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then coveralls; fi
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ env:
     - DISPLAY=:99.0
     - AUDIODEV=null
 
+matrix:
+  include:
+    - os: linux
+      env: USE_ANACONDA=false
+
+    - os: linux
+      env: USE_ANACONDA=true
+
 virtualenv:
   system_site_packages: true
 
@@ -32,6 +40,7 @@ before_install:
   # - travis_retry sudo apt-get install -qq xpra xserver-xorg-video-dummy
 
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri libavbin0
+  - travis_retry sudo apt-get install -qq libportaudio2
   - travis_retry sudo apt-get install -qq flac
   - flac -version
 
@@ -45,23 +54,43 @@ before_install:
   - sudo modprobe snd-dummy
   - sudo lsmod
 
-  # APT Python dependencies for PsychoPy
-  - echo "Installing PsychoPy dependencies via apt..."
-  - travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl
-  - travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
-  - travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj
-  - travis_retry sudo apt-get install -qq python-imaging python-mock
-  - travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8
-  - travis_retry sudo apt-get install -qq python-pyo python-opencv
-  - travis_retry sudo apt-get install -qq python-mock
+  - if [ $USE_ANACONDA != "true" ]; then
+      echo "Installing PsychoPy dependencies via apt...";
+      travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl;
+      travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas;
+      travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj;
+      travis_retry sudo apt-get install -qq python-imaging python-mock;
+      travis_retry sudo apt-get install -qq python-qt4 python-wxgtk2.8;
+      travis_retry sudo apt-get install -qq python-pyo python-opencv;
+      travis_retry sudo apt-get install -qq python-mock;
+      echo "Installing PsychoPy dependencies via pip...";
+      travis_retry sudo pip install --upgrade -force-reinstall -qq pip;
+      travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt;
+    fi
+  - if [ $USE_ANACONDA == "true" ]; then
+      echo "Installing Miniconda environment...";
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+      bash miniconda.sh -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+      hash -r;
+      conda config --set always_yes yes --set changeps1 no;
+    fi
 
-  # PIP dependencies for PsychoPy
-  - echo "Installing PsychoPy dependencies via pip..."
-  - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
-  - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt
+  - if [ $USE_ANACONDA == "true" ]; then conda update -q conda; fi
+  - if [ $USE_ANACONDA == "true" ]; then conda info -a; fi
+  # - if [ $USE_ANACONDA == "true" ]; then conda create -q -n psychopy-conda python=$TRAVIS_PYTHON_VERSION; fi
+  - ls -la ./conda/environment-$TRAVIS_PYTHON_VERSION.yml
+  - if [ $USE_ANACONDA == "true" ]; then conda env create -n psychopy-conda -f ./conda/environment-$TRAVIS_PYTHON_VERSION.yml; fi
+  - if [ $USE_ANACONDA == "true" ]; then conda env list; fi
+  - if [ $USE_ANACONDA == "true" ]; then source activate psychopy-conda; fi
+
+  - echo $PATH
+  - which python
+  - python --version
   - python -c 'import pyglet; print pyglet.version'
   - python -c 'import matplotlib; print matplotlib.__version__'
   - python -c 'import PIL; print PIL.__version__'
+  - python -c 'import openpyxl; print openpyxl.__version__'
 
 install:
   - python setup.py build
@@ -70,7 +99,7 @@ install:
 before_script:
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset;
-    fi;
+    fi
 
 # This might come in handy once we switch to Trusty, as Xvfb on precise
 # doesn't properly support the RANDR extension
@@ -80,9 +109,6 @@ before_script:
 
 script:
   - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
-
-  # This does not work on Precise, probably because ffmpeg is outdated
-  # - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s psychopy
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - sudo apt-cache policy           # What is actually available?
 
   # APT dependencies
-  - echo "\nNow installing dependencies via apt...\n"
+  - echo "Installing dependencies via apt..."
   - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri
   - travis_retry sudo apt-get install -qq python-pygame python-opengl
   - travis_retry sudo apt-get install -qq python-yaml python-xlib
@@ -41,7 +41,7 @@ before_install:
   # - locale -a       # list available locales
 
   # PIP depdendencies
-  - echo "\nNow installing dependencies via pip...\n"
+  - echo "Installing dependencies via pip..."
   - travis_retry sudo pip install --upgrade -force-reinstall -qq cryptography
   - travis_retry sudo pip install --upgrade -force-reinstall -qq pip
   - travis_retry sudo pip install --upgrade -force-reinstall -qq -r requirements_travis.txt

--- a/.travis_coveragerc
+++ b/.travis_coveragerc
@@ -3,3 +3,8 @@ branch = True
 omit =
     /usr/*
     /home/travis/virtualenv/*
+    psychopy/demos/*
+    psychopy/tests/*
+    psychopy/scripts/*
+    psychopy/iohub/*
+    psychopy/contrib/*

--- a/.travis_coveragerc
+++ b/.travis_coveragerc
@@ -6,5 +6,4 @@ omit =
     psychopy/demos/*
     psychopy/tests/*
     psychopy/scripts/*
-    psychopy/iohub/*
     psychopy/contrib/*

--- a/.travis_coveragerc
+++ b/.travis_coveragerc
@@ -6,4 +6,5 @@ omit =
     psychopy/demos/*
     psychopy/tests/*
     psychopy/scripts/*
+    psychopy/iohub/*
     psychopy/contrib/*

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -7,6 +7,7 @@ dependencies:
 - backports
 - bzip2
 - cffi
+- codecov
 - coveralls
 - ffmpeg
 - freetype

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -1,0 +1,68 @@
+name: anaconda-py2
+channels:
+- conda-forge
+- defaults
+dependencies:
+- python=2.7
+- backports
+- bzip2
+- cffi
+- coveralls
+- ffmpeg
+- freetype
+- future
+- gevent
+- greenlet
+- libffi
+- lxml
+- matplotlib
+- moviepy
+- msgpack-python
+- numexpr
+- numpy
+- openpyxl=2.4
+- pandas
+- pillow
+- pip
+- pixman
+- prompt_toolkit
+- psutil
+- pycparser
+- pygments
+- pyopengl
+- pyopenssl
+- pyosf
+- pyqt
+- pyserial
+- pytz
+- pyyaml
+- qt
+- requests
+- scipy
+- setuptools
+- sip
+- six
+- urllib3
+- wheel
+- xlrd
+- xz
+- yaml
+- configobj
+- lzo
+- pytables
+- pytest
+- pytest-cov
+- wxpython=3
+- zlib
+- pip:
+  - et-xmlfile
+  - json-tricks
+  - prompt-toolkit
+  - pygame
+  - pyglet==1.3.0b1
+  - pyparallel
+  - python-bidi
+  - opencv-python
+  - sounddevice
+  - soundfile
+  - tables

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -20,6 +20,7 @@ dependencies:
 - msgpack-python
 - numexpr
 - numpy
+- opencv
 - openpyxl=2.4
 - pandas
 - pillow
@@ -34,9 +35,7 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
-- pytz
 - pyyaml
-- qt
 - requests
 - scipy
 - setuptools
@@ -62,7 +61,6 @@ dependencies:
   - pyglet==1.3.0b1
   - pyparallel
   - python-bidi
-  - opencv-python
   - sounddevice
   - soundfile
   - tables

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -7,6 +7,7 @@ dependencies:
 - backports
 - bzip2
 - cffi
+- codecov
 - coveralls
 - ffmpeg
 - freetype

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -1,0 +1,58 @@
+name: anaconda-py3
+channels:
+- conda-forge
+- defaults
+dependencies:
+- python=3.6
+- backports
+- bzip2
+- cffi
+- ffmpeg
+- freetype
+- future
+- gevent
+- greenlet
+- hdf5
+- lxml
+- matplotlib
+- moviepy
+- msgpack-python
+- numexpr
+- numpy
+- opencv
+- openpyxl
+- pandas
+- pillow
+- pip
+- pyopengl
+- pyosf
+- pyqt
+- pyserial
+- pyyaml
+- qt
+- requests
+- scipy
+- setuptools
+- sip
+- six
+- urllib3
+- wheel
+- x264
+- xlrd
+- xz
+- yaml
+- configobj
+- lzo
+- pytables
+- zlib
+- pip:
+  - json-tricks
+  - pygame
+  - pyglet
+  - pyparallel
+  - python-bidi
+  - sounddevice
+  - soundfile
+  - tables
+  - wxpython
+  - psychopy

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -7,6 +7,7 @@ dependencies:
 - backports
 - bzip2
 - cffi
+- coveralls
 - ffmpeg
 - freetype
 - future
@@ -20,7 +21,7 @@ dependencies:
 - numexpr
 - numpy
 - opencv
-- openpyxl
+- openpyxl=2.4
 - pandas
 - pillow
 - pip
@@ -28,8 +29,9 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
+- pytest
+- pytest-cov
 - pyyaml
-- qt
 - requests
 - scipy
 - setuptools
@@ -44,15 +46,14 @@ dependencies:
 - configobj
 - lzo
 - pytables
+- wxpython
 - zlib
 - pip:
   - json-tricks
   - pygame
-  - pyglet
+  - pyglet==1.3.0b1
   - pyparallel
   - python-bidi
   - sounddevice
   - soundfile
   - tables
-  - wxpython
-  - psychopy

--- a/conda/gen_environment.sh
+++ b/conda/gen_environment.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Create environment.yml without version numbers and installation prefix
+conda env export | cut -f 1 -d '=' | grep -v "^prefix: " > environment.yml

--- a/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
+++ b/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
@@ -98,7 +98,7 @@ Video Display:
             Percent: 54.2
             Free: 7.3G
     Python:
-        exe: C: \Anaconda\python.exe
+        exe: C:\\Anaconda\\python.exe
         version: 2.7.7 |Anaconda 2.1.0 (64-bit)| (default, Jun 11 2014, 10: 40: 02) [MSC v.1500 64 bit (AMD64)]
     Packages:
         numpy: 1.9.0
@@ -128,7 +128,7 @@ Video Display:
 
         15187:
             num_threads: 3
-            exe: C: \Program Files (x86)\Notepad++\notepad++.exe
+            exe: C:\\Program Files (x86)\\Notepad++\\notepad++.exe
             name: notepad++.exe
             cpu_percent: 0.0
             cpu_affinity: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -138,7 +138,7 @@ Video Display:
             nice: 32
         16656:
             num_threads: 11
-            exe: C: \Program Files (x86)\Google\Chrome\Application\chrome.exe
+            exe: C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe
             name: chrome.exe
             cpu_percent: 0.0
             cpu_affinity: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -148,7 +148,7 @@ Video Display:
             nice: 32
         16688:
             num_threads: 17
-            exe: C: \Anaconda\python.exe
+            exe: C:\\Anaconda\\python.exe
             name: python.exe
             cpu_percent: 75.1
             cpu_affinity: [0, 1, 2, 3, 4, 5, 6, 7]
@@ -175,6 +175,7 @@ frame_num	frame_flip_time	playback_duration	frame_num_dx	dropped_count
 20	3.484598	0.828544	1	1	0.000268	0.005463	0.033331	0.033331	24.139
 [...]
 """
+
 
 from psychopy import visual, core, event
 

--- a/psychopy/iohub/devices/eyetracker/hw/smi/iviewx/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/smi/iviewx/eyetracker.py
@@ -1039,7 +1039,7 @@ class _iViewConfigMappings(object):
     # supported calibration modes
     calibration_methods = dict( NO_POINTS=0,TWO_POINTS=2,THREE_POINTS=3,FIVE_POINTS=5, NINE_POINTS=9, THIRTEEN_POINTS=13)
     graphics_env = dict(INTERNAL=1, EXTERNAL=0)
-    auto_pace = dict (True=1, False=0, Yes=1, No=0, On=1, Off=0)
+    auto_pace = {'True': 1, 'False': 0, 'Yes': 1, 'No': 0, 'On': 1, 'Off': 0}
     pacing_speed = dict(SLOW=0, FAST=1)
     target_type= dict(IMAGE=0, CIRCLE_TARGET=1, CIRCLE_TARGET_V2=2, CROSS=3)
 

--- a/psychopy/tests/dummy_xorg.conf
+++ b/psychopy/tests/dummy_xorg.conf
@@ -1,0 +1,21 @@
+Section "Device"
+    Identifier  "Configured Video Device"
+    Driver      "dummy"
+EndSection
+
+Section "Monitor"
+    Identifier  "Configured Monitor"
+    HorizSync 31.5-48.5
+    VertRefresh 50-70
+EndSection
+
+Section "Screen"
+    Identifier  "Default Screen"
+    Monitor     "Configured Monitor"
+    Device      "Configured Video Device"
+    DefaultDepth 24
+    SubSection "Display"
+    Depth 24
+    Modes "1024x768"
+    EndSubSection
+EndSection

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -1,8 +1,11 @@
 urllib3[secure]
+wheel  # Allow us to install binary wheels e.g. for opencv-python
 soundfile
 sounddevice
 pyglet==1.3.0b1
 pillow
+opencv-python
+moviepy
 pyosf
 xlrd
 gevent

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -1,3 +1,4 @@
+urllib3[secure]
 soundfile
 sounddevice
 pyglet==1.3.0b1

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -13,7 +13,10 @@ gevent
 psutil
 msgpack-python
 pyserial
+pyparallel
 pycrsltd
+python-bidi
+cffi
 future
 json_tricks
 codecov

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -8,6 +8,7 @@ opencv-python
 moviepy
 pyosf
 xlrd
+openpyxl
 gevent
 psutil
 msgpack-python

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -1,0 +1,17 @@
+soundfile
+sounddevice
+pyglet==1.3.0b1
+pillow
+pyosf
+xlrd
+gevent
+psutil
+msgpack-python
+pyserial
+pycrsltd
+future
+json_tricks
+codecov
+pytest
+pytest-cov
+coveralls

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -8,6 +8,7 @@ opencv-python
 moviepy
 pyosf
 xlrd
+lxml
 openpyxl
 gevent
 psutil

--- a/setup.py
+++ b/setup.py
@@ -28,16 +28,24 @@ required = ['numpy', 'scipy', 'matplotlib', 'pandas', 'pillow',
             'xlrd', 'openpyxl',  # MS Excel
             'pyserial', 'pyparallel',
             'pyyaml', 'gevent', 'msgpack-python', 'psutil', 'tables',
-            'opencv-python',
-            'moviepy',
-            ]
+            'moviepy']
+
+# `opencv` package should be installed via conda instead
+# cf. https://github.com/ContinuumIO/anaconda-issues/issues/1554
+if 'CONDA_PREFIX' not in os.environ:
+    required.append('opencv-python')
+
 # some optional dependencies
 if platform == 'win32':
     required.extend(['pypiwin32'])
 if platform == 'darwin':
     required.extend(['pyobjc-core', 'pyobjc-framework-Quartz'])
-if PY3:  # doesn't exist on py2
+
+# `pyqt` package should be installed via conda instead
+# cf. https://github.com/ContinuumIO/anaconda-issues/issues/1554
+if PY3 and ('CONDA_PREFIX' not in os.environ):
     required.append('pyqt5')
+
 # for dev you also want:
 # 'sphinx','pytest'
 # 'lxml', 'pyopengl'


### PR DESCRIPTION
I expanded our testing (Travis) setup to use Anaconda for setting up Python 2.7 and 3.6 environments, and tuned some tiny bits and pieces here and there.

This PR:
- Now also tries to build & install PsychoPy, instead of simply running the tests on the downloaded source tree
- Adds Anaconda testing environments for Python 2.7 and 3.6, while preserving our previous test setup. That is, we now have a testing matrix that includes non-Anaconda 2.7, Anaconda 2.7, and Anaconda 3.6
- Fixes bugs in `iohub` and the `MovieStim2` demo

I don't know if all dependencies for properly testing on Python 3 are actually installed, because obviously `pytest` fails quite early. We'll now just have try and fix the Python3 show stoppers one by one, and add additional required packages whenever needed.

As a next step, I would like to add `macOS` to the test matrix, and set up AppVeyor after that.

Relates to #1571.