### PR TITLE
BF: Changes how html files are exported in ref to exp settings

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1833,9 +1833,11 @@ class BuilderFrame(wx.Frame):
 
     def setIsModified(self, newVal=None):
         """Sets current modified status and updates save icon accordingly.
+
         This method is called by the methods fileSave, undo, redo,
         addToUndoStack and it is usually preferably to call those
         than to call this directly.
+
         Call with ``newVal=None``, to only update the save icon(s)
         """
         if newVal is None:
@@ -1851,6 +1853,7 @@ class BuilderFrame(wx.Frame):
 
     def resetUndoStack(self):
         """Reset the undo stack. do *immediately after* creating a new exp.
+
         Implicitly calls addToUndoStack() using the current exp as the state
         """
         self.currentUndoLevel = 1  # 1 is current, 2 is back one setp...
@@ -1864,6 +1867,7 @@ class BuilderFrame(wx.Frame):
         with the @state@. ``state`` should be a copy of the exp
         from *immediately after* the action was taken.
         If no ``state`` is given the current state of the experiment is used.
+
         If we are at end of stack already then simply append the action.  If
         not (user has done an undo) then remove orphan actions and append.
         """
@@ -1881,7 +1885,8 @@ class BuilderFrame(wx.Frame):
 
     def undo(self, event=None):
         """Step the exp back one level in the @currentUndoStack@ if possible,
