### PR TITLE
TESTS: Add Python 3.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ language: python
 
 matrix:
   include:
-    - os: linux
-      python: "2.7_with_system_site_packages"
-      env: DISPLAY=:99.0 AUDIODEV=null
+#    - os: linux
+#      python: "2.7_with_system_site_packages"
+#      env: DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
       env: ANACONDA=true PYTHON_VERSION=2.7 WXPYTHON=3 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
@@ -26,8 +26,8 @@ matrix:
     - os: linux
       env: ANACONDA=true PYTHON_VERSION=3.7 DISPLAY=:99.0 AUDIODEV=null
 
-  allow_failures:
-    - python: "2.7_with_system_site_packages"
+#  allow_failures:
+#    - python: "2.7_with_system_site_packages"
 
 before_install:
   # System setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
     - os: linux
       env: ANACONDA=true PYTHON_VERSION=3.6 DISPLAY=:99.0 AUDIODEV=null
 
+    - os: linux
+      env: ANACONDA=true PYTHON_VERSION=3.7 DISPLAY=:99.0 AUDIODEV=null
+
   allow_failures:
     - python: "2.7_with_system_site_packages"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,16 @@ matrix:
       env: DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
-      python: 2.7
-      env: ANACONDA=true WXPYTHON=3 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
+      env: ANACONDA=true PYTHON_VERSION=2.7 WXPYTHON=3 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
-      python: 2.7
-      env: ANACONDA=true WXPYTHON=4 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
+      env: ANACONDA=true PYTHON_VERSION=2.7 WXPYTHON=4 OPENPYXL=2.4 DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
-      python: 2.7
-      env: ANACONDA=true WXPYTHON=3 OPENPYXL=2.5 DISPLAY=:99.0 AUDIODEV=null
+      env: ANACONDA=true PYTHON_VERSION=2.7 WXPYTHON=3 OPENPYXL=2.5 DISPLAY=:99.0 AUDIODEV=null
 
     - os: linux
-      python: 3.6
-      env: ANACONDA=true DISPLAY=:99.0 AUDIODEV=null
+      env: ANACONDA=true PYTHON_VERSION=3.6 DISPLAY=:99.0 AUDIODEV=null
 
   allow_failures:
     - python: "2.7_with_system_site_packages"
@@ -89,8 +85,8 @@ before_install:
 
   - if [ -n "$ANACONDA" ]; then conda update -q conda; fi
   - if [ -n "$ANACONDA" ]; then conda info -a; fi
-  - if [ -n "$ANACONDA" ]; then ls -la ./conda/environment-$TRAVIS_PYTHON_VERSION.yml; fi
-  - if [ -n "$ANACONDA" ]; then conda env create -n psychopy-conda -f ./conda/environment-$TRAVIS_PYTHON_VERSION.yml; fi
+  - if [ -n "$ANACONDA" ]; then ls -la ./conda/environment-$PYTHON_VERSION.yml; fi
+  - if [ -n "$ANACONDA" ]; then conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml; fi
   - if [ -n "$ANACONDA" ]; then conda env list; fi
   - if [ -n "$ANACONDA" ]; then source activate psychopy-conda; fi
   - if [ -n "$ANACONDA" ]; then if [ -n "$WXPYTHON" ]; then conda install wxpython=$WXPYTHON; fi; fi

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - python=2.7
+- astunparse
 - backports
 - bzip2
 - cffi
@@ -13,6 +14,7 @@ dependencies:
 - freetype
 - future
 - gevent
+- gitpython
 - greenlet
 - libffi
 - lxml
@@ -58,11 +60,14 @@ dependencies:
 - pip:
   - arabic_reshaper
   - et-xmlfile
+  - freetype-py
   - json-tricks
   - prompt-toolkit
   - pygame
   - pyglet==1.3.0b1
   - pyparallel
   - python-bidi
+  - python-gitlab
   - sounddevice
   - soundfile
+  - zmq

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -50,7 +50,6 @@ dependencies:
 - xlrd
 - xz
 - yaml
-- configobj
 - lzo
 - pytables
 - pytest
@@ -59,6 +58,7 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
+  - https://github.com/DiffSK/configobj/archive/master.zip
   - et-xmlfile
   - freetype-py
   - json-tricks

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -1,4 +1,4 @@
-name: anaconda-py2
+name: anaconda-py2.7
 channels:
 - conda-forge
 - defaults

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -39,6 +39,7 @@ dependencies:
 - pyqt
 - pyserial
 - pyyaml
+- pyzmq
 - requests
 - scipy
 - setuptools
@@ -70,4 +71,3 @@ dependencies:
   - python-gitlab
   - sounddevice
   - soundfile
