### PR TITLE
BF: setRedirectUrl function should only exist when URLs are provided.

### DIFF
--- a/psychopy/experiment/components/settings/JS_setupExp.tmpl
+++ b/psychopy/experiment/components/settings/JS_setupExp.tmpl
@@ -11,6 +11,6 @@ function updateInfo() {{
 
   // add info from the URL:
   util.addInfoFromUrl(expInfo);
-  psychoJS.setRedirectUrls({completedURL}, {incompleteURL});
+  {setRedirectURL}
   return Scheduler.Event.NEXT;
 }}

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -260,12 +260,12 @@ class SettingsComponent(object):
                             "remote copies (http:/www.psychopy.org/js)?"),
             label="JS libs", categ='Online')
         self.params['Completed URL'] = Param(
-            'completedURL', valType='str',
+            '', valType='str',
             hint=_translate("Where should participants be redirected after the experiment on completion\n"
                             " INSERT COMPLETION URL E.G.?"),
             label="Completed URL", categ='Online')
         self.params['Incomplete URL'] = Param(
-            'incompleteURL', valType='str',
+            '', valType='str',
             hint=_translate("Where participants are redirected if they do not complete the task\n"
                             " INSERT INCOMPLETION URL E.G.?"),
             label="Incomplete URL", categ='Online')
@@ -488,6 +488,11 @@ class SettingsComponent(object):
         # write the code to set up experiment
         buff.setIndentLevel(0, relative=False)
         template = readTextFile("JS_setupExp.tmpl")
+        setRedirectURL = ''
+        if len(self.params['Completed URL'].val) or len(self.params['Incomplete URL'].val):
+            setRedirectURL = ("psychoJS.setRedirectUrls({completedURL}, {incompleteURL});\n"
+                              .format(completedURL=self.params['Completed URL'],
+                                      incompleteURL=self.params['Incomplete URL']))
         # check where to save data variables
         # if self.params['OSF Project ID'].val:
         #     saveType = "OSF_VIA_EXPERIMENT_SERVER"
@@ -499,8 +504,7 @@ class SettingsComponent(object):
                         params=self.params,
                         name=self.params['expName'].val,
                         loggingLevel=self.params['logging level'].val.upper(),
-                        completedURL=self.params['Completed URL'],
-                        incompleteURL=self.params['Incomplete URL'],
+                        setRedirectURL=setRedirectURL,
                         )
         buff.writeIndentedLines(code)
 

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -2558,7 +2558,7 @@ ParallelOutComponent.order:['address', 'startData', 'stopData']
 ParallelOutComponent.address.default:'0x0378'
 ParallelOutComponent.address.allowedTypes:[]
 ParallelOutComponent.address.allowedUpdates:None
-ParallelOutComponent.address.allowedVals:[u'0x0378', u'0x03BC', u'/dev/parport0', u'/dev/parport1', u'LabJack U3']
+ParallelOutComponent.address.allowedVals:['0x0378', '0x03BC', 'LabJack U3']
 ParallelOutComponent.address.categ:Basic
 ParallelOutComponent.address.hint:Parallel port to be used (you can change these options in preferences>general)
 ParallelOutComponent.address.label:Port address
@@ -3480,7 +3480,7 @@ RatingScaleComponent.visualAnalogScale.updates:constant
 RatingScaleComponent.visualAnalogScale.val:False
 RatingScaleComponent.visualAnalogScale.valType:bool
 SettingsComponent.order:['expName', 'Show info dlg', 'Experiment info', 'Data filename', 'Save excel file', 'Save csv file', 'Save wide csv file', 'Save psydat file', 'Save log file', 'logging level', 'Monitor', 'Screen', 'Full-screen window', 'Window size (pixels)', 'color', 'colorSpace', 'Units', 'HTML path']
-SettingsComponent.Completed URL.default:'completedURL'
+SettingsComponent.Completed URL.default:''
 SettingsComponent.Completed URL.allowedTypes:[]
 SettingsComponent.Completed URL.allowedUpdates:None
 SettingsComponent.Completed URL.allowedVals:[]
