### PR TITLE
FF: Builder cannot compile script

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2237,12 +2237,12 @@ class BuilderFrame(wx.Frame):
         # Compile script from command line using version
         compiler = 'psychopy.scripts.psyexpCompile'
         if not constants.PY3:
-            print(experimentPath, type(experimentPath))
-            experimentPath.decode(sys.getfilesystemencoding())
-        subprocess.check_output("python -m {} {} -v {} -o {}".format(compiler,
-                                                                     self.filename,
-                                                                     version,
-                                                                     experimentPath))
+            filename = self.filename.encode(sys.getfilesystemencoding())
+            experimentPath = experimentPath.encode(sys.getfilesystemencoding())
+        else:
+            filename = self.filename
+        subprocess.check_output(['python', '-m', compiler, filename,
+                                 '-v', version, '-o', experimentPath])
 
 
 class ReadmeFrame(wx.Frame):

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2234,14 +2234,23 @@ class BuilderFrame(wx.Frame):
         else:
             self.fileSave()  # Save on runFile otherwise changes to exp not included when run
         self.exp.expPath = os.path.abspath(expPath)
+
         # Compile script from command line using version
         compiler = 'psychopy.scripts.psyexpCompile'
-        if not constants.PY3:
+
+        if sys.platform == 'win32': # get name of executable
+            pythonExec = sys.executable
+        else:
+            pythonExec = sys.executable.replace(' ', '\ ')
+
+        if not constants.PY3: # encode path in Python2
             filename = self.filename.encode(sys.getfilesystemencoding())
             experimentPath = experimentPath.encode(sys.getfilesystemencoding())
         else:
             filename = self.filename
-        subprocess.check_output(['python', '-m', compiler, filename,
+
+        # run compile
+        subprocess.check_output([pythonExec, '-m', compiler, filename,
                                  '-v', version, '-o', experimentPath])
 
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2236,6 +2236,9 @@ class BuilderFrame(wx.Frame):
         self.exp.expPath = os.path.abspath(expPath)
         # Compile script from command line using version
         compiler = 'psychopy.scripts.psyexpCompile'
+        if not constants.PY3:
+            print(experimentPath, type(experimentPath))
+            experimentPath.decode(sys.getfilesystemencoding())
         subprocess.check_output("python -m {} {} -v {} -o {}".format(compiler,
                                                                      self.filename,
                                                                      version,

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2649,7 +2649,7 @@ class CoderFrame(wx.Frame):
 
         # check syntax by compiling - errors printed (not raised as error)
         try:
-            if type(fullPath) == bytes:
+            if not PY3 or type(fullPath) == bytes:
                 # py_compile.compile doesn't accept Unicode filename.
                 py_compile.compile(fullPath.encode(
                     sys.getfilesystemencoding()), doraise=False)


### PR DESCRIPTION
Two issues are fixed.

1) Builder cannot generate script in Python2 if non-ASCII characters are included in path.  This was fixed by encoding path string into file system coding in Python2.

2) Builder uses Python2 to generate script even when Builder is running on Python3 in Ubuntu (16.04 LTS).  This is because compile is done by "**python** -m psychopy.scripts.psyexpCompile ...".  In Ubuntu commad line should be "**python3** -m ...".  My fix is based on `_runFileAsProcess()` in psychopy/app/coder/coder.py.
