### PR TITLE
BF: Add importing pyglet.media.sources for pyglet 1.3

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -55,6 +55,17 @@ if sys.platform == 'win32':
         # AttributeError if using avbin5 from pyglet 1.2?
         haveAvbin = False
 
+    # for pyglet 1.3
+    if not haveAvbin:
+        try:
+            from pyglet.media.sources import avbin
+            haveAvbin = True
+        except ImportError:
+            haveAvbin = False
+        except AttributeError:
+            haveAvbin = False
+        except Exception:
+            haveAvbin = False
 
 import psychopy  # so we can get the __path__
 from psychopy import core, platform_specific, logging, prefs, monitors


### PR DESCRIPTION
I added importing pyglet.media.sources for pyglet 1.3.

"Pyglet.media import avbin" causes import error,
 because pyglet 1.3 has pyglet.media.sources.avbin instead of pyglet.media.avbin in pyglet 1.2 and 1.1.

The source of pyglet.media.sources.avbin of pyglet 1.3 
https://bitbucket.org/pyglet/pyglet/src/ab98c6b7478422acbf9b893f01c0e7778bc1ad9d/pyglet/media/sources/avbin.py?at=pyglet-1.3-maintenance&fileviewer=file-view-default