### PR TITLE
BF: GLFW TextStim fix

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -143,7 +143,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # if the fillColor and lineColor are not set but color is
         # then the user probably wants color applied to both
-        if (lineColor==(1.0, 1.0, 1.0) and fillColor is None
+        if (tuple(lineColor) == (1.0, 1.0, 1.0) and fillColor is None
                 and color is not None):
             self.color = color
 

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -143,7 +143,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # if the fillColor and lineColor are not set but color is
         # then the user probably wants color applied to both
-        if (tuple(self.lineColor) == (1.0, 1.0, 1.0) and fillColor is None
+        if (lineColor==(1.0, 1.0, 1.0) and fillColor is None
                 and color is not None):
             self.color = color
 

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -143,7 +143,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # if the fillColor and lineColor are not set but color is
         # then the user probably wants color applied to both
-        if (tuple(lineColor) == (1.0, 1.0, 1.0) and fillColor is None
+        if (tuple(self.lineColor) == (1.0, 1.0, 1.0) and fillColor is None
                 and color is not None):
             self.color = color
 

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -778,7 +778,7 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # should text have a depth or just on top?
         GL.glDisable(GL.GL_DEPTH_TEST)
         # update list if necss and then call it
-        if win.winType == 'pyglet':
+        if win.winType in ["pyglet", "glfw"]:
             if self._needSetText:
                 self.setText()
             # and align based on x anchor


### PR DESCRIPTION
 - One `win.winType in ["pyglet", "glfw"]:...` hadn't been changed, so text was misaligned and missing color. 