### PR TITLE
[BF] Replace registerPygletWindowHandles with registerWindowHandles

### DIFF
--- a/docs/source/api/iohub/starting.rst
+++ b/docs/source/api/iohub/starting.rst
@@ -22,7 +22,7 @@ function provides methods for controlling the iohub process and
 accessing iohub devices and events.
 
 .. autoclass:: ioHubConnection
-    :exclude-members: addDeviceToMonitor, getHubServerConfig, getExperimentID, getExperimentMetaData, getSessionMetaData, initializeConditionVariableTable, addRowToConditionVariableTable, registerPygletWindowHandles, unregisterPygletWindowHandles, wait
+    :exclude-members: addDeviceToMonitor, getHubServerConfig, getExperimentID, getExperimentMetaData, getSessionMetaData, initializeConditionVariableTable, addRowToConditionVariableTable, registerWindowHandles, unregisterWindowHandles, wait
     :members:
     :member-order: bysource
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1152,7 +1152,7 @@ class Window(object):
                 if IOHUB_ACTIVE and _hw_handle:
                     from psychopy.iohub.client import ioHubConnection
                     conn = ioHubConnection.ACTIVE_CONNECTION
-                    conn.unregisterPygletWindowHandles(_hw_handle)
+                    conn.unregisterWindowHandles(_hw_handle)
             except Exception:
                 pass
         else:
@@ -1580,7 +1580,7 @@ class Window(object):
                 if self._hw_handle not in winhwnds:
                     winhwnds.append(self._hw_handle)
                 conn = ioHubConnection.ACTIVE_CONNECTION
-                conn.registerPygletWindowHandles(*winhwnds)
+                conn.registerWindowHandles(*winhwnds)
 
     def _setupPygame(self):
         # we have to do an explicit import of pyglet.gl from pyglet


### PR DESCRIPTION
The ioHub server was previously changed renaming `registerPygletWindowHandles` to `registerWindowHandles` and `registerPygletWindowHandles` to `registerWindowHandles`: https://github.com/psychopy/psychopy/commit/55bbce6cab50d2ec1cc7661240cb8a8f26b74f32

This fixes a remaining reference to the old function names that otherwise causes a crash.

Issue appears to be present in 1.85.6