### PR TITLE
BF: Fixes ratingscale customize everything bug for pos attribute.

### DIFF
--- a/psychopy/app/builder/components/ratingScale/__init__.py
+++ b/psychopy/app/builder/components/ratingScale/__init__.py
@@ -211,7 +211,7 @@ class RatingScaleComponent(BaseComponent):
             # clean it up a little, remove win=*, leading / trailing typos
             orig = self.params['customize_everything'].val
             custom = re.sub(r"[\\s,]*win=[^,]*,", '', orig)
-            init_str += ', ' + custom.lstrip('(, ').strip('), ')
+            init_str += ', ' + custom.lstrip('(, ').strip(', ')
         else:
             if self.params['marker'].val:
                 init_str += ', marker=%s' % repr(self.params['marker'].val)


### PR DESCRIPTION
Fixes bug wherein the closing brackets of the pos attribute were stripped during initialisation of ratingScale. Fixes #1227