### PR TITLE
FF: fixing bugs with closing splash and running experiments in Windows wxPython4

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -169,7 +169,7 @@ class PsychoPyApp(wx.App):
             splashBitmap = wx.Image(name=splashFile).ConvertToBitmap()
             splash = AS.AdvancedSplash(None, bitmap=splashBitmap,
                                        timeout=3000,
-                                       style=AS.AS_TIMEOUT | wx.FRAME_SHAPED,
+                                       agwStyle=AS.AS_TIMEOUT | AS.AS_CENTER_ON_SCREEN,
                                        shadowcolour=wx.RED)  # transparency?
             splash.SetTextPosition((10, 240))
             splash.SetText(_translate("  Loading libraries..."))

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1153,7 +1153,7 @@ class BuilderFrame(wx.Frame):
         self.bldrBtnSave = tb.AddSimpleTool(-1, saveBmp,
                                             _translate("Save [%s]") % keys['save'],
                                             _translate("Save current experiment file"))
-        self.bldrBtnSave.Enable(False)
+        self.toolbar.EnableTool(self.bldrBtnSave.Id, False)
         tb.Bind(wx.EVT_TOOL, self.fileSave, self.bldrBtnSave)
         item = tb.AddSimpleTool(wx.ID_ANY, saveAsBmp,
                                 _translate("Save As... [%s]") % keys['saveAs'],
@@ -1197,7 +1197,7 @@ class BuilderFrame(wx.Frame):
                                             _translate("Stop [%s]") % keys['stopScript'],
                                             _translate("Stop experiment"))
         tb.Bind(wx.EVT_TOOL, self.stopFile, self.bldrBtnStop)
-        self.bldrBtnStop.Enable(False)
+        self.toolbar.EnableTool(self.bldrBtnStop.Id, False)
         tb.Realize()
 
     def makeMenus(self):
@@ -1793,7 +1793,7 @@ class BuilderFrame(wx.Frame):
             newVal = self.getIsModified()
         else:
             self.isModified = newVal
-        self.bldrBtnSave.Enable(newVal)
+        self.toolbar.EnableTool(self.bldrBtnSave.Id, newVal)
         self.fileMenu.Enable(wx.ID_SAVE, newVal)
 
     def getIsModified(self):
@@ -1890,7 +1890,7 @@ class BuilderFrame(wx.Frame):
             label = txt % fmt
             enable = True
         self._undoLabel.SetText(label)
-        self.bldrBtnUndo.Enable(enable)
+        self.toolbar.EnableTool(self.bldrBtnUndo.Id, enable)
         self.editMenu.Enable(wx.ID_UNDO, enable)
 
         # check redo
@@ -1904,7 +1904,7 @@ class BuilderFrame(wx.Frame):
             label = txt % fmt
             enable = True
         self._redoLabel.SetText(label)
-        self.bldrBtnRedo.Enable(enable)
+        self.toolbar.EnableTool(self.bldrBtnRedo.Id, enable)
         self.editMenu.Enable(wx.ID_REDO, enable)
 
     def demosUnpack(self, event=None):
@@ -2015,8 +2015,8 @@ class BuilderFrame(wx.Frame):
         # launch the command
         self.scriptProcessID = wx.Execute(command, _opts,
                                           self.scriptProcess)
-        self.bldrBtnRun.Enable(False)
-        self.bldrBtnStop.Enable(True)
+        self.toolbar.EnableTool(self.bldrBtnRun.Id, False)
+        self.toolbar.EnableTool(self.bldrBtnStop.Id, True)
 
     def stopFile(self, event=None):
         """Kills script processes"""
@@ -2030,8 +2030,8 @@ class BuilderFrame(wx.Frame):
     def onProcessEnded(self, event=None):
         """The script/exp has finished running
         """
-        self.bldrBtnRun.Enable(True)
-        self.bldrBtnStop.Enable(False)
+        self.toolbar.EnableTool(self.bldrBtnRun.Id, True)
+        self.toolbar.EnableTool(self.bldrBtnStop.Id, False)
         # update the output window and show it
         text = u""
         if self.scriptProcess.IsInputAvailable():

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2003,7 +2003,7 @@ class BuilderFrame(wx.Frame):
             if hasattr(wx, "EXEC_NOHIDE"):
                 _opts = wx.EXEC_ASYNC | wx.EXEC_NOHIDE  # that hid console!
             else:
-                _opts = wx.EXEC_ASYNC | wx.EXEC_HIDE_CONSOLE  # renamed in wx 4
+                _opts = wx.EXEC_ASYNC | wx.EXEC_SHOW_CONSOLE
         else:
             # for unix this signifies a space in a filename
             fullPath = fullPath.replace(' ', '\ ')

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2025,7 +2025,6 @@ class BuilderFrame(wx.Frame):
         success = wx.Kill(self.scriptProcessID, wx.SIGTERM)
         if success[0] != wx.KILL_OK:
             wx.Kill(self.scriptProcessID, wx.SIGKILL)  # kill it aggressively
-        self.onProcessEnded(event=None)
 
     def onProcessEnded(self, event=None):
         """The script/exp has finished running

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2513,7 +2513,7 @@ class CoderFrame(wx.Frame):
             if hasattr(wx, "EXEC_NOHIDE"):
                 _opts = wx.EXEC_ASYNC | wx.EXEC_NOHIDE  # that hid console!
             else:
-                _opts = wx.EXEC_ASYNC | wx.EXEC_HIDE_CONSOLE  # renamed in wx 4
+                _opts = wx.EXEC_ASYNC | wx.EXEC_SHOW_CONSOLE
         else:
             fullPath = fullPath.replace(' ', '\ ')
             pythonExec = sys.executable.replace(' ', '\ ')

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2510,15 +2510,19 @@ class CoderFrame(wx.Frame):
             command = '"%s" -u "%s"' % (sys.executable, fullPath)
             # self.scriptProcessID = wx.Execute(command, wx.EXEC_ASYNC,
             #    self.scriptProcess)
-            self.scriptProcessID = wx.Execute(
-                command, wx.EXEC_ASYNC | wx.EXEC_NOHIDE, self.scriptProcess)
+            if hasattr(wx, "EXEC_NOHIDE"):
+                _opts = wx.EXEC_ASYNC | wx.EXEC_NOHIDE  # that hid console!
+            else:
+                _opts = wx.EXEC_ASYNC | wx.EXEC_HIDE_CONSOLE  # renamed in wx 4
         else:
             fullPath = fullPath.replace(' ', '\ ')
             pythonExec = sys.executable.replace(' ', '\ ')
             # the quotes would break a unix system command
             command = '%s -u %s' % (pythonExec, fullPath)
-            self.scriptProcessID = wx.Execute(
-                command, wx.EXEC_ASYNC, self.scriptProcess)
+            _opts = wx.EXEC_ASYNC | wx.EXEC_MAKE_GROUP_LEADER
+        # launch the command
+        self.scriptProcessID = wx.Execute(command, _opts,
+                                          self.scriptProcess)
         self.toolbar.EnableTool(self.IDs.cdrBtnRun, False)
         self.toolbar.EnableTool(self.IDs.cdrBtnStop, True)
 


### PR DESCRIPTION
Following bugs are fixed.

- Splash window doesn't close automatically
- Coder experiment doesn't start when Run button is clicked.
- Status of Run/Stop is not updated when Builder experiment is terminated.
- Python crashes when Stop button is pressed during experiment in Builder.

Coders were tested on:
- winpython2.7.10 x86, wxpytho3.0.2
- winpython2.7.10 x86, wxpython4.0.0b2
- winpython3.6.1 x64, wxpython4.0.0.b1
