### PR TITLE
add self._move.close()to MovieStim3._uload,

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -257,11 +257,11 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
         """
         if self.status != STOPPED:
             self.status = STOPPED
-            self._unload()
             self.reset()
             if log and self.autoLog:
                 self.win.logOnFlip("Set %s stopped" % (self.name),
                                    level=logging.EXP, obj=self)
+            self._unload()
 
     def setVolume(self, volume):
         pass  # to do
@@ -472,6 +472,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin):
             self.clearTextures()
         except Exception:
             pass
+        self._mov.close()
         self._mov = None
         self._numpyFrame = None
         self._audioStream = None


### PR DESCRIPTION
add self._mov.close() to MovieStim3._uload, move self._unload() in MovieStim3.stop after logging code.

Calling self._mov.close() seems to prevent invalid handle error in call to
ffmpeg_reader in moviepy module.

See
https://stackoverflow.com/questions/43966523/getting-oserror-winerror-6-the-handle-is-invalid-in-videofileclip-function