### PR TITLE
RF: Finalize CIELAB support and docs

### DIFF
--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -48,7 +48,7 @@ def unpackColors(colors):
     return colors, orig_shape, orig_dim
 
 
-def srgbTF(rgb, reverse=False):
+def srgbTF(rgb, reverse=False, **kwargs):
     """Apply sRGB transfer function (or gamma) to RGB values.
 
     Input values must have been transformed using a conversion matrix derived
@@ -86,7 +86,7 @@ def srgbTF(rgb, reverse=False):
     return to_return
 
 
-def rec709TF(rgb):
+def rec709TF(rgb, **kwargs):
     """Apply the Rec. 709 transfer function (or gamma) to linear RGB values.
 
     This transfer function is defined in the ITU-R BT.709 (2015) recommendation
@@ -139,14 +139,16 @@ def cielab2rgb(lab,
         white point is D65 if None is specified, defined as:
             X, Y, Z = 0.9505, 1.0000, 1.0890
     :param conversionMatrix: tuple, list or ndarray
-        3x3 conversion matrix to transform CIE-XYZ to RGB values. The default
-        matrix is sRGB with a D65 white point if None is specified.
+        3x3 conversion matrix to transform CIE-XYZ to linear RGB values. The
+        default matrix is sRGB with a D65 white point if None is specified.
     :param transferFunc: pyfunc or None
         Signature of the transfer function to use. If None, values are kept as
-        linear RGB. The transfer function must be appropriate for the conversion
-        matrix supplied. Additional arguments to 'transferFunc' can be passed by
-        specifying them as keyword arguments. See applicable gamma functions
-        'srgbTF' and 'rec709TF'.
+        linear RGB (it's assumed your display is gamma corrected via the
+        hardware CLUT). The TF must be appropriate for the conversion matrix
+        supplied (default is sRGB). Additional arguments to 'transferFunc' can
+        be passed by specifying them as keyword arguments. Gamma functions that
+        ship with PsychoPy are 'srgbTF' and 'rec709TF', see their docs for more
+        information.
     :param clip: boolean
         Make all output values representable by the display. However, colors
         outside of the display's gamut may not be valid!

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -126,8 +126,11 @@ def cielab2rgb(lab,
 
     CIEL*a*b* are first transformed into CIE XYZ (1931) color space, then the
     RGB conversion is applied. By default, the sRGB conversion matrix is used
-    (BT.709) with a reference D65 white point. You may specify your own RGB
-    conversion matrix and white point (in CIE XYZ) appropriate for your display.
+    with a reference D65 white point. You may specify your own RGB conversion
+    matrix and white point (in CIE XYZ) appropriate for your display.
+
+    Parameters
+    ----------
 
     :param lab: tuple, list or ndarray
         1-, 2-, 3-D vector of CIEL*a*b* coordinates to convert. The last
@@ -147,12 +150,20 @@ def cielab2rgb(lab,
         hardware CLUT). The TF must be appropriate for the conversion matrix
         supplied (default is sRGB). Additional arguments to 'transferFunc' can
         be passed by specifying them as keyword arguments. Gamma functions that
-        ship with PsychoPy are 'srgbTF' and 'rec709TF', see their docs for more
+        come with PsychoPy are 'srgbTF' and 'rec709TF', see their docs for more
         information.
     :param clip: boolean
         Make all output values representable by the display. However, colors
         outside of the display's gamut may not be valid!
     :return: array of RGB tristimulus values, or None
+
+    Example
+    -------
+
+    import psychopy.tools.colorspacetools as cst
+    cielabColor = (53.0, -20.0, 0.0)  # greenish color (L*, a*, b*)
+    # convert a CIEL*a*b* color to signed RGB with sRGB transfer function
+    rgbColor = cst.cielab2rgb(cielabColor, transferFunc=cst.srgbTF)
 
     """
     lab, orig_shape, orig_dim = unpackColors(lab)

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -456,7 +456,7 @@ class GLFWBackend(BaseBackend):
         # create linear LUT
         newLUT = np.tile(
             createLinearRamp(rampSize=self.getGammaRampSize()), (3, 1)
-        )
+        ).T
         if np.all(gamma == 1.0) == False:
             # correctly handles 1 or 3x1 gamma vals
             newLUT = newLUT ** (1.0 / np.array(gamma))


### PR DESCRIPTION
I finalized the style for specifying arbitrary transfer functions to color space conversion routines (so we don't need to ship all possible TFs) and wrote up some nicer docs. When I introduce additional color space routines, they'll all be structured similarly. Hopefully I can soon make CIELAB an actual working space for stimuli.