### PR TITLE
Fix: updated PyTables API in ioHub/datastore

### DIFF
--- a/psychopy/iohub/datastore/__init__.py
+++ b/psychopy/iohub/datastore/__init__.py
@@ -2,8 +2,26 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import division
+import os
+import atexit
+import numpy as np
 from builtins import str
 from builtins import object
+from pkg_resources import parse_version
+from psychopy.iohub import printExceptionDetailsToStdErr, print2err, ioHubError, DeviceEvent, EventConstants
+
+import tables
+if parse_version(tables.__version__) < parse_version('3'):
+    from tables import openFile as open_file
+    create_table = "createTable"
+    create_group = "createGroup"
+else:
+    from tables import open_file
+    create_table = "create_table"
+    create_group = "create_group"
+from tables import parameters
+
+
 """
 ioHub
 .. file: ioHub/datastore/__init__.py
@@ -15,18 +33,9 @@ Distributed under the terms of the GNU General Public License (GPL version 3 or 
 .. fileauthor:: Sol Simpson <sol@isolver-software.com>
 
 """
-import os, atexit
-
-import tables
-from tables import *
-from tables import parameters
-
-import numpy as N
-
-from psychopy.iohub import printExceptionDetailsToStdErr, print2err, ioHubError, DeviceEvent, EventConstants
 
 
-parameters.MAX_NUMEXPR_THREADS=None
+parameters.MAX_NUMEXPR_THREADS = None
 """The maximum number of threads that PyTables should use internally in
 Numexpr.  If `None`, it is automatically set to the number of cores in
 your machine. In general, it is a good idea to set this to the number of
@@ -34,7 +43,7 @@ cores in your machine or, when your machine has many of them (e.g. > 4),
 perhaps one less than this. < S. Simpson Note: These are 'not' GIL bound
 threads and therefore actually improve performance > """
 
