### PR TITLE
FF: fix sound issues

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -378,13 +378,15 @@ class PrefCtrls(object):
                 options = copy.copy(value)
                 value = value[0]
                 try:
-                    from psychopy import sound
-                    if hasattr(sound, 'getDevices'):
-                        devs = sound.getDevices('output')
-                        for thisDevName in devs:
+                    # getting device name using sounddevice
+                    import sounddevice
+                    devices = sounddevice.query_devices()
+                    for device in devices:
+                        if device['max_output_channels'] > 0:
+                            thisDevName = device['name']
                             if thisDevName not in options:
                                 options.append(thisDevName)
-                except (ValueError, OSError, DependencyError):
+                except (ValueError, OSError, ImportError):
                     pass
             else:
                 options = spec.replace("option(", "").replace("'", "")

--- a/psychopy/demos/coder/input/latencyFromTone.py
+++ b/psychopy/demos/coder/input/latencyFromTone.py
@@ -35,7 +35,7 @@ microphone.switchOn()
 mic = microphone.AdvAudioCapture()
 
 # identify the hardware microphone in use:
-names, idx = sound.backend.pyo.pa_get_input_devices()
+names, idx = sound.backend.get_input_devices()
 inp = sound.backend.pyo.pa_get_default_input()
 msg = 'Speaker vol > 0\nAny key to start...\n\n"%s"' % names[idx.index(inp)]
 

--- a/psychopy/demos/coder/stimuli/soundStimuli.py
+++ b/psychopy/demos/coder/stimuli/soundStimuli.py
@@ -21,7 +21,7 @@ logging.console.setLevel(logging.DEBUG)  # get messages about the sound lib as i
 
 from psychopy import sound, core
 
-print('Using %s(with %s) for sounds' % (sound.audioLib, sound.audioDriver))
+print('Using %s (with %s) for sounds' % (sound.audioLib, sound.audioDriver))
 
 highA = sound.Sound('A', octave=3, sampleRate=44100, secs=0.8, stereo=True)
 highA.setVolume(0.8)

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -110,7 +110,7 @@ class AudioCapture(object):
         def run(self, filename, sec, sampletype=0, buffering=16,
                 chnl=0, chnls=2):
             self.running = True
-            # chnl from pyo.pa_get_input_devices()
+            # chnl from psychopy.sound.backend.get_input_devices()
             inputter = pyo.Input(chnl=chnl, mul=1)
             self.recorder = pyo.Record(inputter, filename, chnls=chnls,
                                        fileformat=0, sampletype=sampletype,

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -74,6 +74,7 @@ for thisLibName in prefs.general['audioLib']:
             from . import backend_pyo as backend
             Sound = backend.SoundPyo
             pyoSndServer = backend.pyoSndServer
+            audioDriver = backend.audioDriver
         elif thisLibName == 'sounddevice':
             from . import backend_sounddevice as backend
             Sound = backend.SoundDeviceSound

--- a/psychopy/sound/backend_pygame.py
+++ b/psychopy/sound/backend_pygame.py
@@ -80,14 +80,23 @@ class SoundPygame(_SoundBase):
     """
 
     def __init__(self, value="C", secs=0.5, octave=4, sampleRate=44100,
-                 bits=16, name='', autoLog=True, loops=0):
+                 bits=16, name='', autoLog=True, loops=0, stereo=True):
         """
         """
         self.name = name  # only needed for autoLogging
         self.autoLog = autoLog
+
+        if stereo == True:
+            stereoChans = 2
+        else:
+            stereoChans = 0
+        if bits == 16:
+            # for pygame bits are signed for 16bit, signified by the minus
+            bits = -16
+
         # check initialisation
         if not mixer.get_init():
-            pygame.mixer.init(sampleRate, -16, 2, 3072)
+            pygame.mixer.init(sampleRate, bits, stereoChans, 3072)
 
         inits = mixer.get_init()
         if inits is None:

--- a/psychopy/sound/backend_pysound.py
+++ b/psychopy/sound/backend_pysound.py
@@ -114,7 +114,7 @@ class SoundPySoundCard(_SoundBase):
 
     def __init__(self, value="C", secs=0.5, octave=4, sampleRate=44100,
                  bits=None, name='', autoLog=True, loops=0, bufferSize=128,
-                 volume=1):
+                 volume=1, stereo=True):
         """Create a sound and get ready to play
 
         :parameters:
@@ -164,6 +164,9 @@ class SoundPySoundCard(_SoundBase):
 
             volume: 0-1.0
 
+            stereo:
+                currently serves no purpose (exists for backwards
+                compatibility)
         """
         self.name = name  # only needed for autoLogging
         self.autoLog = autoLog

--- a/psychopy/voicekey/__init__.py
+++ b/psychopy/voicekey/__init__.py
@@ -82,7 +82,8 @@ class _BaseVoiceKey(object):
                     possible (by calling .save() but not called automatically upon
                     stopping
 
-                'chnl_in' : microphone channel; see pyo.pa_get_input_devices()
+                'chnl_in' : microphone channel;
+                    see psychopy.sound.backend.get_input_devices()
 
                 'chnl_out': not implemented; output device to use
 


### PR DESCRIPTION
Following issues are fixed.

- Pyo causes memory error in the configuration/benchmark wizard and the preference dialog.
- Coder's soundstimuli demo doesn't work with pysoundcard and pygame backend due to lack of 'stereo' parameter

Note: I tried to add warning dialog if pyo is selected as audio library in the preference dialog, but I reverted this modification because sounddevice is used in the preference dialog now and pyo is never imported.