### PR TITLE
BF: Fixes logging error with Rect and attributeTools

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -150,7 +150,7 @@ def logAttrib(obj, log, attrib, value=None):
     If value=None, it will take the value of self.attrib.
     """
     # Default to autoLog if log isn't set explicitly
-    if log or log is None and obj.autoLog:
+    if log or log is None and obj.autoLog == True:
         if value is None:
             value = getattr(obj, attrib)
 

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -26,7 +26,7 @@ class Rect(BaseShapeStim):
     (New in version 1.72.00)
     """
 
-    def __init__(self, win, width=.5, height=.5, **kwargs):
+    def __init__(self, win, width=.5, height=.5, autoLog=None, **kwargs):
         """Rect accepts all input parameters, that
         `~psychopy.visual.ShapeStim` accept, except vertices and closeShape.
         """
@@ -40,6 +40,7 @@ class Rect(BaseShapeStim):
 
         self.__dict__['width'] = width
         self.__dict__['height'] = height
+        self.__dict__['autoLog'] = autoLog
         self._calcVertices()
         kwargs['closeShape'] = True  # Make sure nobody messes around here
         kwargs['vertices'] = self.vertices


### PR DESCRIPTION
Rect autoLog param was overwritten with attributeSetter and thus satisfied logging requirements in attributeTools (i.e., True), even though autoLog set to False.