-parameters.MAX_BLOSC_THREADS=None
+parameters.MAX_BLOSC_THREADS = None
 """The maximum number of threads that PyTables should use internally in
 Blosc.  If `None`, it is automatically set to the number of cores in
 your machine. In general, it is a good idea to set this to the number of
@@ -65,7 +74,7 @@ class ioHubpyTablesFile(object):
 
         self.TABLES = dict()
         self._eventGroupMappings = dict()
-        self.emrtFile = openFile(self.filePath, mode = fmode)
+        self.emrtFile = open_file(self.filePath, mode = fmode)
 
         atexit.register(close_open_data_files, False)
 
@@ -79,15 +88,21 @@ class ioHubpyTablesFile(object):
         dfilter = Filters(complevel=0, complib='zlib', shuffle=False, fletcher32=False)
 
         def eventTableLabel2ClassName(event_table_label):
-            tokens=str(event_table_label[0]+event_table_label[1:].lower()+'Event').split('_')
-            return ''.join([t[0].upper()+t[1:] for t in tokens])
+            tokens = str(event_table_label[0] + event_table_label[1:].lower() + 'Event').split('_')
+            return ''.join([t[0].upper() + t[1:] for t in tokens])
 
         for event_cls_name,event_cls in event_class_dict.items():
             if event_cls.IOHUB_DATA_TABLE:
-                event_table_label=event_cls.IOHUB_DATA_TABLE
+                event_table_label = event_cls.IOHUB_DATA_TABLE
                 if event_table_label not in self.TABLES:
                     try:
-                        self.TABLES[event_table_label]=self.emrtFile.createTable(self._eventGroupMappings[event_table_label],eventTableLabel2ClassName(event_table_label),event_cls.NUMPY_DTYPE, title="%s Data"%(device_instance.__class__.__name__,),filters=dfilter.copy())
+                        self.TABLES[event_table_label] = getattr(self.emrtFile, create_table)(
+                            self._eventGroupMappings[event_table_label],
+                            eventTableLabel2ClassName(event_table_label),
+                            event_cls.NUMPY_DTYPE,
+                            title = "%s Data" % (device_instance.__class__.__name__,),
+                            filters = dfilter.copy()
+                        )
                         self.flush()
                         #print2err("----------- CREATED TABLES ENTRY ------------")
                         #print2err("\tevent_cls: {0}".format(event_cls))
@@ -97,7 +112,7 @@ class ioHubpyTablesFile(object):
                         #print2err("\t_eventGroupMappings[event_table_label]: {0}".format(self._eventGroupMappings[event_table_label]))
                         #print2err("----------------------------------------------")
                     except NodeError:
-                        self.TABLES[event_table_label]=self._eventGroupMappings[event_table_label]._f_get_child(eventTableLabel2ClassName(event_table_label))# self.emrtFile.createTable(,eventTableLabel2ClassName(event_table_label),event_cls.NUMPY_DTYPE, title="%s Data"%(device_instance.__class__.__name__,),filters=dfilter.copy())
+                        self.TABLES[event_table_label] = self._eventGroupMappings[event_table_label]._f_get_child(eventTableLabel2ClassName(event_table_label))# getattr(self.emrtFile, create_table)(,eventTableLabel2ClassName(event_table_label),event_cls.NUMPY_DTYPE, title="%s Data"%(device_instance.__class__.__name__,),filters=dfilter.copy())
                         #print2err("----------- USED EXISTING TABLE FOR TABLES ENTRY ------------")
                         #print2err("\tevent_cls: {0}".format(event_cls))
                         #print2err("\tevent_cls_name: {0}".format(event_cls_name))
@@ -140,75 +155,75 @@ class ioHubpyTablesFile(object):
 
         self._buildEventGroupMappingDict()
 
-        self.TABLES['EXPERIMENT_METADETA']=self.emrtFile.root.data_collection.experiment_meta_data
-        self.TABLES['SESSION_METADETA']=self.emrtFile.root.data_collection.session_meta_data
-        self.TABLES['CLASS_TABLE_MAPPINGS']=self.emrtFile.root.class_table_mapping
+        self.TABLES['EXPERIMENT_METADETA'] = self.emrtFile.root.data_collection.experiment_meta_data
+        self.TABLES['SESSION_METADETA'] = self.emrtFile.root.data_collection.session_meta_data
+        self.TABLES['CLASS_TABLE_MAPPINGS'] = self.emrtFile.root.class_table_mapping
 
         # create tables dict of hdf5 path mappings
 
 
         try:
-            self.TABLES['KEYBOARD_KEY']=self.emrtFile.root.data_collection.events.keyboard.KeyboardKeyEvent
+            self.TABLES['KEYBOARD_KEY'] = self.emrtFile.root.data_collection.events.keyboard.KeyboardKeyEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['KEYBOARD_CHAR']=self.emrtFile.root.data_collection.events.keyboard.KeyboardCharEvent
+            self.TABLES['KEYBOARD_CHAR'] = self.emrtFile.root.data_collection.events.keyboard.KeyboardCharEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['MOUSE_INPUT']=self.emrtFile.root.data_collection.events.mouse.MouseInputEvent
+            self.TABLES['MOUSE_INPUT'] = self.emrtFile.root.data_collection.events.mouse.MouseInputEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['TOUCH']=self.emrtFile.root.data_collection.events.touch.TouchEvent
+            self.TABLES['TOUCH'] = self.emrtFile.root.data_collection.events.touch.TouchEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['GAMEPAD_STATE_CHANGE']=self.emrtFile.root.data_collection.events.gamepad.GamepadStateChangeEvent
+            self.TABLES['GAMEPAD_STATE_CHANGE'] = self.emrtFile.root.data_collection.events.gamepad.GamepadStateChangeEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['MESSAGE']=self.emrtFile.root.data_collection.events.experiment.MessageEvent
+            self.TABLES['MESSAGE'] = self.emrtFile.root.data_collection.events.experiment.MessageEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['LOG']=self.emrtFile.root.data_collection.events.experiment.LogEvent
+            self.TABLES['LOG'] = self.emrtFile.root.data_collection.events.experiment.LogEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['MULTI_CHANNEL_ANALOG_INPUT']=self.emrtFile.root.data_collection.events.analog_input.MultiChannelAnalogInputEvent
+            self.TABLES['MULTI_CHANNEL_ANALOG_INPUT'] = self.emrtFile.root.data_collection.events.analog_input.MultiChannelAnalogInputEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['ANALOG_INPUT']=self.emrtFile.root.data_collection.events.mcu.AnalogInputEvent
+            self.TABLES['ANALOG_INPUT'] = self.emrtFile.root.data_collection.events.mcu.AnalogInputEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['THRESHOLD']=self.emrtFile.root.data_collection.events.mcu.ThresholdEvent
+            self.TABLES['THRESHOLD'] = self.emrtFile.root.data_collection.events.mcu.ThresholdEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['DIGITAL_INPUT']=self.emrtFile.root.data_collection.events.mcu.DigitalInputEvent
+            self.TABLES['DIGITAL_INPUT'] = self.emrtFile.root.data_collection.events.mcu.DigitalInputEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
@@ -232,123 +247,150 @@ class ioHubpyTablesFile(object):
             pass
 
         try:
-            self.TABLES['MONOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker.MonocularEyeSampleEvent
+            self.TABLES['MONOCULAR_EYE_SAMPLE'] = self.emrtFile.root.data_collection.events.eyetracker.MonocularEyeSampleEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['BINOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker.BinocularEyeSampleEvent
+            self.TABLES['BINOCULAR_EYE_SAMPLE'] = self.emrtFile.root.data_collection.events.eyetracker.BinocularEyeSampleEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['FIXATION_START']=self.emrtFile.root.data_collection.events.eyetracker.FixationStartEvent
+            self.TABLES['FIXATION_START'] = self.emrtFile.root.data_collection.events.eyetracker.FixationStartEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['FIXATION_END']=self.emrtFile.root.data_collection.events.eyetracker.FixationEndEvent
+            self.TABLES['FIXATION_END'] = self.emrtFile.root.data_collection.events.eyetracker.FixationEndEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['SACCADE_START']=self.emrtFile.root.data_collection.events.eyetracker.SaccadeStartEvent
+            self.TABLES['SACCADE_START'] = self.emrtFile.root.data_collection.events.eyetracker.SaccadeStartEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['SACCADE_END']=self.emrtFile.root.data_collection.events.eyetracker.SaccadeEndEvent
+            self.TABLES['SACCADE_END'] = self.emrtFile.root.data_collection.events.eyetracker.SaccadeEndEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['BLINK_START']=self.emrtFile.root.data_collection.events.eyetracker.BlinkStartEvent
+            self.TABLES['BLINK_START'] = self.emrtFile.root.data_collection.events.eyetracker.BlinkStartEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
         try:
-            self.TABLES['BLINK_END']=self.emrtFile.root.data_collection.events.eyetracker.BlinkEndEvent
+            self.TABLES['BLINK_END'] = self.emrtFile.root.data_collection.events.eyetracker.BlinkEndEvent
         except Exception:
             # Just means the table for this event type has not been created as the event type is not being recorded
             pass
 
     def buildOutTemplate(self):
-        self.emrtFile.title=DATA_FILE_TITLE
-        self.emrtFile.FILE_VERSION=FILE_VERSION
-        self.emrtFile.SCHEMA_DESIGNER=SCHEMA_AUTHORS
-        self.emrtFile.SCHEMA_MODIFIED=SCHEMA_MODIFIED_DATE
+        self.emrtFile.title = DATA_FILE_TITLE
+        self.emrtFile.FILE_VERSION = FILE_VERSION
+        self.emrtFile.SCHEMA_DESIGNER = SCHEMA_AUTHORS
+        self.emrtFile.SCHEMA_MODIFIED = SCHEMA_MODIFIED_DATE
 
         #CREATE GROUPS
 
-        #self.emrtFile.createGroup(self.emrtFile.root, 'analysis', title='Data Analysis Files, notebooks, scripts and saved results tables.')
+        #getattr(self.emrtFile, create_group)(self.emrtFile.root, 'analysis', title='Data Analysis Files, notebooks, scripts and saved results tables.')
 
-        self.TABLES['CLASS_TABLE_MAPPINGS']=self.emrtFile.createTable(self.emrtFile.root,'class_table_mapping', ClassTableMappings, title='Mapping of ioHub DeviceEvent Classes to ioHub DataStore Tables.')
+        self.TABLES['CLASS_TABLE_MAPPINGS'] = getattr(self.emrtFile, create_table)(
+            self.emrtFile.root,
+            'class_table_mapping',
+            ClassTableMappings,
+            title='Mapping of ioHub DeviceEvent Classes to ioHub DataStore Tables.'
+        )
 
-        self.emrtFile.createGroup(self.emrtFile.root, 'data_collection', title='Data Collected using the ioHub Event Framework.')
+        getattr(self.emrtFile, create_group)(
+            self.emrtFile.root,
+            'data_collection',
+            title='Data Collected using the ioHub Event Framework.'
+        )
         self.flush()
 
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection, 'events', title='All Events that were Saved During Experiment Sessions.')
+        getattr(self.emrtFile, create_group)(
+            self.emrtFile.root.data_collection,
+            'events',
+            title='All Events that were Saved During Experiment Sessions.'
+        )
 
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection, 'condition_variables', title="Tables created to Hold Experiment DV and IV's Values Saved During an Experiment Session.")
+        getattr(self.emrtFile, create_group)(
+            self.emrtFile.root.data_collection,
+            'condition_variables',
+            title="Tables created to Hold Experiment DV and IV's Values Saved During an Experiment Session."
+        )
         self.flush()
 
 
-        self.TABLES['EXPERIMENT_METADETA']=self.emrtFile.createTable(self.emrtFile.root.data_collection,'experiment_meta_data', ExperimentMetaData, title='Information About Experiments Saved to This ioHub DataStore File.')
-        self.TABLES['SESSION_METADETA']=self.emrtFile.createTable(self.emrtFile.root.data_collection,'session_meta_data', SessionMetaData, title='Information About Sessions Saved to This ioHub DataStore File.')
+        self.TABLES['EXPERIMENT_METADETA'] = getattr(self.emrtFile, create_table)(
+            self.emrtFile.root.data_collection,
+            'experiment_meta_data',
+            ExperimentMetaData,
+            title='Information About Experiments Saved to This ioHub DataStore File.'
+        )
+        self.TABLES['SESSION_METADETA'] = getattr(self.emrtFile, create_table)(
+            self.emrtFile.root.data_collection,
+            'session_meta_data',
+            SessionMetaData,
+            title='Information About Sessions Saved to This ioHub DataStore File.'
+        )
         self.flush()
 
 
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'experiment', title='Experiment Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'keyboard', title='Keyboard Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'mouse', title='Mouse Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'touch', title='Touch Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'gamepad', title='GamePad Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'analog_input', title='AnalogInput Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'eyetracker', title='EyeTracker Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'mcu', title='MCU Device Events.')
-        self.emrtFile.createGroup(self.emrtFile.root.data_collection.events, 'serial', title='Serial Interface Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'experiment', title='Experiment Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'keyboard', title='Keyboard Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'mouse', title='Mouse Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'touch', title='Touch Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'gamepad', title='GamePad Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'analog_input', title='AnalogInput Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'eyetracker', title='EyeTracker Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'mcu', title='MCU Device Events.')
+        getattr(self.emrtFile, create_group)(self.emrtFile.root.data_collection.events, 'serial', title='Serial Interface Events.')
         self.flush()
 
         self._buildEventGroupMappingDict()
 
 
     def _buildEventGroupMappingDict(self):
-        self._eventGroupMappings['KEYBOARD_KEY']=self.emrtFile.root.data_collection.events.keyboard
-        self._eventGroupMappings['KEYBOARD_CHAR']=self.emrtFile.root.data_collection.events.keyboard
-        self._eventGroupMappings['MOUSE_INPUT']=self.emrtFile.root.data_collection.events.mouse
-        self._eventGroupMappings['TOUCH']=self.emrtFile.root.data_collection.events.touch
-        self._eventGroupMappings['GAMEPAD_STATE_CHANGE']=self.emrtFile.root.data_collection.events.gamepad
-        self._eventGroupMappings['MULTI_CHANNEL_ANALOG_INPUT']=self.emrtFile.root.data_collection.events.analog_input
-        self._eventGroupMappings['ANALOG_INPUT']=self.emrtFile.root.data_collection.events.mcu
-        self._eventGroupMappings['THRESHOLD']=self.emrtFile.root.data_collection.events.mcu
-        self._eventGroupMappings['DIGITAL_INPUT']=self.emrtFile.root.data_collection.events.mcu
-        self._eventGroupMappings['SERIAL_INPUT']=self.emrtFile.root.data_collection.events.serial
-        self._eventGroupMappings['SERIAL_BYTE_CHANGE']=self.emrtFile.root.data_collection.events.serial
-        self._eventGroupMappings['PSTBOX_BUTTON']=self.emrtFile.root.data_collection.events.serial
-        self._eventGroupMappings['MESSAGE']=self.emrtFile.root.data_collection.events.experiment
-        self._eventGroupMappings['LOG']=self.emrtFile.root.data_collection.events.experiment
-        self._eventGroupMappings['MONOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['BINOCULAR_EYE_SAMPLE']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['FIXATION_START']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['FIXATION_END']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['SACCADE_START']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['SACCADE_END']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['BLINK_START']=self.emrtFile.root.data_collection.events.eyetracker
-        self._eventGroupMappings['BLINK_END']=self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['KEYBOARD_KEY'] = self.emrtFile.root.data_collection.events.keyboard
+        self._eventGroupMappings['KEYBOARD_CHAR'] = self.emrtFile.root.data_collection.events.keyboard
+        self._eventGroupMappings['MOUSE_INPUT'] = self.emrtFile.root.data_collection.events.mouse
+        self._eventGroupMappings['TOUCH'] = self.emrtFile.root.data_collection.events.touch
+        self._eventGroupMappings['GAMEPAD_STATE_CHANGE'] = self.emrtFile.root.data_collection.events.gamepad
+        self._eventGroupMappings['MULTI_CHANNEL_ANALOG_INPUT'] = self.emrtFile.root.data_collection.events.analog_input
+        self._eventGroupMappings['ANALOG_INPUT'] = self.emrtFile.root.data_collection.events.mcu
+        self._eventGroupMappings['THRESHOLD'] = self.emrtFile.root.data_collection.events.mcu
+        self._eventGroupMappings['DIGITAL_INPUT'] = self.emrtFile.root.data_collection.events.mcu
+        self._eventGroupMappings['SERIAL_INPUT'] = self.emrtFile.root.data_collection.events.serial
+        self._eventGroupMappings['SERIAL_BYTE_CHANGE'] = self.emrtFile.root.data_collection.events.serial
+        self._eventGroupMappings['PSTBOX_BUTTON'] = self.emrtFile.root.data_collection.events.serial
+        self._eventGroupMappings['MESSAGE'] = self.emrtFile.root.data_collection.events.experiment
+        self._eventGroupMappings['LOG'] = self.emrtFile.root.data_collection.events.experiment
+        self._eventGroupMappings['MONOCULAR_EYE_SAMPLE'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['BINOCULAR_EYE_SAMPLE'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['FIXATION_START'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['FIXATION_END'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['SACCADE_START'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['SACCADE_END'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['BLINK_START'] = self.emrtFile.root.data_collection.events.eyetracker
+        self._eventGroupMappings['BLINK_END'] = self.emrtFile.root.data_collection.events.eyetracker
 
 
     def addClassMapping(self,ioClass,ctable):
         names = [ x['class_id'] for x in self.TABLES['CLASS_TABLE_MAPPINGS'].where("(class_id == %d)"%(ioClass.EVENT_TYPE_ID)) ]
         if len(names)==0:
-            trow=self.TABLES['CLASS_TABLE_MAPPINGS'].row
-            trow['class_id']=ioClass.EVENT_TYPE_ID
+            trow = self.TABLES['CLASS_TABLE_MAPPINGS'].row
+            trow['class_id'] = ioClass.EVENT_TYPE_ID
             trow['class_type_id'] = 1 # Device or Event etc.
             trow['class_name'] = ioClass.__name__
             trow['table_path']  = ctable._v_pathname
@@ -357,22 +399,22 @@ class ioHubpyTablesFile(object):
 
     def createOrUpdateExperimentEntry(self,experimentInfoList):
         #ioHub.print2err("createOrUpdateExperimentEntry called with: ",experimentInfoList)
-        experiment_metadata=self.TABLES['EXPERIMENT_METADETA']
+        experiment_metadata = self.TABLES['EXPERIMENT_METADETA']
 
         result = [ row for row in experiment_metadata.iterrows() if row['code'] == experimentInfoList[1] ]
         if len(result)>0:
-            result=result[0]
-            self.active_experiment_id=result['experiment_id']
+            result = result[0]
+            self.active_experiment_id = result['experiment_id']
             return self.active_experiment_id
 
-        max_id=0
-        id_col=experiment_metadata.col('experiment_id')
+        max_id = 0
+        id_col = experiment_metadata.col('experiment_id')
 
         if len(id_col) > 0:
-            max_id=N.amax(id_col)
+            max_id = np.amax(id_col)
 
-        self.active_experiment_id=max_id+1
-        experimentInfoList[0]=self.active_experiment_id
+        self.active_experiment_id = max_id + 1
+        experimentInfoList[0] = self.active_experiment_id
         experiment_metadata.append([experimentInfoList,])
         self.flush()
         #ioHub.print2err("Experiment ID set to: ",self.active_experiment_id)
@@ -380,16 +422,16 @@ class ioHubpyTablesFile(object):
 
     def createExperimentSessionEntry(self,sessionInfoDict):
         #ioHub.print2err("createExperimentSessionEntry called with: ",sessionInfoDict)
-        session_metadata=self.TABLES['SESSION_METADETA']
+        session_metadata = self.TABLES['SESSION_METADETA']
 
-        max_id=0
-        id_col=session_metadata.col('session_id')
+        max_id = 0
+        id_col = session_metadata.col('session_id')
         if len(id_col) > 0:
-            max_id=N.amax(id_col)
+            max_id = np.amax(id_col)
 
-        self.active_session_id=int(max_id+1)
+        self.active_session_id = int(max_id + 1)
 
-        values=(self.active_session_id,self.active_experiment_id,sessionInfoDict['code'],sessionInfoDict['name'],sessionInfoDict['comments'],sessionInfoDict['user_variables'])
+        values = (self.active_session_id,self.active_experiment_id,sessionInfoDict['code'],sessionInfoDict['name'],sessionInfoDict['comments'],sessionInfoDict['user_variables'])
         session_metadata.append([values,])
         self.flush()
 
@@ -397,20 +439,20 @@ class ioHubpyTablesFile(object):
         return self.active_session_id
 
     def _initializeConditionVariableTable(self,experiment_id,session_id,np_dtype):
-        experimentConditionVariableTable=None
-        exp_session=[('EXPERIMENT_ID','i4'),('SESSION_ID','i4')]
+        experimentConditionVariableTable = None
+        exp_session = [('EXPERIMENT_ID','i4'),('SESSION_ID','i4')]
         exp_session.extend(np_dtype)
-        np_dtype=exp_session
+        np_dtype = exp_session
         #print2err('np_dtype: ',np_dtype,' ',type(np_dtype))
-        self._EXP_COND_DTYPE=N.dtype(np_dtype)
+        self._EXP_COND_DTYPE = np.dtype(np_dtype)
         try:
-            expCondTableName="EXP_CV_%d"%(experiment_id)
-            experimentConditionVariableTable=self.emrtFile.root.data_collection.condition_variables._f_getChild(expCondTableName)
-            self.TABLES['EXP_CV']=experimentConditionVariableTable
+            expCondTableName = "EXP_CV_%d"%(experiment_id)
+            experimentConditionVariableTable = self.emrtFile.root.data_collection.condition_variables._f_getChild(expCondTableName)
+            self.TABLES['EXP_CV'] = experimentConditionVariableTable
         except NoSuchNodeError as nsne:
             try:
-                experimentConditionVariableTable=self.emrtFile.createTable(self.emrtFile.root.data_collection.condition_variables,expCondTableName,self._EXP_COND_DTYPE,title='Condition Variable Values for Experiment ID %d'%(experiment_id))
-                self.TABLES['EXP_CV']=experimentConditionVariableTable
+                experimentConditionVariableTable = getattr(self.emrtFile, create_table)(self.emrtFile.root.data_collection.condition_variables,expCondTableName,self._EXP_COND_DTYPE,title='Condition Variable Values for Experiment ID %d'%(experiment_id))
+                self.TABLES['EXP_CV'] = experimentConditionVariableTable
                 self.emrtFile.flush()
             except Exception:
                 printExceptionDetailsToStdErr()
@@ -419,23 +461,23 @@ class ioHubpyTablesFile(object):
             print2err('Error getting experimentConditionVariableTable for experiment %d, table name: %s'%(experiment_id,expCondTableName))
             printExceptionDetailsToStdErr()
             return False
-        self._activeRunTimeConditionVariableTable=experimentConditionVariableTable
+        self._activeRunTimeConditionVariableTable = experimentConditionVariableTable
         return True
 
     def _addRowToConditionVariableTable(self,experiment_id,session_id,data):
         if self.emrtFile and 'EXP_CV' in self.TABLES and self._EXP_COND_DTYPE is not None:
-            temp=[experiment_id,session_id]
+            temp = [experiment_id,session_id]
             temp.extend(data)
-            data=temp
+            data = temp
             try:
-                etable=self.TABLES['EXP_CV']
+                etable = self.TABLES['EXP_CV']
                 #print2err('data: ',data,' ',type(data))
 
                 for i,d in enumerate(data):
                     if isinstance(d,(list,tuple)):
-                        data[i]=tuple(d)
+                        data[i] = tuple(d)
 
-                np_array= N.array([tuple(data),],dtype=self._EXP_COND_DTYPE)
+                np_array = np.array([tuple(data),],dtype=self._EXP_COND_DTYPE)
                 etable.append(np_array)
 
                 self.bufferedFlush()
@@ -450,12 +492,12 @@ class ioHubpyTablesFile(object):
 
     def checkForExperimentAndSessionIDs(self,event=None):
         if self.active_experiment_id is None or self.active_session_id is None:
-            exp_id=self.active_experiment_id
+            exp_id = self.active_experiment_id
             if exp_id is None:
-                exp_id=0
-            sess_id=self.active_session_id
+                exp_id = 0
+            sess_id = self.active_session_id
             if sess_id is None:
-                sess_id=0
+                sess_id = 0
 
             #import iohub
             #iohub.print2err(Computer.getTime()," Experiment or Session ID is None, event not being saved: "+str(event),' exp_id: ',exp_id,' sess_id: ', sess_id)
@@ -464,29 +506,29 @@ class ioHubpyTablesFile(object):
 
     def checkIfSessionCodeExists(self,sessionCode):
         if self.emrtFile:
-            sessionsForExperiment=self.emrtFile.root.data_collection.session_meta_data.where("experiment_id == %d"%(self.active_experiment_id,))
-            sessionCodeMatch=[sess for sess in sessionsForExperiment if sess['code'] == sessionCode]
+            sessionsForExperiment = self.emrtFile.root.data_collection.session_meta_data.where("experiment_id == %d"%(self.active_experiment_id,))
+            sessionCodeMatch = [sess for sess in sessionsForExperiment if sess['code'] == sessionCode]
             if len(sessionCodeMatch)>0:
                 return True
             return False
 
     def _handleEvent(self, event):
         try:
-            eventClass=None
+            eventClass = None
 
             if self.checkForExperimentAndSessionIDs(event) is False:
                 return False
 
-            etype=event[DeviceEvent.EVENT_TYPE_ID_INDEX]
+            etype = event[DeviceEvent.EVENT_TYPE_ID_INDEX]
 
 #            print2err("*** ",DeviceEvent.EVENT_TYPE_ID_INDEX, '_handleEvent: ',etype,' : event list: ',event)
-            eventClass=EventConstants.getClass(etype)
+            eventClass = EventConstants.getClass(etype)
 
-            etable=self.TABLES[eventClass.IOHUB_DATA_TABLE]
-            event[DeviceEvent.EVENT_EXPERIMENT_ID_INDEX]=self.active_experiment_id
-            event[DeviceEvent.EVENT_SESSION_ID_INDEX]=self.active_session_id
+            etable = self.TABLES[eventClass.IOHUB_DATA_TABLE]
+            event[DeviceEvent.EVENT_EXPERIMENT_ID_INDEX] = self.active_experiment_id
+            event[DeviceEvent.EVENT_SESSION_ID_INDEX] = self.active_session_id
 
-            np_array= N.array([tuple(event),],dtype=eventClass.NUMPY_DTYPE)
+            np_array = np.array([tuple(event),],dtype=eventClass.NUMPY_DTYPE)
             etable.append(np_array)
 
             self.bufferedFlush()
@@ -504,21 +546,21 @@ class ioHubpyTablesFile(object):
             if self.checkForExperimentAndSessionIDs(len(events)) is False:
                 return False
 
-            event=events[0]
+            event = events[0]
 
-            etype=event[DeviceEvent.EVENT_TYPE_ID_INDEX]
+            etype = event[DeviceEvent.EVENT_TYPE_ID_INDEX]
             #ioHub.print2err("etype: ",etype)
-            eventClass=EventConstants.getClass(etype)
-            etable=self.TABLES[eventClass.IOHUB_DATA_TABLE]
+            eventClass = EventConstants.getClass(etype)
+            etable = self.TABLES[eventClass.IOHUB_DATA_TABLE]
             #ioHub.print2err("eventClass: etable",eventClass,etable)
 
-            np_events=[]
+            np_events = []
             for event in events:
-                event[DeviceEvent.EVENT_EXPERIMENT_ID_INDEX]=self.active_experiment_id
-                event[DeviceEvent.EVENT_SESSION_ID_INDEX]=self.active_session_id
+                event[DeviceEvent.EVENT_EXPERIMENT_ID_INDEX] = self.active_experiment_id
+                event[DeviceEvent.EVENT_SESSION_ID_INDEX] = self.active_session_id
                 np_events.append(tuple(event))
 
-            np_array= N.array(np_events,dtype=eventClass.NUMPY_DTYPE)
+            np_array = np.array(np_events,dtype=eventClass.NUMPY_DTYPE)
             #ioHub.print2err('np_array:',np_array)
             etable.append(np_array)
 
@@ -532,15 +574,15 @@ class ioHubpyTablesFile(object):
     def bufferedFlush(self,eventCount=1):
         # if flushCounter threshold is >=0 then do some checks. If it is < 0, then
         # flush only occurs when command is sent to ioHub, so do nothing here.
-        if self.flushCounter>=0:
-            if self.flushCounter==0:
+        if self.flushCounter >= 0:
+            if self.flushCounter == 0:
                 self.flush()
                 return True
-            if self.flushCounter<=self._eventCounter:
+            if self.flushCounter <= self._eventCounter:
                 self.flush()
-                self._eventCounter=0
+                self._eventCounter = 0
                 return True
-            self._eventCounter+=eventCount
+            self._eventCounter += eventCount
             return False
 
 
@@ -555,7 +597,7 @@ class ioHubpyTablesFile(object):
 
     def close(self):
         self.flush()
-        self._activeRunTimeConditionVariableTable=None
+        self._activeRunTimeConditionVariableTable = None
         self.emrtFile.close()
 
     def __del__(self):

--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -19,7 +19,6 @@ standard_library.install_aliases()
 from builtins import next
 from past.builtins import basestring
 from builtins import object
-from tables import *  # TODO walkGroups, listNodes, getNode -> changed API
 import os
 from collections import namedtuple
 import json
@@ -27,14 +26,28 @@ import json
 from psychopy import gui, iohub
 from psychopy.iohub import FileDialog
 
-_hubFiles=[]
+from pkg_resources import parse_version
+import tables
+if parse_version(tables.__version__) < parse_version('3'):
+    from tables import openFile as open_file
+    walk_groups = "walkGroups"
+    list_nodes = "listNodes"
+    get_node = "getNode"
+else:
+    from tables import open_file
+    walk_groups = "walk_groups"
+    list_nodes = "list_nodes"
+    get_node = "get_node"
 
-def openHubFile(filepath,filename,mode):
+
+_hubFiles = []
+
+def openHubFile(filepath, filename, mode):
     """
     Open an HDF5 DataStore file and register it so that it is closed even on interpreter crash.
     """
     global _hubFiles
-    hubFile=openFile(os.path.join(filepath,filename), mode)
+    hubFile = open_file(os.path.join(filepath, filename), mode)
     _hubFiles.append(hubFile)
     return hubFile
 
@@ -43,10 +56,13 @@ def displayDataFileSelectionDialog(starting_dir=None):
     Shows a FileDialog and lets you select a .hdf5 file to open for processing.
     """
 
