### PR TITLE
BF: print(RunTimeInfo()) not working due to unicode/str error

### DIFF
--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -580,7 +580,7 @@ class RunTimeInfo(dict):
             # get keys for items matching this section label;
             #  use reverse-alpha order if easier to read:
             revSet = ('PsychoPy', 'Window', 'Python', 'OpenGL')
-            sectKeys.sort(key=str.lower, reverse=bool(sect in revSet))
+            sectKeys.sort(reverse=bool(sect in revSet))
             for k in sectKeys:
                 selfk = self[k]  # alter a copy for display purposes
                 try:


### PR DESCRIPTION
The code was trying to sort by lower() which wasn't necessary and
hard to implement in a way that supports Py2 and Py3 together

fixes #1825