### PR TITLE
BF: the use of adding a hex in Py3 doesn't work

### DIFF
--- a/psychopy/visual/backends/gamma.py
+++ b/psychopy/visual/backends/gamma.py
@@ -85,7 +85,7 @@ def setGammaRamp(screenID, newRamp, nAttempts=3, xDisplay=None):
         newRamp.byteswap(True)
         for n in range(nAttempts):
             success = windll.gdi32.SetDeviceGammaRamp(
-                0xFFFFFFFF & screenID, newRamp.ctypes)  # FB 504
+                screenID, newRamp.ctypes)  # FB 504
             if success:
                 break
         assert success, 'SetDeviceGammaRamp failed'
@@ -123,7 +123,7 @@ def getGammaRamp(screenID, xDisplay=None):
         # init R, G, and B ramps
         origramps = numpy.empty((3, rampSize), dtype=numpy.uint16)
         success = windll.gdi32.GetDeviceGammaRamp(
-            0xFFFFFFFF & screenID, origramps.ctypes)  # FB 504
+            screenID, origramps.ctypes)  # FB 504
         if not success:
             raise AssertionError('GetDeviceGammaRamp failed')
         origramps = origramps/65535.0  # rescale to 0:1

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -19,11 +19,12 @@ import os
 import numpy as np
 
 import psychopy
-from psychopy import logging, event, platform_specific
+from psychopy import logging, event, platform_specific, constants
 from psychopy.tools.attributetools import attributeSetter
 from .gamma import setGamma, setGammaRamp, getGammaRamp, getGammaRampSize
 from .. import globalVars
 from ._base import BaseBackend
+import codecs
 
 import pyglet
 # Ensure setting pyglet.options['debug_gl'] to False is done prior to any
@@ -326,7 +327,11 @@ class PygletBackend(BaseBackend):
         for the current Window
         """
         if sys.platform == 'win32':
-            _screenID = self.winHandle._dc
+            scrBytes = self.winHandle._dc
+            if constants.PY3:
+                _screenID = int.from_bytes(scrBytes, byteorder='little')
+            else:
+                _screenID = int(codecs.encode(scrBytes, 'hex'), 16)
         elif sys.platform == 'darwin':
             try:
                 _screenID = self.winHandle._screen.id  # pyglet1.2alpha1


### PR DESCRIPTION
The problem is how to convert a 4-byte value into an int, which is what
the 0xFFFFFFFF line was doing.
Instead, convert to int when returning the window handle from pyglet._dc