### PR TITLE
ENH: Return stdout, stderr of pythonw invocation during app startup

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -88,7 +88,11 @@ Options:
             if '--no-splash' in sys.argv:
                 cmd.append('--no-splash')
 
-            core.shellCall(cmd, env=dict(env, PYTHONW='True'))
+            stdout, stderr = core.shellCall(cmd,
+                                            env=dict(env, PYTHONW='True'),
+                                            stderr=True)
+            print(stdout, file=sys.stdout)
+            print(stderr, file=sys.stderr)
             sys.exit()
         else:
             start_app()


### PR DESCRIPTION
Running `psychopyApp.py` used to silently fail (return code 0, no error message) for me on macOS with a Miniconda installation. Turned out that one dependency (`wxpython`) was missing, but I never got to see the exception error message because the output of the `pythonw` executable that we invoke via `shellCall()` was silently discarded. This commit changes this behavior: we will now retrieve `stdout` and `stderr`, and "re-print" them to the appropriate streams.