### PR TITLE
BF: New loop 'Selected rows' - should be created as type 'str' not 'c…

### DIFF
--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -81,7 +81,7 @@ class TrialHandler(object):
             hint=_translate("The start and end of the loop (see flow "
                             "timeline)"))
         self.params['Selected rows'] = Param(
-            selectedRows, valType='code',
+            selectedRows, valType='str',
             updates=None, allowedUpdates=None,
             label=_localized['Selected rows'],
             hint=_translate("Select just a subset of rows from your condition"


### PR DESCRIPTION
In Builder new loop elements default the 'Selected rows' parameter to type 'code' but the XML reader enforces that this field is 'str'. The reader text implies that this should be the default for new loops since 1.81.00.