### PR TITLE
BF: Builder crashes due to non-ASCII characters in path of condition file and TextComponent in Python2

### DIFF
--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -360,7 +360,7 @@ class Experiment(object):
         thisChild = xml.SubElement(parent, thisType)
         thisChild.set('name', name)
         if hasattr(param, 'val'):
-            thisChild.set('val', "{}".format(param.val).replace("\n", "&#10;"))
+            thisChild.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
         if hasattr(param, 'valType'):
             thisChild.set('valType', param.valType)
         if hasattr(param, 'updates'):

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -268,12 +268,12 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         with open(fileName, 'rU') as fileUniv:
             # use pandas reader, which can handle commas in fields, etc
             trialsArr = pd.read_csv(fileUniv, encoding='utf-8')
-            logging.debug("Read csv file with pandas: {}".format(fileName))
+            logging.debug(u"Read csv file with pandas: {}".format(fileName))
             trialList, fieldNames = pandasToDictList(trialsArr)
 
     elif fileName.endswith(('.xlsx','.xls')) and haveXlrd:
         trialsArr = pd.read_excel(fileName)
-        logging.debug("Read excel file with pandas: {}".format(fileName))
+        logging.debug(u"Read excel file with pandas: {}".format(fileName))
         trialList, fieldNames = pandasToDictList(trialsArr)
 
     elif fileName.endswith('.xlsx'):
@@ -288,7 +288,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             wb = load_workbook(filename=fileName, data_only=True)
         ws = wb.worksheets[0]
 
-        logging.debug("Read excel file with openpyxl: {}".format(fileName))
+        logging.debug(u"Read excel file with openpyxl: {}".format(fileName))
         try:
             # in new openpyxl (2.3.4+) get_highest_xx is deprecated
             nCols = ws.max_column


### PR DESCRIPTION
Following bugs are fixed:

1. Builder cannot open condition file when non-ASCII characters are included in the file path in Python2.
2. Builder cannot save experiment when non-ASCII charcteers are included in "Text" field of TextComponent in Python2.

Please see #1608 for detail of error messages.