-        and update the windows
+        and update the windows.
+
         Returns the final undo level (1=current, >1 for further in past)
         or -1 if redo failed (probably can't undo)
         """
@@ -1898,7 +1903,8 @@ class BuilderFrame(wx.Frame):
 
     def redo(self, event=None):
         """Step the exp up one level in the @currentUndoStack@ if possible,
-        and update the windows
+        and update the windows.
+        
         Returns the final undo level (0=current, >0 for further in past)
         or -1 if redo failed (probably can't redo)
         """

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 import wx
 import wx.stc
 from wx.lib import platebtn, scrolledpanel
+
 try:
     from wx import aui
 except Exception:
@@ -1006,7 +1007,6 @@ class BuilderFrame(wx.Frame):
         self.htmlPath = None
         self.project = None  # type: pavlovia.PavloviaProject
         self.btnHandles = {}  # stores toolbar buttons so they can be altered
-        self.exportOnSave = False
 
         if fileName in self.appData['frames']:
             self.frameData = self.appData['frames'][fileName]
@@ -1663,14 +1663,19 @@ class BuilderFrame(wx.Frame):
         settingsHTMLpath = self.exp.settings.params['HTML path'].val
         expPath, expName = os.path.split(self.filename)
         if htmlPath is None and self.exp.settings.params['HTML path']:
-            htmlPath = os.path.join(expPath, settingsHTMLpath)
+            htmlPath = self._getHtmlPath(self.filename)
+
         # present dialog box
         dlg = ExportFileDialog(self, wx.ID_ANY,
                                title=_translate("Export HTML file"),
-                               filePath=htmlPath)
-        if not self.exportOnSave:
+                               filePath=htmlPath,
+                               exp=self.exp)
+        export = dlg.exportOnSave
+        if self.exp.settings.params['exportHTML'].val == 'manually':
             retVal = dlg.ShowModal()
-            self.exportOnSave = dlg.exportOnSave.GetValue()
+            self.exp.settings.params['exportHTML'].val = export.GetString(export.GetCurrentSelection())
+            if retVal != wx.ID_OK:  # User cancelled export
+                return False
 
         htmlPath = os.path.join(htmlPath, expName.replace('.psyexp', '.js'))
         # then save the actual script
@@ -1828,11 +1833,9 @@ class BuilderFrame(wx.Frame):
 
     def setIsModified(self, newVal=None):
         """Sets current modified status and updates save icon accordingly.
-
         This method is called by the methods fileSave, undo, redo,
         addToUndoStack and it is usually preferably to call those
         than to call this directly.
-
         Call with ``newVal=None``, to only update the save icon(s)
         """
         if newVal is None:
@@ -1848,7 +1851,6 @@ class BuilderFrame(wx.Frame):
 
     def resetUndoStack(self):
         """Reset the undo stack. do *immediately after* creating a new exp.
-
         Implicitly calls addToUndoStack() using the current exp as the state
         """
         self.currentUndoLevel = 1  # 1 is current, 2 is back one setp...
@@ -1862,7 +1864,6 @@ class BuilderFrame(wx.Frame):
         with the @state@. ``state`` should be a copy of the exp
         from *immediately after* the action was taken.
         If no ``state`` is given the current state of the experiment is used.
-
         If we are at end of stack already then simply append the action.  If
         not (user has done an undo) then remove orphan actions and append.
         """
@@ -1881,7 +1882,6 @@ class BuilderFrame(wx.Frame):
     def undo(self, event=None):
         """Step the exp back one level in the @currentUndoStack@ if possible,
         and update the windows
-
         Returns the final undo level (1=current, >1 for further in past)
         or -1 if redo failed (probably can't undo)
         """
@@ -1899,7 +1899,6 @@ class BuilderFrame(wx.Frame):
     def redo(self, event=None):
         """Step the exp up one level in the @currentUndoStack@ if possible,
         and update the windows
-
         Returns the final undo level (0=current, >0 for further in past)
         or -1 if redo failed (probably can't redo)
         """
@@ -2211,7 +2210,7 @@ class BuilderFrame(wx.Frame):
         # Compile script from command line using version
         compiler = 'psychopy.scripts.psyexpCompile'
 
-        if sys.platform == 'win32': # get name of executable
+        if sys.platform == 'win32':  # get name of executable
             pythonExec = sys.executable
         else:
             pythonExec = sys.executable.replace(' ', '\ ')
@@ -2238,12 +2237,11 @@ class BuilderFrame(wx.Frame):
 
     def _getHtmlPath(self, filename):
         expPath = os.path.split(filename)[0]
+        if not os.path.isdir(expPath):
+            self.fileSave()
+            return self._getHtmlPath(self.filename)
         htmlFolder = self.exp.settings.params['HTML path'].val
         htmlPath = os.path.join(expPath, htmlFolder)
-        if not os.path.isdir(htmlPath):
-            self.fileSave()
-            self._getHtmlPath(self.filename)
-            return
         return htmlPath
 
     def _getExportPref(self, pref):
@@ -2391,11 +2389,12 @@ class ReadmeFrame(wx.Frame):
 class ExportFileDialog(wx.Dialog):
     def __init__(self, parent, ID, title, size=wx.DefaultSize,
                  pos=wx.DefaultPosition, style=wx.DEFAULT_DIALOG_STYLE,
-                 filePath=None):
+                 filePath=None, exp=None):
         wx.Dialog.__init__(self, parent, ID, title,
                            size=size, pos=pos, style=style)
         # Now continue with the normal construction of the dialog
         # contents
+        self.exp = exp
         sizer = wx.BoxSizer(wx.VERTICAL)
         msg = _translate("Warning, HTML outputs are very new.\n"
                          "Treat with caution (CHECK YOUR EXPERIMENT)!")
@@ -2414,15 +2413,19 @@ class ExportFileDialog(wx.Dialog):
 
         sizer.Add(box, 0, wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 
+        # Set save on export HTML choice
         box = wx.BoxSizer(wx.HORIZONTAL)
-
-        self.exportOnSave = wx.CheckBox(self, wx.ID_ANY,
-                                        label=_translate(
-                                            "Continuously export on save"))
-        self.exportOnSave.SetHelpText("Tick this if you want the HTML file to export"
-                                      " (and overwrite) on every save of the experiment."
-                                      " Only works for THIS SESSION.")
-        box.Add(self.exportOnSave, 1, wx.ALIGN_CENTRE | wx.ALL, 5)
+        choices = ['on Save', 'on Sync', 'manually']
+        exportLabel = _translate("Select 'manually' to receive this alert when exporting HTML.\n"
+                                 "Click 'OK' to export HTML, or click 'Cancel' to return.")
+        self.exportOnSave = wx.Choice(self, wx.ID_ANY,
+                                      size=wx.DefaultSize,
+                                      choices=choices)
+        self.exportOnSave.SetSelection(choices.index(self.exp.settings.params['exportHTML']))
+        self.exportText = wx.StaticText(self, wx.ID_ANY, exportLabel)
+        self.exportOnSave.SetHelpText(exportLabel)
+        box.Add(self.exportOnSave, .5, wx.ALIGN_CENTRE | wx.ALL, 5)
+        box.Add(self.exportText, 1, wx.ALIGN_CENTRE | wx.ALL, 5)
 
         sizer.Add(box, 0, wx.GROW | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 5)
 


### PR DESCRIPTION
In fileExport method, htmlPath now set by _getHtmlPath. In fileExport, the html export dlg view is now conditional on online settings in exp settings, where dlg is only shown if export is manual. When shown, the export dlg choices set online settings choice in experiment settings. If dlg is cancelled, no export occurs.
Note. _getHtmlPath method recursive function corrected so that recursion occurs before HTML path is set and returned