### PR TITLE
BF: was passing function rather than returned value

### DIFF
--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -186,7 +186,7 @@ class SerialDevice(object):
         elif length > 1:
             retVal = self.com.readlines()
         else:  # was -1?
-            retVal = self.com.read(self.com.inWaiting)
+            retVal = self.com.read(self.com.inWaiting())
         return retVal
 
     def __del__(self):


### PR DESCRIPTION
```getResponse``` in ```serialdevice.py``` was passing the function rather than the function's result, if requested to get all the buffer contents.