### PR TITLE
FF: fix compatibility issues with Python 3 and wxpython 4

### DIFF
--- a/psychopy/app/builder/components/unknown/__init__.py
+++ b/psychopy/app/builder/components/unknown/__init__.py
@@ -30,6 +30,7 @@ class UnknownComponent(BaseComponent):
         self.exp = exp  # so we can access the experiment if necess
         self.parentName = parentName  # to access the routine too if needed
         self.params = {}
+        self.depends = []
         _hint = _translate("Name of this component (alpha-numeric or _, "
                            "no spaces)")
         self.params['name'] = Param(name, valType='code',

--- a/psychopy/app/builder/dialogs/dlgsConditions.py
+++ b/psychopy/app/builder/dialogs/dlgsConditions.py
@@ -25,6 +25,8 @@ from psychopy import gui
 from .. experiment import _valid_var_re, _nonalphanumeric_re
 from ...localization import _translate
 
+from psychopy.constants import PY3
+
 darkblue = wx.Colour(30, 30, 150, 255)
 darkgrey = wx.Colour(65, 65, 65, 255)
 white = wx.Colour(255, 255, 255, 255)
@@ -59,7 +61,7 @@ class DlgConditions(wx.Dialog):
     def __init__(self, grid=None, fileName=False, parent=None, title='',
                  trim=True, fixed=False, hasHeader=True, gui=True,
                  extraRows=0, extraCols=0,
-                 clean=True, pos=None, preview=True,
+                 clean=True, pos=wx.DefaultPosition, preview=True,
                  _restore=None, size=wx.DefaultSize,
                  style=wx.DEFAULT_DIALOG_STYLE | wx.DIALOG_NO_PARENT):
         self.parent = parent  # gets the conditionsFile info
@@ -623,8 +625,15 @@ class DlgConditions(wx.Dialog):
             if fullPathList:
                 fileName = fullPathList[0]  # wx.MULTIPLE -> list
         if os.path.isfile(fileName) and fileName.endswith('.pkl'):
-            f = open(fileName)
-            contents = pickle.load(f)
+            f = open(fileName, 'rb')
+            # Converting newline characters.
+            if PY3:
+                # 'b' is necessary in Python3 because byte object is 
+                # returned when file is opened in binary mode.
+                buffer = f.read().replace(b'\r\n',b'\n').replace(b'\r',b'\n')
+            else:
+                buffer = f.read().replace('\r\n','\n').replace('\r','\n')
+            contents = pickle.loads(buffer)
             f.close()
             if self.parent:
                 self.parent.conditionsFile = fileName

--- a/psychopy/app/builder/dialogs/dlgsConditions.py
+++ b/psychopy/app/builder/dialogs/dlgsConditions.py
@@ -459,7 +459,7 @@ class DlgConditions(wx.Dialog):
             # data matrix on top, buttons below
             self.border = wx.FlexGridSizer(2, 1)
         else:
-            self.border = wx.FlexGridSizer(4)
+            self.border = wx.FlexGridSizer(4, 1, wx.Size(0,0))
         self.border.Add(self.sizer, proportion=1,
                         flag=wx.ALL | wx.EXPAND, border=8)
 

--- a/psychopy/app/builder/experiment.py
+++ b/psychopy/app/builder/experiment.py
@@ -172,7 +172,7 @@ class Experiment(object):
         self.psychopyVersion = __version__
         # What libs are needed (make sound come first)
         self.psychopyLibs = ['sound', 'gui', 'visual', 'core',
-                             'data', 'event', 'logging']
+                             'data', 'event', 'logging', 'clock']
         _settingsComp = getComponents(fetchIcons=False)['SettingsComponent']
         self.settings = _settingsComp(parentName='', exp=self)
         # this will be the xml.dom.minidom.doc object for saving

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2132,7 +2132,10 @@ class CoderFrame(wx.Frame):
 
         # is the file still there
         if os.path.isfile(filename):
-            doc.SetText(open(filename).read().decode('utf8'))
+            if PY3:
+                doc.SetText(open(filename).read())
+            else:
+                doc.SetText(open(filename).read().decode('utf8'))
             doc.fileModTime = os.path.getmtime(filename)
             doc.EmptyUndoBuffer()
             doc.Colourise(0, -1)

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -403,7 +403,7 @@ class TrialHandler(_BaseTrialHandler):
             thisLine = []
             lines.append(thisLine)
             # write a header line
-            for heading in stimOut + dataHead:
+            for heading in list(stimOut) + dataHead:
                 if heading == 'ran_sum':
                     heading = 'n'
                 elif heading == 'order_raw':

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -320,13 +320,25 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             trialList.append(thisTrial)
 
     elif fileName.endswith('.pkl'):
-        f = open(fileName, 'rU')  # is U needed?
+        f = open(fileName, 'rb')
+        # Converting newline characters.
+        if PY3:
+            # 'b' is necessary in Python3 because byte object is 
+            # returned when file is opened in binary mode.
+            buffer = f.read().replace(b'\r\n',b'\n').replace(b'\r',b'\n')
+        else:
+            buffer = f.read().replace('\r\n','\n').replace('\r','\n')
         try:
-            trialsArr = pickle.load(f)
+            trialsArr = pickle.loads(buffer)
         except Exception:
             raise IOError('Could not open %s as conditions' % fileName)
         f.close()
         trialList = []
