### PR TITLE
BF: movie3 seek behavior + audio

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -28,15 +28,14 @@ movie is long then audio will be huge and currently the whole thing gets
 # Copyright (C) 2015 Jonathan Peirce
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from __future__ import absolute_import, division, print_function		
+from __future__ import absolute_import, division, print_function
 
 from builtins import str
-from past.utils import old_div
 reportNDroppedFrames = 10
 
 import os
 
-from psychopy import logging, prefs #adding prefs to be able to check sound lib -JK
+from psychopy import logging
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
@@ -203,7 +202,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
             # size, duration, fps
         # mov.audio has attributes
             # duration, fps (aka sampleRate), to_soundarray()
-        self._frameInterval = old_div(1.0, self._mov.fps)
+        self._frameInterval = 1.0/self._mov.fps
         self.duration = self._mov.duration
         self.filename = filename
         self._updateFrameTexture()
@@ -214,16 +213,16 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         """
         status = self.status
         if status != PLAYING:
-            self.status = PLAYING #moved this to get better audio behavior - JK
-            #Added extra check to prevent audio doubling - JK
-            if self._audioStream is not None and self._audioStream.status is not PLAYING: 
+            if self._audioStream is not None:
                 self._audioStream.play()
             if status == PAUSED:
-                if self.getCurrentFrameTime() < 0: #Check for valid timestamp, correct if needed -JK
+                if self.getCurrentFrameTime() < 0:
                     self._audioSeek(0)
                 else:
                     self._audioSeek(self.getCurrentFrameTime())
+            self.status = PLAYING
             self._videoClock.reset(-self.getCurrentFrameTime())
+
             if log and self.autoLog:
                 self.win.logOnFlip("Set %s playing" % (self.name),
                                    level=logging.EXP, obj=self)
@@ -237,10 +236,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         if self.status == PLAYING:
             self.status = PAUSED
             if self._audioStream:
-                if prefs.general['audioLib'] == ['sounddevice']:
-                    self._audioStream.pause() #sounddevice has a "pause" function -JK
-                else:
-                    self._audioStream.stop()
+                self._audioStream.stop()
             if log and self.autoLog:
                 self.win.logOnFlip("Set %s paused" %
                                    (self.name), level=logging.EXP, obj=self)
@@ -298,11 +294,11 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         return self._nextFrameT - self._frameInterval
 
     def _updateFrameTexture(self):
-        if self._nextFrameT is None or self._nextFrameT < 0:
-            # movie has no current position (or invalid position -JK), 
-            # need to reset the clock to zero in order to have the 
-            # timing logic work otherwise the video stream would skip 
-            # frames until the time since creating the movie object has passed
+        if self._nextFrameT is None:
+            # movie has no current position, need to reset the clock
+            # to zero in order to have the timing logic work
+            # otherwise the video stream would skip frames until the
+            # time since creating the movie object has passed
             self._videoClock.reset()
             self._nextFrameT = 0
 
@@ -442,20 +438,16 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
 
     def _audioSeek(self, t):
         sound = self.sound
+        # for sound we need to extract the array again and just begin at new
+        # loc
         if self._audioStream is None:
             return  # do nothing
-        #check if sounddevice  is being used. If so we can use seek. If not we have to 
-        #reload the audio stream and begin at the new loc
-        if prefs.general['audioLib'] == ['sounddevice']:
-            self._audioStream.seek(t)
-        else:
-            self._audioStream.stop()
-            sndArray = self._mov.audio.to_soundarray()
-            startIndex = int(t * self._mov.audio.fps)
-            self._audioStream = sound.Sound(
-                sndArray[startIndex:, :], sampleRate=self._mov.audio.fps)
-            if self.status != PAUSED: #Allows for seeking while paused - JK
-                self._audioStream.play()
+        self._audioStream.stop()
+        sndArray = self._mov.audio.to_soundarray()
+        startIndex = int(t * self._mov.audio.fps)
+        self._audioStream = sound.Sound(
+            sndArray[startIndex:, :], sampleRate=self._mov.audio.fps)
+        self._audioStream.play()
 
     def _getAudioStreamTime(self):
         return self._audio_stream_clock.getTime()


### PR DESCRIPTION
A handful of bug fixes and upgrades to allow for future sounddevice implementation (currently not stable enough to use, sadly).

Bugs fixed:
Previously, seek(0) would sometimes act like a negative value and cause a crash by trying to find either a nonexistent frame or nonexistent point in the audio stream [partly due to getcurrentframetime subtracting the frame interval...which makes sense except when you seek(0)] Checks have been added to ensure that any attempt to seek to a negative value lands you at 0, for either audio or video.
Seeking while paused could double your audio stream or create other audio bugs. Moving the movie status update when using "play" and checking it when audioseeking prevents this. 
A further check has also been added to stop the program from attempting to play the audio again if the audio is already playing (sound doubling was a pernicious bug).

New functionality:
It is now possible to seek while paused in movies with audio.
sounddevice, in theory, allows for much more memory-efficient audio streaming, and includes both a "seek" and "pause" function of its own (which the other audio libs do not). movie3 now checks if you are using sounddevice and attempts to use that functionality if so. Depends heavily on sounddevice working, which it doesn't always...