-    fdlg=FileDialog(message="Select a ioHub DataStore File",
-                    defaultDir=starting_dir,fileTypes=FileDialog.IODATA_FILES,display_index=0)
+    fdlg = FileDialog(
+        message="Select a ioHub DataStore File",
+        defaultDir=starting_dir,
+        fileTypes=FileDialog.IODATA_FILES,
+        display_index=0)
 
-    status,filePathList=fdlg.show()
+    status, filePathList = fdlg.show()
 
     if status != FileDialog.OK_RESULT:
         print(" Data File Selection Cancelled.")
@@ -56,19 +72,19 @@ def displayDataFileSelectionDialog(starting_dir=None):
 
 def displayEventTableSelectionDialog(title, list_label, list_values, default=u'Select'):
     if default not in list_values:
-        list_values.insert(0,default)
+        list_values.insert(0, default)
     else:
         list_values.remove(list_values)
-        list_values.insert(0,default)
+        list_values.insert(0, default)
 
-    selection_dict=dict(list_label=list_values)
-    dlg_info=dict(selection_dict)
+    selection_dict = dict(list_label=list_values)
+    dlg_info = dict(selection_dict)
     infoDlg = gui.DlgFromDict(dictionary=dlg_info, title=title)
     if not infoDlg.OK:
         return None
 
