### PR TITLE
BF: Run `glfw.terminate()` later during cleanup.

### DIFF
--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import atexit
 from builtins import object
 import sys
 import threading
@@ -39,6 +40,7 @@ except ImportError:
 try:
     import glfw
     haveGLFW = True
+    atexit.register(glfw.terminate)
 except ImportError:
     haveGLFW = False
 
@@ -72,17 +74,13 @@ def quit():
     """
     # pygame.quit()  # safe even if pygame was never initialised
     logging.flush()
-    
+
     for thisThread in threading.enumerate():
         if hasattr(thisThread, 'stop') and hasattr(thisThread, 'running'):
             # this is one of our event threads - kill it and wait for success
             thisThread.stop()
             while thisThread.running == 0:
                 pass  # wait until it has properly finished polling
-
-    # call terminate() on GLFW if available
-    if haveGLFW:
-        glfw.terminate()
 
     sys.exit(0)  # quits the python session entirely
 
@@ -126,7 +124,7 @@ def shellCall(shellCmd, stdin='', stderr=False, env=None, encoding=None):
     """
     if encoding is None:
         encoding = locale.getpreferredencoding()
-    
+
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
         shellCmdList = shlex.split(shellCmd)

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -72,17 +72,13 @@ def quit():
     """
     # pygame.quit()  # safe even if pygame was never initialised
     logging.flush()
-    
+
     for thisThread in threading.enumerate():
         if hasattr(thisThread, 'stop') and hasattr(thisThread, 'running'):
             # this is one of our event threads - kill it and wait for success
             thisThread.stop()
             while thisThread.running == 0:
                 pass  # wait until it has properly finished polling
-
-    # call terminate() on GLFW if available
-    if haveGLFW:
-        glfw.terminate()
 
     sys.exit(0)  # quits the python session entirely
 
@@ -126,7 +122,7 @@ def shellCall(shellCmd, stdin='', stderr=False, env=None, encoding=None):
     """
     if encoding is None:
         encoding = locale.getpreferredencoding()
-    
+
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
         shellCmdList = shlex.split(shellCmd)

--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -9,7 +9,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import atexit
 from builtins import object
 import sys
 import threading
@@ -40,7 +39,6 @@ except ImportError:
 try:
     import glfw
     haveGLFW = True
-    atexit.register(glfw.terminate)
 except ImportError:
     haveGLFW = False
 
@@ -74,13 +72,17 @@ def quit():
     """
     # pygame.quit()  # safe even if pygame was never initialised
     logging.flush()
-
+    
     for thisThread in threading.enumerate():
         if hasattr(thisThread, 'stop') and hasattr(thisThread, 'running'):
             # this is one of our event threads - kill it and wait for success
             thisThread.stop()
             while thisThread.running == 0:
                 pass  # wait until it has properly finished polling
+
+    # call terminate() on GLFW if available
+    if haveGLFW:
+        glfw.terminate()
 
     sys.exit(0)  # quits the python session entirely
 
@@ -124,7 +126,7 @@ def shellCall(shellCmd, stdin='', stderr=False, env=None, encoding=None):
     """
     if encoding is None:
         encoding = locale.getpreferredencoding()
-
+    
     if type(shellCmd) == str:
         # safely split into cmd+list-of-args, no pipes here
         shellCmdList = shlex.split(shellCmd)

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -14,6 +14,7 @@ and initialize an instance using the attributes of the Window.
 """
 
 from __future__ import absolute_import, print_function
+import atexit
 import sys, os
 import numpy as np
 from psychopy import logging, event, prefs
@@ -30,6 +31,7 @@ if not glfw.init():
                        "has been correctly installed or use a "
                        "different backend. Exiting.")
 
+atexit.register(glfw.terminate)
 import pyglet
 pyglet.options['debug_gl'] = False
 GL = pyglet.gl


### PR DESCRIPTION
Addresses #2089.

Currently, if `core.quit()` is called while a GLFW Window is open, `glfw.terminate()` (in core.py) runs before the window's `close_on_exit()` (via atexit). This PR registers `terminate()` with atexit when core is imported, meaning it ought to run *after* `close_on_exit()` (which is registered later).

Example:
```python
from psychopy import core, visual

win = visual.Window(winType='glfw')

core.quit()
```

@mdcutone, what do you think?