### PR TITLE
BF: allow Aperture to have uppercase letters in filename

### DIFF
--- a/psychopy/visual/aperture.py
+++ b/psychopy/visual/aperture.py
@@ -97,7 +97,7 @@ class Aperture(MinimalStim, ContainerMixin):
             self.units = win.units
 
         # set vertices using shape, or default to a circle with nVerts edges
-        if hasattr(shape, 'lower'):
+        if hasattr(shape, 'lower') and not os.path.isfile(shape):
             shape = shape.lower()
         if shape is None or shape == 'circle':
             # NB: pentagon etc point upwards by setting x,y to be y,x


### PR DESCRIPTION
Aperture would fail if provided a filename that contained upper case characters, because the argument is always converted to lower case.

Here, it checks that it is not a file before converting to lower case.