-    while list(dlg_info.values())[0] ==default and infoDlg.OK:
-            dlg_info=dict(selection_dict)
+    while list(dlg_info.values())[0] == default and infoDlg.OK:
+            dlg_info = dict(selection_dict)
             infoDlg = gui.DlgFromDict(dictionary=dlg_info, title=title)
 
     if not infoDlg.OK:
@@ -100,7 +116,7 @@ class ExperimentDataAccessUtility(object):
     Returns:
         object: the created instance of the ExperimentDataAccessUtility, ready to get your data!
     """
-    def __init__(self, hdfFilePath, hdfFileName, experimentCode=None,sessionCodes=[],mode='r'):
+    def __init__(self, hdfFilePath, hdfFileName, experimentCode=None, sessionCodes=[], mode='r'):
         """
         An instance of the ExperimentDataAccessUtility class is created by providing
         the location and name of the file to read, as well as any session code
@@ -118,17 +134,17 @@ class ExperimentDataAccessUtility(object):
         Returns:
             object: the created instance of the ExperimentDataAccessUtility, ready to get your data!
         """
-        self.hdfFilePath=hdfFilePath
-        self.hdfFileName=hdfFileName
-        self.mode=mode
-        self.hdfFile=None
+        self.hdfFilePath = hdfFilePath
+        self.hdfFileName = hdfFileName
+        self.mode = mode
+        self.hdfFile = None
 
-        self._experimentCode=experimentCode
-        self._sessionCodes=sessionCodes
-        self._lastWhereClause=None
+        self._experimentCode = experimentCode
+        self._sessionCodes = sessionCodes
+        self._lastWhereClause = None
 
         try:
-            self.hdfFile=openHubFile(hdfFilePath,hdfFileName,mode)
+            self.hdfFile = openHubFile(hdfFilePath, hdfFileName, mode)
         except Exception as e:
             print(e)
             raise ExperimentDataAccessException(e)
@@ -145,9 +161,9 @@ class ExperimentDataAccessUtility(object):
             tableName (str): The DataStore table name to print metadata information out for.
         """
         if self.hdfFile:
