### PR TITLE
Moved back to gitpython from dulwich

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -10,7 +10,7 @@ dependencies:
 - cffi
 - codecov
 - coveralls
-- dulwich
+- gitpython
 - ffmpeg
 - freetype
 - future

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -10,7 +10,7 @@ dependencies:
 - cffi
 - codecov
 - coveralls
-- dulwich
+- gitpython
 - ffmpeg
 - freetype
 - future

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -10,7 +10,7 @@ dependencies:
 - cffi
 - codecov
 - coveralls
-- dulwich
+- gitpython
 - ffmpeg
 - freetype
 - future

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -445,7 +445,7 @@ def syncProject(parent, project=None, closeFrameWhenDone=False):
         time.sleep(0.001)
         # git push -u origin master
         try:
-            project.firstPush()
+            project.firstPush(infoStream=syncFrame.syncPanel)
             project._newRemote = False
         except Exception as e:
             closeFrameWhenDone = False

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -8,7 +8,8 @@ import time
 import os
 import traceback
 
-from .functions import setLocalPath, showCommitDialog, logInPavlovia
+from .functions import (setLocalPath, showCommitDialog, logInPavlovia,
+                        checkGitPresent)
 from psychopy.localization import _translate
 from psychopy.projects import pavlovia
 from psychopy import logging
@@ -311,6 +312,7 @@ class DetailsPanel(scrlpanel.ScrolledPanel):
         self.Layout()
 
     def onSyncButton(self, event):
+        checkGitPresent(self.parent)
 
         if self.project is None:
             raise AttributeError("User pressed the sync button with no "
@@ -374,6 +376,7 @@ def syncProject(parent, project=None, closeFrameWhenDone=False):
         0 for fail
         -1 for cancel at some point in the process
     """
+    checkGitPresent(parent)
 
     isCoder = hasattr(parent, 'currentDoc')
     if not project and "BuilderFrame" in repr(parent):
@@ -423,6 +426,7 @@ def syncProject(parent, project=None, closeFrameWhenDone=False):
             return
 
     # a sync will be necessary so can create syncFrame
+    checkGitPresent(parent)
     syncFrame = sync.SyncFrame(parent=parent, id=wx.ID_ANY, project=project)
 
     if project._newRemote:

--- a/psychopy/constants.py
+++ b/psychopy/constants.py
@@ -44,12 +44,14 @@ PSYCHOPY_USERAGENT = ("PsychoPy: open-source Psychology & Neuroscience tools; "
 # see https://github.com/dulwich/dulwich/issues/666
 ENVIRON = copy.copy(os.environ)
 if sys.platform == 'darwin':
-    _gitStandalonePath = abspath(join(sys.executable,
-                                      '..', '..', 'Resources',
-                                      'git-core'))
+    _gitStandalonePath = abspath(join(sys.executable, '..', '..',
+                                      'Resources', 'git-core'))
     if os.path.exists(_gitStandalonePath):
         ENVIRON["PATH"] = "{}:".format(_gitStandalonePath) + ENVIRON["PATH"]
+        os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = _gitStandalonePath
+
 elif sys.platform == 'win32':
     _gitStandalonePath = abspath(join(sys.executable, '..', 'MinGit', 'cmd'))
     if os.path.exists(_gitStandalonePath):
         ENVIRON["PATH"] = "{};".format(_gitStandalonePath) + ENVIRON["PATH"]
+        os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = _gitStandalonePath

--- a/psychopy/constants.py
+++ b/psychopy/constants.py
@@ -43,15 +43,20 @@ PSYCHOPY_USERAGENT = ("PsychoPy: open-source Psychology & Neuroscience tools; "
 # isn't currently possible (e.g. pull overwrites any local commits!)
 # see https://github.com/dulwich/dulwich/issues/666
 ENVIRON = copy.copy(os.environ)
+gitExe = None
 if sys.platform == 'darwin':
     _gitStandalonePath = abspath(join(sys.executable, '..', '..',
                                       'Resources', 'git-core'))
     if os.path.exists(_gitStandalonePath):
         ENVIRON["PATH"] = "{}:".format(_gitStandalonePath) + ENVIRON["PATH"]
-        os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = _gitStandalonePath
+        gitExe = join(_gitStandalonePath, 'git')
 
 elif sys.platform == 'win32':
     _gitStandalonePath = abspath(join(sys.executable, '..', 'MinGit', 'cmd'))
     if os.path.exists(_gitStandalonePath):
         ENVIRON["PATH"] = "{};".format(_gitStandalonePath) + ENVIRON["PATH"]
         os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = _gitStandalonePath
+        gitExe = join(_gitStandalonePath, 'git.exe')
+
+if gitExe:
+    os.environ["GIT_PYTHON_GIT_EXECUTABLE"] = gitExe

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -28,6 +28,6 @@ pytest-cov
 pytest-xdist
 coveralls
 python-gitlab
+gitpython
 astunparse
 esprima
-dulwich

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     moviepy
     opencv-python
     python-gitlab
-    dulwich
+    gitpython
     astunparse
     esprima
     freetype-py

--- a/setupApp.py
+++ b/setupApp.py
@@ -95,7 +95,7 @@ packages = ['wx', 'psychopy',
             # for Py3 compatibility
             'future', 'past', 'lib2to3',
             'json_tricks',  # allows saving arrays/dates in json
-            'gitpython', 'gitlab',
+            'git', 'gitlab',
             'astunparse', 'esprima',  # for translating/adapting py/JS
             'pylsl', 'pygaze',
             ]

--- a/setupApp.py
+++ b/setupApp.py
@@ -95,7 +95,7 @@ packages = ['wx', 'psychopy',
             # for Py3 compatibility
             'future', 'past', 'lib2to3',
             'json_tricks',  # allows saving arrays/dates in json
-            'dulwich', 'gitlab',
+            'gitpython', 'gitlab',
             'astunparse', 'esprima',  # for translating/adapting py/JS
             'pylsl', 'pygaze',
             ]

--- a/setupApp.sh
+++ b/setupApp.sh
@@ -36,7 +36,7 @@ for i in todo; do
 
     ${pythons[$i]} setupApp.py py2app || { echo 'setupApp.py failed' ; exit 1; }
     # copy over git-core folder
-    cp -R /usr/local/git/libexec/git-core dist/${names[$i]}.app/Contents/Resources/git-core
+    cp -R -L /usr/local/git/libexec/git-core dist/${names[$i]}.app/Contents/Resources/git-core
 
     # remove matplotlib tests (45mb)
     rm -r dist/${names[$i]}.app/Contents/Resources/lib/python2.7/matplotlib/tests


### PR DESCRIPTION
Turns out the dulwich (and libgit2 which also looked promising) don't support proper pull with
merge option. 

That means we need to stick with the original git executables (and access via gitpython for simplicity for now). Sadly we're now packaging those inside PsychoPy which adds hundreds of MB :-(