### PR TITLE
DOC: corrected PyPi name, pysounddevice to sounddevice

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -91,7 +91,7 @@ OR you could just install the subsets of packages that you want::
   pip install requests[security] pyosf
 
   # alternative audio (easier than pyo to install)
-  pip install cffi pysounddevice pysoundfile
+  pip install cffi sounddevice pysoundfile
 
 Handy extra options::
 


### PR DESCRIPTION
pysounddevice does not exist on PyPi, corrected the documentation

I'm not sure if it is by design but sounddevice does not appear in "...if you want **everything** available..." part?