### PR TITLE
BF: Make colorPicker return RGB rather than RGBA

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -589,6 +589,7 @@ class PsychoPyApp(wx.App):
                 if dlg.ShowModal() == wx.ID_OK:
                     data = dlg.GetColourData()
                     rgb = data.GetColour().Get()
+                    rgb = rgb[0:3] # drop alpha value if present
                     rgb = map(lambda x: "%.3f" %
                               ((x - 127.5) / 127.5), list(rgb))
                     rgb = '[' + ','.join(rgb) + ']'


### PR DESCRIPTION
Fixes #1985.
Ensure `colorPicker` returns an RBG triplet rather than RGB + alpha. Currently causes errors when assigning colors, as 3 rather than 4 channel values are expected.