### PR TITLE
BF/RF/ENH for qtgui.py

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -12,8 +12,7 @@ from __future__ import absolute_import, print_function
 from builtins import str
 from past.builtins import unicode
 try:
-    from PyQt4 import QtGui
-    QtWidgets = QtGui  # in qt4 these were all in one package
+    from PyQt4 import QtGui as QtWidgets  # in qt4 these were all in one package
     from PyQt4.QtCore import Qt
 except ImportError:
     from PyQt5 import QtWidgets
@@ -29,7 +28,7 @@ from psychopy.localization import _translate
 
 OK = QtWidgets.QDialogButtonBox.Ok
 
-qtapp = None
+qtapp = QtWidgets.QApplication.instance()
 
 
 def ensureQtApp():

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -22,7 +22,6 @@ except ImportError:
 
 from psychopy import logging
 import numpy as np
-import string
 import os
 import sys
 import json
@@ -78,8 +77,8 @@ class Dlg(QtWidgets.QDialog):
                  labelButtonCancel=_translate(" Cancel "),
                  screen=-1):
 
-        global app  # avoid recreating for every gui
-        app = ensureQtApp()
+        global qtapp  # avoid recreating for every gui
+        qtapp = ensureQtApp()
         QtWidgets.QDialog.__init__(self, None, Qt.WindowTitleHint)
 
         self.inputFields = []
@@ -191,11 +190,9 @@ class Dlg(QtWidgets.QDialog):
                         jtext = "[" + str(new_text) + "]"
                         self.data[ix] = json.loads(jtext)[0]
                     elif thisType == float:
-                        self.data[ix] = string.atof(str(new_text))
+                        self.data[ix] = float(str(new_text))
                     elif thisType == int:
-                        self.data[ix] = string.atoi(str(new_text))
-                    elif thisType == int:
-                        self.data[ix] = string.atol(str(new_text))
+                        self.data[ix] = int(str(new_text))
                     elif thisType == dict:
                         jtext = "[" + str(new_text) + "]"
                         self.data[ix] = json.loads(jtext)[0]

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -187,9 +187,9 @@ class Dlg(QtWidgets.QDialog):
                         jtext = "[" + str(new_text) + "]"
                         self.data[ix] = json.loads(jtext)[0]
                     elif thisType == float:
-                        self.data[ix] = float(str(new_text))
+                        self.data[ix] = float(new_text)
                     elif thisType == int:
-                        self.data[ix] = int(str(new_text))
+                        self.data[ix] = int(new_text)
                     elif thisType == dict:
                         jtext = "[" + str(new_text) + "]"
                         self.data[ix] = json.loads(jtext)[0]

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -34,11 +34,10 @@ qtapp = None
 
 def ensureQtApp():
     global qtapp
-    # make sure there's a wxApp prior to showing a gui, e.g., for expInfo
+    # make sure there's a QApplication prior to showing a gui, e.g., for expInfo
     # dialog
     if qtapp is None:
         qtapp = QtWidgets.QApplication(sys.argv)
-    return qtapp
 
 
 wasMouseVisible = True
@@ -77,8 +76,7 @@ class Dlg(QtWidgets.QDialog):
                  labelButtonCancel=_translate(" Cancel "),
                  screen=-1):
 
-        global qtapp  # avoid recreating for every gui
-        qtapp = ensureQtApp()
+        ensureQtApp()
         QtWidgets.QDialog.__init__(self, None, Qt.WindowTitleHint)
 
         self.inputFields = []
@@ -458,8 +456,7 @@ def fileSaveDlg(initFilePath="", initFileName="",
                    "txt (*.txt);;"
                    "pickled files (*.pickle *.pkl);;"
                    "shelved files (*.shelf)")
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
 
     fdir = os.path.join(initFilePath, initFileName)
     r = QtWidgets.QFileDialog.getSaveFileName(parent=None, caption=prompt,
@@ -496,8 +493,7 @@ def fileOpenDlg(tryFilePath="",
 
     If user cancels, then None is returned.
     """
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
 
     if allowed is None:
         allowed = ("All files (*.*);;"
@@ -521,29 +517,25 @@ def fileOpenDlg(tryFilePath="",
 
 
 def infoDlg(title=_translate("Information"), prompt=None):
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
     _pr = _translate("No details provided. ('prompt' value not set).")
     QtWidgets.QMessageBox.information(None, title, prompt or _pr)
 
 
 def warnDlg(title=_translate("Warning"), prompt=None):
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
     _pr = _translate("No details provided. ('prompt' value not set).")
     QtWidgets.QMessageBox.warning(None, title, prompt or _pr)
 
 
 def criticalDlg(title=_translate("Critical"), prompt=None):
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
     _pr = _translate("No details provided. ('prompt' value not set).")
     QtWidgets.QMessageBox.critical(None, title, prompt or _pr)
 
 
 def aboutDlg(title=_translate("About Experiment"), prompt=None):
-    global qtapp  # avoid recreating for every gui
-    qtapp = ensureQtApp()
+    ensureQtApp()
     _pr = _translate("No details provided. ('prompt' value not set).")
     QtWidgets.QMessageBox.about(None, title, prompt or _pr)
 


### PR DESCRIPTION
BF:
 - `string.ato*` were deprecated in python 2.0, and removed >= 3.0. I replaced them with `float()`/`int()`, where appropriate.

RF:
 - Simplified checks for existing QApplications (I don't think it's necessary to return anything if `qtapp` is global?)
 - Removed extra casts to string (superfluous without the `string.ato*` calls?)
 - Minor import cleanup

ENH:
 - Robustified against existing QApplications, i.e. if there's already one created by something else, we'll use that one


minimal example for the BF (from docs):

```python
from psychopy import gui

info = {'Observer':'jwp', 'GratingOri':45, 'ExpVersion': 1.1, 'Group': ['Test', 'Control']}

dictDlg = gui.DlgFromDict(dictionary=info, title='TestExperiment', fixed=['ExpVersion'])
# change something, e.g. GratingOri to 450

print(info)

# output on master (+ python 3.5):
#{'ExpVersion': 1.1, 'Observer': 'jwp', 'GratingOri': '450', 'Group': 'Test'}
#2.9157  ERROR   Error in handleLineEditChange: inputFieldName=GratingOri, type=<class 'int'>, value=450, error=module 'string' has no attribute 'atoi'

# output on branch:
#{'Observer': 'jwp', 'Group': 'Test', 'GratingOri': 450, 'ExpVersion': 1.1}
```
