### PR TITLE
ENH: Allow adjustment of Slider's marker size

### DIFF
--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -29,13 +29,18 @@ class Test_Slider(object):
             for l in s.labelObjs:
                 assert l.color == color
 
-            del s
-
     def test_change_color(self):
         s = Slider(self.win, color='black')
 
         with pytest.raises(AttributeError):
             s.color = 'blue'
+
+    def test_size(self):
+        sizes = [(1, 0.1), (1.5, 0.5)]
+
+        for size in sizes:
+            s = Slider(self.win, size=size)
+            assert s.size == size
 
     def test_change_size(self):
         s = Slider(self.win, size=(1, 0.1))
@@ -48,3 +53,10 @@ class Test_Slider(object):
 
         for marker_scaling_factor in marker_scaling_factors:
             s = Slider(self.win, markerScalingFactor=marker_scaling_factor)
+            assert s.markerScalingFactor == marker_scaling_factor
+
+    def test_change_marker_scaling_factor(self):
+        s = Slider(self.win, markerScalingFactor=1.0)
+
+        with pytest.raises(AttributeError):
+            s.markerScalingFactor = 0.5

--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -36,3 +36,15 @@ class Test_Slider(object):
 
         with pytest.raises(AttributeError):
             s.color = 'blue'
+
+    def test_change_size(self):
+        s = Slider(self.win, size=(1, 0.1))
+
+        with pytest.raises(AttributeError):
+            s.size = 1.5
+
+    def test_marker_scaling_factor(self):
+        marker_scaling_factors = [1, 1.0]
+
+        for marker_scaling_factor in marker_scaling_factors:
+            s = Slider(self.win, markerScalingFactor=marker_scaling_factor)

--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -41,7 +41,7 @@ class Test_Slider(object):
         s = Slider(self.win, size=(1, 0.1))
 
         with pytest.raises(AttributeError):
-            s.size = 1.5
+            s.size = (1.5, 0.5)
 
     def test_marker_scaling_factor(self):
         marker_scaling_factors = [1, 1.0]

--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -32,7 +32,7 @@ class Test_Slider(object):
             del s
 
     def test_change_color(self):
-        s = Slider(self.win)
+        s = Slider(self.win, color='black')
 
         with pytest.raises(AttributeError):
             s.color = 'blue'

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -142,9 +142,9 @@ class Slider(MinimalStim):
             self.units = units
 
         if size is None:
-            self.size = defaultSizes[self.units]
+            self._size = defaultSizes[self.units]
         else:
-            self.size = size
+            self._size = size
 
         self._markerScalingFactor = markerScalingFactor
         self.flip = flip
@@ -220,6 +220,13 @@ class Slider(MinimalStim):
         """ Color of the line/ticks/labels according to the color space.
         """
         return self._color
+
+    @property
+    def size(self):
+        """The size for the scale defines the area taken up by the line and
+            the ticks.
+        """
+        return self._size
 
     @property
     def markerScalingFactor(self):
@@ -556,7 +563,7 @@ class Slider(MinimalStim):
             marker_size = min(self.size)*2 * self.markerScalingFactor
             self.marker = ShapeStim(self.win, units=self.units,
                                     vertices=[[0,0],[0.5,0.5],[0.5,-0.5]],
-                                    size=min(self.size)*2,
+                                    size=marker_size,
                                     ori=ori,
                                     fillColor='DarkRed',
                                     lineColor='DarkRed')

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -58,7 +58,6 @@ class Slider(MinimalStim):
                  flip=False,
                  style='rating',
                  granularity=0,
-                 textSize=1.0,
                  readOnly=False,
                  color='LightGray',
                  font='Helvetica Bold',
@@ -70,7 +69,7 @@ class Slider(MinimalStim):
 
         Parameters
         ----------
-        win : psychopy.window
+        win : psychopy.visual.Window
             Into which the scale will be rendered
 
         ticks : list or tuple
@@ -100,23 +99,15 @@ class Slider(MinimalStim):
             By default the labels will be below or left of the line. This
             puts them above (or right)
 
-        granularity : int, float
+        granularity : int or float
             The smallest valid increments for the scale. 0 gives a continuous
             (e.g. "VAS") scale. 1 gives a traditional likert scale. Something
             like 0.1 gives a limited fine-grained scale.
-
-        marker : string or a psychopy visual object
-            'circle' or 'triangle' will result in these being created
-            Any PsychoPy visual object (gratings, images, shapes etc) can be
-            provided here instead though (use the same units as the scale).
 
         color :
             Color of the line/ticks/labels according to the color space
 
         font : font name
-
-        textSize : int, float
-            Size of the labels in whatever units you have set
 
         autodraw :
 
@@ -134,21 +125,24 @@ class Slider(MinimalStim):
         self.win = win
         self.ticks = np.asarray(ticks)
         self.labels = labels
+
         if pos is None:
             self.pos = (0, 0)
         else:
             self.pos = pos
-        if units:
-            self.units = units
-        else:
+
+        if units is None:
             self.units = win.units
+        else:
+            self.units = units
+
         if size is None:
             self.size = defaultSizes[self.units]
         else:
             self.size = size
+
         self.flip = flip
         self.granularity = granularity
-        self.textSize = textSize
         self._color = color
         self.font = font
         self.autoDraw = autoDraw
@@ -287,10 +281,11 @@ class Slider(MinimalStim):
             markerSize = (self._tickL, self._tickL * aspect)
         else:
             markerSize = self._tickL
