### PR TITLE
BF: compiling nested loops was crashing on the JS outputs

### DIFF
--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -44,7 +44,7 @@ class Flow(list):
                 currentList.append(thisEntry.loop) # this loop is child of current
                 loopDict[thisEntry.loop] = []  # and is (current) empty list awaiting children
                 currentList = loopDict[thisEntry.loop]
-                loopStack.append(thisEntry.loop)  # update the list of loops (for depth)
+                loopStack.append(loopDict[thisEntry.loop])  # update the list of loops (for depth)
             elif thisEntry.getType() == 'LoopTerminator':
                 loopStack.pop()
                 currentList = loopStack[-1]


### PR DESCRIPTION
loopStack should contain the list of children for each loop,
not the loop itself.