### PR TITLE
BF: Make colorPicker return RGB rather than RGBA

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -588,7 +588,7 @@ class PsychoPyApp(wx.App):
                 dlg.GetColourData().SetChooseFull(True)
                 if dlg.ShowModal() == wx.ID_OK:
                     data = dlg.GetColourData()
-                    rgb = data.GetColour().Get()
+                    rgb = data.GetColour().Get(includeAlpha=False)
                     rgb = map(lambda x: "%.3f" %
                               ((x - 127.5) / 127.5), list(rgb))
                     rgb = '[' + ','.join(rgb) + ']'


### PR DESCRIPTION
Fixes #1985.
Ensure colorPicker returns an RBG triplet rather than RGB + alpha. Currently causes errors when assigning colors, as 3 rather than 4 channel values are expected.
Second attempt at this, as found there was an API-based way to not return the alpha value, rather than truncating the returned list manually. NB the displayed colour picker still has an active alpha control. This could cause users some confusion, as they may apply a value of alpha other than 1.0 in the colour picker UI but not have it reflected in the returned colour.