### PR TITLE
BF: fix problem with wx3.0 somehow overwriting the preferred encoding

### DIFF
--- a/docs/source/about/credits.rst
+++ b/docs/source/about/credits.rst
@@ -32,11 +32,13 @@ Support and training providers
 
 Software projects aren't just about code. A great deal of work is done by the community in terms of supporting each other.
 
-You can see the most `active posters on the users list <https://groups.google.com/forum/#!aboutgroup/psychopy-users>`_ and those `answering PsychoPy questions on StackOverflow here <http://stackoverflow.com/tags/psychopy/info>`_ but notable examples that have done a fantastic job of supporting users:
+You can see the most `active posters on the user forum <https://discourse.psychopy.org/u?period=all`_ and those `answering PsychoPy questions on StackOverflow here <http://stackoverflow.com/tags/psychopy/info>`_ but notable examples that have done a fantastic job of supporting users:
+
     * Jeremy Gray (USA)
     * Mike MacAskill (New Zealand)
     * Jonas Lindeløv (Denmark)
     * Richard Höchenberger (Germany)
+
 If you need PsychoPy/Python workshop then these might be good people to contact (according to where you are) but please understand that we need to charge for running workshops because it takes us away form our "day jobs"
 
 Funding

--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -261,9 +261,11 @@ def wait(secs, hogCPUperiod=0.2):
 
     If you want to suppress checking for pyglet events during the wait,
     do this once::
+
         core.checkPygletDuringWait = False
 
     and from then on you can do::
+
         core.wait(sec)
 
     This will preserve terminal-window focus during command line usage.

--- a/psychopy/localization/__init__.py
+++ b/psychopy/localization/__init__.py
@@ -20,8 +20,8 @@ import os
 import glob
 import codecs
 from psychopy import logging, prefs, constants
-
 import wx
+import locale as locale_pkg
 
 def setLocaleWX():
     """Sets up the locale for the wx application. Only call this after the app
@@ -30,10 +30,16 @@ def setLocaleWX():
     :return: wx.Locale object
     """
     # set locale for wx app (before splash screen):
+    encod = locale_pkg.getpreferredencoding(do_setlocale=False)
     if locale.IsAvailable(languageID):
         wxlocale = wx.Locale(languageID)
     else:
         wxlocale = wx.Locale(wx.LANGUAGE_DEFAULT)
+    # wx.Locale on Py2.7/wx3.0 seems to delete the preferred encoding (utf-8)
+    # Check if that happened and reinstate if needed.
+    if locale_pkg.getpreferredencoding(do_setlocale=False) == '':
+        locale_pkg.setlocale(locale_pkg.LC_ALL,
+                             "{}.{}".format(codeFromWxId[languageID], encod))
     return wxlocale
 
 # Get a dict of locale aliases from wx.Locale() -- same cross-platform


### PR DESCRIPTION
Before calling wx.Locale() the locale.getpreferredencoding returns 'utf-8'
Immediately after, it returns '' but that causes matplotlib to fail (it
expects to get some encoding or None but not ''). We work around that by
detecting the preferred encoding and then, if it gets set to '' we revert
it to the original