### PR TITLE
TESTS: Split out system and Python setup into separate shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,70 +30,18 @@ matrix:
 #    - python: "2.7_with_system_site_packages"
 
 before_install:
-  # System setup
-  - travis_retry sudo apt-get update -qq
-  - travis_retry sudo apt-get install -qq lsb-release
-  - source /etc/lsb-release
-  - echo ${DISTRIB_CODENAME}
-  - wget -O- http://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-  - wget -q -O- http://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
-  - travis_retry sudo apt-get update -qq
-  - sudo apt-cache policy  # What is actually available?
+  - pwd
+  - ./travis/00_set_up_packaging_system.sh
+  - ./travis/10_install_system_dependencies.sh
 
-  # This might come in handy once we switch to Trusty, as its Xvfb
-  # doesn't properly support the RANDR extension
-  # - travis_retry sudo apt-get install -qq xpra xserver-xorg-video-dummy
-
-  - travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri libavbin0
-  - travis_retry sudo apt-get install -qq libportaudio2
-  - travis_retry sudo apt-get install -qq flac
-  - travis_retry sudo apt-get install -qq libav-tools  # this install ffmpeg
-  - travis_retry sudo apt-get install -qq libwebkitgtk-1.0-0
-  - flac -version
-
-  # Locales
-  # - travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
-  - travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
-  # - sudo dpkg-reconfigure locales
-  # - locale -a  # list available locales
-
-  - travis_retry sudo apt-get install -qq libasound2-dev alsa-utils alsa-oss
-  - sudo modprobe snd-dummy
-  - sudo lsmod
-
-  # upgrade pip to 9.0.x because 10.0.x says cannot uninstall distutils so --upgrade fails
-  - if [ -z $ANACONDA ]; then travis_retry sudo pip install --upgrade -qq pip==9.0.3; fi
-  - if [ -z $ANACONDA ]; then
-      echo "Installing PsychoPy dependencies via apt...";
-      travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl;
-      travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas;
-      travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj;
-      travis_retry sudo apt-get install -qq python-imaging python-mock;
-      travis_retry sudo apt-get install -qq python-qt4 python-wxgtk3.0;
-      travis_retry sudo apt-get install -qq python-pyo python-opencv;
-      travis_retry sudo apt-get install -qq python-mock;
-      echo "Installing PsychoPy dependencies via pip...";
-      sudo pip install requests[security];
-
-      travis_retry sudo pip install --upgrade -qq -r requirements_travis.txt;
-    fi
+  # Install & activate conda environment if requested; otherwise,
+  # install system Python dependencies.
   - if [ -n "$ANACONDA" ]; then
-      echo "Installing Miniconda environment...";
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-      bash miniconda.sh -b -p $HOME/miniconda;
-      export PATH="$HOME/miniconda/bin:$PATH";
-      hash -r;
-      conda config --set always_yes yes --set changeps1 no;
+      ./travis/20_install_miniconda_python.sh;
+      source ~/miniconda/bin/activate psychopy-conda;
+    else
+      ./travis/20_install_system_python.sh;
     fi
-
-  - if [ -n "$ANACONDA" ]; then conda update -q conda; fi
-  - if [ -n "$ANACONDA" ]; then conda info -a; fi
-  - if [ -n "$ANACONDA" ]; then ls -la ./conda/environment-$PYTHON_VERSION.yml; fi
-  - if [ -n "$ANACONDA" ]; then conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml; fi
-  - if [ -n "$ANACONDA" ]; then conda env list; fi
-  - if [ -n "$ANACONDA" ]; then source activate psychopy-conda; fi
-  - if [ -n "$ANACONDA" ]; then if [ -n "$WXPYTHON" ]; then conda install wxpython=$WXPYTHON; fi; fi
-  - if [ -n "$ANACONDA" ]; then if [ -n "$OPENPYXL" ]; then conda install openpyxl=$OPENPYXL; fi; fi
 
   - echo $PATH
   - which python

--- a/travis/00_set_up_packaging_system.sh
+++ b/travis/00_set_up_packaging_system.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Fail script immediately on any errors in external commands,
+# and display each line as it gets executed.
+set -ev
+
+source ./travis/travis_retry.bash
+
+travis_retry sudo apt-get update -qq
+travis_retry sudo apt-get install -qq lsb-release
+source /etc/lsb-release
+echo ${DISTRIB_CODENAME}
+wget -O- http://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+wget -q -O- http://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
+travis_retry sudo apt-get update -qq
+sudo apt-cache policy  # What is actually available?

