### PR TITLE
BF: incorrect units in images_blocks Builder demo 

### DIFF
--- a/psychopy/demos/builder/images_blocks/blockedTrials.psyexp
+++ b/psychopy/demos/builder/images_blocks/blockedTrials.psyexp
@@ -43,7 +43,7 @@
         <Param name="pos" updates="constant" val="(0, 0)" valType="code"/>
         <Param name="interpolate" updates="constant" val="linear" valType="str"/>
         <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="pix" valType="str"/>
+        <Param name="units" updates="None" val="height" valType="str"/>
         <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
         <Param name="ori" updates="constant" val="0" valType="code"/>


### PR DESCRIPTION
Changed image stimulus units from `pix` to `height` so that the image stimuli display correctly (with a size of (0.5, 0.5), they were invisible with pixel units).