### PR TITLE
BF: Preference cannot be saved if newline character is included in the name of sound device

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -383,7 +383,8 @@ class PrefCtrls(object):
                     devices = sounddevice.query_devices()
                     for device in devices:
                         if device['max_output_channels'] > 0:
-                            thisDevName = device['name']
+                            # newline characters must be removed
+                            thisDevName = device['name'].replace('\r\n','')
                             if thisDevName not in options:
                                 options.append(thisDevName)
                 except (ValueError, OSError, ImportError):

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -112,7 +112,8 @@ def getDevices(kind=None):
     devs = {}
     for ii in allDevs:  # in pyo this is a dict but keys are ii ! :-/
         dev = allDevs[ii]
-        devName = dev['name']
+        # newline characters must be removed
+        devName = dev['name'].replace('\r\n','')
         devs[devName] = dev
         dev['id'] = ii
     return devs

--- a/psychopy/sound/backend_pysound.py
+++ b/psychopy/sound/backend_pysound.py
@@ -36,7 +36,9 @@ def getDevices(kind=None):
         if (dev['max_output_channels']==0 and kind=='output' or
                 dev['max_input_channels']==0 and kind=='input'):
             continue
-        devs[dev['name']] = dev
+        # newline characters must be removed
+        devName = dev['name'].replace('\r\n','')
+        devs[devName] = dev
         dev['id'] = ii
     return devs
 

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -45,7 +45,9 @@ def getDevices(kind=None):
     if type(allDevs) == dict:
         allDevs = [allDevs]
     for ii, dev in enumerate(allDevs):
-        devs[dev['name']] = dev
+        # newline characters must be removed
+        devName = dev['name'].replace('\r\n','')
+        devs[devName] = dev
         dev['id'] = ii
     return devs
 


### PR DESCRIPTION
I experienced the same error reported at [1.90.1 language localization locale](https://discourse.psychopy.org/t/1-90-1-language-localization-locale/4293).
There are some audio devices which have newline characters in their device name like below ('\r\n' follows 'Hands-Free%0').

`u'\u30d8\u30c3\u30c9\u30bb\u30c3\u30c8 (@System32\\drivers\\bthhfenum.sys,#2;%1 Hands-Free%0\r\n;(PLT_E500))'`

Such name causes "cannot be safely quoted" error in ConfigObj. 
To avoid this problem, '\r\n' in the name of audio devices should be removed.