--- a/travis/10_install_system_dependencies.sh
+++ b/travis/10_install_system_dependencies.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Fail script immediately on any errors in external commands,
+# and display each line as it gets executed.
+set -ev
+
+source ./travis/travis_retry.bash
+
+# This might come in handy once we switch to Trusty, as its Xvfb
+# doesn't properly support the RANDR extension
+# - travis_retry sudo apt-get install -qq xpra xserver-xorg-video-dummy
+
+travis_retry sudo apt-get install -qq xvfb xauth libgl1-mesa-dri libavbin0
+travis_retry sudo apt-get install -qq libportaudio2
+travis_retry sudo apt-get install -qq flac
+travis_retry sudo apt-get install -qq libav-tools  # this install ffmpeg
+travis_retry sudo apt-get install -qq libwebkitgtk-1.0-0
+flac -version
+
+# Locales
+# - travis_retry sudo apt-get install -qq language-pack-en-base  # English locales
+travis_retry sudo apt-get install -qq language-pack-ja-base  # Japanese locale
+# - sudo dpkg-reconfigure locales
+# - locale -a  # list available locales
+
+travis_retry sudo apt-get install -qq libasound2-dev alsa-utils alsa-oss
+sudo modprobe snd-dummy
+sudo lsmod

--- a/travis/20_install_miniconda_python.sh
+++ b/travis/20_install_miniconda_python.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# Fail script immediately on any errors in external commands,
+# and display each line as it gets executed.
+set -ev
+
+echo "Installing Miniconda environment..."
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+bash miniconda.sh -b -p $HOME/miniconda
+export PATH="$HOME/miniconda/bin:$PATH"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+conda update -q conda
+conda info -a
+ls -la ./conda/environment-$PYTHON_VERSION.yml
+conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml
+conda env list
+source activate psychopy-conda
+if [ -n "$WXPYTHON" ]; then conda install wxpython=$WXPYTHON; fi
+if [ -n "$OPENPYXL" ]; then conda install openpyxl=$OPENPYXL; fi

--- a/travis/20_install_system_python.sh
+++ b/travis/20_install_system_python.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Fail script immediately on any errors in external commands,
+# and display each line as it gets executed.
+set -ev
+
+source ./travis/travis_retry.bash
+
+# upgrade pip to 9.0.x because 10.0.x says cannot uninstall distutils so --upgrade fails
+travis_retry sudo pip install --upgrade -qq pip==9.0.3
+echo "Installing PsychoPy dependencies via apt..."
+travis_retry sudo apt-get install -qq python-xlib python-pygame python-opengl
+travis_retry sudo apt-get install -qq python-numpy python-scipy python-matplotlib python-pandas
+travis_retry sudo apt-get install -qq python-yaml python-lxml python-configobj
+travis_retry sudo apt-get install -qq python-imaging python-mock
+travis_retry sudo apt-get install -qq python-qt4 python-wxgtk3.0
+travis_retry sudo apt-get install -qq python-pyo python-opencv
+travis_retry sudo apt-get install -qq python-mock
+echo "Installing PsychoPy dependencies via pip..."
+sudo pip install requests[security]
+
+travis_retry sudo pip install --upgrade -qq -r requirements_travis.txt

--- a/travis/travis_retry.bash
+++ b/travis/travis_retry.bash
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copied from https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_retry.bash
+# (Permalink: https://github.com/travis-ci/travis-build/blob/4e57ccad0d384bf48848d95c9ab19b039af32551/lib/travis/build/bash/travis_retry.bash)
+
+
+travis_retry() {
+  local result=0
+  local count=1
+  while [[ "${count}" -le 3 ]]; do
+    [[ "${result}" -ne 0 ]] && {
+      echo -e "\\n${ANSI_RED}The command \"${*}\" failed. Retrying, ${count} of 3.${ANSI_RESET}\\n" >&2
+    }
+    "${@}" && { result=0 && break; } || result="${?}"
+    count="$((count + 1))"
+    sleep 1
+  done
+
+  [[ "${count}" -gt 3 ]] && {
+    echo -e "\\n${ANSI_RED}The command \"${*}\" failed 3 times.${ANSI_RESET}\\n" >&2
+  }
+
+  return "${result}"
+}


### PR DESCRIPTION
This should make the test setup procedures much more readable as we can get rid of all those repetitive `if` statements.

The individual steps were not modified.