### PR TITLE
RF: Adds serialdevice string-to-byte conversion for Python 3

### DIFF
--- a/psychopy/hardware/cedrus.py
+++ b/psychopy/hardware/cedrus.py
@@ -158,12 +158,12 @@ class RB730(object):
 
     def measureRoundTrip(self):
         # round trip
-        self.sendMessage('e4')  # start round trip
+        self.sendMessage(b'e4')  # start round trip
         # wait for 'X'
         while True:
             if self.readMessage() == 'X':
                 break
-        self.sendMessage('X')  # send it back
+        self.sendMessage(b'X')  # send it back
 
         # wait for final time info
         msgBack = ''
@@ -185,15 +185,15 @@ class RB730(object):
         return keys
 
     def resetTrialTimer(self):
-        self.sendMessage('e5')
+        self.sendMessage(b'e5')
 
     def resetBaseTimer(self):
-        self.sendMessage('e1')
+        self.sendMessage(b'e1')
 
     def getBaseTimer(self):
         """Retrieve the current time on the base timer
         """
-        self.sendMessage('e3')
+        self.sendMessage(b'e3')
         # core.wait(0.05)
         localTimer = core.Clock()
 
@@ -206,6 +206,6 @@ class RB730(object):
     def getInfo(self):
         """Get the name of this device
         """
-        self.sendMessage('_d1')
+        self.sendMessage(b'_d1')
         core.wait(0.1)
         return self.readMessage()

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -430,7 +430,7 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         bits.mode = 'mono++' # 'color++', 'mono++', 'bits++', 'status'
 
     """
-    name = 'CRS Bits#'
+    name = b'CRS Bits#'
 
     def __init__(self, win=None, portName=None, mode='', checkConfigLevel=1,
                  gammaCorrect='hardware', gamma=None, noComms=False):
@@ -579,17 +579,17 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         self.read(timeout=0.5)  # clear input buffer
         info = {}
         # get product ('Bits_Sharp'?)
-        self.sendMessage('$ProductType\r')
+        self.sendMessage(b'$ProductType\r')
         time.sleep(0.1)
         info['ProductType'] = self.read().replace('#ProductType;', '')
         info['ProductType'] = info['ProductType'].replace(';\n\r', '')
         # get serial number
-        self.sendMessage('$SerialNumber\r')
+        self.sendMessage(b'$SerialNumber\r')
         time.sleep(0.1)
         info['SerialNumber'] = self.read().replace('#SerialNumber;', '')
         info['SerialNumber'] = info['SerialNumber'].replace('\x00\n\r', '')
         # get firmware date
-        self.sendMessage('$FirmwareDate\r')
+        self.sendMessage(b'$FirmwareDate\r')
         time.sleep(0.1)
         info['FirmwareDate'] = self.read().replace('#FirmwareDate;', '')
         info['FirmwareDate'] = info['FirmwareDate'].replace(';\n\r', '')
@@ -616,30 +616,30 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         elif ('mode' in self.__dict__) and value == self.mode:
             return  # nothing to do here. Move along please
         elif value == 'status':
-            self.sendMessage('$statusScreen\r')
+            self.sendMessage(b'$statusScreen\r')
             self.__dict__['mode'] = 'status'
             return
         elif 'storage' in value.lower():
-            self.sendMessage('$USB_massStorage\r')
+            self.sendMessage(b'$USB_massStorage\r')
             self.__dict__['mode'] = 'massStorage'
         elif value.startswith('bits'):
-            self.sendMessage('$BitsPlusPlus\r')
+            self.sendMessage(b'$BitsPlusPlus\r')
             self.__dict__['mode'] = 'bits++'
             self.setLUT()
         elif value.startswith('mono'):
             if not self.win.useFBO:
                 raise Exception("Mono++ " + requiresFBO)
-            self.sendMessage('$monoPlusPlus\r')
+            self.sendMessage(b'$monoPlusPlus\r')
             self.__dict__['mode'] = 'mono++'
         elif value.startswith('colo'):
             if not self.win.useFBO:
                 raise Exception("Color++ " + requiresFBO)
-            self.sendMessage('$colorPlusPlus\r')
+            self.sendMessage(b'$colorPlusPlus\r')
             self.__dict__['mode'] = 'color++'
         elif value.startswith('auto'):
             if not self.win.useFBO:
                 raise Exception("Auto++ " + requiresFBO)
-            self.sendMessage('$autoPlusPlus\r')
+            self.sendMessage(b'$autoPlusPlus\r')
             self.__dict__['mode'] = 'auto++'
         else:
             msg = ("Bits# doesn't know how to use mode "
@@ -679,9 +679,9 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
     @temporalDithering.setter
     def temporalDithering(self, value):
         if value:
-            self.sendMessage('$TemporalDithering=[ON]\r')
+            self.sendMessage(b'$TemporalDithering=[ON]\r')
         else:
-            self.sendMessage('$TemporalDithering=[OFF]\r')
+            self.sendMessage(b'$TemporalDithering=[OFF]\r')
         self.__dict__['temporalDithering'] = value
 
     @property
@@ -693,7 +693,7 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
 
     @gammaCorrectFile.setter
     def gammaCorrectFile(self, value):
-        self.sendMessage('$enableGammaCorrection=[%s]\r' % (value))
+        self.sendMessage(b'$enableGammaCorrection=[%s]\r' % (value))
         self.__dict__['gammaCorrectFile'] = value
 
     @property
@@ -707,14 +707,14 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
 
     @monitorEDID.setter
     def monitorEDID(self, value):
-        self.sendMessage('$setMonitorType=[%s]\r' % (value))
+        self.sendMessage(b'$setMonitorType=[%s]\r' % (value))
         self.__dict__['monitorEDID'] = value
 
     # functions
     def beep(self, freq=800, dur=1):
         """Make a beep of a given frequency and duration
         """
-        self.sendMessage('$Beep=[%i, %.4f]\r' % (freq, dur))
+        self.sendMessage(b'$Beep=[%i, %.4f]\r' % (freq, dur))
 
     def getVideoLine(self, lineN, nPixels, timeout=1.0, nAttempts=10):
         """Return the r,g,b values for a number of pixels on a particular