+        if PY3:
+            # In Python3, strings returned by pickle() is unhashable.
+            # So, we have to convert them to str.
+            trialsArr = [[str(item) if isinstance(item, str) else item
+                          for item in row] for row in trialsArr]
         fieldNames = trialsArr[0]  # header line first
         _assertValidVarNames(fieldNames, fileName)
         for row in trialsArr[1:]:

--- a/psychopy/demos/builder/branchedExp/branching.psyexp
+++ b/psychopy/demos/builder/branchedExp/branching.psyexp
@@ -8,7 +8,7 @@
     <Param name="Full-screen window" val="True" valType="bool" updates="None"/>
     <Param name="colorSpace" val="rgb" valType="str" updates="None"/>
     <Param name="Save log file" val="True" valType="bool" updates="None"/>
-    <Param name="Experiment info" val="{'participant':'ID01', 'session':001}" valType="code" updates="None"/>
+    <Param name="Experiment info" val="{'participant':'ID01', 'session':'001'}" valType="code" updates="None"/>
     <Param name="Save excel file" val="True" valType="bool" updates="None"/>
     <Param name="Save psydat file" val="True" valType="bool" updates="None"/>
     <Param name="logging level" val="warning" valType="code" updates="None"/>

--- a/psychopy/demos/builder/mental_rotation/MentalRot.psyexp
+++ b/psychopy/demos/builder/mental_rotation/MentalRot.psyexp
@@ -1,487 +1,490 @@
 <?xml version="1.0" ?>
-<PsychoPy2experiment encoding="utf-8" version="1.83.02">
+<PsychoPy2experiment encoding="utf-8" version="1.85.6">
   <Settings>
-    <Param name="Show mouse" updates="None" val="False" valType="bool"/>
-    <Param name="Data filename" updates="None" val="u'data/%s_%s_%s' % (expInfo['participant'], expName, expInfo['date'])" valType="code"/>
-    <Param name="Monitor" updates="None" val="testMonitor" valType="str"/>
-    <Param name="Enable Escape" updates="None" val="True" valType="bool"/>
-    <Param name="color" updates="None" val="$[0,0,0]" valType="str"/>
-    <Param name="Window size (pixels)" updates="None" val="[1040, 800]" valType="code"/>
-    <Param name="Full-screen window" updates="None" val="False" valType="bool"/>
-    <Param name="colorSpace" updates="None" val="rgb" valType="str"/>
-    <Param name="Experiment info" updates="None" val="{u'session': u'001', u'participant': u''}" valType="code"/>
-    <Param name="Save csv file" updates="None" val="False" valType="bool"/>
-    <Param name="Show info dlg" updates="None" val="True" valType="bool"/>
-    <Param name="Save wide csv file" updates="None" val="True" valType="bool"/>
-    <Param name="Save psydat file" updates="None" val="True" valType="bool"/>
     <Param name="expName" updates="None" val="MentalRot" valType="str"/>
-    <Param name="logging level" updates="None" val="exp" valType="code"/>
-    <Param name="blendMode" updates="None" val="avg" valType="str"/>
-    <Param name="Save excel file" updates="None" val="False" valType="bool"/>
-    <Param name="Units" updates="None" val="height" valType="str"/>
-    <Param name="Save log file" updates="None" val="True" valType="bool"/>
-    <Param name="Saved data folder" updates="None" val="" valType="code"/>
+    <Param name="Show info dlg" updates="None" val="True" valType="bool"/>
+    <Param name="Enable Escape" updates="None" val="True" valType="bool"/>
+    <Param name="Experiment info" updates="None" val="{u'session': u'001', u'participant': u''}" valType="code"/>
+    <Param name="Use version" updates="None" val="" valType="str"/>
+    <Param name="Full-screen window" updates="None" val="False" valType="bool"/>
+    <Param name="Window size (pixels)" updates="None" val="[1040, 800]" valType="code"/>
     <Param name="Screen" updates="None" val="1" valType="num"/>
+    <Param name="Monitor" updates="None" val="testMonitor" valType="str"/>
+    <Param name="color" updates="None" val="$[0,0,0]" valType="str"/>
+    <Param name="colorSpace" updates="None" val="rgb" valType="str"/>
+    <Param name="Units" updates="None" val="height" valType="str"/>
+    <Param name="blendMode" updates="None" val="avg" valType="str"/>
+    <Param name="Show mouse" updates="None" val="False" valType="bool"/>
+    <Param name="Data filename" updates="None" val="'data' + os.sep + '%s_%s' % (expInfo['participant'], expInfo['date'])" valType="code"/>
+    <Param name="Save log file" updates="None" val="True" valType="bool"/>
+    <Param name="Save wide csv file" updates="None" val="True" valType="bool"/>
+    <Param name="Save csv file" updates="None" val="False" valType="bool"/>
+    <Param name="Save excel file" updates="None" val="False" valType="bool"/>
+    <Param name="Save psydat file" updates="None" val="True" valType="bool"/>
+    <Param name="logging level" updates="None" val="exp" valType="code"/>
+    <Param name="OSF Project ID" updates="None" val="" valType="str"/>
+    <Param name="HTML path" updates="None" val="html" valType="str"/>
+    <Param name="JS libs" updates="None" val="packaged" valType="str"/>
   </Settings>
   <Routines>
     <Routine name="plot_data">
       <CodeComponent name="plot_data_array">
-        <Param name="Begin Experiment" updates="constant" val="from matplotlib import pyplot&amp;#10;import pandas as pd" valType="extendedCode"/>
         <Param name="name" updates="None" val="plot_data_array" valType="code"/>
