### PR TITLE
BF/RF: Only download ffmpeg if no local binary could be found

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -316,16 +316,20 @@ class PsychoPyApp(wx.App):
                                           args=(True,))
         versionsThread.start()
 
-        # if we have imageio then try to download ffmpeg
         try:
             import imageio
             haveImageio = True
-        except:
+        except ImportError:
             haveImageio = False
+
         if haveImageio:
-            # download() returns immediately if we have it already
-            ffmpegDownloader = threading.Thread(target=imageio.plugins.ffmpeg.download)
-            ffmpegDownloader.start()
+            # Use pre-installed ffmpeg if available.
+            # Otherwise, download ffmpeg binary.
+            try:
+                imageio.plugins.ffmpeg.get_exe()
+            except imageio.core.NeedDownloadError:
+                ffmpegDownloader = threading.Thread(target=imageio.plugins.ffmpeg.download)
+                ffmpegDownloader.start()
 
         ok, msg = checkCompatibility(last, self.version, self.prefs, fix=True)
         # tell the user what has changed


### PR DESCRIPTION
Previously, we would always use the downloaded version of ffmpeg with imageio. We now only download if no already installed binary could be found. Closes GH-1805.