### PR TITLE
BF: iohub python 3 compatibility

### DIFF
--- a/psychopy/iohub/constants.py
+++ b/psychopy/iohub/constants.py
@@ -761,9 +761,9 @@ elif sys.platform == 'darwin':
         F4 = 131  # Keycode on Apple wireless kb
         VK_ISO_SECTION = 0x0A
         VK_JIS_YEN = 0x5D
-        VK_JIS_UNDERSCORE = 0x5E,
-        VK_JIS_KEYPAD_COMMA = 0x5F,
-        VK_JIS_EISU = 0x66,
+        VK_JIS_UNDERSCORE = 0x5E
+        VK_JIS_KEYPAD_COMMA = 0x5F
+        VK_JIS_EISU = 0x66
         VK_JIS_KANA = 0x68
         VK_RETURN = 0x24
         VK_TAB = 0x30

--- a/psychopy/iohub/devices/keyboard/darwin.py
+++ b/psychopy/iohub/devices/keyboard/darwin.py
@@ -24,7 +24,7 @@ except NameError:
 
 import unicodedata
 
-from darwinkey import code2label
+from .darwinkey import code2label
 
 #print2err("code2label: ",code2label)
 carbon_path = ctypes.util.find_library('Carbon')

--- a/psychopy/iohub/devices/keyboard/darwinkey.py
+++ b/psychopy/iohub/devices/keyboard/darwinkey.py
@@ -86,7 +86,8 @@ QZ_F3 = 160  # Keycode on Apple wireless kb
 QZ_F4 = 131  # Keycode on Apple wireless kb
 
 code2label = {}
-for k, v in locals().items():
+# need tp copy locals for py3
+for k, v in locals().copy().items():
     if k.startswith('QZ_'):
         klabel = u'' + k[3:].lower()
         code2label[klabel] = v


### PR DESCRIPTION
A few minor issues cropping up with iohub on Python 3:

1) trailing commas were causing a few of the keycodes to be represented as tuples, which was ignored in python 2 but in 3 gives:
```
TypeError: '>' not supported between instances of 'tuple' and 'int'
```

2) darwinkey needed to be a relative import

3) locals() returns a view in python 3, which means we can't change it when iterating over it. Explicitly creating a copy should preserve the old behavior.