-        <Param name="Begin Routine" updates="constant" val="def plotYX(yaxis, xaxis, description=''):&amp;#10;    pyplot.grid(True)&amp;#10;    pyplot.title(description)&amp;#10;    pyplot.xlabel('Angle')&amp;#10;    pyplot.ylabel('Response time (s)')&amp;#10;    pyplot.xlim([0, 315])&amp;#10;    #slope,inter = np.polyfit(xaxis[:5],yaxis[:5],1)&amp;#10;    pyplot.plot(xaxis, yaxis) #, xaxis[:5], np.array(xaxis[:5]) * slope + inter)&amp;#10;    pyplot.draw()&amp;#10;    pyplot.show()&amp;#10;&amp;#10;filename = 'mental_rotation_data.csv'&amp;#10;with open(filename, 'wb') as fd:&amp;#10;    fd.write(data_string)&amp;#10;&amp;#10;data = pd.read_csv(filename)&amp;#10;data = data[data['rt'] &lt; 4]  # trim RT at 4 sec&amp;#10;mrt = data.loc[:,'rt']&amp;#10;correct = data.loc[:, 'corr']&amp;#10;angle = data.loc[:, 'angle']&amp;#10;&amp;#10;dfsum = data.groupby('angle', as_index=False).mean()&amp;#10;m = dfsum.loc[:, 'rt']&amp;#10;a = dfsum.loc[:, 'angle']&amp;#10;&amp;#10;scored_data = zip(a, m)&amp;#10;print('average time (sec) at each rotation:')&amp;#10;print &quot;  0  45  90  135 180 225 270 315&quot;&amp;#10;print &quot;--&gt; %s &lt;--&quot; % repr([round(i,3) for i in m]).strip('[]').replace(',', '  ')&amp;#10;print &quot;\n% correct        :&quot;, 100 * correct.mean()&amp;#10;print &quot;overall speed (s):&quot;, mrt.mean()&amp;#10;&amp;#10;plotYX(m, a)&amp;#10;&amp;#10;with open(filename, 'a+b') as fd:&amp;#10;    fd.write('\n\n' + repr(scored_data))" valType="extendedCode"/>
+        <Param name="Begin Experiment" updates="constant" val="from matplotlib import pyplot&amp;#10;import pandas as pd" valType="extendedCode"/>
+        <Param name="Begin Routine" updates="constant" val="def plotYX(yaxis, xaxis, description=''):&amp;#10;    pyplot.grid(True)&amp;#10;    pyplot.title(description)&amp;#10;    pyplot.xlabel('Angle')&amp;#10;    pyplot.ylabel('Response time (s)')&amp;#10;    pyplot.xlim([0, 315])&amp;#10;    #slope,inter = np.polyfit(xaxis[:5],yaxis[:5],1)&amp;#10;    pyplot.plot(xaxis, yaxis) #, xaxis[:5], np.array(xaxis[:5]) * slope + inter)&amp;#10;    pyplot.draw()&amp;#10;    pyplot.show()&amp;#10;&amp;#10;fname = 'mental_rotation_data.csv'&amp;#10;with open(fname, 'w') as fd:&amp;#10;    fd.write(data_string)&amp;#10;&amp;#10;data = pd.read_csv(fname)&amp;#10;data = data[data['rt'] &lt; 4]  # trim RT at 4 sec&amp;#10;mrt = data.loc[:,'rt']&amp;#10;correct = data.loc[:, 'corr']&amp;#10;angle = data.loc[:, 'angle']&amp;#10;&amp;#10;dfsum = data.groupby('angle', as_index=False).mean()&amp;#10;m = dfsum.loc[:, 'rt']&amp;#10;a = dfsum.loc[:, 'angle']&amp;#10;&amp;#10;scored_data = zip(a, m)&amp;#10;print('average time (sec) at each rotation:')&amp;#10;print(&quot;  0  45  90  135 180 225 270 315&quot;)&amp;#10;print(&quot;--&gt; %s &lt;--&quot; % repr([round(i,3) for i in m]).strip('[]').replace(',', '  '))&amp;#10;print(&quot;\n% correct        :&quot;, 100 * correct.mean())&amp;#10;print(&quot;overall speed (s):&quot;, mrt.mean())&amp;#10;&amp;#10;plotYX(m, a)&amp;#10;&amp;#10;with open(fname, 'a+') as fd:&amp;#10;    fd.write('\n\n' + repr(scored_data))" valType="extendedCode"/>
+        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Routine" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Experiment" updates="constant" val="" valType="extendedCode"/>
-        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
       </CodeComponent>
     </Routine>
     <Routine name="pause">
       <TextComponent name="mini_pause">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="mini_pause" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="white" valType="str"/>
-        <Param name="text" updates="constant" val=" " valType="str"/>
-        <Param name="stopVal" updates="constant" val=".5" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val=".5" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="white" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val=" " valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.1" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
       <CodeComponent name="code_4">
-        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="name" updates="None" val="code_4" valType="code"/>
+        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="Begin Routine" updates="constant" val="if trials.thisN == 4 and expInfo['participant'] == 'JRG':    &amp;#10;    trials.finished = True" valType="extendedCode"/>
+        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Routine" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Experiment" updates="constant" val="" valType="extendedCode"/>
-        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
       </CodeComponent>
     </Routine>
     <Routine name="Intructions_1">
       <StaticComponent name="ISI_2">
