### PR TITLE
DOC: Update builderTerminateLoops.rst

### DIFF
--- a/docs/source/recipes/builderTerminateLoops.rst
+++ b/docs/source/recipes/builderTerminateLoops.rst
@@ -13,8 +13,14 @@ Of course you need to check the condition for that with some form of `if` statem
 
 **Example 1**: You have a change-blindness study in which a pair of images flashes on and off, with intervening blanks, in a loop called `presentationLoop`. You record the key press of the subject with a :ref:`keyboard` called `resp1`. Using the 'ForceEndTrial' parameter of `resp1` you can end the current cycle of the loop but to end the loop itself you would need a :ref:`code`. Insert the following two lines in the `End Routine` parameter for the Code Component, which will test whether more than zero keys have been pressed::
 
-	if len(resp1.keys)>0:
+	if resp1.keys is not None and len(resp1.keys)>0 :
+    		trials.finished=1
+		
+or::	
+
+	if resp1.keys :
 		presentationLoop.finished=1
+		
 
 **Example 2**: Sometimes you may have more possible trials than you can actually display. By default, a loop will present all possible trials (nReps * length-of-list). If you only want to present the first 10 of all possible trials, you can use a code component to count how many have been shown, and then finish the loop after doing 10.
 


### PR DESCRIPTION
DOC: To prevent error :

if len(key_resp.keys) <1:
TypeError: Object of type 'NoneType' has no len()

As discussed in https://discourse.psychopy.org/t/error-feedback-has-syntax-error/1509 and https://groups.google.com/forum/#!msg/psychopy-users/jZDTXg8oXgY/8v94pS3YDQAJ