### PR TITLE
BF/RF: GLFW textstim and stencil buffer fixes

### DIFF
--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -258,7 +258,7 @@ class GLFWBackend(BaseBackend):
         win.multiSample = msaa_samples > 0
 
         # disable stencil buffer
-        if win.allowStencil:
+        if not win.allowStencil:
             win.stencilBits = 0
 
         # set buffer configuration hints

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -200,9 +200,9 @@ class GLFWBackend(BaseBackend):
                 vidmode_is_supported = True
                 break
 
-        _size, _bpc, _hz = glfw.get_video_mode(this_screen)
         if not vidmode_is_supported:
             # the requested video mode is not supported, use current
+            _size, _bpc, _hz = glfw.get_video_mode(this_screen)
             logging.warning(
                 ("The specified video mode is not supported by this display, "
                  "using native mode ..."))

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -175,7 +175,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # generate the texture and list holders
         self._listID = GL.glGenLists(1)
         # pygame text needs a surface to render to:
-        if not self.win.winType == "pyglet":
+        if not self.win.winType in ["pyglet", "glfw"]:
             self._texID = GL.GLuint()
             GL.glGenTextures(1, ctypes.byref(self._texID))
 
@@ -247,7 +247,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
         be a string specifying the name of the font (in system resources).
         """
         self.__dict__['font'] = None  # until we find one
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             self._font = pyglet.font.load(font, int(self._heightPix),
                                           dpi=72, italic=self.italic,
                                           bold=self.bold)
@@ -436,7 +436,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
         GL.glActiveTexture(GL.GL_TEXTURE1)
         GL.glEnable(GL.GL_TEXTURE_2D)
         GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             # unbind the main texture
             GL.glActiveTexture(GL.GL_TEXTURE0)
 #            GL.glActiveTextureARB(GL.GL_TEXTURE0_ARB)
@@ -449,7 +449,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
             GL.glBindTexture(GL.GL_TEXTURE_2D, self._texID)
             GL.glEnable(GL.GL_TEXTURE_2D)
 
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             GL.glActiveTexture(GL.GL_TEXTURE0)
             GL.glEnable(GL.GL_TEXTURE_2D)
             self._pygletTextObj.draw()
@@ -482,7 +482,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
         """
         desiredRGB = self._getDesiredRGB(self.rgb, self.colorSpace,
                                          self.contrast)
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             self._pygletTextObj = pyglet.font.Text(
                 self._font, self.text,
                 halign=self.alignHoriz, valign=self.alignVert,
@@ -552,7 +552,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
             top = self._fontHeightPix
         # there seems to be a rounding err in pygame font textures
         Btex, Ttex, Ltex, Rtex = -0.01, 0.98, 0, 1.0
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             # unbind the mask texture
             GL.glActiveTexture(GL.GL_TEXTURE1)
             GL.glEnable(GL.GL_TEXTURE_2D)
@@ -570,7 +570,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
             GL.glEnable(GL.GL_TEXTURE_2D)
             GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
 
-        if self.win.winType == "pyglet":
+        if self.win.winType in ["pyglet", "glfw"]:
             self._pygletTextObj.draw()
         else:
             # draw a 4 sided polygon


### PR DESCRIPTION
Made changes which allow the Pyglet text renderer to be used with GLFW. Seems to work fine after running a bunch of demos. Also fixed a bug where the depth of the stencil buffer was incorrectly set when opening a GLFW window. That made the 'allowStencil' argument produce unexpected results. 