### PR TITLE
FF: Coder can't open/paste text including non-ASCII characters

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1128,8 +1128,6 @@ class CodeEditor(wx.stc.StyledTextCtrl):
                 except:
                     # if not then wx conversion broke so get raw data instead
                     txt = dataObj.GetDataHere()
-            else:
-                print("pass!")
             self.ReplaceSelection(txt)
 
     def _GetSelectedLineNumbers(self):

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -33,6 +33,7 @@ import threading
 import bdb
 import pickle
 import py_compile
+import locale
 
 from . import psychoParser, introspect
 from .. import stdOutRich, dialogs
@@ -1123,7 +1124,7 @@ class CodeEditor(wx.stc.StyledTextCtrl):
             if not PY3:
                 try:
                     # if we can decode/encode to utf-8 then all is good
-                    txt.decode('utf-8')
+                    txt.encode('utf-8')
                 except:
                     # if not then wx conversion broke so get raw data instead
                     txt = dataObj.GetDataHere()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2230,12 +2230,21 @@ class CoderFrame(wx.Frame):
                                              readonly=readonly)
             # load text from document
             if os.path.isfile(filename):
-                with open(filename, 'rU') as f:
+                try:
                     if PY3:
-                        self.currentDoc.SetText(f.read())
+                        with open(filename, 'rU', encoding='utf8') as f:
+                            self.currentDoc.SetText(f.read())
+                            self.currentDoc.newlines = f.newlines
                     else:
-                        self.currentDoc.SetText(f.read().decode('utf8'))
-                    self.currentDoc.newlines = f.newlines
+                        with open(filename, 'rU') as f:
+                            self.currentDoc.SetText(f.read().decode('utf8'))
+                            self.currentDoc.newlines = f.newlines
+                except UnicodeDecodeError:
+                    dlg = dialogs.MessageDialog(self, message=_translate(
+                        'Failed to open {}. Make sure that encoding of '
+                        'the file is utf-8.').format(filename), type='Info')
+                    dlg.ShowModal()
+                    dlg.Destroy()
                 self.currentDoc.fileModTime = os.path.getmtime(filename)
                 self.fileHistory.AddFileToHistory(filename)
             else:

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1121,10 +1121,11 @@ class CodeEditor(wx.stc.StyledTextCtrl):
         clip.Close()
         if success:
             txt = dataObj.GetText()
-            if not PY3 and dataObj.GetFormat().GetType() != wx.DF_UNICODETEXT:
+            # dealing with unicode error in wx3 for Mac
+            if wx.__version__[0] == '3' and sys.platform == 'darwin':
                 try:
                     # if we can decode/encode to utf-8 then all is good
-                    txt.encode('utf-8')
+                    txt.decode('utf-8')
                 except:
                     # if not then wx conversion broke so get raw data instead
                     txt = dataObj.GetDataHere()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1121,13 +1121,15 @@ class CodeEditor(wx.stc.StyledTextCtrl):
         clip.Close()
         if success:
             txt = dataObj.GetText()
-            if not PY3:
+            if not PY3 and dataObj.GetFormat().GetType() != wx.DF_UNICODETEXT:
                 try:
                     # if we can decode/encode to utf-8 then all is good
                     txt.encode('utf-8')
                 except:
                     # if not then wx conversion broke so get raw data instead
                     txt = dataObj.GetDataHere()
+            else:
+                print("pass!")
             self.ReplaceSelection(txt)
 
     def _GetSelectedLineNumbers(self):

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -13,14 +13,14 @@ from sys import platform
 from psychopy import core, logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
-from ._base import _SoundBase
-
 try:
     import pyo
     import sounddevice
 except ImportError as err:
     # convert this import error to our own, pyo probably not installed
     raise exceptions.DependencyError(repr(err))
+
+from ._base import _SoundBase
 
 import atexit
 import sys


### PR DESCRIPTION
**1.** Coder can't open file which contains non-ASCII characters in Python 3 on OS whose default encoding is not UTF-8 (e.g. Windows).  Encoding (utf-8) must be specified to open such file in Python 3.

**2.** Coder can't paste text which contains non-ASCII characters in Python2. The variable `txt` in line 1126 of coder.py is unicode. So we have to  use `encode()`, not `decode()`.

**3.** Script that imports `psychopy.sound` causes RuntimeError when the script is finished when audio library is pyo and running on Windows10.  I experienced this error with pyo 0.8.8 in both of python 2 and 
Following single line is enough to replicate this phenomenon.

```
import psychopy.sound
```

This error doesn't occur when pyo 0.8.8 is directly imported (i.e. `import pyo`).  I investigated this issue and noticed that importing `psychopy.sound._base._SoundBase` before importing pyo causes this error.  Moving `from ._base import _SoundBase` below `import pyo`, the error doesn't occur.  I tested this fix on Ubuntu 16.04LTS and found no problem.