### PR TITLE
BF: Removes unnamed columns for data.importConditions.

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -268,11 +268,15 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             # use pandas reader, which can handle commas in fields, etc
             trialsArr = pd.read_csv(fileUniv, encoding='utf-8')
             logging.debug(u"Read csv file with pandas: {}".format(fileName))
+            trialsArr = trialsArr.loc[:, ~trialsArr.columns.str.contains('^Unnamed: ')]  # clear unnamed cols
+            logging.debug(u"Clearing unnamed columns from {}".format(fileName))
             trialList, fieldNames = pandasToDictList(trialsArr)
 
     elif fileName.endswith(('.xlsx','.xls')) and haveXlrd:
         trialsArr = pd.read_excel(fileName)
         logging.debug(u"Read excel file with pandas: {}".format(fileName))
+        trialsArr = trialsArr.loc[:, ~trialsArr.columns.str.contains('^Unnamed: ')] # clear unnamed cols
+        logging.debug(u"Clearing unnamed columns from {}".format(fileName))
         trialList, fieldNames = pandasToDictList(trialsArr)
 
     elif fileName.endswith('.xlsx'):


### PR DESCRIPTION
The importConditions function uses Pandas to import data from csv or excel files. However, if a column header is empty, an incorrect Value Error is raised telling the user that column headers cannot contain punctuation or spaces. This is because Pandas names unnamed columns on import with names that contain spaces. To fix, unnamed columns are removed from the dataframe, assuming that columns are unnamed because the user does not want to use those columns in the experiment.