### PR TITLE
NF: Add file gltools.py

### DIFF
--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -48,7 +48,8 @@ def getDriverInfo():
 
 def blitFramebuffer(srcRect, dstRect, filter='linear'):
     """Copy a block of pixels between framebuffers via blitting. Read and draw
-    framebuffers must be bound prior to calling this function.
+    framebuffers must be bound prior to calling this function. Beware, the
+    scissor box and viewport are changed when this is called to dstRect.
 
     Parameters
     ----------

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -92,7 +92,7 @@ def blitFramebuffer(srcRect, dstRect, filter='linear'):
 
 
 def getIntegerv(parName):
-    """Get an integer parameter value, return it as a Python integer.
+    """Get a single integer parameter value, return it as a Python integer.
 
     Parameters
     ----------
@@ -107,11 +107,28 @@ def getIntegerv(parName):
     val = GL.GLint()
     GL.glGetIntegerv(parName, val)
 
-    return val.value
+    return int(val.value)
 
+def getFloatv(parName):
+    """Get a single float parameter value, return it as a Python float.
+
+    Parameters
+    ----------
+    pName : :obj:`float'
+        OpenGL property enum to query.
+
+    Returns
+    -------
+    int
+
+    """
+    val = GL.GLfloat()
+    GL.glGetFloatv(parName, val)
+
+    return float(val.value)
 
 def getString(parName):
-    """Get a string parameter value, return it as a Python UTF-8 string.
+    """Get a single string parameter value, return it as a Python UTF-8 string.
 
     Parameters
     ----------

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -61,12 +61,18 @@ def checkFramebufferComplete(fboId):
 
     """
     return GL.glCheckFramebufferStatus(GL.GL_FRAMEBUFFER) == \
-        GL.GL_FRAMEBUFFER_COMPLETE
+           GL.GL_FRAMEBUFFER_COMPLETE
 
 
 def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
     """Create a multisample framebuffer for rendering. Objects drawn to the
-    framebuffer will be anti-aliased if GL_MULTISAMPLE is active.
+    framebuffer will be anti-aliased if 'GL_MULTISAMPLE' is active. A combined
+    depth and stencil buffer is created with 'GL_DEPTH24_STENCIL8' format.
+
+    Multisampling is computationally intensive for your graphics hardware and
+    consumes substantial amounts of VRAM. Furthermore, samples must be
+    'resolved' prior to display by copying (using blitFramebuffer, see Examples)
+    to a non-multisample buffer.
 
     Parameters
     ----------
@@ -89,11 +95,12 @@ def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
     --------
     # create a multisample FBO with 8 samples
     msaaFbo, colorRb, depthRb = createMultisampleFBO(800, 600, 8)
-    GL.glBindFramebuffer(GL.GL_READ_FRAMEBUFFER, msaaFbo)
+    GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, msaaFbo)  # bind it
 
     # resolve samples into another framebuffer texture
+    GL.glBindFramebuffer(GL.GL_READ_FRAMEBUFFER, msaaFbo)
     GL.glBindFramebuffer(GL.GL_DRAW_FRAMEBUFFER, fbo)
-    blitFramebuffer((0, 0, 800, 600))
+    gltools.blitFramebuffer((0, 0, 800, 600))
 
     """
     # determine if the 'samples' value is valid
@@ -118,7 +125,7 @@ def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
     GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, fboId)
 
     # Color render buffer only instead of a texture. I can't think of a use case
-    # to pass around a multisampled texture.
+    # to pass around a multisampled texture (yet).
     colorRbId = GL.GLuint()
     GL.glGenRenderbuffers(1, ctypes.byref(colorRbId))
     GL.glBindRenderbuffer(GL.GL_RENDERBUFFER, colorRbId)
@@ -176,7 +183,7 @@ def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
 
 
 def createFBO(width, height, textureFormat="rgba8"):
-    """Generate a new Framebuffer object.
+    """Generate a new Framebuffer object (FBO).
 
     Returns
     -------

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -125,6 +125,3 @@ def getString(parName):
     val = ctypes.cast(GL.glGetString(parName), ctypes.c_char_p).value
     return val.decode('UTF-8')
 
-
-if __name__ == "__main__":
-    print(getDriverInfo())

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Helper functions for OpenGL operations.
+
+"""
+
+# Part of the PsychoPy library
+# Copyright (C) 2018 Jonathan Peirce
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import ctypes
+import pyglet.gl as GL
+
+
+def getDriverInfo():
+    """Get general information about the OpenGL implementation on this machine.
+    This should provide a consistent means of doing so regardless of the OpenGL
+    interface we are using.
+
+    Returns are dictionary with the following fields:
+
+        vendor, renderer, version, majorVersion, minorVersion, doubleBuffer,
+        maxTextureSize, stereo, maxSamples, extensions
+
+    Supported extensions are returned as a list in the GL_EXTENSIONS field. You
+    can check if a platform supports an extension by checking the membership of
+    the extension name in that list.
+
+    Returns
+    -------
+    dict
+
+    """
+    gl_info = {
+        "vendor": getString(GL.GL_VENDOR),
+        "renderer": getString(GL.GL_RENDERER),
+        "version": getString(GL.GL_VERSION),
+        "majorVersion": getIntegerv(GL.GL_MAJOR_VERSION),
+        "minorVersion": getIntegerv(GL.GL_MINOR_VERSION),
+        "doubleBuffer": getIntegerv(GL.GL_DOUBLEBUFFER),
+        "maxTextureSize": getIntegerv(GL.GL_MAX_TEXTURE_SIZE),
+        "stereo": getIntegerv(GL.GL_STEREO),
+        "maxSamples": getIntegerv(GL.GL_MAX_SAMPLES),
+        "extensions": [i for i in getString(GL.GL_EXTENSIONS).split(' ')]}
+
+    return gl_info
+
+
+def blitFramebuffer(srcRect, dstRect, filter='linear'):
+    """Copy a block of pixels between framebuffers via blitting. Read and draw
+    framebuffers must be bound prior to calling this function.
+
+    Parameters
+    ----------
+    srcRect : :obj:`list` of :obj:`int`
+    dstRect : :obj:`list` of :obj:`int`
+    filter : :obj:`str`
+        Interpolation method to use if the image is stretched, can be 'linear'
+        or 'nearest'.
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    # bind framebuffer to read pixels from
+    GL.glBindFramebuffer(GL.GL_READ_FRAMEBUFFER, srcFbo)
+
+    # bind framebuffer to draw pixels to
+    GL.glBindFramebuffer(GL.GL_DRAW_FRAMEBUFFER, dstFbo)
+
+    blitFramebuffer((0,0,800,600), (0,0,800,600))
+
+    # unbind both read and draw buffers
+    GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, 0)
+
+    """
+    # texture filters
+    filters = {'linear': GL.GL_LINEAR, 'nearest': GL.GL_NEAREST}
+
+    GL.glViewport(*dstRect)
+    GL.glEnable(GL.GL_SCISSOR_TEST)
+    GL.glScissor(*dstRect)
+    GL.glBlitFramebuffer(srcRect[0], srcRect[1], srcRect[2], srcRect[3],
+                         dstRect[0], dstRect[1], dstRect[2], dstRect[3],
+                         GL.GL_COLOR_BUFFER_BIT,  # colors only for now
+                         filters[filter])
+
+    GL.glDisable(GL.GL_SCISSOR_TEST)
+
+
+def getIntegerv(parName):
+    """Get an integer parameter value, return it as a Python integer.
+
+    Parameters
+    ----------
+    pName : :obj:`int'
+        OpenGL property enum to query (e.g. GL_MAJOR_VERSION).
+
+    Returns
+    -------
+    int
+
+    """
+    val = GL.GLint()
+    GL.glGetIntegerv(parName, val)
+
+    return val.value
+
+
+def getString(parName):
+    """Get a string parameter value, return it as a Python UTF-8 string.
+
+    Parameters
+    ----------
+    pName : :obj:`int'
+        OpenGL property enum to query (e.g. GL_VENDOR).
+
+    Returns
+    -------
+    str
+
+    """
+    val = ctypes.cast(GL.glGetString(parName), ctypes.c_char_p).value
+    return val.decode('UTF-8')
+
+
+if __name__ == "__main__":
+    print(getDriverInfo())

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -196,20 +196,6 @@ def createFBO(width, height, textureFormat="rgba8"):
     return fboId
 
 
-def createRenderbuffer():
-    """Generate a new Renderbuffer.
-
-    Returns
-    -------
-    int
-
-    """
-    rb_id = GL.GLuint()
-    GL.glGenRenderbuffers(1, ctypes.byref(rb_id))
-
-    return rb_id
-
-
 def blitFramebuffer(srcRect, dstRect=None, filter=GL.GL_LINEAR):
     """Copy a block of pixels between framebuffers via blitting. Read and draw
     framebuffers must be bound prior to calling this function. Beware, the
@@ -246,22 +232,19 @@ def blitFramebuffer(srcRect, dstRect=None, filter=GL.GL_LINEAR):
     GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, 0)
 
     """
-    # texture filters
-    filters = {'linear': GL.GL_LINEAR, 'nearest': GL.GL_NEAREST}
-
     # in most cases srcRect and dstRect will be the same.
     if dstRect is None:
         dstRect = srcRect
 
-    GL.glViewport(*dstRect)
-    GL.glEnable(GL.GL_SCISSOR_TEST)
-    GL.glScissor(*dstRect)
+    #GL.glViewport(*dstRect)
+    #GL.glEnable(GL.GL_SCISSOR_TEST)
+    #GL.glScissor(*dstRect)
     GL.glBlitFramebuffer(srcRect[0], srcRect[1], srcRect[2], srcRect[3],
                          dstRect[0], dstRect[1], dstRect[2], dstRect[3],
                          GL.GL_COLOR_BUFFER_BIT,  # colors only for now
-                         filters[filter])
+                         filter)
 
-    GL.glDisable(GL.GL_SCISSOR_TEST)
+    #GL.glDisable(GL.GL_SCISSOR_TEST)
 
 
 def getIntegerv(parName):

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -107,9 +107,9 @@ def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
     max_samples = getIntegerv(GL.GL_MAX_SAMPLES)
     if isinstance(samples, int):
         if (samples & (samples - 1)) != 0:
-            logging.error('Invalid number of samples, must be power-of-two.')
-        elif 0 > samples > max_samples:
-            logging.error('Invalid number of samples, must be <{}.'.format(
+            raise ValueError('Invalid number of samples, must be power-of-two.')
+        elif samples < 0 or samples > max_samples:
+            raise ValueError('Invalid number of samples, must be <{}.'.format(
                 max_samples))
         elif samples == 1:
             # warn that you are creating a single sample texture, use a regular
@@ -173,11 +173,12 @@ def createMultisampleFBO(width, height, samples, colorFormat=GL.GL_RGBA8):
 
     # check completeness
     if not checkFramebufferComplete(fboId):
-        logging.error('Failed to create a multi-sample framebuffer. Exiting.')
         # delete the framebuffer and all the resources associated with it
         GL.glDeleteRenderbuffers(1, colorRbId)
         GL.glDeleteRenderbuffers(1, depthRbId)
         GL.glDeleteFramebuffers(1, fboId)
+        raise RuntimeError(
+            'Failed to create a multisample framebuffer. Exiting.')
 
     return fboId, colorRbId, depthRbId
 
@@ -265,11 +266,11 @@ def createFBO(width, height, colorFormat=GL.GL_RGBA8):
 
     # check completeness
     if not checkFramebufferComplete(fboId):
-        logging.error('Failed to create a multi-sample framebuffer. Exiting.')
         # delete the framebuffer and all the resources associated with it
         GL.glDeleteTextures(1, colorTextureId)
         GL.glDeleteRenderbuffers(1, depthRbId)
         GL.glDeleteFramebuffers(1, fboId)
+        raise RuntimeError('Failed to create a framebuffer. Exiting.')
 
     return fboId, colorTextureId, depthRbId
 


### PR DESCRIPTION
The file 'gltools' contains OpenGL related helper functions. Notably functions for creating framebuffers to be used as off-screen render targets (including multisample FBOs). Having reusable code for these operations will come in handy for supporting a variety of stereo rendering routines. Everything was tested and seems to work fine, I've also fully documented the functions within.