### PR TITLE
Don't mutate list while iterating

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -189,7 +189,7 @@ class _SoundStream(object):
         t0 = time.time()
         self.frameN += 1
         toSpk.fill(0)
-        for thisSound in self.sounds:
+        for thisSound in self.sounds.copy():
             dat = thisSound._nextBlock()  # fetch the next block of data
             dat *= thisSound.volume  # Set the volume block by block
             if self.channels == 2 and len(dat.shape) == 2:


### PR DESCRIPTION
A classic Python bug.

There may be a better solution than what I'm suggesting here, but in any case the list `self.sounds` should not be mutated while being iterated.

This fixes the crackling problem described in https://discourse.psychopy.org/t/sound-crackling-under-specific-conditions-demo-included/5480.