### PR TITLE
BF: Allow earlier destruction of GLFW window

### DIFF
--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -569,11 +569,8 @@ class GLFWBackend(BaseBackend):
         """
         _hw_handle = None
         try:
-            _hw_handle = self.win._hw_handle
-            # We need to call this when closing a window, however the window
-            # object is None at this point! So the GLFW window object lives on.
-            win = glfw.get_window_user_pointer(self.winHandle)
-            glfw.destroy_window(win)
+            self.setMouseVisibility(True)
+            glfw.destroy_window(self.winHandle)
         except Exception:
             pass
         # If iohub is running, inform it to stop looking for this win id

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -567,9 +567,15 @@ class GLFWBackend(BaseBackend):
     def close(self):
         """Close the window and uninitialize the resources
         """
+        # Test if the window has already been closed
+        if glfw.window_should_close(self.winHandle):
+            return
+
         _hw_handle = None
+
         try:
             self.setMouseVisibility(True)
+            glfw.set_window_should_close(self.winHandle, 1)
             glfw.destroy_window(self.winHandle)
         except Exception:
             pass


### PR DESCRIPTION
Currently, the GLFW window sticks around until the python script terminates. This allows destruction of the window + context before that point.

Example:
```python
from psychopy import core, visual

win = visual.Window(winType='glfw', allowGUI=False, pos=(0, 0), size=(400, 400))
core.wait(2.0)
win.close()
core.wait(2.0)
```