### PR TITLE
Configuration file to re-enable lgtm.com analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,17 @@
+# This configuration file contains configuration that enables Psychopy to be
+# analysed by lgtm.com (see https://lgtm.com/projects/g/psychopy/psychopy)
+#
+# More details on configuration options:
+# https://lgtm.com/docs/lgtm/lgtm-configuration-file
+
+extraction:
+  python: 
+    prepare: 
+      packages: 
+        - python-wxtools
+        - libgtk-3-dev
+        - mesa-common-dev
+        - libglu1-mesa-dev
+        - libgstreamer1.0-dev
+        - libgstreamer-plugins-base1.0-dev
+        - libwebkitgtk-3.0-dev

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,5 +1,5 @@
-# This configuration file contains configuration that enables Psychopy to be
-# analysed by lgtm.com (see https://lgtm.com/projects/g/psychopy/psychopy)
+# This file contains configuration that re-enables PsychoPy analysis on
+# lgtm.com (see https://lgtm.com/projects/g/psychopy/psychopy)
 #
 # More details on configuration options:
 # https://lgtm.com/docs/lgtm/lgtm-configuration-file


### PR DESCRIPTION
@boazmohar pinged us on the lgtm.com forums (https://discuss.lgtm.com/t/unable-to-build-psychopy/777). [I see](https://discourse.psychopy.org/t/static-code-analysis/3369) that you've been using [our analysis](https://lgtm.com/projects/g/psychopy/psychopy) results to improve PyschoPy — glad it's useful to you!

Recent changes (I think 38e87ce and/or 8d4d08f) to setup.py in PsychoPy meant that lgtm.com could no longer analyse the project due to some missing dependencies. We're working hard to improve the automatic detection and installation of dependencies, but in the meantime I've put together this configuration file that will give lgtm a nudge in the right direction. If you require more dependencies in the future, it's best to add them to this file. At the moment, lgtm uses the [Travis whitelist](https://github.com/travis-ci/apt-package-whitelist/raw/master/ubuntu-trusty) for Debian packages.

Do let me know if there's anything else I can help with! Full disclosure: I'm part of the lgtm team :smile: 