### PR TITLE
BF: Fix a potential type error on Python 3 installations, as outlined…

### DIFF
--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -333,7 +333,10 @@ class PygletBackend(BaseBackend):
         if sys.platform == 'win32':
             scrBytes = self.winHandle._dc
             if constants.PY3:
-                _screenID = 0xFFFFFFFF & int.from_bytes(scrBytes, byteorder='little')
+                try:
+                    _screenID = 0xFFFFFFFF & int.from_bytes(scrBytes, byteorder='little')
+                except TypeError:
+                    _screenID = 0xFFFFFFFF & scrBytes
             else:
                 try:
                     _screenID = 0xFFFFFFFF & scrBytes


### PR DESCRIPTION
…here: https://discourse.psychopy.org/t/typeerror-cannot-convert-int-object-to-byte/4340/5?u=blackyfuchsberger

Comment: In contrast to the solution suggested in the linked discussion, this bug fix uses exceptions in order reflect code that is found later in the file.