### PR TITLE
FIX: changing sound duration in builder causes the routine with the sound to not be played due to indentation bug

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -143,8 +143,8 @@ class SoundComponent(BaseComponent):
                 self.writeStopTestCode(buff)
                 code = "%s.stop()  # stop the sound (if longer than duration)\n"
                 buff.writeIndented(code % self.params['name'])
-                # because of the 'if' statement of the time test
-                buff.setIndentLevel(-1, relative=True)
+            # because of the 'if' statement of the time test
+            buff.setIndentLevel(-1, relative=True)
 
     def writeFrameCodeJS(self, buff):
         """Write the code that will be called every frame


### PR DESCRIPTION
Hi there,

this is a small PR to fix the problem with setting sound duration.

### How to reproduce the problem
1. Open psychopy 1.90.3 builder. (the problem seems to have been introduced in this version)
2. Add sound component to the routine. At this point if you play the procedure the sound would still play.
3. Change the sound duration. At this point the routine will be ommitted and thus there would be no sound.

### This fix
The problem comes from missing ` buff.setIndentLevel(-1, relative=True)` in one of the code branches. I just changed the indentation of that code which fixes the indentation of the generated code. :)