### PR TITLE
FF: json_tricks upstream is now fixed so relax version requirement

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -57,7 +57,7 @@ dependencies:
 - zlib
 - pip:
   - et-xmlfile
-  - json-tricks==3.8.0
+  - json-tricks
   - prompt-toolkit
   - pygame
   - pyglet==1.3.0b1

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -51,7 +51,7 @@ dependencies:
 - wxpython
 - zlib
 - pip:
-  - json-tricks==3.8.0
+  - json-tricks
   - pygame
   - pyglet==1.3.0b1
   - pyparallel

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -19,7 +19,7 @@ pycrsltd
 python-bidi
 cffi
 future
-json_tricks==3.8.0
+json_tricks
 codecov
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ required = ['requests[security]',
             'wxPython', 'pyglet', 'pygame', 'configobj',
             'soundfile', 'sounddevice',
             'python-bidi', 'cffi',
-            'future', 'json_tricks==3.8.0',
+            'future', 'json_tricks',
             'pyosf',
             'xlrd', 'openpyxl',  # MS Excel
             'pyserial', 'pyparallel',


### PR DESCRIPTION
It was just 3.11.0-3.11.1 that wzs broken? Version 3.11.2 is the current
default install and that works fine