### PR TITLE
PKG: Update classifiers – We support Python 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
 
 [options]
 install_requires =


### PR DESCRIPTION
Tests pass on Python 3.7, so add it to the list of supported languages.