### PR TITLE
BF: Fixes GUI crash when entering text

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -175,7 +175,8 @@ class Dlg(QtWidgets.QDialog):
 
             def handleLineEditChange(new_text):
                 ix = self.inputFields.index(inputBox)
-                thisType = self.inputFieldTypes[ix]
+                fieldNames = list(self.inputFieldTypes.keys())
+                thisType = self.inputFieldTypes[fieldNames[ix]]
 
                 try:
                     if thisType in (str, unicode, bytes):


### PR DESCRIPTION
The qtgui was crashing when user entered text because self.inputFieldTypes dict was throwing a key error when field names were being accessed as though they were a list, i.e. with an integer index value.