### PR TITLE
BF: Fixed FBO missing depth attachment.

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1492,6 +1492,10 @@ class Window(object):
                                     GL.GL_DEPTH24_STENCIL8_EXT,
                                     int(self.size[0]), int(self.size[1]))
         GL.glFramebufferRenderbufferEXT(GL.GL_FRAMEBUFFER_EXT,
+                                        GL.GL_DEPTH_ATTACHMENT_EXT,
+                                        GL.GL_RENDERBUFFER_EXT,
+                                        self._stencilTexture)
+        GL.glFramebufferRenderbufferEXT(GL.GL_FRAMEBUFFER_EXT,
                                         GL.GL_STENCIL_ATTACHMENT_EXT,
                                         GL.GL_RENDERBUFFER_EXT,
                                         self._stencilTexture)


### PR DESCRIPTION
When creating an FBO, only the stencil, not the depth component of the storage buffer is attached to the render buffer. This causes unexpected behaviour when using glDepthTest when rendering 3D objects.