### PR TITLE
BF: headLocked ineffective when in monoscopic mode (Oculus Rift)

### DIFF
--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -950,6 +950,15 @@ class Rift(window.Window):
         else:
             return self._projectionMatrix
 
+    @property
+    def headLocked(self):
+        """Enable/disable head locking."""
+        return self._headLocked
+
+    @headLocked.setter
+    def headLocked(self, val):
+        self._headLocked = bool(val)
+
     def pollControllers(self):
         """Update all connected controller states. This should be called at
         least once per frame.

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -916,7 +916,10 @@ class Rift(window.Window):
                     ovr.capi.getEyeViewMatrix(self.eyePoses[eye])
         else:
             # view matrix derived from head position when in monoscopic mode
-            self._viewMatrix = ovr.capi.getEyeViewMatrix(self.headPose)
+            if self._headLocked:
+                self._viewMatrix = ovr.capi.getEyeViewMatrix(self.hmdOriginPose)
+            else:
+                self._viewMatrix = ovr.capi.getEyeViewMatrix(self.headPose)
 
         # get the poses for the touch controllers
         # NB - this does not work well when head locked, hands are not


### PR DESCRIPTION
Someone pointed out head locking the HMD view doesn't work when in monoscopic mode. This patch fixes that. I also added an attribute that allows head locking to be set during runtime.