### PR TITLE
TESTS: Remove gitpython dependency

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -15,7 +15,6 @@ dependencies:
 - freetype
 - future
 - gevent
-- gitpython
 - greenlet
 - json_tricks
 - libffi

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -15,7 +15,6 @@ dependencies:
 - freetype
 - future
 - gevent
-- gitpython
 - greenlet
 - hdf5
 - json_tricks

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -15,7 +15,6 @@ dependencies:
 - freetype
 - future
 - gevent
-- gitpython
 - greenlet
 - hdf5
 - json_tricks


### PR DESCRIPTION
We use dulwich now.