-        <Param name="code" updates="None" val="" valType="code"/>
         <Param name="name" updates="None" val="ISI_2" valType="code"/>
-        <Param name="stopVal" updates="constant" val="0.5" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="0.5" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="code" updates="None" val="" valType="code"/>
       </StaticComponent>
       <TextComponent name="text_4">
+        <Param name="name" updates="None" val="text_4" valType="code"/>
+        <Param name="startType" updates="None" val="time (s)" valType="str"/>
+        <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
+        <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
         <Param name="opacity" updates="constant" val="1" valType="code"/>
         <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="name" updates="None" val="text_4" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val=".8" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="constant" val="Welcome. You will see two letters on the screen that have been rotated. For each pair of letters, indicate if they are mirror images of each other when they two letters are in their normal upright position. (Ignore the rotations.) &amp;#10; &amp;#10;Press 'm' if they are mirror images of each other. Press 'n' if they are the same (not mirror images).   &amp;#10; &amp;#10;Press the 'm' to continue." valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="startType" updates="None" val="time (s)" valType="str"/>
         <Param name="ori" updates="constant" val="0" valType="code"/>
-        <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
-        <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="text" updates="constant" val="Welcome. You will see two letters on the screen that have been rotated. For each pair of letters, indicate if they are mirror images of each other when they two letters are in their normal upright position. (Ignore the rotations.) &amp;#10; &amp;#10;Press 'm' if they are mirror images of each other. Press 'n' if they are the same (not mirror images).   &amp;#10; &amp;#10;Press the 'm' to continue." valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.04" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val=".8" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
       <KeyboardComponent name="key_resp_4">
-        <Param name="correctAns" updates="constant" val="" valType="str"/>
-        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="None" val="key_resp_4" valType="code"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="allowedKeys" updates="constant" val="'m'" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="allowedKeys" updates="constant" val="'m'" valType="code"/>
+        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="store" updates="constant" val="last key" valType="str"/>
+        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
+        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
+        <Param name="correctAns" updates="constant" val="" valType="str"/>
         <Param name="syncScreenRefresh" updates="constant" val="True" valType="bool"/>
       </KeyboardComponent>
     </Routine>
     <Routine name="Intructions_2">
       <KeyboardComponent name="key_resp_6">
-        <Param name="correctAns" updates="constant" val="$same" valType="str"/>
-        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="None" val="key_resp_6" valType="code"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="allowedKeys" updates="constant" val="'n'" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="allowedKeys" updates="constant" val="'n'" valType="code"/>
+        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="store" updates="constant" val="nothing" valType="str"/>
+        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
+        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
+        <Param name="correctAns" updates="constant" val="$same" valType="str"/>
         <Param name="syncScreenRefresh" updates="constant" val="True" valType="bool"/>
       </KeyboardComponent>
       <ImageComponent name="image_L_3">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_L_3" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[-.25, .2]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="FR.png" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[-.25, .2]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="0" valType="code"/>
+        <Param name="image" updates="set every repeat" val="FR.png" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <ImageComponent name="image_R_3">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_R_3" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[0.25, .2]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="-90" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="F.png" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0.25, .2]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="-90" valType="code"/>
+        <Param name="image" updates="set every repeat" val="F.png" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <TextComponent name="text_5">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="text_5" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val=".8" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="constant" val="Here, the letter on the right is a mirror image of the letter on the left. They would still be different after mentally rotating them to line up. So press 'm' (different). If they are the same, you would press 'n'. &amp;#10; &amp;#10;Try to respond as accurately as you can. Also try to be fast, but emphasize being accurate. Press 'n' to start." valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, -.2]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, -.2]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val="Here, the letter on the right is a mirror image of the letter on the left. They would still be different after mentally rotating them to line up. So press 'm' (different). If they are the same, you would press 'n'. &amp;#10; &amp;#10;Try to respond as accurately as you can. Also try to be fast, but emphasize being accurate. Press 'n' to start." valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.05" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val=".8" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
     </Routine>
     <Routine name="Practice">
       <CodeComponent name="code_2">
-        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="name" updates="None" val="code_2" valType="code"/>
+        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="Begin Routine" updates="constant" val="if same == 'n':&amp;#10;    limage = 'F.png'&amp;#10;    rimage = 'FR.png'&amp;#10;    if random() &gt; .5:&amp;#10;       rimage, limage = limage, rimage&amp;#10;else:&amp;#10;    limage = rimage = 'F.png'&amp;#10;    if random() &gt; .5:&amp;#10;        limage = rimage = 'FR.png'" valType="extendedCode"/>
+        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Routine" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Experiment" updates="constant" val="" valType="extendedCode"/>
-        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
       </CodeComponent>
       <KeyboardComponent name="key_resp_5">
-        <Param name="correctAns" updates="constant" val="$same" valType="str"/>
-        <Param name="storeCorrect" updates="constant" val="True" valType="bool"/>
         <Param name="name" updates="None" val="key_resp_5" valType="code"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="allowedKeys" updates="constant" val="'n','m'" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="allowedKeys" updates="constant" val="'n','m'" valType="code"/>
+        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="store" updates="constant" val="last key" valType="str"/>
+        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
+        <Param name="storeCorrect" updates="constant" val="True" valType="bool"/>
+        <Param name="correctAns" updates="constant" val="$same" valType="str"/>
         <Param name="syncScreenRefresh" updates="constant" val="True" valType="bool"/>
       </KeyboardComponent>
       <ImageComponent name="image_L_2">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_L_2" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[-.25, 0]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="leftori" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="$limage" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[-.25, 0]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="leftori" valType="code"/>
