### PR TITLE
fixed color specification of shapes using hex

### DIFF
--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -211,7 +211,7 @@ def setColor(obj, color, colorSpace=None, operation='',
             return
         elif color[0] == '#' or color[0:2] == '0x':
             # e.g. obj.rgb=[0,0,0]
-            setattr(obj, rgbAttrib, np.array(colors.hex2rgb255(color))- [1,1,1])
+            setattr(obj, rgbAttrib, np.array(colors.hex2rgb255(color)))
             obj.__dict__[colorSpaceAttrib] = 'hex'  # eg obj.colorSpace='hex'
             obj.__dict__[colorAttrib] = color  # eg Qr='#000000'
             setTexIfNoShaders(obj)


### PR DESCRIPTION
When specifying the color of shapes (circle/rectangle) using hex such as '#000000', this is converted to RGB tuple correctly using the `colors.hex2rgb()` function, but in the helper code, 1 is subtracted from the values, giving the wrong colors...