### PR TITLE
BF: importConditions() should return list of fieldNames

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -769,9 +769,8 @@ class TrialHandler2(_BaseTrialHandler):
 
         :Parameters:
 
-            trialList: a simple list (or flat array) of dictionaries
-                specifying conditions. This can be imported from an
-                excel / csv file using :func:`~psychopy.data.importConditions`
+            trialList: filename or a simple list (or flat array) of
+                dictionaries specifying conditions
 
             nReps: number of repeats for all conditions
 
@@ -845,7 +844,9 @@ class TrialHandler2(_BaseTrialHandler):
         # user has hopefully specified a filename
         elif isinstance(trialList, basestring) and os.path.isfile(trialList):
             # import conditions from that file
-            self.trialList, self.columns = importConditions(trialList, True)
+            self.trialList, self.columns = importConditions(
+                trialList,
+                returnFieldNames=True)
         else:
             self.trialList = trialList
             self.columns = list(trialList[0].keys())

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -237,7 +237,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         if trialsArr.shape == ():
             # convert 0-D to 1-D with one element:
             trialsArr = trialsArr[np.newaxis]
-        fieldNames = trialsArr.dtype.names
+        fieldNames = list(trialsArr.dtype.names)
         _assertValidVarNames(fieldNames, fileName)
 
         # convert the record array into a list of dicts

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -430,6 +430,24 @@ class TestTrialHandler2Output(object):
 
         assert header == expected_header
 
+    def test_conditions_from_csv(self):
+        conditions_file = pjoin(fixturesPath, 'trialTypes.csv')
+        trials = data.TrialHandler2(conditions_file, nReps=1)
+
+        assert type(trials.columns) == list
+
+        for _ in trials:
+            pass
+
+    def test_conditions_from_xlsx(self):
+        conditions_file = pjoin(fixturesPath, 'trialTypes.xlsx')
+        trials = data.TrialHandler2(conditions_file, nReps=1)
+
+        assert type(trials.columns) == list
+
+        for _ in trials:
+            pass
+
 
 if __name__ == '__main__':
     pytest.main()


### PR DESCRIPTION
`data.utils.importConditions()` returned a tuple of `fieldNames`, but `TrialHandler2` expects a list (so it can `.append()` to it).