-  - zmq

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -16,6 +16,7 @@ dependencies:
 - gevent
 - gitpython
 - greenlet
+- json_tricks
 - libffi
 - lxml
 - matplotlib
@@ -38,6 +39,7 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
+- python-bidi
 - pyyaml
 - pyzmq
 - requests
@@ -62,12 +64,10 @@ dependencies:
   - https://github.com/DiffSK/configobj/archive/master.zip
   - et-xmlfile
   - freetype-py
-  - json-tricks
   - prompt-toolkit
   - pygame
   - pyglet==1.3.0b1
   - pyparallel
-  - python-bidi
   - python-gitlab
   - sounddevice
   - soundfile

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -17,6 +17,7 @@ dependencies:
 - gitpython
 - greenlet
 - hdf5
+- json_tricks
 - lxml
 - matplotlib
 - moviepy
@@ -34,6 +35,7 @@ dependencies:
 - pyserial
 - pytest
 - pytest-cov
+- python-bidi
 - pyyaml
 - pyzmq
 - requests
@@ -56,11 +58,9 @@ dependencies:
   - arabic_reshaper
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
-  - json-tricks
   - pygame
   - pyglet==1.3.0b1
   - pyparallel
-  - python-bidi
   - python-gitlab
   - sounddevice
   - soundfile

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - python=3.6
+- astunparse
 - backports
 - bzip2
 - cffi
@@ -13,6 +14,7 @@ dependencies:
 - freetype
 - future
 - gevent
+- gitpython
 - greenlet
 - hdf5
 - lxml
@@ -52,10 +54,13 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
+  - freetype-py
   - json-tricks
   - pygame
   - pyglet==1.3.0b1
   - pyparallel
   - python-bidi
+  - python-gitlab
   - sounddevice
   - soundfile
+  - zmq

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -1,4 +1,4 @@
-name: anaconda-py3
+name: anaconda-py3.6
 channels:
 - conda-forge
 - defaults

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -35,6 +35,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pyyaml
+- pyzmq
 - requests
 - scipy
 - setuptools
@@ -63,4 +64,3 @@ dependencies:
   - python-gitlab
   - sounddevice
   - soundfile
-  - zmq

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -47,13 +47,13 @@ dependencies:
 - xlrd
 - xz
 - yaml
-- configobj
 - lzo
 - pytables
 - wxpython
 - zlib
 - pip:
   - arabic_reshaper
+  - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - json-tricks
   - pygame

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -59,7 +59,7 @@ dependencies:
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - pygame
-  - pyglet==1.3.0b1
+  - pyglet
   - pyparallel
   - python-gitlab
   - sounddevice

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - python=3.7
+- astunparse
 - backports
 - bzip2
 - cffi
@@ -55,7 +56,6 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
-  - https://github.com/simonpercivall/astunparse/archive/master.zip
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   # - opencv-python

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -58,7 +58,6 @@ dependencies:
   - arabic_reshaper
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
-  # - opencv-python
   - pygame
   - pyglet==1.3.0b1
   - pyparallel

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -46,13 +46,13 @@ dependencies:
 - xlrd
 - xz
 - yaml
-- configobj
 - lzo
 - pytables
 - wxpython
 - zlib
 - pip:
   - arabic_reshaper
+  - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - json-tricks
   - pygame

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -1,4 +1,4 @@
-name: anaconda-py3
+name: anaconda-py3.7
 channels:
 - conda-forge
 - defaults

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -23,6 +23,7 @@ dependencies:
 - msgpack-python
 - numexpr
 - numpy
+- opencv
 - openpyxl
 - pandas
 - pillow
@@ -57,7 +58,7 @@ dependencies:
   - https://github.com/simonpercivall/astunparse/archive/master.zip
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
-  - opencv-python
+  # - opencv-python
   - pygame
   - pyglet==1.3.0b1
   - pyparallel

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -17,6 +17,7 @@ dependencies:
 - gitpython
 - greenlet
 - hdf5
+- json_tricks
 - lxml
 - matplotlib
 - moviepy
@@ -33,6 +34,7 @@ dependencies:
 - pyserial
 - pytest
 - pytest-cov
+- python-bidi
 - pyyaml
 - pyzmq
 - requests
@@ -55,12 +57,10 @@ dependencies:
   - arabic_reshaper
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
-  - json-tricks
   - pygame
   - pyglet==1.3.0b1
   - pyosf
   - pyparallel
-  - python-bidi
   - python-gitlab
   - sounddevice
   - soundfile

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -27,7 +27,6 @@ dependencies:
 - pillow
 - pip
 - pyopengl
-- pyosf
 - pyqt
 - pyserial
 - pytest