+        <Param name="image" updates="set every repeat" val="$limage" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <ImageComponent name="image_R_2">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_R_2" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[0.25, 0]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="rightori" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="$rimage" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0.25, 0]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="rightori" valType="code"/>
+        <Param name="image" updates="set every repeat" val="$rimage" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <TextComponent name="text_2">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="text_2" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="constant" val="'m' if mirror images of each other &amp;#10;'n' if both are the same" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, -.3]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, -.3]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val="'m' if mirror images of each other &amp;#10;'n' if both are the same" valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.03" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
     </Routine>
     <Routine name="the_end">
       <TextComponent name="text_3">
+        <Param name="name" updates="None" val="text_3" valType="code"/>
+        <Param name="startType" updates="None" val="time (s)" valType="str"/>
+        <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
+        <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
         <Param name="opacity" updates="constant" val="1" valType="code"/>
         <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="name" updates="None" val="text_3" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="constant" val="The end. &amp;#10; &amp;#10;Press space to see your data." valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="startType" updates="None" val="time (s)" valType="str"/>
         <Param name="ori" updates="constant" val="0" valType="code"/>
-        <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
-        <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="text" updates="constant" val="The end. &amp;#10; &amp;#10;Press space to see your data." valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.05" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
       <KeyboardComponent name="key_resp_2">
-        <Param name="correctAns" updates="constant" val="" valType="str"/>
-        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="None" val="key_resp_2" valType="code"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="allowedKeys" updates="constant" val="'space'" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="allowedKeys" updates="constant" val="'space'" valType="code"/>
+        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="store" updates="constant" val="nothing" valType="str"/>
+        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
+        <Param name="storeCorrect" updates="constant" val="False" valType="bool"/>
+        <Param name="correctAns" updates="constant" val="" valType="str"/>
         <Param name="syncScreenRefresh" updates="constant" val="True" valType="bool"/>
       </KeyboardComponent>
     </Routine>
     <Routine name="Trial">
       <CodeComponent name="code">
-        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="name" updates="None" val="code" valType="code"/>
+        <Param name="Begin Experiment" updates="constant" val="" valType="extendedCode"/>
         <Param name="Begin Routine" updates="constant" val="if same == 'n':&amp;#10;    limage = 'F.png'&amp;#10;    rimage = 'FR.png'&amp;#10;    if random() &gt; .5:&amp;#10;       rimage, limage = limage, rimage&amp;#10;else:&amp;#10;    limage = rimage = 'F.png'&amp;#10;    if random() &gt; .5:&amp;#10;        limage = rimage = 'FR.png'" valType="extendedCode"/>
+        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Routine" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Experiment" updates="constant" val="" valType="extendedCode"/>
-        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
       </CodeComponent>
       <KeyboardComponent name="Response">
-        <Param name="correctAns" updates="constant" val="('n','m')[$same=='n']" valType="str"/>
-        <Param name="storeCorrect" updates="constant" val="True" valType="bool"/>
         <Param name="name" updates="None" val="Response" valType="code"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="allowedKeys" updates="constant" val="'n','m'" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="allowedKeys" updates="constant" val="'n','m'" valType="code"/>
+        <Param name="discard previous" updates="constant" val="True" valType="bool"/>
         <Param name="store" updates="constant" val="last key" valType="str"/>
+        <Param name="forceEndRoutine" updates="constant" val="True" valType="bool"/>
+        <Param name="storeCorrect" updates="constant" val="True" valType="bool"/>
+        <Param name="correctAns" updates="constant" val="('n','m')[$same=='n']" valType="str"/>
         <Param name="syncScreenRefresh" updates="constant" val="True" valType="bool"/>
       </KeyboardComponent>
       <ImageComponent name="image_L">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_L" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[-.25, 0]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="leftori" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="$limage" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[-.25, 0]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="leftori" valType="code"/>
+        <Param name="image" updates="set every repeat" val="$limage" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <ImageComponent name="image_R">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
-        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
         <Param name="name" updates="constant" val="image_R" valType="code"/>
-        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
-        <Param name="pos" updates="constant" val="[0.25, 0]" valType="code"/>
-        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
-        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="set every repeat" val="rightori" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
-        <Param name="image" updates="set every repeat" val="$rimage" valType="str"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="$[1,1,1]" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0.25, 0]" valType="code"/>
         <Param name="size" updates="constant" val="[.3,.3]" valType="code"/>
+        <Param name="ori" updates="set every repeat" val="rightori" valType="code"/>
+        <Param name="image" updates="set every repeat" val="$rimage" valType="str"/>
+        <Param name="mask" updates="constant" val="raisedCos" valType="str"/>
+        <Param name="texture resolution" updates="constant" val="128" valType="code"/>
+        <Param name="interpolate" updates="constant" val="linear" valType="str"/>
+        <Param name="flipVert" updates="constant" val="False" valType="bool"/>
+        <Param name="flipHoriz" updates="constant" val="False" valType="bool"/>
       </ImageComponent>
       <TextComponent name="text">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="text" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="constant" val="'m' for &quot;different&quot; &amp;#10;'n' for &quot;same&quot;" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, -.3]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, -.3]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val="'m' for &quot;different&quot; &amp;#10;'n' for &quot;same&quot;" valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.03" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
       <CodeComponent name="add_data">