-            hubFile=self.hdfFile
-            for group in hubFile.walkGroups("/"):
-                for table in hubFile.listNodes(group, classname='Table'):
+            hubFile = self.hdfFile
+            for group in getattr(hubFile, walk_groups)("/"):
+                for table in getattr(hubFile, listNodes)(group, classname='Table'):
                     if table.name == tableName:
                         print('------------------')
                         print("Path:", table)
@@ -156,7 +172,7 @@ class ExperimentDataAccessUtility(object):
                         print("Number of cols in table:", len(table.colnames))
                         print("Attribute name := type, shape:")
                         for name in table.colnames:
-                            print('\t',name, ':= %s, %s' % (table.coldtypes[name], table.coldtypes[name].shape))
+                            print('\t', name, ':= %s, %s' % (table.coldtypes[name], table.coldtypes[name].shape))
                         print('------------------')
                         return
 
@@ -174,19 +190,19 @@ class ExperimentDataAccessUtility(object):
         **Docstr TBC.**
         """
         if self.hdfFile:
-            expcols=self.hdfFile.root.data_collection.experiment_meta_data.colnames
+            expcols = self.hdfFile.root.data_collection.experiment_meta_data.colnames
             if 'sessions' not in expcols:
                 expcols.append('sessions')
             ExperimentMetaDataInstance = namedtuple('ExperimentMetaDataInstance', expcols)
-            experiments=[]
+            experiments = []
             for e in self.hdfFile.root.data_collection.experiment_meta_data:
-                self._experimentID=e['experiment_id']
-                a_exp=list(e[:])
+                self._experimentID = e['experiment_id']
+                a_exp = list(e[:])
                 a_exp.append(self.getSessionMetaData())
                 experiments.append(ExperimentMetaDataInstance(*a_exp))
             return experiments
 
-    def getSessionMetaData(self,sessions=None):
+    def getSessionMetaData(self, sessions=None):
         """
         Returns the the metadata associated with the experiment session codes in use.
 
