### PR TITLE
ENH: reduce chance that Display++ will time out (video line)

### DIFF
--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -716,7 +716,7 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         """
         self.sendMessage(b'$Beep=[%i, %.4f]\r' % (freq, dur))
 
-    def getVideoLine(self, lineN, nPixels, timeout=1.0, nAttempts=10):
+    def getVideoLine(self, lineN, nPixels, timeout=10.0, nAttempts=10):
         """Return the r,g,b values for a number of pixels on a particular
         video line
 


### PR DESCRIPTION
My otherwise-behaving Display++ is unable to return the pixel values within the previous default timeout - leaving it stuck at the status screen.