### PR TITLE
BF: Fixes refcount issue with monitor centre. Fixes #1827.

### DIFF
--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -90,6 +90,7 @@ class SimpleGrid(grid.Grid):  # , wxGridAutoEditMixin):
         for nRow in range(self.nRows):
             for nCol in range(self.nCols):
                 self.SetCellEditor(nRow, nCol, self.numEditor)
+                self.numEditor.IncRef()
         self.setData(data)
         # self.SetMargins(-5,-5)
         self.Bind(wx.EVT_IDLE, self.OnIdle)


### PR DESCRIPTION
In monitor center, the SimpleGrid class needs to increment the refcount when the refcounted object, in this case the GridCellFloatEditor, is assigned to multiple objects, in this case the cell editor objects that exist in the grid cell. See https://github.com/wxWidgets/Phoenix/issues/627 for explanation. Fixes #1827.