@@ -194,61 +210,61 @@ class ExperimentDataAccessUtility(object):
         """
         if self.hdfFile:
             if sessions is None:
-                sessions=[]
+                sessions = []
 
-            sessionCodes=self._sessionCodes
-            sesscols=self.hdfFile.root.data_collection.session_meta_data.colnames
+            sessionCodes = self._sessionCodes
+            sesscols = self.hdfFile.root.data_collection.session_meta_data.colnames
             SessionMetaDataInstance = namedtuple('SessionMetaDataInstance', sesscols)
             for r in self.hdfFile.root.data_collection.session_meta_data:
-                if (len(sessionCodes) == 0 or r['code'] in sessionCodes) and r['experiment_id']==self._experimentID:
-                    rcpy=list(r[:])
-                    rcpy[-1]=json.loads(rcpy[-1])
+                if (len(sessionCodes) == 0 or r['code'] in sessionCodes) and r['experiment_id'] == self._experimentID:
+                    rcpy = list(r[:])
+                    rcpy[-1] = json.loads(rcpy[-1])
                     sessions.append(SessionMetaDataInstance(*rcpy))
             return sessions
 
-    def getTableForPath(self,path):
+    def getTableForPath(self, path):
         """
         Given a valid table path within the DataStore file, return the accociated table.
         """
-        self.hdfFile.getNode(path)
+        getattr(self.hdfFile, get_node)(path)
 
-    def getEventTable(self,event_type):
+    def getEventTable(self, event_type):
         """
         Returns the DataStore table that contains events of the specified type.
 
         **Docstr TBC.**
         """
         if self.hdfFile:
-            klassTables=self.hdfFile.root.class_table_mapping
-            deviceEventTable=None
-            event_column=None
-            event_value=None
+            klassTables = self.hdfFile.root.class_table_mapping
+            deviceEventTable = None
+            event_column = None
+            event_value = None
 
-            if isinstance(event_type,basestring):
-                if event_type.find('Event')>=0:
-                    event_column='class_name'
-                    event_value=event_type
+            if isinstance(event_type, basestring):
+                if event_type.find('Event') >= 0:
+                    event_column = 'class_name'
+                    event_value = event_type
                 else:
-                    event_value=''
-                    tokens=event_type.split('_')
+                    event_value = ''
+                    tokens = event_type.split('_')
                     for t in tokens:
-                        event_value+=t[0].upper()+t[1:].lower()
-                    event_value=event_type+'Event'
-                event_value='"%s"'%(event_value)
-            elif isinstance(event_type,(int,int)):
-                event_column='class_id'
-                event_value=event_type
+                        event_value += t[0].upper()+t[1:].lower()
+                    event_value = event_type+'Event'
+                event_value = '"%s"' % (event_value)
+            elif isinstance(event_type, (int, int)):
+                event_column = 'class_id'
+                event_value = event_type
             else:
                 iohub.print2err("getEventTable error: event_type arguement must be a string or and int")
                 return None
 
-            result=[row.fetch_all_fields() for row in klassTables.where('({0} == {1}) & (class_type_id == 1)'.format(event_column,event_value))]
-            if len(result)!= 1:
-                iohub.print2err("event_type_id passed to getEventAttribute can only return one row from CLASS_MAPPINGS: ",len(result))
+            result = [row.fetch_all_fields() for row in klassTables.where('({0} == {1}) & (class_type_id == 1)'.format(event_column, event_value))]
+            if len(result) != 1:
+                iohub.print2err("event_type_id passed to getEventAttribute can only return one row from CLASS_MAPPINGS: ", len(result))
                 return None
 
-            tablePathString=result[0][3]
-            return self.hdfFile.getNode(tablePathString)
+            tablePathString = result[0][3]
+            return getattr(self.hdfFile, get_node)(tablePathString)
         return None
 
     def getEventMappingInformation(self):
@@ -257,30 +273,30 @@ class ExperimentDataAccessUtility(object):
         the given DataStore file.
         """
         if self.hdfFile:
-            eventMappings=dict()
-            class_2_table=self.hdfFile.root.class_table_mapping
-            EventTableMapping=namedtuple('EventTableMapping',self.hdfFile.root.class_table_mapping.colnames)
+            eventMappings = dict()
+            class_2_table = self.hdfFile.root.class_table_mapping
+            EventTableMapping = namedtuple('EventTableMapping', self.hdfFile.root.class_table_mapping.colnames)
             for row in class_2_table[:]:
