### PR TITLE
BF: Removed 'endSession' (Oculus Rift)

### DIFF
--- a/psychopy/demos/coder/hardware/RiftHeadTrackingExample.py
+++ b/psychopy/demos/coder/hardware/RiftHeadTrackingExample.py
@@ -76,5 +76,4 @@ while not stopApp:
         hmd.recenterTrackingOrigin()
 
 # cleanly end the session
-hmd.endSession()
 core.quit()

--- a/psychopy/demos/coder/hardware/RiftMinimal.py
+++ b/psychopy/demos/coder/hardware/RiftMinimal.py
@@ -33,5 +33,4 @@ while not stopApp:
         stopApp = True
 
 # cleanly end the session
-hmd.endSession()
 core.quit()

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -1336,16 +1336,6 @@ class Rift(window.Window):
             self._projectionMatrix = ovr.capi.getEyeProjectionMatrix(
                 0, self._nearClip, self._farClip)
 
-    def endSession(self):
-        """Safely close the VR session.
-
-        Returns
-        -------
-        None
-
-        """
-        ovr.capi.endSession()
-
     def controllerConnected(self, controller='xbox'):
         """Check if a given device is connected to the Haptics engine.
 


### PR DESCRIPTION
Calling "Rift.endSession()" crashes PsychXR since the last firmware update. I removed it for now and it appears to have no ill effect. 