### PR TITLE
NF: Added CIEL*a*b* color space conversion.

### DIFF
--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -112,7 +112,8 @@ def cielab2rgb(lab, whiteXYZ=None, conversionMatrix=None, clip=False):
     elif orig_dim == 3:
         rgb_out = numpy.reshape(rgb_out, orig_shape)
 
-    return rgb_out
+    return rgb_out * 2.0 - 1.0
+
 
 def dkl2rgb(dkl, conversionMatrix=None):
     """Convert from DKL color space (Derrington, Krauskopf & Lennie) to RGB.


### PR DESCRIPTION
New function to convert CIEL*a*b* to RGB values. By default the conversion is between CIELAB and sRGB (BT. 709). You can specify your own conversion matrices and white point if needed (CIE XYZ 1931 working space). Any reasonable array (Nx3, NxNx3) can be converted. Output is in PsychoPy signed RGB values. 

Someone once requested this feature on the message boards, https://discourse.psychopy.org/t/rgb-to-cielab-conversion/3662/6