### PR TITLE
ENH: Allow users to disable the "initial rule" of StairHandler

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -69,6 +69,7 @@ class StairHandler(_BaseTrialHandler):
                  nTrials=0,
                  nUp=1,
                  nDown=3,  # correct responses before stim goes down
+                 applyInitialRule=True,
                  extraInfo=None,
                  method='2AFC',
                  stepType='db',
@@ -109,6 +110,11 @@ class StairHandler(_BaseTrialHandler):
             nDown:
                 The number of 'correct' (or 1) responses before the
                 staircase level decreases.
+
+            applyInitialRule : bool
+                Whether to apply a 1-up/1-down rule until the first reversal
+                point (if `True`), before switching to the specified up/down
+                rule.
 
             extraInfo:
                 A dictionary (typically) that will be stored along with
@@ -155,6 +161,7 @@ class StairHandler(_BaseTrialHandler):
         self.startVal = startVal
         self.nUp = nUp
         self.nDown = nDown
+        self.applyInitialRule = applyInitialRule
         self.extraInfo = extraInfo
         self.method = method
         self.stepType = stepType
@@ -198,7 +205,7 @@ class StairHandler(_BaseTrialHandler):
         self.maxVal = maxVal
         self.autoLog = autoLog
         # a flag for the 1-up 1-down initial rule:
-        self.initialRule = 0
+        self.initialRule = False
 
         # self.originPath and self.origin (the contents of the origin file)
         self.originPath, self.origin = self.getOriginPathAndFile(originPath)
@@ -276,7 +283,7 @@ class StairHandler(_BaseTrialHandler):
         current direction.
         """
 
-        if len(self.reversalIntensities) < 1:
+        if not self.reversalIntensities and self.applyInitialRule:
             # always using a 1-down, 1-up rule initially
             if self.data[-1] == 1:  # last answer correct
                 # got it right
@@ -297,7 +304,8 @@ class StairHandler(_BaseTrialHandler):
                 self.currentDirection = 'up'
         elif self.correctCounter >= self.nDown:
             # n right, time to go down!
-            if self.currentDirection != 'down':
+            # 'start' covers `applyInitialRule=False`.
+            if self.currentDirection not in ['start', 'down']:
                 reversal = True
             else:
                 reversal = False
@@ -305,7 +313,8 @@ class StairHandler(_BaseTrialHandler):
         elif self.correctCounter <= -self.nUp:
             # n wrong, time to go up!
             # note current direction
-            if self.currentDirection != 'up':
+            # 'start' covers `applyInitialRule=False`.
+            if self.currentDirection not in ['start', 'up']:
                 reversal = True
             else:
                 reversal = False
@@ -317,14 +326,15 @@ class StairHandler(_BaseTrialHandler):
         # add reversal info
         if reversal:
             self.reversalPoints.append(self.thisTrialN)
-            if len(self.reversalIntensities) < 1:
-                self.initialRule = 1
+            if not self.reversalIntensities and self.applyInitialRule:
+                self.initialRule = True
             self.reversalIntensities.append(self.intensities[-1])
 
         # test if we're done
         if (len(self.reversalIntensities) >= self.nReversals and
                     len(self.intensities) >= self.nTrials):
             self.finished = True
+
         # new step size if necessary
         if reversal and self._variableStep:
             if len(self.reversalIntensities) >= len(self.stepSizes):
@@ -336,8 +346,9 @@ class StairHandler(_BaseTrialHandler):
                 self.stepSizeCurrent = self.stepSizes[_sz]
 
         # apply new step size
-        if len(self.reversalIntensities) < 1 or self.initialRule == 1:
-            self.initialRule = 0  # reset the flag
+        if ((not self.reversalIntensities or self.initialRule) and
+                self.applyInitialRule):
+            self.initialRule = False  # reset the flag
             if self.data[-1] == 1:
                 self._intensityDec()
             else:
@@ -371,7 +382,7 @@ class StairHandler(_BaseTrialHandler):
                 # do stuff here for the trial
 
         """
-        if self.finished == False:
+        if not self.finished:
             # check that all 'otherData' is aligned with current trialN
             for key in self.otherData:
                 while len(self.otherData[key]) < self.thisTrialN:

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -333,6 +333,27 @@ class TestStairHandler(_BaseTestStairHandler):
                                       nReversals=len(step_sizes) + 1)
         assert staircase.nReversals == len(step_sizes) + 1
 
+    def test_applyInitialRule_False(self):
+        start_val = 10
+        step_sizes = 2
+        staircase = data.StairHandler(startVal=start_val, stepSizes=step_sizes,
+                                      nReversals=2, nUp=1, nDown=2,
+                                      applyInitialRule=False,
+                                      stepType='lin')
+
+        responses = [0, 1, 1, 0]
+        intensities = [10, 12, 12, 10]
+
+        for r in responses:
+            try:
+                staircase.__next__()
+                staircase.addResponse(r)
+            except StopIteration:
+                break
+
+        assert staircase.data == responses
+        assert staircase.intensities == intensities
+
     def test_comparison_equals(self):
         s1 = data.StairHandler(5)
         s2 = data.StairHandler(5)


### PR DESCRIPTION
The "initial rule"  disregards user-specified n-up/n-down settings and performs a 1-up/1-down staircase until the first reversal point is found. This commit introduces a new keyword argument `applyInitialRule` that can be used to alter this behavior.
