### PR TITLE
BF: Builder variables should not be used as the column name in condit…

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1570,6 +1570,23 @@ class DlgLoopProperties(_BaseParamsDlg):
                 self.conditionsFile = self.conditionsFileOrig
                 self.conditions = self.conditionsOrig
                 return  # no update or display changes
+            
+            # check for Builder variables
+            builderVariables = []
+            for condName in self.condNamesInFile:
+                if condName in self.exp.namespace.builder:
+                    builderVariables.append(condName)
+            if builderVariables:
+                msg = _translate('Builder variable(s) ({}) in file:{}'.format(
+                    ','.join(builderVariables), newFullPath.split(os.path.sep)[-1]))
+                self.currentCtrls['conditions'].setValue(msg)
+                msg = 'Rejected Builder variable(s) ({}) in file:{}'.format(
+                    ','.join(builderVariables), newFullPath.split(os.path.sep)[-1])
+                logging.error(msg)
+                self.conditionsFile = self.conditionsFileOrig
+                self.conditions = self.conditionsOrig
+                return  # no update or display changes
+            
             duplCondNames = []
             if len(self.condNamesInFile):
                 for condName in self.condNamesInFile:


### PR DESCRIPTION
Builder variables can be used as the column name in conditions file, which can cause annoying problems.  For example, using `filename` in the condition file as following, name of output files are overwritten.

![3](https://user-images.githubusercontent.com/2094930/41270582-ff3b9fae-6e46-11e8-8985-38003830a032.png)

I think that Builder must check whether Builder variables are included in the column names of conditions file.