### PR TITLE
BF: __del__ method within radial.py causes ModuleNotFoundError: import

### DIFF
--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -616,10 +616,3 @@ class RadialStim(GratingStim):
         GL.glDisableClientState(GL.GL_TEXTURE_COORD_ARRAY)
 
         GL.glEndList()
-
-    def __del__(self):
-        """Remove textures from graphics card to prevent crash
-        """
-        if not self.useShaders:
-            GL.glDeleteLists(self._listID, 1)
-        self.clearTextures()

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -217,7 +217,10 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
     def __del__(self):
         if GL:  # because of pytest fail otherwise
-            GL.glDeleteLists(self._listID, 1)
+            try:
+                GL.glDeleteLists(self._listID, 1)
+            except Exception:
+                pass  # probably we don't have a _listID property
 
     @attributeSetter
     def height(self, height):


### PR DESCRIPTION
BF: __del__ method within radial.py causes ModuleNotFoundError: import of pyglet halted; None in sys.modules

remove __del_ method so that __del__ method of grating is called