@@ -733,7 +733,7 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         # define sub-function oneAttempt
         def oneAttempt():
             self.com.flushInput()
-            self.sendMessage('$GetVideoLine=[%i, %i]\r' % (lineN, nPixels))
+            self.sendMessage(b'$GetVideoLine=[%i, %i]\r' % (lineN, nPixels))
             # the box implicitly ends up in status mode
             self.__dict__['mode'] = 'status'
             # prepare to read

--- a/psychopy/hardware/crs/colorcal.py
+++ b/psychopy/hardware/crs/colorcal.py
@@ -177,7 +177,7 @@ class ColorCAL(object):
 
         """
         # use a long timeout for measurement:
-        val = self.sendMessage('MES', timeout=5)
+        val = self.sendMessage(b'MES', timeout=5)
         vals = val.split(',')
         ok = (vals[0] == 'OK00')
         # transform raw x,y,z by calibration matrix
@@ -206,7 +206,7 @@ class ColorCAL(object):
         Other values will be a string or None.
 
         """
-        val = self.sendMessage('IDR').split(',')
+        val = self.sendMessage(b'IDR').split(',')
         ok = (val[0] == 'OK00')
         if ok:
             firmware = val[2]
@@ -247,7 +247,7 @@ class ColorCAL(object):
 
             ColorCAL.getNeedsCalibrateZero()
         """
-        val = self.sendMessage("UZC", timeout=1.0)
+        val = self.sendMessage(b"UZC", timeout=1.0)
         if val == 'OK00':
             pass
         elif val == 'ER11':

--- a/psychopy/hardware/minolta.py
+++ b/psychopy/hardware/minolta.py
@@ -153,7 +153,7 @@ class LS100(object):
                 time.sleep(0.2)
                 for n in range(10):
                     # set to use absolute measurements
-                    reply = self.sendMessage('MDS,04')
+                    reply = self.sendMessage(b'MDS,04')
                     if reply[0:2] == 'OK':
                         self.OK = True
                         break
@@ -174,13 +174,13 @@ class LS100(object):
 
         See user manual for other modes
         """
