### PR TITLE
FF: Builder params (e.g. images) weren't being found in resources

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2355,8 +2355,10 @@ class BuilderFrame(wx.Frame):
         version = self.exp.settings.params['Use version'].val
         if version:
             cmd.extend(['-v', version])
-
+        logging.info(' '.join(cmd))
         out = subprocess.check_output(cmd)
+        print(out)  # so that any errors/debug messages in compile are printed
+
     def onPavloviaSync(self, evt=None):
         projectsPavlovia.syncPavlovia(parent=self, project=self.project)
 

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -637,7 +637,6 @@ class Experiment(object):
         join = os.path.join
         abspath = os.path.abspath
         srcRoot = os.path.split(self.filename)[0]
-
         def getPaths(filePath):
             """Helper to return absolute and relative paths (or None)
 
@@ -679,7 +678,8 @@ class Experiment(object):
                         return fileList
             paths = []
             # does it look at all like an excel file?
-            if (not isinstance(filePath, basestring) or filePath.split('.')[1] not in ['csv', 'xlsx', 'xls']):
+            if ( (not isinstance(filePath, basestring)) or
+                    (filePath.split('.')[1] not in ['csv', 'xlsx', 'xls']) ):
                 return paths
             thisFile = getPaths(filePath)
             # does it exist?
@@ -714,7 +714,8 @@ class Experiment(object):
             elif thisEntry.getType() == 'Routine':
                 # find all params of all compons and check if valid filename
                 for thisComp in thisEntry:
-                    for thisParam in thisComp.params:
+                    for paramName in thisComp.params:
+                        thisParam = thisComp.params[paramName]
                         thisFile = ''
                         if isinstance(thisParam, basestring):
                             thisFile = getPaths(thisParam)


### PR DESCRIPTION
We thought we were fetching the parameter, but we were actually only
fetching the *name* of the parameter (which was never a filename obvs!)