### PR TITLE
 RF, BF: Ignore Num Lock in global key events

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -1168,6 +1168,7 @@ def _onGLFWKey(*args, **kwargs):
     _keyBuffer.append((key_name, modifiers, keyTime))  # tuple
     logging.data("%s: %s" % (keySource, key_name))
 
+
 def _onGLFWText(*args, **kwargs):
     """Handle unicode character events if _onGLFWKey() cannot.
 
@@ -1188,6 +1189,7 @@ def _onGLFWText(*args, **kwargs):
     keySource = 'KeyPress'
     _keyBuffer.append((text, keyTime))
     logging.data("%s: %s" % (keySource, text))
+
 
 def _onGLFWMouseButton(*args, **kwargs):
     """Callback for mouse press events. Both press and release actions are
@@ -1222,6 +1224,7 @@ def _onGLFWMouseButton(*args, **kwargs):
         elif button == glfw.MOUSE_BUTTON_RIGHT:
             mouseButtons[2] = 0
 
+
 def _onGLFWMouseScroll(*args, **kwargs):
     """Callback for mouse scrolling events. For most computer mice with scroll
     wheels, only the vertical (Y-offset) is relevant.
@@ -1233,17 +1236,20 @@ def _onGLFWMouseScroll(*args, **kwargs):
     msg = "Mouse: wheel shift=(%i,%i)"
     logging.data(msg % (x_offset, y_offset))
 
+
 def _getGLFWJoystickButtons(*args, **kwargs):
     """
     :return:
     """
     pass
 
+
 def _getGLFWJoystickAxes(*args, **kwargs):
     """
     :return:
     """
     pass
+
 
 if havePyglet:
     globalKeys = _GlobalEventKeys()

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -221,9 +221,7 @@ def _onPygletKey(symbol, modifiers, emulated=False):
 
 
 def _process_global_event_key(key, modifiers):
-    # The statement can be simplified to:
-    # `if modifiers == 0` once PR #1373 is merged.
-    if (modifiers is None) or (modifiers == 0):
+    if modifiers == 0:
         modifier_keys = ()
     else:
         modifier_keys = ['%s' % m.strip('MOD_').lower() for m in

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -228,6 +228,10 @@ def _process_global_event_key(key, modifiers):
                          (pyglet.window.key.modifiers_string(modifiers)
                           .split('|'))]
 
+        # Ignore Num Lock.
+        if 'numlock' in modifier_keys:
+            modifier_keys.remove('numlock')
+
     index_key = globalKeys._gen_index_key((key, modifier_keys))
 
     if index_key in globalKeys:
@@ -984,7 +988,7 @@ class _GlobalEventKeys(MutableMapping):
                       + string.punctuation + ' \t')
     _valid_keys.update(['escape', 'left', 'right', 'up', 'down'])
 
-    _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock', 'numlock',
+    _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock',
                         'scrolllock', 'command', 'option', 'windows'}
 
     def __init__(self):
@@ -1069,8 +1073,10 @@ class _GlobalEventKeys(MutableMapping):
 
         modifiers : collection of strings
             Modifier keys. Valid keys are:
-            'shift', 'ctrl', 'alt' (not on macOS), 'capslock', 'numlock',
+            'shift', 'ctrl', 'alt' (not on macOS), 'capslock',
             'scrolllock', 'command' (macOS only), 'option' (macOS only)
+
+            Num Lock is not supported.
 
         name : string
             The name of the event. Will be used for logging. If None,

--- a/psychopy/tests/test_events/test_keyboard_events.py
+++ b/psychopy/tests/test_events/test_keyboard_events.py
@@ -319,6 +319,16 @@ class TestGLobalEventKeys(object):
         assert index_key.key == key
         assert index_key.modifiers == modifiers
 
+    def test_numlock(self):
+        key = 'a'
+        modifiers = ('numlock',)
+        func = self._func
+
+        global_keys = event._GlobalEventKeys()
+
+        with pytest.raises(ValueError):
+            global_keys.add(key=key, modifiers=modifiers, func=func)
+
 
 if __name__ == '__main__':
     import pytest


### PR DESCRIPTION
Num Lock status seems to be "on" on Windows systems, leading to unexpected behavior. We now simply ignore Num Lock, don't consider it a valid user-specified modifier anymore. Closes GH-1792.
