### PR TITLE
RF: Blendmode dropdown in noise component

### DIFF
--- a/psychopy/experiment/components/noise/__init__.py
+++ b/psychopy/experiment/components/noise/__init__.py
@@ -238,9 +238,8 @@ class NoiseStimComponent(BaseVisualComponent):
 
         msg = _translate("OpenGL Blendmode [avg, add (avg is most common mode in PsychoPy, add is used if you want to generate the sum of two components)]")
         self.params['blendmode'] = Param(
-            blendmode, valType='str', allowedTypes=[],
+            blendmode, valType='str', allowedVals=['avg', 'add'],
             updates='constant',
-            allowedVals=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['blendmode'], categ="Basic")


### PR DESCRIPTION
Changes the Blendmode entry in the noise component dialog to be drop down instead of text entry.
Brings this into line with other components.