### PR TITLE
BF: Fixes Coder URL decomposition, and win.Close error.

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -480,7 +480,10 @@ class UnitTestFrame(wx.Frame):
         # "C:\Program Files\wxPython2.8 Docs and Demos\samples\hangman\hangman.py"
         tmpFilename, tmpLineNumber = evt.GetString().rsplit('", line ', 1)
         filename = tmpFilename.split('File "', 1)[1]
-        lineNumber = int(tmpLineNumber.split(',')[0])
+        if PY3:
+            lineNumber = int(tmpLineNumber.split(',')[0])
+        else:
+            lineNumber = int(tmpLineNumber.split()[0])
         self.app.coder.gotoLine(filename, lineNumber)
 
     def onCloseTests(self, evt):
@@ -2886,9 +2889,9 @@ class CoderFrame(wx.Frame):
         tmpFilename, tmpLineNumber = evt.GetString().rsplit('", line ', 1)
         filename = tmpFilename.split('File "', 1)[1]
         if PY3:
-            lineNumber = int(tmpLineNumber.split()[0])
-        else:
             lineNumber = int(tmpLineNumber.split(',')[0])
+        else:
+            lineNumber = int(tmpLineNumber.split()[0])
         self.gotoLine(filename, lineNumber)
 
     def onUnitTests(self, evt=None):

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -356,6 +356,10 @@ class PygletBackend(BaseBackend):
         """Close the window and uninitialize the resources
         """
 
+        # Check if window has device context and is thus not closed
+        if self.winHandle._dc is None:
+            return
+
         # restore the gamma ramp that was active when window was opened
         if not self._TravisTesting:
             self.gammaRamp = self._origGammaRamp

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -355,9 +355,8 @@ class PygletBackend(BaseBackend):
     def close(self):
         """Close the window and uninitialize the resources
         """
-
         # Check if window has device context and is thus not closed
-        if self.winHandle._dc is None:
+        if self.winHandle.context is None:
             return
 
         # restore the gamma ramp that was active when window was opened


### PR DESCRIPTION
Regarding the win.Close fix, a NoneType error was raised when repeated win.Close functions are called because the Windows device context is set to None on closure in the first instance, thus causing conversion of the device context to a screenID integer to fail in the second instance