### PR TITLE
ENH: raise a warning rather than an error if the gamma ramp size is 0

### DIFF
--- a/psychopy/visual/backends/gamma.py
+++ b/psychopy/visual/backends/gamma.py
@@ -283,6 +283,13 @@ def getGammaRampSize(screenID, xDisplay=None):
         rampSize = 256
 
     if rampSize == 0:
-        raise RuntimeError("Gamma ramp size is reported as 0.")
+
+        logging.warn(
+            "The size of the gamma ramp was reported as 0. This can " +
+            "mean that gamma settings have no effect. Proceeding with " +
+            "a default gamma ramp size."
+        )
+
+        rampSize = 256
 
     return rampSize


### PR DESCRIPTION
Rather than raising an error when the LUT size is returned as 0, issue a warning and proceed with an assumed LUT size of 256. This relates to #1982.

Hopefully this will become less encountered - updated drivers seem to report the correct LUT size. 