-                eventMappings[row['class_id']]=EventTableMapping(*row)
+                eventMappings[row['class_id']] = EventTableMapping(*row)
             return eventMappings
         return None
 
-    def getEventsByType(self, condition_str = None):
+    def getEventsByType(self, condition_str=None):
         """
         Returns a dict of all event tables within the DataStore file that have
         atleast one event instance saved. Keys are Event Type constants,
         as specified by Psychopy.iohub.EventConstants.
         Each value is a row iterator for events of that type.
         """
-        eventTableMappings=self.getEventMappingInformation()
+        eventTableMappings = self.getEventMappingInformation()
         if eventTableMappings:
-            events_by_type=dict()
-            for event_type_id,event_mapping_info in eventTableMappings.items():
+            events_by_type = dict()
+            for event_type_id, event_mapping_info in eventTableMappings.items():
                 try:
-                    cond="(type == %d)"%(event_type_id)
+                    cond = "(type == %d)" % (event_type_id)
                     if condition_str:
-                        cond+=" & "+condition_str
-                    events_by_type[event_type_id]= next(self.hdfFile.getNode(event_mapping_info.table_path).where(cond))
+                        cond += " & "+condition_str
+                    events_by_type[event_type_id] = next(getattr(self.hdfFile, get_node)(event_mapping_info.table_path).where(cond))
                 except StopIteration:
                     pass
             return events_by_type
@@ -290,70 +306,70 @@ class ExperimentDataAccessUtility(object):
         """
         **Docstr TBC.**
         """
-        cv_group=self.hdfFile.root.data_collection.condition_variables
-        ecv="EXP_CV_%d"%(self._experimentID,)
+        cv_group = self.hdfFile.root.data_collection.condition_variables
+        ecv = "EXP_CV_%d" % (self._experimentID,)
         if ecv in cv_group._v_leaves:
-            ecvTable=cv_group._v_leaves[ecv]
+            ecvTable = cv_group._v_leaves[ecv]
             return ecvTable.colnames
         return None
 
-    def getConditionVariables(self,filter=None):
+    def getConditionVariables(self, filter=None):
         """
         **Docstr TBC.**
         """
         if filter is None:
-            session_ids=[]
+            session_ids = []
             for s in self.getExperimentMetaData()[0].sessions:
                 session_ids.append(s.session_id)
-            filter=dict(session_id=(' in ',session_ids))
+            filter = dict(session_id=(' in ', session_ids))
 
-        ConditionSetInstance=None
+        ConditionSetInstance = None
 
         for conditionVarName, conditionVarComparitor in filter.items():
             avComparison, value = conditionVarComparitor
 
-            cv_group=self.hdfFile.root.data_collection.condition_variables
-            cvrows=[]
-            ecv="EXP_CV_%d"%(self._experimentID,)
+            cv_group = self.hdfFile.root.data_collection.condition_variables
+            cvrows = []
+            ecv = "EXP_CV_%d" % (self._experimentID,)
             if ecv in cv_group._v_leaves:
-                ecvTable=cv_group._v_leaves[ecv]
+                ecvTable = cv_group._v_leaves[ecv]
 
                 if ConditionSetInstance is None:
-                    colnam=ecvTable.colnames
+                    colnam = ecvTable.colnames
                     ConditionSetInstance = namedtuple('ConditionSetInstance', colnam)
 
-                cvrows.extend([ConditionSetInstance(*r[:]) for r in ecvTable if all([eval("{0} {1} {2}".format(r[conditionVarName],conditionVarComparitor[0],conditionVarComparitor[1])) for conditionVarName, conditionVarComparitor in filter.items()])])
+                cvrows.extend([ConditionSetInstance(*r[:]) for r in ecvTable if all([eval("{0} {1} {2}".format(r[conditionVarName], conditionVarComparitor[0], conditionVarComparitor[1])) for conditionVarName, conditionVarComparitor in filter.items()])])
         return cvrows
 
-    def getValuesForVariables(self,cv, value, cvNames):
+    def getValuesForVariables(self, cv, value, cvNames):
         """
         **Docstr TBC.**
         """
 
-        if isinstance(value,(list,tuple)):
-            resolvedValues=[]
+        if isinstance(value, (list, tuple)):
+            resolvedValues = []
             for v in value:
-                if isinstance(value,basestring) and value.startswith('@') and value.endswith('@'):
-                    value=value[1:-1]
+                if isinstance(value, basestring) and value.startswith('@') and value.endswith('@'):
+                    value = value[1:-1]
                     if value in cvNames:
-                        resolvedValues.append(getattr(cv,v))
+                        resolvedValues.append(getattr(cv, v))
                     else:
-                        raise ExperimentDataAccessException("getEventAttributeValues: {0} is not a valid attribute name in {1}".format(v,cvNames))
+                        raise ExperimentDataAccessException("getEventAttributeValues: {0} is not a valid attribute name in {1}".format(v, cvNames))
                         return None
-                elif isinstance(value,basestring):
+                elif isinstance(value, basestring):
                     resolvedValues.append(value)
             return resolvedValues
-        elif isinstance(value,basestring) and value.startswith('@') and value.endswith('@'):
-            value=value[1:-1]
+        elif isinstance(value, basestring) and value.startswith('@') and value.endswith('@'):
+            value = value[1:-1]
             if value in cvNames:
-                return getattr(cv,value)
+                return getattr(cv, value)
             else:
-                raise ExperimentDataAccessException("getEventAttributeValues: {0} is not a valid attribute name in {1}".format(value,cvNames))
+                raise ExperimentDataAccessException("getEventAttributeValues: {0} is not a valid attribute name in {1}".format(value, cvNames))
                 return None
         else:
-            raise ExperimentDataAccessException("Unhandled value type !: {0} is not a valid type for value {1}".format(type(value),value))
+            raise ExperimentDataAccessException("Unhandled value type !: {0} is not a valid type for value {1}".format(type(value), value))
 
-    def getEventAttributeValues(self,event_type_id,event_attribute_names,filter_id=None, conditionVariablesFilter=None, startConditions=None,endConditions=None):
+    def getEventAttributeValues(self, event_type_id, event_attribute_names, filter_id=None, conditionVariablesFilter=None, startConditions=None, endConditions=None):
         """
         **Docstr TBC.**
 
@@ -368,47 +384,47 @@ class ExperimentDataAccessUtility(object):
             Values for the specified event type and event attribute columns which match the provided experiment condition variable filter, starting condition filer, and ending condition filter criteria.
         """
         if self.hdfFile:
-            klassTables=self.hdfFile.root.class_table_mapping
+            klassTables = self.hdfFile.root.class_table_mapping
 
-            deviceEventTable=None
+            deviceEventTable = None
 
-            result=[row.fetch_all_fields() for row in klassTables.where('(class_id == %d) & (class_type_id == 1)'%(event_type_id))]
+            result = [row.fetch_all_fields() for row in klassTables.where('(class_id == %d) & (class_type_id == 1)' % (event_type_id))]
             if len(result) is not 1:
                 raise ExperimentDataAccessException("event_type_id passed to getEventAttribute should only return one row from CLASS_MAPPINGS.")
