### PR TITLE
DOC: clarifying the type of the .data attribute

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -107,8 +107,9 @@ class TrialHandler(_BaseTrialHandler):
 
         :Attributes (after creation):
 
-            .data - a dictionary of numpy arrays, one for each data type
-                stored
+            .data - a dictionary (or more strictly, a `DataHandler` sub-
+                class of a dictionary) of numpy arrays, one for each data 
+                type stored
 
             .trialList - the original list of dicts, specifying the conditions
 


### PR DESCRIPTION
Tiny change to document that the .data attribute of a `TrialHandler` is actually a `DataHandler` (a subclass of `dict`), rather than a standard dictionary, making it easier to understand why it has a `.add()` method and so on.