### PR TITLE
Extend class "DlgFromDict"

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -348,7 +348,7 @@ class DlgFromDict(Dlg):
         A list of keys for which the values shall be displayed in non-editable
         fields
         
-    order : bool | list
+    sort_keys : bool | list
         Either a list of keys defining the display order of keys in
         ``dictionary´´. If not all keys in ``dictionary´´ are contained in
         ``order´´, those will appear in random order after all ordered keys.
@@ -396,14 +396,14 @@ class DlgFromDict(Dlg):
     See GUI.py for a usage demo, including order and tip (tooltip).
     """
 
-    def __init__(self, dictionary, title='', labels=None, fixed=None, order=None, tip=None,
+    def __init__(self, dictionary, title='', labels=None, fixed=None, sort_keys=None, tip=None,
                  copy_dict=False, preserve_types=True, show=True):
         # We don't explicitly check for None identity
         # for backward-compatibility reasons.
         if not fixed:
             fixed = []
-        if not order:
-            order = []
+        if not sort_keys:
+            sort_keys = []
         if not tip:
             tip = dict()
 
@@ -420,10 +420,10 @@ class DlgFromDict(Dlg):
         self.labels = dict()
         self.types = dict()
 
-        if type(order) == bool:
+        if type(sort_keys) == bool:
             self._keys.sort()
-        elif order:
-            self._keys = list(order) + list(set(self._keys).difference(set(order)))
+        elif sort_keys:
+            self._keys = list(sort_keys) + list(set(self._keys).difference(set(sort_keys)))
 
         for field in self._keys:
             self.types[field] = type(self.dictionary[field])


### PR DESCRIPTION
Extended class "DlgFromDict" with the following features:

(1) The "sort_keys" parameter now also accepts a list defining the order of the displayed fields. This allows for a user defined order of input fields in the dialog.

(2) A "labels" parameter can be used to define labels which are displayed instead of the keys. This allows for comprehensible captions for input fields in the dialog while maintaining brief key strings.

(3) A "preserve_type" parameter can be used to enforce preservation of the variable types provided in the dictionary, if at all possible. This remedies the following problem currently occurring under Windows. Say, the call to DlgFromDict() is:

```
dictionary = {'Parameter1', 99}   # the 99 is an int
DlgFromDict(dictionary)
```

The dialog will display an input field labeled "Parameter1" with a pre-entered value of 99. If the user then deletes the latter "9" and inputs "7", the returned dictionary will be:

```
dictionary = {'Parameter1', 97}   # the 97 is still an int
```

However, if the user deletes the "99" - thus having the field be empty at some point during user input - and then re-enters "97", the dictionary will be:

```
dictionary = {'Parameter1', '97'}   # the 97 has become a string
```

So, in the former case, the provided value will remain an int. In the latter case, since an empty input field cannot be converted to int, the variable type will switch to string and remain so. That's not nice and fixed in this edit.
