### PR TITLE
FF/BF: gamma ramps and monitor gamma

### DIFF
--- a/psychopy/visual/backends/gamma.py
+++ b/psychopy/visual/backends/gamma.py
@@ -55,6 +55,7 @@ def setGamma(
         newGamma.shape = [3, 1]
     elif type(newGamma) is numpy.ndarray:
         newGamma.shape = [3, 1]
+
     # create LUT from gamma values
     newLUT = numpy.tile(
         createLinearRamp(rampType=rampType, rampSize=rampSize, driver=driver),
@@ -63,6 +64,7 @@ def setGamma(
     if numpy.all(newGamma == 1.0) == False:
         # correctly handles 1 or 3x1 gamma vals
         newLUT = newLUT**(1.0/numpy.array(newGamma))
+
     setGammaRamp(screenID, newLUT, xDisplay=xDisplay)
 
 
@@ -198,13 +200,19 @@ def createLinearRamp(rampType=None, rampSize=256, driver=None):
     if rampType is None:
 
         # try to determine rampType from heuristics including sys info
-        if driver is not None:
 
-            osxVer = platform.mac_ver()[0]  # '' on non-Mac
+        osxVer = platform.mac_ver()[0]  # '' on non-Mac
 
-            # try to deduce ramp type
-            if osxVer:
-                osxVerTuple = _versionTuple(osxVer)
+        # try to deduce ramp type
+
+        # OSX
+        if osxVer:
+            osxVerTuple = _versionTuple(osxVer)
+
+            # driver provided
+            if driver is not None:
+
+                # nvidia
                 if 'NVIDIA' in driver:
                     # leopard nVidia cards don't finish at 1.0!
                     if _versionTuple("10.5") < osxVerTuple < _versionTuple("10.6"):
@@ -214,14 +222,18 @@ def createLinearRamp(rampType=None, rampSize=256, driver=None):
                         rampType = 3
                     else:
                         rampType = 1
+
                 else:  # is ATI or unkown manufacturer, default to (1:256)/256
                     # this is certainly correct for radeon2600 on 10.5.8 and
                     # radeonX1600 on 10.4.9
                     rampType = 1
-            else:  # is ATI or unknown manufacturer, default to (1:256)/256
+
+            else:  # is ATI or unkown manufacturer, default to (1:256)/256
                 # this is certainly correct for radeon2600 on 10.5.8 and
                 # radeonX1600 on 10.4.9
                 rampType = 1
+
+        # win32 or linux
         else:  # for win32 and linux this is sensible, not clear about Vista and Windows7
             rampType = 0
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1263,7 +1263,7 @@ class Window(object):
             self.useNativeGamma = False
         elif not self.monitor.gammaIsDefault():
             if self.monitor.getGamma() is not None:
-                self.__dict__['gamma'] = self.monitor.getGamma()
+                gammaVal = self.monitor.getGamma()
                 self.useNativeGamma = False
         else:
             self.__dict__['gamma'] = None  # gamma wasn't set anywhere


### PR DESCRIPTION
Two gamma-related issues:

1) #1736 changed the ramp type decision tree. It wasn't correct initially, but I think the update incorrectly set the win32 and linux ramp types to 1 when driver info was provided. Here, I've tried to clarify the tree.

~~2) If a window is created with a monitor object, the monitor's gamma value was not being used.~~

This was a side effect of 1).

I'll close this and reopen a separate PR for 1.