### PR TITLE
BF: Fixes add bug with experiment settings dialogue.

### DIFF
--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -560,7 +560,6 @@ class ListWidget(GlobSizer):
         """The plus button has been pressed
         """
         btn = self.FindItem(event.GetEventObject())
-
         row, col = btn.GetPos()
         self.InsertRow(row)
         newEntry = {}

--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -560,7 +560,8 @@ class ListWidget(GlobSizer):
         """The plus button has been pressed
         """
         btn = self.FindItem(event.GetEventObject())
-        row, col = btn.GetPosTuple()
+
+        row, col = btn.GetPos()
         self.InsertRow(row)
         newEntry = {}
         for fieldName in self.fieldNames:
@@ -573,7 +574,7 @@ class ListWidget(GlobSizer):
         """Called when the minus button is pressed.
         """
         btn = self.FindItem(event.GetEventObject())
-        row, col = btn.GetPosTuple()
+        row, col = btn.GetPos()
         self.DeleteRow(row)
         self.Layout()
         self.parent.Fit()


### PR DESCRIPTION
With Python 3, adding new elements for experiment info in experiment settings dialogue box raises an attribute error with GBSizerItem. This commit fixes the bug by replacing btn.GetPosTuple() with btn.GetPos(). No issues raised.