### PR TITLE
Test suite fully passed on Py3 / wx4 / openpyxl2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,6 @@ matrix:
       python: 3.6
       env: ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
 
-  allow_failures:
-
-    - os: linux
-      python: 2.7
-      env: ANACONDA=true WXPYTHON=4 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
-
-    - os: linux
-      python: 3.6
-      env: ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
-
 
 before_install:
   # System setup


### PR DESCRIPTION
Also anaconda is working. All 5 environments are now required to pass.

Thanks to @hoechenberger, @hsogo (and all the @psychopy/coredev) for their help getting us here.

I do not for a moment think that this is all the compatibility bugs fixed, but it's a really big step!