### PR TITLE
BF: Fixes error raised when stream inits with fewer chans than data

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -57,7 +57,8 @@ _localized = {'expName': _translate("Experiment name"),
               'Save psydat file':  _translate("Save psydat file"),
               'logging level': _translate("Logging level"),
               'Use version': _translate("Use PsychoPy version"),
-              'Completion URL': _translate("Completion URL")}
+              'Completion URL': _translate("Completion URL"),
+              'Force stereo': _translate("Force stereo")}
 
 thisFolder = os.path.split(__file__)[0]
 #
@@ -148,6 +149,10 @@ class SettingsComponent(object):
             hint=_translate("The version of PsychoPy to use when running "
                             "the experiment."),
             label=_localized["Use version"], categ='Basic')
+        self.params['Force stereo'] = Param(
+            enableEscape, valType='bool', allowedTypes=[],
+            hint=_translate("Force audio to stereo (2-channel) output"),
+            label=_localized["Force stereo"])
 
         # screen params
         self.params['Full-screen window'] = Param(

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -82,8 +82,8 @@ class SoundComponent(BaseComponent):
                 inits['stopVal'].val = -1
             elif float(inits['stopVal'].val) > 2:
                 inits['stopVal'].val = -1
-        buff.writeIndented("%s = sound.Sound(%s, secs=%s)\n" %
-                           (inits['name'], inits['sound'], inits['stopVal']))
+        buff.writeIndented("%s = sound.Sound(%s, secs=%s, stereo=%s)\n" %
+                           (inits['name'], inits['sound'], inits['stopVal'], self.exp.settings.params['Force stereo']))
         buff.writeIndented("%(name)s.setVolume(%(volume)s)\n" % (inits))
 
     def writeRoutineStartCode(self, buff):

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -2390,7 +2390,7 @@ ParallelOutComponent.order:['address', 'startData', 'stopData']
 ParallelOutComponent.address.default:'0x0378'
 ParallelOutComponent.address.allowedTypes:[]
 ParallelOutComponent.address.allowedUpdates:None
-ParallelOutComponent.address.allowedVals:[u'0x0378', u'0x03BC', u'/dev/parport0', u'/dev/parport1', u'LabJack U3']
+ParallelOutComponent.address.allowedVals:['0x0378', '0x03BC', 'LabJack U3']
 ParallelOutComponent.address.categ:Basic
 ParallelOutComponent.address.hint:Parallel port to be used (you can change these options in preferences>general)
 ParallelOutComponent.address.label:Port address
@@ -3360,6 +3360,18 @@ SettingsComponent.Experiment info.staticUpdater:None
 SettingsComponent.Experiment info.updates:None
 SettingsComponent.Experiment info.val:{'participant':'', 'session':'001'}
 SettingsComponent.Experiment info.valType:code
+SettingsComponent.Force stereo.default:True
+SettingsComponent.Force stereo.allowedTypes:[]
+SettingsComponent.Force stereo.allowedUpdates:None
+SettingsComponent.Force stereo.allowedVals:[]
+SettingsComponent.Force stereo.categ:Basic
+SettingsComponent.Force stereo.hint:Force audio to stereo (2-channel) output
+SettingsComponent.Force stereo.label:Force stereo
+SettingsComponent.Force stereo.readOnly:False
+SettingsComponent.Force stereo.staticUpdater:None
+SettingsComponent.Force stereo.updates:None
+SettingsComponent.Force stereo.val:True
+SettingsComponent.Force stereo.valType:bool
 SettingsComponent.Full-screen window.default:True
 SettingsComponent.Full-screen window.allowedTypes:[]
 SettingsComponent.Full-screen window.allowedUpdates:None
@@ -3519,7 +3531,7 @@ SettingsComponent.Units.valType:str
 SettingsComponent.Use version.default:''
 SettingsComponent.Use version.allowedTypes:[]
 SettingsComponent.Use version.allowedUpdates:None
-SettingsComponent.Use version.allowedVals:['latest', '3', '3.0', '', '3.0.0b1']
+SettingsComponent.Use version.allowedVals:['latest', '3', '3.0', '', '3.0.0b2']
 SettingsComponent.Use version.categ:Basic
 SettingsComponent.Use version.hint:The version of PsychoPy to use when running the experiment.
 SettingsComponent.Use version.label:Use PsychoPy version


### PR DESCRIPTION
This fix is specific to backend_sounddevice. The fix will raise an error
if channels in stream < data, because this causes problems when combining
the two arrays in the callback function. No problems if data file is mono and
stream is stereo.