### PR TITLE
BF: Switch to AddTool for Builder Frame as AddSimpleTool deprecated...

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1155,68 +1155,71 @@ class BuilderFrame(wx.Frame):
         keys = {k: self.app.keys[k].replace('Ctrl+', ctrlKey)
                 for k in self.app.keys}
 
-        item = tb.AddSimpleTool(wx.ID_ANY, newBmp,
-                                _translate("New [%s]") % keys['new'],
-                                _translate("Create new experiment file"))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("New [%s]") % keys['new'],
+                          newBmp,
+                          _translate("Create new experiment file"))
         tb.Bind(wx.EVT_TOOL, self.app.newBuilderFrame, item)
-        item = tb.AddSimpleTool(wx.ID_ANY, openBmp,
-                                _translate("Open [%s]") % keys['open'],
-                                _translate("Open an existing experiment file"))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("Open [%s]") % keys['open'],
+                          openBmp,
+                          _translate("Open an existing experiment file"))
         tb.Bind(wx.EVT_TOOL, self.fileOpen, item)
-        self.bldrBtnSave = tb.AddSimpleTool(-1, saveBmp,
-                                            _translate("Save [%s]") % keys[
-                                                'save'],
-                                            _translate(
-                                                "Save current experiment file"))
+        self.bldrBtnSave = tb.AddTool(-1,
+                                      _translate("Save [%s]") % keys['save'],
+                                      saveBmp,
+                                      _translate("Save current experiment file"))
         self.toolbar.EnableTool(self.bldrBtnSave.Id, False)
         tb.Bind(wx.EVT_TOOL, self.fileSave, self.bldrBtnSave)
-        item = tb.AddSimpleTool(wx.ID_ANY, saveAsBmp,
-                                _translate("Save As... [%s]") % keys['saveAs'],
-                                _translate(
-                                    "Save current experiment file as..."))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("Save As... [%s]") % keys['saveAs'],
+                          saveAsBmp,
+                          _translate("Save current experiment file as..."))
         tb.Bind(wx.EVT_TOOL, self.fileSaveAs, item)
-        self.bldrBtnUndo = tb.AddSimpleTool(wx.ID_ANY, undoBmp,
-                                            _translate("Undo [%s]") % keys[
-                                                'undo'],
-                                            _translate("Undo last action"))
+        self.bldrBtnUndo = tb.AddTool(wx.ID_ANY,
+                                      _translate("Undo [%s]") % keys['undo'],
+                                      undoBmp,
+                                      _translate("Undo last action"))
         tb.Bind(wx.EVT_TOOL, self.undo, self.bldrBtnUndo)
-        self.bldrBtnRedo = tb.AddSimpleTool(wx.ID_ANY, redoBmp,
-                                            _translate("Redo [%s]") % keys[
-                                                'redo'],
-                                            _translate("Redo last action"))
+        self.bldrBtnRedo = tb.AddTool(wx.ID_ANY,
+                                      _translate("Redo [%s]") % keys['redo'],
+                                      redoBmp,
+                                      _translate("Redo last action"))
         tb.Bind(wx.EVT_TOOL, self.redo, self.bldrBtnRedo)
 
         tb.AddSeparator()
-        self.bldrBtnPrefs = tb.AddSimpleTool(wx.ID_ANY, preferencesBmp,
-                                             _translate("Preferences"),
-                                             _translate(
-                                                 "Application preferences"))
+        self.bldrBtnPrefs = tb.AddTool(wx.ID_ANY,
+                                       _translate("Preferences"),
+                                       preferencesBmp,
+                                       _translate("Application preferences"))
         tb.Bind(wx.EVT_TOOL, self.app.showPrefs, self.bldrBtnPrefs)
-        item = tb.AddSimpleTool(wx.ID_ANY, monitorsBmp,
-                                _translate("Monitor Center"),
-                                _translate("Monitor settings and calibration"))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("Monitor Center"),
+                          monitorsBmp,
+                          _translate("Monitor settings and calibration"))
         tb.Bind(wx.EVT_TOOL, self.app.openMonitorCenter,
                 id=item.GetId())
 
         tb.AddSeparator()
-        item = tb.AddSimpleTool(wx.ID_ANY, settingsBmp,
-                                _translate("Experiment Settings"),
-                                _translate("Settings for this exp"))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("Experiment Settings"),
+                          settingsBmp,
+                          _translate("Settings for this exp"))
         tb.Bind(wx.EVT_TOOL, self.setExperimentSettings, item)
-        item = tb.AddSimpleTool(wx.ID_ANY, compileBmp,
-                                _translate("Compile Script [%s]") %
-                                keys['compileScript'],
-                                _translate("Compile to script"))
+        item = tb.AddTool(wx.ID_ANY,
+                          _translate("Compile Script [%s]") % keys['compileScript'],
+                          compileBmp,
+                          _translate("Compile to script"))
         tb.Bind(wx.EVT_TOOL, self.compileScript, item)
-        self.bldrBtnRun = tb.AddSimpleTool(wx.ID_ANY, runBmp,
-                                           _translate("Run [%s]") % keys[
-                                               'runScript'],
-                                           _translate("Run experiment"))
+        self.bldrBtnRun = tb.AddTool(wx.ID_ANY,
+                                     _translate("Run [%s]") % keys['runScript'],
+                                     runBmp,
+                                     _translate("Run experiment"))
         tb.Bind(wx.EVT_TOOL, self.runFile, self.bldrBtnRun)
-        self.bldrBtnStop = tb.AddSimpleTool(wx.ID_ANY, stopBmp,
-                                            _translate("Stop [%s]") % keys[
-                                                'stopScript'],
-                                            _translate("Stop experiment"))
+        self.bldrBtnStop = tb.AddTool(wx.ID_ANY,
+                                      _translate("Stop [%s]") % keys['stopScript'],
+                                      stopBmp,
+                                      _translate("Stop experiment"))
         tb.Bind(wx.EVT_TOOL, self.stopFile, self.bldrBtnStop)
         self.toolbar.EnableTool(self.bldrBtnStop.Id, False)
 


### PR DESCRIPTION
However, having found msg in _psychopyApp.py that AddTool breaks in version 3.0.2, holding off on further work. If it is time to switch, will replace remaining AddSimpleTool calls.