@@ -55,6 +54,7 @@ dependencies:
   - json-tricks
   - pygame
   - pyglet==1.3.0b1
+  - pyosf
   - pyparallel
   - python-bidi
   - sounddevice

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -1,0 +1,61 @@
+name: anaconda-py3
+channels:
+- conda-forge
+- defaults
+dependencies:
+- python=3.7
+- backports
+- bzip2
+- cffi
+- codecov
+- coveralls
+- ffmpeg
+- freetype
+- future
+- gevent
+- greenlet
+- hdf5
+- lxml
+- matplotlib
+- moviepy
+- msgpack-python
+- numexpr
+- numpy
+- opencv
+- openpyxl
+- pandas
+- pillow
+- pip
+- pyopengl
+- pyosf
+- pyqt
+- pyserial
+- pytest
+- pytest-cov
+- pyyaml
+- requests
+- scipy
+- setuptools
+- sip
+- six
+- pytables
+- urllib3
+- wheel
+- x264
+- xlrd
+- xz
+- yaml
+- configobj
+- lzo
+- pytables
+- wxpython
+- zlib
+- pip:
+  - arabic_reshaper
+  - json-tricks
+  - pygame
+  - pyglet==1.3.0b1
+  - pyparallel
+  - python-bidi
+  - sounddevice
+  - soundfile

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -34,6 +34,7 @@ dependencies:
 - pytest
 - pytest-cov
 - pyyaml
+- pyzmq
 - requests
 - scipy
 - setuptools
@@ -63,4 +64,3 @@ dependencies:
   - python-gitlab
   - sounddevice
   - soundfile
-  - zmq

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - python=3.7
+- astunparse
 - backports
 - bzip2
 - cffi
@@ -13,6 +14,7 @@ dependencies:
 - freetype
 - future
 - gevent
+- gitpython
 - greenlet
 - hdf5
 - lxml
@@ -51,11 +53,14 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
+  - freetype-py
   - json-tricks
   - pygame
   - pyglet==1.3.0b1
   - pyosf
   - pyparallel
   - python-bidi
+  - python-gitlab
   - sounddevice
   - soundfile
+  - zmq

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -4,6 +4,7 @@ channels:
 - defaults
 dependencies:
 - python=3.7
+- astunparse
 - backports
 - bzip2
 - cffi
@@ -55,7 +56,6 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
-  - astunparse
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - pygame

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -4,7 +4,6 @@ channels:
 - defaults
 dependencies:
 - python=3.7
-- astunparse
 - backports
 - bzip2
 - cffi
@@ -55,6 +54,7 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
+  - https://github.com/simonpercivall/astunparse/archive/master.zip
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - pygame

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -28,6 +28,7 @@ dependencies:
 - pillow
 - pip
 - pyopengl
+- pyosf
 - pyqt
 - pyserial
 - pytest
@@ -59,7 +60,6 @@ dependencies:
   - opencv-python
   - pygame
   - pyglet==1.3.0b1
-  - pyosf
   - pyparallel
   - python-gitlab
   - sounddevice

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -23,7 +23,6 @@ dependencies:
 - msgpack-python
 - numexpr
 - numpy
-- opencv
 - openpyxl
 - pandas
 - pillow
@@ -57,6 +56,7 @@ dependencies:
   - https://github.com/simonpercivall/astunparse/archive/master.zip
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
+  - opencv-python
   - pygame
   - pyglet==1.3.0b1
   - pyosf

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -4,7 +4,6 @@ channels:
 - defaults
 dependencies:
 - python=3.7
-- astunparse
 - backports
 - bzip2
 - cffi
@@ -56,6 +55,7 @@ dependencies:
 - zlib
 - pip:
   - arabic_reshaper
+  - astunparse
   - https://github.com/DiffSK/configobj/archive/master.zip
   - freetype-py
   - pygame

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -9,7 +9,11 @@ import sys
 import platform
 import configobj
 from configobj import ConfigObj
-import validate
+
+try:
+    import validate
+except ImportError:
+    from configobj import validate
 
 join = os.path.join
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ install_requires =
     msgpack-python
     psutil
     tables
-    zmq
+    pyzmq
     moviepy
     opencv-python
     python-gitlab


### PR DESCRIPTION
I've been working on this off-and-on for a couple weeks now, and finally the builds pass on Travis.

This PR adds support for running the test suite on Python 3.7 on Travis and temporarily disables the remaining Python 2.7 test that was using the "system Python", which hasn't properly worked in months now. (This just is just commented out and can therefore be easily re-enabled at a later time should we desire)

It also adds support for future releases of `configobj` via https://github.com/psychopy/psychopy/pull/2062/commits/de2aae9494938ee849b073d4e8b6611aa7c446c0