### PR TITLE
PKG, BF: added 'include version' to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -35,3 +35,4 @@ prune docs/source/nonSphinx
 prune windlls
 include versioneer.py
 include psychopy/_version.py
+include version


### PR DESCRIPTION
This is to have the file 'version' in the sdist, and fix the problem with
'pip install' not finding the version file.
See issue #2049, #2095