### PR TITLE
DOCS: Rift doc fixes.

### DIFF
--- a/docs/source/api/tools/rifttools.rst
+++ b/docs/source/api/tools/rifttools.rst
@@ -1,0 +1,18 @@
+
+:mod:`psychopy.tools.rifttools`
+------------------------------------
+.. automodule:: psychopy.tools.rifttools
+.. currentmodule:: psychopy.tools.rifttools
+    
+.. autodata:: ovrSizei
+.. autodata:: ovrRect
+.. autodata:: ovrVector3f
+.. autodata:: ovrMatrix4f
+.. autodata:: ovrQuat
+.. autodata:: ovrPosef
+.. autodata:: ovrFovPort
+
+.. autodata:: OVR_EYE_LEFT
+.. autodata:: OVR_EYE_RIGHT
+.. autodata:: OVR_HAND_LEFT
+.. autodata:: OVR_HAND_RIGHT

--- a/docs/source/api/visual/rift.rst
+++ b/docs/source/api/visual/rift.rst
@@ -16,9 +16,6 @@ Attributes
     Rift.resolution
     Rift.displayRefreshRate
     Rift.trackingOriginType
-    Rift.getTrackingOriginType
-    Rift.setTrackinOrigin
-    Rift.recenterTrackingOrigin
     Rift.shouldQuit
     Rift.isVisible
     Rift.isHmdMounted

--- a/docs/source/api/visual/rift.rst
+++ b/docs/source/api/visual/rift.rst
@@ -16,7 +16,17 @@ Attributes
     Rift.resolution
     Rift.displayRefreshRate
     Rift.trackingOriginType
-    
+    Rift.getTrackingOriginType
+    Rift.setTrackinOrigin
+    Rift.recenterTrackingOrigin
+    Rift.shouldQuit
+    Rift.isVisible
+    Rift.isHmdMounted
+    Rift.isHmdPresent
+    Rift.shouldRecenter
+    Rift.absTime
+    Rift.viewMatrix
+    Rift.projectionMatrix
         
 Details
 =============
@@ -24,4 +34,3 @@ Details
 .. autoclass:: Rift
     :members:
     :undoc-members:
-    :inherited-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ import sys, os, psychopy
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-    'sphinx.ext.imgmath']
+    'sphinx.ext.imgmath', 'sphinx.ext.napoleon']
 autoclass_content='both'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -86,7 +86,12 @@ add_module_names = True
 pygments_style = 'sphinx'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+#modindex_common_prefix =
+
+# NumPy-style doc settings.
+napoleon_numpy_docstring = True
+napoleon_include_private_with_doc = True
+napoleon_include_special_with_doc = False
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -808,10 +808,7 @@ class Rift(window.Window):
         GL.glEnable(GL.GL_BLEND)
 
     def setBuffer(self, buffer, clear=True):
-        """Set the active view and use the appropriate frustum settings. For
-        stereoscopic displays, this demuxes drawing commands to the appropriate
-        view buffer. Set clear=False to prevent clearing the buffer prior to
-        use.
+        """Set the active stereo draw buffer.
 
         Warning! The window.Window.size property will return the buffer's
         dimensions in pixels instead of the window's when setBuffer is set to

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -449,6 +449,7 @@ class Rift(window.Window):
 
     @property
     def trackingOriginType(self):
+        """Current tracking origin type."""
         return self.getTrackingOriginType()
 
     @trackingOriginType.setter


### PR DESCRIPTION
Set of Rift docs were missing a few commits, here are the rest. I also enabled support for NumPy style docstrings in the 'conf.py'. 