-            tablePathString=result[0][3]
-            deviceEventTable=self.hdfFile.getNode(tablePathString)
+            tablePathString = result[0][3]
+            deviceEventTable = getattr(self.hdfFile, get_node)(tablePathString)
 
             for ename in event_attribute_names:
                 if ename not in deviceEventTable.colnames:
-                    raise ExperimentDataAccessException("getEventAttribute: %s does not have a column named %s"%(deviceEventTable.title,event_attribute_names))
+                    raise ExperimentDataAccessException("getEventAttribute: %s does not have a column named %s" % (deviceEventTable.title, event_attribute_names))
                     return None
 
-            resultSetList=[]
+            resultSetList = []
 
-            csier=list(event_attribute_names)
+            csier = list(event_attribute_names)
             csier.append('query_string')
             csier.append('condition_set')
-            EventAttributeResults=namedtuple('EventAttributeResults',csier)
+            EventAttributeResults = namedtuple('EventAttributeResults', csier)
 
             if deviceEventTable is not None:
-                if not isinstance(event_attribute_names, (list,tuple)):
-                    event_attribute_names=[event_attribute_names,]
+                if not isinstance(event_attribute_names, (list, tuple)):
+                    event_attribute_names = [event_attribute_names, ]
 
-                filteredConditionVariableList=None
+                filteredConditionVariableList = None
                 if conditionVariablesFilter is None:
                     filteredConditionVariableList= self.getConditionVariables()
                 else:
-                    filteredConditionVariableList=self.getConditionVariables(conditionVariablesFilter)
+                    filteredConditionVariableList = self.getConditionVariables(conditionVariablesFilter)
 
-                cvNames=self.getConditionVariableNames()
+                cvNames = self.getConditionVariableNames()
 
                 # no futher where clause building needed; get reseults and return
                 if startConditions is None and endConditions is None:
                     for cv in filteredConditionVariableList:
 
-                        wclause="( experiment_id == {0} ) & ( session_id == {1} )".format(self._experimentID,cv.session_id)
+                        wclause = "( experiment_id == {0} ) & ( session_id == {1} )".format(self._experimentID, cv.session_id)
 
-                        wclause+=" & ( type == {0} ) ".format(event_type_id)
+                        wclause += " & ( type == {0} ) ".format(event_type_id)
 
                         if filter_id is not None:
                             wclause += "& ( filter_id == {0} ) ".format(filter_id)
@@ -420,8 +436,8 @@ class ExperimentDataAccessUtility(object):
                         resultSetList[-1].append(wclause)
                         resultSetList[-1].append(cv)
 
-                        eventAttributeResults=EventAttributeResults(*resultSetList[-1])
-                        resultSetList[-1]=eventAttributeResults
+                        eventAttributeResults = EventAttributeResults(*resultSetList[-1])
+                        resultSetList[-1] = eventAttributeResults
 
                     return resultSetList
 
@@ -429,9 +445,9 @@ class ExperimentDataAccessUtility(object):
                 for cv in filteredConditionVariableList:
                     resultSetList.append([])
 
-                    wclause="( experiment_id == {0} ) & ( session_id == {1} )".format(self._experimentID,cv.session_id)
+                    wclause = "( experiment_id == {0} ) & ( session_id == {1} )".format(self._experimentID, cv.session_id)
 
-                    wclause+=" & ( type == {0} ) ".format(event_type_id)
+                    wclause += " & ( type == {0} ) ".format(event_type_id)
 
                     if filter_id is not None:
                         wclause += "& ( filter_id == {0} ) ".format(filter_id)
@@ -440,35 +456,35 @@ class ExperimentDataAccessUtility(object):
                     if startConditions is not None:
                         wclause += "& ("
                         for conditionAttributeName, conditionAttributeComparitor in startConditions.items():
-                            avComparison,value=conditionAttributeComparitor
-                            value=self.getValuesForVariables(cv,value, cvNames)
-                            wclause += " ( {0} {1} {2} ) & ".format(conditionAttributeName,avComparison,value)
-                        wclause=wclause[:-3]
-                        wclause+=" ) "
+                            avComparison, value = conditionAttributeComparitor
+                            value = self.getValuesForVariables(cv, value, cvNames)
+                            wclause += " ( {0} {1} {2} ) & ".format(conditionAttributeName, avComparison, value)
+                        wclause = wclause[:-3]
+                        wclause += " ) "
 
                     # end Conditions need to be added to where clause
                     if endConditions is not None:
                         wclause += " & ("
                         for conditionAttributeName, conditionAttributeComparitor in endConditions.items():
-                            avComparison,value=conditionAttributeComparitor
-                            value=self.getValuesForVariables(cv,value, cvNames)
-                            wclause += " ( {0} {1} {2} ) & ".format(conditionAttributeName,avComparison,value)
-                        wclause=wclause[:-3]
-                        wclause+=" ) "
+                            avComparison, value=conditionAttributeComparitor
+                            value = self.getValuesForVariables(cv, value, cvNames)
+                            wclause += " ( {0} {1} {2} ) & ".format(conditionAttributeName, avComparison, value)
+                        wclause = wclause[:-3]
+                        wclause += " ) "
 
                     for ename in event_attribute_names:
                         resultSetList[-1].append(deviceEventTable.readWhere(wclause, field=ename))
                     resultSetList[-1].append(wclause)
                     resultSetList[-1].append(cv)
 
-                    eventAttributeResults=EventAttributeResults(*resultSetList[-1])
-                    resultSetList[-1]=eventAttributeResults
+                    eventAttributeResults = EventAttributeResults(*resultSetList[-1])
+                    resultSetList[-1] = eventAttributeResults
 
                 return resultSetList
 
             return None
 
-    def getEventIterator(self,event_type):
+    def getEventIterator(self, event_type):
         """
         **Docstr TBC.**
 
@@ -489,11 +505,11 @@ class ExperimentDataAccessUtility(object):
             _hubFiles.remove(self.hdfFile)
         self.hdfFile.close()
 
-        self.experimentCodes=None
-        self.hdfFilePath=None
-        self.hdfFileName=None
-        self.mode=None
-        self.hdfFile=None
+        self.experimentCodes = None
+        self.hdfFilePath = None
+        self.hdfFileName = None
+        self.mode = None
+        self.hdfFile = None
 
     def __del__(self):
         try:

--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -19,7 +19,7 @@ standard_library.install_aliases()
 from builtins import next
 from past.builtins import basestring
 from builtins import object
-from tables import *
+from tables import *  # TODO walkGroups, listNodes, getNode -> changed API
 import os
 from collections import namedtuple
 import json


### PR DESCRIPTION
As per this issue #1548 ioHub/datastore needed an update to be compatible with the PyTables API version > 3.x

* I've removed the `from tables import *` statements and added explicit imports, to make the files easier to debug.
* Rather than checking PyTables version on every API call, I do the check once after the import statements and use `getattr` for all API calls, as I found that more elegant - not sure what you think.
* I haven't included any tests yet, as this may take a little longer, I only tested with my local set-up and serial device (successfully)
* I've also added some white space around operators and fixed some other Pep8 formatting issues, not sure if this is wanted (do you follow another code style guide?)

In terms of testing, please let me know how to proceed. I plan on writing some dummies for external devices to make ioHub testable at all, but it will take a while to work through the code base first.