### PR TITLE
RF: fixed incorrect code styling in #1949

### DIFF
--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -49,11 +49,11 @@ class Test_Slider(object):
             s.size = (1.5, 0.5)
 
     def test_marker_scaling_factor(self):
-        marker_scaling_factors = [1, 1.0]
+        markerScalingFactors = [1, 1.0]
 
-        for marker_scaling_factor in marker_scaling_factors:
-            s = Slider(self.win, markerScalingFactor=marker_scaling_factor)
-            assert s.markerScalingFactor == marker_scaling_factor
+        for thisScalingFactor in markerScalingFactors:
+            s = Slider(self.win, markerScalingFactor=thisScalingFactor)
+            assert s.markerScalingFactor == thisScalingFactor
 
     def test_change_marker_scaling_factor(self):
         s = Slider(self.win, markerScalingFactor=1.0)

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -299,13 +299,13 @@ class Slider(MinimalStim):
         if self.units == 'norm':
             # convert to make marker round
             aspect = self.win.size[0] / self.win.size[1]
-            marker_size = np.array([self._tickL, self._tickL * aspect])
+            markerSize = np.array([self._tickL, self._tickL * aspect])
         else:
-            marker_size = self._tickL
+            markerSize = self._tickL
 
-        marker_size *= self.markerScalingFactor
+        markerSize *= self.markerScalingFactor
         self.marker = Circle(self.win, units=self.units,
-                             size=marker_size,
+                             size=markerSize,
                              color='red')
 
         # create a rectangle to check for clicks
@@ -562,10 +562,10 @@ class Slider(MinimalStim):
             else:
                 ori = 0
 
-            marker_size = min(self.size)*2 * self.markerScalingFactor
+            markerSize = min(self.size)*2 * self.markerScalingFactor
             self.marker = ShapeStim(self.win, units=self.units,
                                     vertices=[[0,0],[0.5,0.5],[0.5,-0.5]],
-                                    size=marker_size,
+                                    size=markerSize,
                                     ori=ori,
                                     fillColor='DarkRed',
                                     lineColor='DarkRed')


### PR DESCRIPTION
PEP8 says consistency within a project is the #1 priority :-)

For info, the fact that in tests we do use methods like`test_marker_scaling_factor` is because pytest/nose didn't used to support methods written in camelCase.