### PR TITLE
BF: sys.platform comparison for linux/python3 in some files

### DIFF
--- a/psychopy/iohub/constants.py
+++ b/psychopy/iohub/constants.py
@@ -692,7 +692,7 @@ try:
 
         VirtualKeyCodes.initialize()
 
-    elif sys.platform == 'linux2':
+    elif sys.platform.startswith('linux'):
         class VirtualKeyCodes(Constants):
             @classmethod
             def getName(cls,id):

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """
@@ -56,7 +56,7 @@ class Display(Device):
         self._coord2pix=None
         self._pix2coord=None
 
-        if sys.platform == 'linux2':
+        if sys.startswith('linux'):
             self._xwindow=None
 
         if Display._computer_display_runtime_info_list is None:

--- a/psychopy/tests/test_hardware/test_ports.py
+++ b/psychopy/tests/test_hardware/test_ports.py
@@ -52,7 +52,7 @@ def test_getLinuxSerialPorts():
     should_have = ["/dev/ttyS1","/dev/ttyACM1","/dev/ttyUSB1"]
     with nested(mock.patch("sys.platform","linux2"),
                 mock.patch("glob.iglob",globMock)):
-       assertPorts(should_have,hw.getSerialPorts())
+        assertPorts(should_have,hw.getSerialPorts())
 
 @require_mock
 def test_getDarwinSerialPorts():

--- a/psychopy/tests/test_iohub/testutil.py
+++ b/psychopy/tests/test_iohub/testutil.py
@@ -45,7 +45,7 @@ skip_not_completed = pytest.mark.skipif("True",
 skip_under_windoz = pytest.mark.skipif("sys.platform == 'win32'",
                                        reason="Cannot be tested under Windoz.")
 
-skip_under_linux = pytest.mark.skipif("sys.platform == 'linux2'",
+skip_under_linux = pytest.mark.skipif("sys.platform.startswith('linux')",
                                        reason="Cannot be tested under Linux.")
 
 skip_under_osx = pytest.mark.skipif("sys.platform == 'darwin'",

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1507,7 +1507,7 @@ class Window(object):
             except Exception:
                 # pyglet 1.2 with 64bit python?
                 self._hw_handle = self.winHandle._nswindow.windowNumber()
-        elif sys.platform == 'linux2':
+        elif sys.platform.startswith('linux'):
             self._hw_handle = self.winHandle._window
 
         if self.useFBO:  # check for necessary extensions


### PR DESCRIPTION
I stumbled over this when running an ioHub example on linux/pthon3 and realized, that many `sys.platform` checks are already conducted with `sys.platform.startwith('linux')` while some still tested for `linux2` only.

I did not update the occurrence in `psychopy/tests/test_hardware/test_ports.py`, so that test will mock the version to `linux2` which should be okay for testing, if I understand correctly.