-        reply = self.sendMessage('MDS,%s' % mode)
+        reply = self.sendMessage(b'MDS,%s' % mode)
         return self.checkOK(reply)
 
     def measure(self):
         """Measure the current luminance and set .lastLum to this value
         """
-        reply = self.sendMessage('MES')
+        reply = self.sendMessage(b'MES')
         if self.checkOK(reply):
             lum = float(reply.split()[-1])
             return lum
@@ -195,7 +195,7 @@ class LS100(object):
     def clearMemory(self):
         """Clear the memory of the device from previous measurements
         """
-        reply = self.sendMessage('CLE')
+        reply = self.sendMessage(b'CLE')
         ok = self.checkOK(reply)
         return ok
 

--- a/psychopy/hardware/pr.py
+++ b/psychopy/hardware/pr.py
@@ -120,13 +120,13 @@ class PR650(object):
             logging.info("Successfully opened %s" % self.portString)
             time.sleep(0.1)  # wait while establish connection
             # turn on the backlight as feedback
-            reply = self.sendMessage('b1\n')
+            reply = self.sendMessage(b'b1\n')
             if reply != self.codes['OK']:
                 self._error("PR650 isn't communicating")
 
         if self.OK:
             # set command to make sure using right units etc...
-            reply = self.sendMessage('s01,,,,,,01,1')
+            reply = self.sendMessage(b's01,,,,,,01,1')
 
     def _error(self, msg):
         self.OK = False
@@ -164,12 +164,12 @@ class PR650(object):
         issued to retrieve info about that measurement.
         """
         t1 = time.clock()
-        reply = self.sendMessage('m0\n', timeOut)  # measure and hold data
+        reply = self.sendMessage(b'm0\n', timeOut)  # measure and hold data
         # using the hold data method the PR650 we can get interogate it
         # several times for a single measurement
 
         if reply == self.codes['OK']:
-            raw = self.sendMessage('d2')
+            raw = self.sendMessage(b'd2')
             xyz = raw.split(',')  # parse into words
             self.lastQual = str(xyz[0])
             if self.codes[self.lastQual] == 'OK':
@@ -216,7 +216,7 @@ class PR650(object):
         be passed to ``.parseSpectrumOutput()``. It's more efficient to
         parse R,G,B strings at once than each individually.
         """
-        raw = self.sendMessage('d5')  # returns a list where each list
+        raw = self.sendMessage(b'd5')  # returns a list where each list
         if parse:
             # skip the first 2 entries (info)
             return self.parseSpectrumOutput(raw[2:])
@@ -356,18 +356,18 @@ class PR655(PR650):
     def startRemoteMode(self):
         """Sets the Colorimeter into remote mode
         """
-        reply = self.sendMessage('PHOTO', timeout=10.0)
+        reply = self.sendMessage(b'PHOTO', timeout=10.0)
 
     def getDeviceType(self):
         """Return the device type (e.g. 'PR-655' or 'PR-670')
         """
-        reply = self.sendMessage('D111')  # returns errCode,
+        reply = self.sendMessage(b'D111')  # returns errCode,
         return _stripLineEnds(reply.split(',')[-1])  # last element
 
     def getDeviceSN(self):
         """Return the device serial number
         """
-        reply = self.sendMessage('D110')  # returns errCode,
+        reply = self.sendMessage(b'D110')  # returns errCode,
         return _stripLineEnds(reply.split(',')[-1])  # last element
 
     def sendMessage(self, message, timeout=0.5, DEBUG=False):
@@ -416,7 +416,7 @@ class PR655(PR650):
             :func:`~PR655.measure` automatically populates pr655.lastTristim
             with just the tristimulus coordinates
         """
-        result = self.sendMessage('D2')
+        result = self.sendMessage(b'D2')
         return result.split(',')
 
     def getLastUV(self):
@@ -429,7 +429,7 @@ class PR655(PR650):
             :func:`~PR655.measure` automatically populates pr655.lastUV
             with [u,v]
         """