-        <Param name="Begin Experiment" updates="constant" val="data_string = 'angle,rt,corr\n'" valType="extendedCode"/>
         <Param name="name" updates="None" val="add_data" valType="code"/>
+        <Param name="Begin Experiment" updates="constant" val="data_string = 'angle,rt,corr\n'" valType="extendedCode"/>
         <Param name="Begin Routine" updates="constant" val="" valType="extendedCode"/>
+        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
         <Param name="End Routine" updates="constant" val="data_string += '%d,%.3f,%d\n' % (abs(angle), Response.rt, Response.corr)" valType="extendedCode"/>
         <Param name="End Experiment" updates="constant" val="" valType="extendedCode"/>
-        <Param name="Each Frame" updates="constant" val="" valType="extendedCode"/>
       </CodeComponent>
       <TextComponent name="trial_count">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="trial_count" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="black" valType="str"/>
-        <Param name="text" updates="set every repeat" val="$trials.thisN" valType="str"/>
-        <Param name="stopVal" updates="constant" val="" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[.4, -.4]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="black" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[.4, -.4]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="set every repeat" val="$trials.thisN" valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.03" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
     </Routine>
     <Routine name="pause_start">
       <TextComponent name="mini_pause_2">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="mini_pause_2" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="white" valType="str"/>
-        <Param name="text" updates="constant" val=" +" valType="str"/>
-        <Param name="stopVal" updates="constant" val="1.5" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="1.5" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="white" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val=" +" valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.05" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
     </Routine>
     <Routine name="licence">
       <TextComponent name="licence_info">
-        <Param name="opacity" updates="constant" val="1" valType="code"/>
-        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
         <Param name="name" updates="None" val="licence_info" valType="code"/>
-        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
-        <Param name="color" updates="constant" val="white" valType="str"/>
-        <Param name="text" updates="constant" val="AUTHORS: Jeremy R. Gray &amp; Nathaniel R. Pasmanter &amp;#10;CONTACT: jrgray@gmail.com &amp;#10; &amp;#10;COPYRIGHT (c) 2013 MICHIGAN STATE UNIVERSITY BOARD OF TRUSTEES &amp;#10;ALL RIGHTS RESERVED &amp;#10; &amp;#10;PERMISSION IS GRANTED TO USE, COPY, CREATE DERIVATIVE WORKS AND REDISTRIBUTE &amp;#10;THIS SOFTWARE AND SUCH DERIVATIVE WORKS FOR ANY PURPOSE, SO LONG AS NO FEE IS &amp;#10;CHARGED, AND SO LONG AS THE AUTHORSHIP AND COPYRIGHT NOTICE ABOVE, THIS GRANT &amp;#10;OF PERMISSION, AND THE DISCLAIMER BELOW APPEAR IN ALL COPIES MADE; AND SO LONG &amp;#10;AS THE NAME OF MICHIGAN STATE UNIVERSITY IS NOT USED IN ANY ADVERTISING OR &amp;#10;PUBLICITY PERTAINING TO THE USE OR DISTRIBUTION OF THIS SOFTWARE WITHOUT &amp;#10;SPECIFIC, WRITTEN PRIOR AUTHORIZATION. &amp;#10; &amp;#10;THIS SOFTWARE IS PROVIDED AS IS, WITHOUT REPRESENTATION FROM MICHIGAN STATE &amp;#10;UNIVERSITY AS TO ITS FITNESS FOR ANY PURPOSE, AND WITHOUT WARRANTY BY MICHIGAN &amp;#10;STATE UNIVERSITY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT &amp;#10;LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A &amp;#10;PARTICULAR PURPOSE. THE MICHIGAN STATE UNIVERSITY BOARD OF TRUSTEES SHALL NOT &amp;#10;BE LIABLE FOR ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR &amp;#10;CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING OUT OF OR IN &amp;#10;CONNECTION WITH THE USE OF THE SOFTWARE, EVEN IF IT HAS BEEN OR IS HEREAFTER &amp;#10;ADVISED OF THE POSSIBILITY OF SUCH DAMAGES." valType="str"/>
-        <Param name="stopVal" updates="constant" val="1.0" valType="code"/>
-        <Param name="durationEstim" updates="None" val="" valType="code"/>
-        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
-        <Param name="flip" updates="constant" val="" valType="str"/>
-        <Param name="startEstim" updates="None" val="" valType="code"/>
-        <Param name="units" updates="None" val="from exp settings" valType="str"/>
         <Param name="startType" updates="None" val="time (s)" valType="str"/>
-        <Param name="ori" updates="constant" val="0" valType="code"/>
         <Param name="stopType" updates="None" val="duration (s)" valType="str"/>
         <Param name="startVal" updates="None" val="0.0" valType="code"/>
