### PR TITLE
FF: Custom builder components can't be imported

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -130,14 +130,17 @@ def getIcons(filename=None):
 
     return icons
 
-# load the icons for all the components
-compons = experiment.getAllComponents()
-componIcons = {}
-for thisName, thisCompon in compons.items():
-    if thisName in components.iconFiles:
-        componIcons[thisName] = getIcons(components.iconFiles[thisName])
-    else:
-        componIcons[thisName] = getIcons(None)
+def getAllIcons(folderList=()):
+    """load the icons for all the components
+    """
+    compons = experiment.getAllComponents(folderList)
+    componIcons = {}
+    for thisName, thisCompon in compons.items():
+        if thisName in components.iconFiles:
+            componIcons[thisName] = getIcons(components.iconFiles[thisName])
+        else:
+            componIcons[thisName] = getIcons(None)
+    return componIcons
 
 class RoutineCanvas(wx.ScrolledWindow):
     """Represents a single routine (used as page in RoutinesNotebook)"""
@@ -483,6 +486,7 @@ class RoutineCanvas(wx.ScrolledWindow):
         dc.SetId(id)
 
         iconYOffset = (6, 6, 0)[self.drawSize]
+        componIcons = getAllIcons(self.app.prefs.builder['componentsFolders'])
         thisIcon = componIcons[component.getType()]["{}".format(
             self.iconSize)]  # getType index 0 is main icon
         dc.DrawBitmap(thisIcon, self.iconXpos, yPos + iconYOffset, True)
@@ -804,6 +808,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
     def addComponentButton(self, name, panel):
         """Create a component button and add it to a specific panel's sizer
         """
+        componIcons = getAllIcons(self.app.prefs.builder['componentsFolders'])
         thisComp = self.components[name]
         shortName = name
         for redundant in ['component', 'Component']:

--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -94,7 +94,7 @@ def getComponents(folder=None, fetchIcons=True):
     """
     if folder is None:
         pth = folder = dirname(__file__)
-        pkg = 'psychopy.app.builder.components'
+        pkg = 'psychopy.experiment.components'
     else:
         # default shared location is often not actually a folder
         if not os.path.isdir(folder):
@@ -140,9 +140,9 @@ def getComponents(folder=None, fetchIcons=True):
 
         # importlib.import_module eases 2.7 -> 3.x migration
         if cmpfile.endswith('.py'):
-            explicit_rel_path = 'psychopy.experiment.components.' + cmpfile[:-3]
+            explicit_rel_path = pkg + '.' + cmpfile[:-3]
         else:
-            explicit_rel_path = 'psychopy.experiment.components.' + cmpfile
+            explicit_rel_path = pkg + '.' + cmpfile
         module = import_module(explicit_rel_path, package=pkg)
         # check for orphaned pyc files (__file__ is not a .py file)
         if module.__file__.endswith('.pyc'):


### PR DESCRIPTION
Builder window crashes if `componentsFolders` is set to load custom builder components.  Error message is:

> Traceback (most recent call last):
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\\_psychopyApp.py", line 487, in showBuilder
>     self.newBuilderFrame()
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\\_psychopyApp.py", line 473, in newBuilderFrame
>     fileName=fileName, app=self)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\builder\builder.py", line 1098, in \_\_init\_\_
>     self.componentButtons = ComponentsPanel(self)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\builder\builder.py", line 727, in \_\_init\_\_
>     self.app.prefs.builder['componentsFolders'])
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\experiment\components\\_\_init_\_.py", line 58, in getAllComponents
>     userComps = getComponents(folder)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\experiment\components\\_\_init_\_.py", line 146, in getComponents
>     module = import_module(explicit_rel_path, package=pkg)
>   File "C:\Users\Hiroyuki\Dropbox\WinPython-PsychoPy\python-2.7.10\lib\importlib\\_\_init_\_.py", line 37, in import_module
>     \_\_import\_\_(name)
> ImportError: No module named GazeParserCheck

In psychopy/experiment/components/\_\_init\_\_.py, component folders were not correctly used to import component.  In addition, icons of custom components weren't loaded.  These issues are fixed.

By the way, after applying this fix, my custom components still can't be imported with following error:

> Traceback (most recent call last):
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\\_psychopyApp.py", line 487, in showBuilder
>     self.newBuilderFrame()
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\\_psychopyApp.py", line 473, in newBuilderFrame
>     fileName=fileName, app=self)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\builder\builder.py", line 1098, in \_\_init\_\_
>     self.componentButtons = ComponentsPanel(self)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\builder\builder.py", line 727, in \_\_init\_\_
>     self.app.prefs.builder['componentsFolders'])
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\experiment\components\\_\_init\_\_.py", line 58, in getAllComponents
>     userComps = getComponents(folder)
>   File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\experiment\components\\_\_init\_\_.py", line 146, in getComponents
>     module = import_module(explicit_rel_path, package=pkg)
>   File "C:\Users\Hiroyuki\Dropbox\WinPython-PsychoPy\python-2.7.10\lib\importlib\\_\_init\_\_.py", line 37, in import_module
>     \_\_import\_\_(name)
>   File "C:/Users/hiroyuki/Desktop/GazeParserComponents\GazeParserComponents\GazeParserCheck.py", line 7, in <module>
>     from psychopy.app.builder.components._base import BaseVisualComponent, Param
> ImportError: No module named components._base

Do custom components have to be rewritten to import base classes of components from `psychopy.experiment.components` to support PsychoPy 1.90?