-        result = self.sendMessage('D3')
+        result = self.sendMessage(b'D3')
         return result.split(',')
 
     def getLastXY(self):
@@ -443,7 +443,7 @@ class PR655(PR650):
             :func:`~PR655.measure` automatically populates pr655.lastXY
             with [x,y]
         """
-        result = self.sendMessage('D1')
+        result = self.sendMessage(b'D1')
         return result.split(',')
 
     def getLastSpectrum(self, parse=True):
@@ -460,7 +460,7 @@ class PR655(PR650):
             be passed to :func:`~PR655.parseSpectrumOutput`. It's more
             efficient to parse R,G,B strings at once than each individually.
         """
-        raw = self.sendMessage('D5')  # returns a list where each list
+        raw = self.sendMessage(b'D5')  # returns a list where each list
         if parse:
             # skip the first 2 entries (info)
             return self.parseSpectrumOutput(raw[2:])
@@ -479,7 +479,7 @@ class PR655(PR650):
             :func:`~PR655.measure` automatically populates
             pr655.lastColorTemp with the color temp in Kelvins
         """
-        result = self.sendMessage('D4')
+        result = self.sendMessage(b'D4')
         return result.split(',')
 
     def measure(self, timeOut=30.0):
@@ -492,7 +492,7 @@ class PR655(PR650):
             - `.lastCIExy`
             - `.lastCIEuv`
         """
-        reply = self.sendMessage('M0', timeout=30)
+        reply = self.sendMessage(b'M0', timeout=30)
         self.measured = True
         CIEuv = self.getLastUV()
         CIExy = self.getLastXY()

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -30,7 +30,7 @@ class SerialDevice(object):
     on known serial ports on the computer and test whether it has found the
     device using isAwake() (which the sub-classes need to implement).
     """
-    name = 'baseSerialClass'
+    name = b'baseSerialClass'
     longName = ""
     # list of supported devices (if more than one supports same protocol)
     driverFor = []
@@ -38,7 +38,7 @@ class SerialDevice(object):
     def __init__(self, port=None, baudrate=9600,
                  byteSize=8, stopBits=1,
                  parity="N",  # 'N'one, 'E'ven, 'O'dd, 'M'ask,
-                 eol="\n",
+                 eol=b"\n",
                  maxAttempts=1, pauseDuration=0.1,
                  checkAwake=True):
 
@@ -56,11 +56,13 @@ class SerialDevice(object):
             ports = [port]
 
         self.pauseDuration = pauseDuration
-        self.isOpen = False
         self.com = None
         self.OK = False
         self.maxAttempts = maxAttempts
-        self.eol = eol
+        if type(eol) is bytes:
+            self.eol = eol
+        else:
+            self.eol = bytes(eol, 'utf-8')
         self.type = self.name  # for backwards compatibility
 
         # try to open the port
@@ -154,13 +156,15 @@ class SerialDevice(object):
             inStr = self.com.read(self.com.inWaiting())
             msg = "Sending '%s' to %s but found '%s' on the input buffer"
             logging.warning(msg % (message, self.name, inStr))
+        if type(message) is not bytes:
+            message = bytes(message, 'utf-8')
         if not message.endswith(self.eol):
             message += self.eol  # append a newline if necess
         self.com.write(message)
         self.com.flush()
         if autoLog:
-            msg = 'Sent %s message:' % (self.name)
-            logging.debug(msg + message.replace(self.eol, ''))  # complete msg
+            msg = b'Sent %s message:' % (self.name)
+            logging.debug(msg + message.replace(self.eol, b''))  # complete msg
             # we aren't in a time-critical period so flush msg
             logging.flush()
 
@@ -188,3 +192,9 @@ class SerialDevice(object):
     def __del__(self):
         if self.com is not None:
             self.com.close()
+
+    @property
+    def isOpen(self):
+        if self.com is None:
+            return None
+        return self.com.isOpen()


### PR DESCRIPTION
Serial devices were failing to communicate using Python 3. By default, Python 2 stores strings as bytes and Python 3 stores strings as unicode. As serialdevice communicates using bytearrays, Python 3 strings must to be converted to bytes before being sent to serialdevice.