+        <Param name="stopVal" updates="constant" val="1.0" valType="code"/>
+        <Param name="startEstim" updates="None" val="" valType="code"/>
+        <Param name="durationEstim" updates="None" val="" valType="code"/>
+        <Param name="units" updates="None" val="from exp settings" valType="str"/>
+        <Param name="color" updates="constant" val="white" valType="str"/>
+        <Param name="opacity" updates="constant" val="1" valType="code"/>
+        <Param name="colorSpace" updates="constant" val="rgb" valType="str"/>
+        <Param name="pos" updates="constant" val="[0, 0]" valType="code"/>
+        <Param name="ori" updates="constant" val="0" valType="code"/>
+        <Param name="text" updates="constant" val="AUTHORS: Jeremy R. Gray &amp; Nathaniel R. Pasmanter &amp;#10;CONTACT: jrgray@gmail.com &amp;#10; &amp;#10;COPYRIGHT (c) 2013 MICHIGAN STATE UNIVERSITY BOARD OF TRUSTEES &amp;#10;ALL RIGHTS RESERVED &amp;#10; &amp;#10;PERMISSION IS GRANTED TO USE, COPY, CREATE DERIVATIVE WORKS AND REDISTRIBUTE &amp;#10;THIS SOFTWARE AND SUCH DERIVATIVE WORKS FOR ANY PURPOSE, SO LONG AS NO FEE IS &amp;#10;CHARGED, AND SO LONG AS THE AUTHORSHIP AND COPYRIGHT NOTICE ABOVE, THIS GRANT &amp;#10;OF PERMISSION, AND THE DISCLAIMER BELOW APPEAR IN ALL COPIES MADE; AND SO LONG &amp;#10;AS THE NAME OF MICHIGAN STATE UNIVERSITY IS NOT USED IN ANY ADVERTISING OR &amp;#10;PUBLICITY PERTAINING TO THE USE OR DISTRIBUTION OF THIS SOFTWARE WITHOUT &amp;#10;SPECIFIC, WRITTEN PRIOR AUTHORIZATION. &amp;#10; &amp;#10;THIS SOFTWARE IS PROVIDED AS IS, WITHOUT REPRESENTATION FROM MICHIGAN STATE &amp;#10;UNIVERSITY AS TO ITS FITNESS FOR ANY PURPOSE, AND WITHOUT WARRANTY BY MICHIGAN &amp;#10;STATE UNIVERSITY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT &amp;#10;LIMITATION THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A &amp;#10;PARTICULAR PURPOSE. THE MICHIGAN STATE UNIVERSITY BOARD OF TRUSTEES SHALL NOT &amp;#10;BE LIABLE FOR ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR &amp;#10;CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING OUT OF OR IN &amp;#10;CONNECTION WITH THE USE OF THE SOFTWARE, EVEN IF IT HAS BEEN OR IS HEREAFTER &amp;#10;ADVISED OF THE POSSIBILITY OF SUCH DAMAGES." valType="str"/>
         <Param name="font" updates="constant" val="Arial" valType="str"/>
         <Param name="letterHeight" updates="constant" val="0.1" valType="code"/>
+        <Param name="wrapWidth" updates="constant" val="" valType="code"/>
+        <Param name="flip" updates="constant" val="" valType="str"/>
       </TextComponent>
     </Routine>
   </Routines>
@@ -490,15 +493,15 @@
     <Routine name="Intructions_2"/>
     <Routine name="pause_start"/>
     <LoopInitiator loopType="TrialHandler" name="trials">
-      <Param name="conditionsFile" updates="None" val="MentalRot.csv" valType="str"/>
       <Param name="name" updates="None" val="trials" valType="code"/>
-      <Param name="isTrials" updates="None" val="True" valType="bool"/>
-      <Param name="random seed" updates="None" val="" valType="code"/>
-      <Param name="loopType" updates="None" val="random" valType="str"/>
       <Param name="nReps" updates="None" val="6" valType="code"/>
+      <Param name="conditions" updates="None" val="[{'angle': 0, 'rightori': 0, 'leftori': 0, 'same': 'n'}, {'angle': 0, 'rightori': 0, 'leftori': 0, 'same': 'y'}, {'angle': 45, 'rightori': 45, 'leftori': 0, 'same': 'n'}, {'angle': 45, 'rightori': 45, 'leftori': 0, 'same': 'y'}, {'angle': 90, 'rightori': 90, 'leftori': 0, 'same': 'n'}, {'angle': 90, 'rightori': 90, 'leftori': 0, 'same': 'y'}, {'angle': 135, 'rightori': 135, 'leftori': 0, 'same': 'n'}, {'angle': 135, 'rightori': 135, 'leftori': 0, 'same': 'y'}, {'angle': 180, 'rightori': 180, 'leftori': 0, 'same': 'n'}, {'angle': 180, 'rightori': 180, 'leftori': 0, 'same': 'y'}, {'angle': 225, 'rightori': 225, 'leftori': 0, 'same': 'n'}, {'angle': 225, 'rightori': 225, 'leftori': 0, 'same': 'y'}, {'angle': 270, 'rightori': 270, 'leftori': 0, 'same': 'n'}, {'angle': 270, 'rightori': 270, 'leftori': 0, 'same': 'y'}, {'angle': 315, 'rightori': 315, 'leftori': 0, 'same': 'n'}, {'angle': 315, 'rightori': 315, 'leftori': 0, 'same': 'y'}]" valType="str"/>
+      <Param name="conditionsFile" updates="None" val="MentalRot.csv" valType="str"/>
       <Param name="endPoints" updates="None" val="[0, 1]" valType="num"/>