+
         self.marker = Circle(self.win, units=self.units,
                              size=markerSize,
-                             color='red',
-                             )
+                             color='red')
+
         # create a rectangle to check for clicks
         self.validArea = Rect(self.win, units=self.units,
                               pos=self.pos,
@@ -512,20 +507,21 @@ class Slider(MinimalStim):
     def style(self, style):
         """Sets some predefined styles or use these to create your own.
 
-        Styles can be combined in a list e.g. ['whiteOnBlack','labels45']
-
-        Known styles currently include:
-
-            'triangleMarker': the marker is a triangle
-            'slider': looks more like an application slider control
-            'whiteOnBlack': a sort of color-inverse rating scale
-            'labels45' the text is rotated by 45 degrees
-
         If you fancy creating and including your own styles that would be great!
 
         Parameters
         ----------
         style: list of strings
+
+            Known styles currently include:
+
+                'rating': the marker is a circle
+                'triangleMarker': the marker is a triangle
+                'slider': looks more like an application slider control
+                'whiteOnBlack': a sort of color-inverse rating scale
+                'labels45' the text is rotated by 45 degrees
+
+            Styles can be combined in a list e.g. `['whiteOnBlack','labels45']`
 
         """
         self.__dict__['style'] = style
@@ -547,7 +543,7 @@ class Slider(MinimalStim):
                                     size=min(self.size)*2,
                                     ori=ori,
                                     fillColor='DarkRed',
-                                    lineColor='darkRed')
+                                    lineColor='DarkRed')
 
         if 'slider' in style:
             # make it more like a slider using a box instead of line
@@ -564,10 +560,10 @@ class Slider(MinimalStim):
                 markerW = self.size[0]*0.8
                 markerH = self.size[1]*0.1
             self.marker = Rect(self.win, units=self.units,
-                             width= markerW,
-                             height= markerH,
-                             fillColor='DarkSlateGray',
-                             lineColor='GhostWhite')
+                               width= markerW,
+                               height= markerH,
+                               fillColor='DarkSlateGray',
+                               lineColor='GhostWhite')
 
         if 'whiteOnBlack' in style:
             self.line.color = 'black'

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -55,6 +55,7 @@ class Slider(MinimalStim):
                  pos=None,
                  size=None,
                  units=None,
+                 markerScalingFactor=1.0,
                  flip=False,
                  style='rating',
                  granularity=0,
@@ -94,6 +95,10 @@ class Slider(MinimalStim):
             This also controls whether the scale is horizontal or vertical.
 
         units : the units to interpret the pos and size
+
+        markerScalingFactor : float
+            The factor by which to scale the marker size, relative to the
+            defaults.
 
         flip : bool
             By default the labels will be below or left of the line. This
@@ -141,6 +146,7 @@ class Slider(MinimalStim):
         else:
             self.size = size
 
+        self._markerScalingFactor = markerScalingFactor
         self.flip = flip
         self.granularity = granularity
         self._color = color
@@ -215,6 +221,13 @@ class Slider(MinimalStim):
         """
         return self._color
 
+    @property
+    def markerScalingFactor(self):
+        """The factor by which to scale the marker size, relative to the
+           defaults.
+        """
+        return self._markerScalingFactor
+
     def reset(self):
         """Resets the slider to its starting state (so that it can be restarted
         on each trial with a new stimulus)
@@ -278,12 +291,13 @@ class Slider(MinimalStim):
         if self.units == 'norm':
             # convert to make marker round
             aspect = self.win.size[0] / self.win.size[1]
-            markerSize = (self._tickL, self._tickL * aspect)
+            marker_size = np.array([self._tickL, self._tickL * aspect])
         else:
-            markerSize = self._tickL
+            marker_size = self._tickL
 
+        marker_size *= self.markerScalingFactor
         self.marker = Circle(self.win, units=self.units,
-                             size=markerSize,
+                             size=marker_size,
                              color='red')
 
         # create a rectangle to check for clicks
@@ -538,6 +552,8 @@ class Slider(MinimalStim):
                 ori = 180
             else:
                 ori = 0
+
+            marker_size = min(self.size)*2 * self.markerScalingFactor
             self.marker = ShapeStim(self.win, units=self.units,
                                     vertices=[[0,0],[0.5,0.5],[0.5,-0.5]],
                                     size=min(self.size)*2,
@@ -559,6 +575,9 @@ class Slider(MinimalStim):
             else:
                 markerW = self.size[0]*0.8
                 markerH = self.size[1]*0.1
+
+            markerW *= self.markerScalingFactor
+            markerH *= self.markerScalingFactor
             self.marker = Rect(self.win, units=self.units,
                                width= markerW,
                                height= markerH,

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -23,8 +23,9 @@ from .text import TextStim
 from ..tools.attributetools import logAttrib, setAttribute, attributeSetter
 from ..constants import FINISHED, STARTED, NOT_STARTED
 
+
 defaultSizes = {'norm': [1.0, 0.1]}
-knownStyles = []
+
 
 class Slider(MinimalStim):
     """A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale.
@@ -524,6 +525,7 @@ class Slider(MinimalStim):
 
     knownStyles = ['slider', 'rating', 'labels45', 'whiteOnBlack',
                    'triangleMarker']
+
     @attributeSetter
     def style(self, style):
         """Sets some predefined styles or use these to create your own.


### PR DESCRIPTION
Colleagues suggested that the default marker for `rating` was too big and that a larger marker for `slider` would look nicer. This PR adds the ability to adjust the marker size via a keyword argument.

Also included:

- `size` is now a readonly prop
- small style & doc cleanups, removed references to unused params