### PR TITLE
BF: getMovieFrame('front') with useFBO=True returned wrong buffer

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -938,9 +938,9 @@ class Window(object):
         if buffer == 'back':
             GL.glReadBuffer(GL.GL_BACK)
         else:
-            GL.glReadBuffer(GL.GL_FRONT)
             if self.useFBO:
                 GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT, 0)
+            GL.glReadBuffer(GL.GL_FRONT)
 
         # fetch the data with glReadPixels
         # pyglet.gl stores the data in a ctypes buffer


### PR DESCRIPTION
effectively gave the screen one frame behind

See #1725 point number 5