-      <Param name="conditions" updates="None" val="[{'angle': 0, 'rightori': 0, 'leftori': 0, 'same': u'n'}, {'angle': 0, 'rightori': 0, 'leftori': 0, 'same': u'y'}, {'angle': 45, 'rightori': 45, 'leftori': 0, 'same': u'n'}, {'angle': 45, 'rightori': 45, 'leftori': 0, 'same': u'y'}, {'angle': 90, 'rightori': 90, 'leftori': 0, 'same': u'n'}, {'angle': 90, 'rightori': 90, 'leftori': 0, 'same': u'y'}, {'angle': 135, 'rightori': 135, 'leftori': 0, 'same': u'n'}, {'angle': 135, 'rightori': 135, 'leftori': 0, 'same': u'y'}, {'angle': 180, 'rightori': 180, 'leftori': 0, 'same': u'n'}, {'angle': 180, 'rightori': 180, 'leftori': 0, 'same': u'y'}, {'angle': 225, 'rightori': 225, 'leftori': 0, 'same': u'n'}, {'angle': 225, 'rightori': 225, 'leftori': 0, 'same': u'y'}, {'angle': 270, 'rightori': 270, 'leftori': 0, 'same': u'n'}, {'angle': 270, 'rightori': 270, 'leftori': 0, 'same': u'y'}, {'angle': 315, 'rightori': 315, 'leftori': 0, 'same': u'n'}, {'angle': 315, 'rightori': 315, 'leftori': 0, 'same': u'y'}]" valType="str"/>
-      <Param name="Selected rows" updates="None" val="" valType="code"/>
+      <Param name="Selected rows" updates="None" val="" valType="str"/>
+      <Param name="loopType" updates="None" val="random" valType="str"/>
+      <Param name="random seed" updates="None" val="" valType="code"/>
+      <Param name="isTrials" updates="None" val="True" valType="bool"/>
     </LoopInitiator>
     <Routine name="Trial"/>
     <Routine name="pause"/>

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -148,6 +148,10 @@ def _onPygletKey(symbol, modifiers, emulated=False):
             return
         useText = False
         thisKey = thisKey.lstrip('_').lstrip('NUM_')
+        # Pyglet 1.3.0 returns 'enter' when Return key (0xFF0D) is pressed 
+        # in Python3.  So we have to replace 'enter' with 'return'.
+        if thisKey == 'enter':
+            thisKey = 'return'
         keySource = 'Keypress'
     _keyBuffer.append((thisKey, modifiers, keyTime))  # tuple
     logging.data("%s: %s" % (keySource, thisKey))

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -149,7 +149,7 @@ def _onPygletKey(symbol, modifiers, emulated=False):
         useText = False
         thisKey = thisKey.lstrip('_').lstrip('NUM_')
         # Pyglet 1.3.0 returns 'enter' when Return key (0xFF0D) is pressed 
-        # in Python3.  So we have to replace 'enter' with 'return'.
+        # in Windows Python3. So we have to replace 'enter' with 'return'.
         if thisKey == 'enter':
             thisKey = 'return'
         keySource = 'Keypress'

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -407,7 +407,7 @@ def fileOpenDlg(tryFilePath="",
     global app  # avoid recreating for every gui
     app = ensureWxApp()
     dlg = wx.FileDialog(None, prompt, tryFilePath, tryFileName, allowed,
-                        wx.FD_OPEN | wx.FILE_MUST_EXIST | wx.MULTIPLE)
+                        wx.FD_OPEN | wx.FD_FILE_MUST_EXIST | wx.FD_MULTIPLE)
     if dlg.ShowModal() == OK:
         # get names of images and their directory
         fullPaths = dlg.GetPaths()

--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -1010,7 +1010,10 @@ class RatingScale(MinimalStim):
         _tickStretch = self.tickMarks/self.hStretchTotal
         adjValue = value - self.offsetHoriz
         markerPos = adjValue * _tickStretch + self.tickMarks/2.0
-        rounded = round(markerPos * self.scaledPrecision)
+        # We need float value in getRating(), but round() returns
+        # numpy.float64 if argument is numpy.float64 in Python3.
+        # So we have to convert return value of round() to float.
+        rounded = float(round(markerPos * self.scaledPrecision))
         return rounded/self.scaledPrecision
 
     def _getMarkerFromTick(self, tick):


### PR DESCRIPTION
I've fixed several compatibility issues with Python3 and wxpython4.  I think I should send pull request before making further modification.  Following issues are fixed.

- Builder
  * StaticPeriod component doesn't work because `psychopy.clock` is not imported.
  * branchingDemo doesn't work due to inappropriate initial value in expInfo dialog in Python 3.
  * **Custom codes in mentalRot demo are incompatible with Python 3 (e.g. print sentence).**
  * .pkl condition file can't be read in Python 3.
  * Conditions dialog can't be opened in wxpython 4.
  * Layout of condition dialog is odd in wxpython 4.
- Coder
  * Coder can't reload file when the file is modified outside of PsychoPy due to encoding in Python 3.
- General
  * Pyglet recognizes `0xFF0D` as `'enter'` in Python 3 **(maybe environment-dependent? Ubunts 16.04LTS+python 3.5.2 doesn't seem to have this issue)**
  * **TrialHandler crashes because type of `stimOut` is `odict_keys` in Python 3.**
  * **RatingScale can't get marker from mouse position in Python 3 because `round()` returns `numpy.float64` in Python 3.**

I tested these fixes in following setups.
- Windows10, python 3.6.1 x64, wxpython 4.0.0
- Windows10, python 2.7.10 x86, wxpython 4.0.0
- Ubuntu 16.04LTS, python 3.5.2 x64, wxpython 4.0.0.

Non-bold issues are described in following threads.

- **Builder demos don't run in Python3**  #1617
- **Python3 compatibility issues** [https://discourse.psychopy.org/t/python3-compatibility-issues/3581](url)
- **How is the state of progress on migration to wxpython 4?** [https://discourse.psychopy.org/t/how-is-the-state-of-progress-on-migration-to-wxpython-4/3570/12](url)
