### PR TITLE
FF: fixed imports of experiment (moved out of builder) in test framework

### DIFF
--- a/psychopy/tests/test_app/test_builder/genComponsTemplate.py
+++ b/psychopy/tests/test_app/test_builder/genComponsTemplate.py
@@ -10,7 +10,8 @@ if parse_version(wx.__version__) < parse_version('2.9'):
     tmpApp = wx.PySimpleApp()
 else:
     tmpApp = wx.App(False)
-from psychopy.app import builder, projects, experiment
+from psychopy import experiment
+from psychopy.app import builder, projects
 from psychopy.experiment.components import getAllComponents
 
 # usage: generate or compare all Component.param settings & options


### PR DESCRIPTION
genComponentsTemplate didn't know about the change!

fixes #1713