### PR TITLE
ENH: Refactors JS loop compile. Writes code regardless of codetype viewed.

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -89,7 +89,6 @@ class Experiment(object):
         self._expHandler = TrialHandler(exp=self, name='thisExp')
         self._expHandler.type = 'ExperimentHandler'  # true at run-time
         self._expHandler.name = self._expHandler.params['name'].val  # thisExp
-        self._compileLoop = True
 
     def requirePsychopyLibs(self, libs=()):
         """Add a list of top-level psychopy libs that the experiment
@@ -117,9 +116,7 @@ class Experiment(object):
         """Write a PsychoPy script for the experiment
         """
         # set this so that params write for approp target
-        self._compileLoop = True  # Must update on every compile else False after first call to writeScript
         utils.scriptTarget = target
-
         self.flow._prescreenValues()
         self.expPath = expPath
         script = IndentingBuffer(u'')  # a string buffer object
@@ -176,13 +173,12 @@ class Experiment(object):
             # functions that may or may not get called later.
             # Do the Routines of the experiment first
             routinesToWrite = list(self.routines)
+            loopTypes = {'LoopInitiator': False, 'LoopTerminator': False}
             for thisItem in self.flow:
-                if thisItem.getType() in ['LoopInitiator', 'LoopTerminator']:
-                    if self._compileLoop:  # If loops not already compiled
+                if thisItem.getType() in loopTypes:
+                    if not loopTypes[thisItem.getType()]:  # If False, then write loop
+                        loopTypes[thisItem.getType()] = True
                         self.flow.writeLoopHandlerJS(script)
-                        self._compileLoop = False
-                    else:
-                        pass
                 elif thisItem.name in routinesToWrite:
                     self._currentRoutine = self.routines[thisItem.name]
                     self._currentRoutine.writeRoutineBeginCodeJS(script)

--- a/psychopy/experiment/components/code/__init__.py
+++ b/psychopy/experiment/components/code/__init__.py
@@ -150,42 +150,33 @@ class CodeComponent(BaseComponent):
                   'stopType', 'durationEstim'):
             del self.params[p]
 
+
     def writeInitCode(self, buff):
-        if self.params['Code Type'].val in ['Py', 'both']:
-            buff.writeIndentedLines(str(self.params['Begin Experiment']) + '\n')
+        buff.writeIndentedLines(str(self.params['Begin Experiment']) + '\n')
 
     def writeInitCodeJS(self, buff):
-        if self.params['Code Type'].val in ['JS', 'both']:
-            buff.writeIndentedLines(str(self.params['Begin JS Experiment']) + '\n')
+        buff.writeIndentedLines(str(self.params['Begin JS Experiment']) + '\n')
 
     def writeRoutineStartCode(self, buff):
-        if self.params['Code Type'].val in ['Py', 'both']:
-            buff.writeIndentedLines(str(self.params['Begin Routine']) + '\n')
+        buff.writeIndentedLines(str(self.params['Begin Routine']) + '\n')
 
     def writeRoutineStartCodeJS(self, buff):
-        if self.params['Code Type'].val in ['JS', 'both']:
-            buff.writeIndentedLines(str(self.params['Begin JS Routine']) + '\n')
+        buff.writeIndentedLines(str(self.params['Begin JS Routine']) + '\n')
 
     def writeFrameCode(self, buff):
-        if self.params['Code Type'].val in ['Py', 'both']:
-            buff.writeIndentedLines(str(self.params['Each Frame']) + '\n')
+        buff.writeIndentedLines(str(self.params['Each Frame']) + '\n')
 
     def writeFrameCodeJS(self, buff):
-        if self.params['Code Type'].val in ['JS', 'both']:
-            buff.writeIndentedLines(str(self.params['Each JS Frame']) + '\n')
+        buff.writeIndentedLines(str(self.params['Each JS Frame']) + '\n')
 
     def writeRoutineEndCode(self, buff):
-        if self.params['Code Type'].val in ['Py', 'both']:
-            buff.writeIndentedLines(str(self.params['End Routine']) + '\n')
+        buff.writeIndentedLines(str(self.params['End Routine']) + '\n')
 
     def writeRoutineEndCodeJS(self, buff):
-        if self.params['Code Type'].val in ['JS', 'both']:
-            buff.writeIndentedLines(str(self.params['End JS Routine']) + '\n')
+        buff.writeIndentedLines(str(self.params['End JS Routine']) + '\n')
 
     def writeExperimentEndCode(self, buff):
-        if self.params['Code Type'].val in ['Py', 'both']:
-            buff.writeIndentedLines(str(self.params['End Experiment']) + '\n')
+        buff.writeIndentedLines(str(self.params['End Experiment']) + '\n')
 
     def writeExperimentEndCodeJS(self, buff):
-        if self.params['Code Type'].val in ['JS', 'both']:
-            buff.writeIndentedLines(str(self.params['End JS Experiment']) + '\n')
+        buff.writeIndentedLines(str(self.params['End JS Experiment']) + '\n')


### PR DESCRIPTION
Regarding the code component, this fix now writes the code stored in the parameters for the respective Python or JS outputs, irrespective of what code type is viewed in the code component dlg. This removes the need to select the correct code type in the code component dlg in order to have the code compiled.