### PR TITLE
BF: gamma table issues

### DIFF
--- a/psychopy/tests/test_all_visual/test_gamma.py
+++ b/psychopy/tests/test_all_visual/test_gamma.py
@@ -109,5 +109,32 @@ def test_setGammaRamp():
     assert numpy.allclose(desiredRamp, setRamp, atol=1.0 / desiredRamp.shape[1])
 
 
+def test_gammaSetGetMatch():
+    """test that repeatedly getting and setting the gamma table has no
+    cumulative effect."""
+
+    startGammaTable = None
+
+    n_repeats = 2
+
+    for _ in range(n_repeats):
+
+        win = visual.Window([600, 600], autoLog=False)
+
+        for _ in range(5):
+            win.flip()
+
+        if startGammaTable is None:
+            startGammaTable = win.backend.getGammaRamp()
+        else:
+            currGammaTable = win.backend.getGammaRamp()
+
+            assert numpy.all(currGammaTable == startGammaTable)
+
+        win.close()
+
+    utils.skip_under_travis()
+
+
 if __name__=='__main__':
     test_high_gamma()

--- a/psychopy/visual/backends/gamma.py
+++ b/psychopy/visual/backends/gamma.py
@@ -126,7 +126,8 @@ def getGammaRamp(screenID, xDisplay=None):
             screenID, origramps.ctypes)  # FB 504
         if not success:
             raise AssertionError('GetDeviceGammaRamp failed')
-        origramps = origramps/65535.0  # rescale to 0:1
+        origramps.byteswap(True)  # back to 0:255
+        origramps = origramps/255.0  # rescale to 0:1
 
     if sys.platform == 'darwin':
         # init R, G, and B ramps

--- a/psychopy/visual/backends/gamma.py
+++ b/psychopy/visual/backends/gamma.py
@@ -80,7 +80,7 @@ def setGammaRamp(screenID, newRamp, nAttempts=3, xDisplay=None):
     if newRamp.shape[0] != 3 and newRamp.shape[1] == 3:
         newRamp = numpy.ascontiguousarray(newRamp.transpose())
     if sys.platform == 'win32':
-        newRamp = (255.0 * newRamp).astype(numpy.uint16)
+        newRamp = (numpy.around(255.0 * newRamp)).astype(numpy.uint16)
         # necessary, according to pyglet post from Martin Spacek
         newRamp.byteswap(True)
         for n in range(nAttempts):
@@ -100,7 +100,7 @@ def setGammaRamp(screenID, newRamp, nAttempts=3, xDisplay=None):
         assert not error, 'CGSetDisplayTransferByTable failed'
 
     if sys.platform.startswith('linux') and not _TravisTesting:
-        newRamp = (65535 * newRamp).astype(numpy.uint16)
+        newRamp = (numpy.around(65535 * newRamp)).astype(numpy.uint16)
         success = xf86vm.XF86VidModeSetGammaRamp(
             xDisplay, screenID, LUTlength,
             newRamp[0, :].ctypes,


### PR DESCRIPTION
This relates to issue #1859.

The first problem was that, on windows, the gamma table that was read was not the same as the gamma table that was set. The set operation used a ```byteswap```, whereas the get operation did not.

To expand:

* It seems like windows takes a 16 bit unsigned integer for each entry in the LUT. The first 8 bits are taken as the LUT index and the second 8 bits are ignored/undefined.
* The ```byteswap``` function swaps the first and last bytes, so one can make a LUT between 0 and 255 and then use ```byteswap``` to move that into the first byte rather than the second.
* When reading the LUT, the first 8 bits will where the LUT is defined. That means that we can do a ```byteswap``` to shift them into the second 8 bits and then normalise by dividing by 255. This should remove the get/set discrepancy.

The second problem was that a linear gamma table, defined between 0 and 1, was not producing evenly spaced integers with an 8-bit LUT between 0 and 255. The problem seems to be that the integer conversion was truncating, so a rounding operation was added prior to type conversion.



