### PR TITLE
BF: Cleaned up documentation

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -147,6 +147,13 @@ class _SoundBase(object):
                 Middle octave of a piano is 4. Most computers won't
                 output sounds in the bottom octave (1) and the top
                 octave (8) is generally painful
+
+            hamming: boolean (default True) to indicate if the sound should
+                be apodized (i.e., the onset and offset smoothly ramped up from
+                down to zero). The function apodize uses a Hanning window, but
+                arguments named 'hamming' are preserved so that existing code
+                is not broken by the change from Hamming to Hanning internally.
+                Not applied to sounds from files.
         """
         # Re-init sound to ensure bad values will raise error during setting:
         self._snd = None

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -279,7 +279,11 @@ class SoundPyo(_SoundBase):
 
         bits: has no effect for the pyo backend
 
-        hamming: whether to apply a Hanning window (5ms) for generated tones.
+        hamming: boolean (default True) to indicate if the sound should
+            be apodized (i.e., the onset and offset smoothly ramped up from
+            down to zero). The function apodize uses a Hanning window, but
+            arguments named 'hamming' are preserved so that existing code
+            is not broken by the change from Hamming to Hanning internally.
             Not applied to sounds from files.
         """
         global pyoSndServer

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -254,7 +254,12 @@ class SoundDeviceSound(_SoundBase):
                            - -1 means store all
                            - 0 (no buffer) means stream from disk
                            - potentially we could buffer a few secs(!?)
-        :param hamming: boolean (True to smooth the onset/offset)
+        :param hamming: boolean (default True) to indicate if the sound should
+                        be apodized (i.e., the onset and offset smoothly ramped up from
+                        down to zero). The function apodize uses a Hanning window, but
+                        arguments named 'hamming' are preserved so that existing code
+                        is not broken by the change from Hamming to Hanning internally.
+                        Not applied to sounds from files.
         :param startTime: for sound files this controls the start of snippet
         :param stopTime: for sound files this controls the end of snippet
         :param name: string for logging purposes


### PR DESCRIPTION
Revised the documentation to explain that arguments named 'hamming' are preserved even though the apodize function now uses a Hanning window instead.