@@ -3491,7 +3491,7 @@ SettingsComponent.Completed URL.label:Completed URL
 SettingsComponent.Completed URL.readOnly:False
 SettingsComponent.Completed URL.staticUpdater:None
 SettingsComponent.Completed URL.updates:None
-SettingsComponent.Completed URL.val:completedURL
+SettingsComponent.Completed URL.val:
 SettingsComponent.Completed URL.valType:str
 SettingsComponent.Data filename.default:u'data/%s_%s_%s' % (expInfo['participant'], expName, expInfo['date'])
 SettingsComponent.Data filename.allowedTypes:[]
@@ -3565,7 +3565,7 @@ SettingsComponent.HTML path.staticUpdater:None
 SettingsComponent.HTML path.updates:None
 SettingsComponent.HTML path.val:html
 SettingsComponent.HTML path.valType:str
-SettingsComponent.Incomplete URL.default:'incompleteURL'
+SettingsComponent.Incomplete URL.default:''
 SettingsComponent.Incomplete URL.allowedTypes:[]
 SettingsComponent.Incomplete URL.allowedUpdates:None
 SettingsComponent.Incomplete URL.allowedVals:[]
@@ -3576,7 +3576,7 @@ SettingsComponent.Incomplete URL.label:Incomplete URL
 SettingsComponent.Incomplete URL.readOnly:False
 SettingsComponent.Incomplete URL.staticUpdater:None
 SettingsComponent.Incomplete URL.updates:None
-SettingsComponent.Incomplete URL.val:incompleteURL
+SettingsComponent.Incomplete URL.val:
 SettingsComponent.Incomplete URL.valType:str
 SettingsComponent.JS libs.default:'packaged'
 SettingsComponent.JS libs.allowedTypes:[]
@@ -3713,7 +3713,7 @@ SettingsComponent.Units.valType:str
 SettingsComponent.Use version.default:''
 SettingsComponent.Use version.allowedTypes:[]
 SettingsComponent.Use version.allowedUpdates:None
-SettingsComponent.Use version.allowedVals:['latest', u'1', u'1.90', u'1.85', u'1.84', u'1.83', u'1.82', u'1.81', u'1.80', u'1.79', u'1.78', u'1.77', u'1.76', '', u'1.90.2', u'1.90.1', u'1.90.0', u'1.85.6', u'1.85.4', u'1.85.3', u'1.85.2', u'1.85.1', u'1.85.0', u'1.84.2', u'1.84.1', u'1.84.0', u'1.83.04', u'1.83.03', u'1.83.01', u'1.83.00', u'1.82.01', u'1.82.00', u'1.81.03', u'1.81.02', u'1.81.01', u'1.81.00', u'1.80.06', u'1.80.05', u'1.80.03', u'1.80.02', u'1.80.01', u'1.80.00', u'1.79.00', u'1.78.01', u'1.78.00', u'1.77.02', u'1.77.01', u'1.77.00', u'1.76.00']
+SettingsComponent.Use version.allowedVals:['latest', '1', '1.90', '1.85', '1.84', '1.83', '1.82', '1.81', '1.80', '1.79', '1.78', '1.77', '1.76', '', '1.90.2', '1.90.1', '1.90.0', '1.85.6', '1.85.4', '1.85.3', '1.85.2', '1.85.1', '1.85.0', '1.84.2', '1.84.1', '1.84.0', '1.83.04', '1.83.03', '1.83.01', '1.83.00', '1.82.01', '1.82.00', '1.81.03', '1.81.02', '1.81.01', '1.81.00', '1.80.06', '1.80.05', '1.80.03', '1.80.02', '1.80.01', '1.80.00', '1.79.00', '1.78.01', '1.78.00', '1.77.02', '1.77.01', '1.77.00', '1.76.00']
 SettingsComponent.Use version.categ:Basic
 SettingsComponent.Use version.hint:The version of PsychoPy to use when running the experiment.
 SettingsComponent.Use version.label:Use PsychoPy version


### PR DESCRIPTION
The setRedirectURL function takes string arguments from online experiment
settings, however the default setting was redirecting to nonexisting URLs.
This fix changes the default value in the URL params, and only writes
the setRedirectURL function in the JS if an entry is provided for one of
the URL params in exp. settings.