### PR TITLE
TESTS: Small changes to Travis environments

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -48,6 +48,7 @@ dependencies:
 - setuptools
 - sip
 - six
+- pyglet>=1.3
 - pytables
 - urllib3
 - wheel
@@ -69,6 +70,5 @@ dependencies:
   - freetype-py
   - prompt-toolkit
   - pygame
-  - pyglet==1.3.0b1
   - pyparallel
   - python-gitlab

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -39,6 +39,7 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
+- pysoundfile
 - python-bidi
 - pyyaml
 - pyzmq
@@ -57,6 +58,7 @@ dependencies:
 - pytables
 - pytest
 - pytest-cov
+- python-sounddevice
 - wxpython
 - zlib
 - pip:
@@ -70,5 +72,3 @@ dependencies:
   - pyglet==1.3.0b1
   - pyparallel
   - python-gitlab
-  - sounddevice
-  - soundfile

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -34,9 +34,11 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
+- pysoundfile
 - pytest
 - pytest-cov
 - python-bidi
+- python-sounddevice
 - pyyaml
 - pyzmq
 - requests
@@ -64,5 +66,3 @@ dependencies:
   - pyglet==1.3.0b1
   - pyparallel
   - python-gitlab
-  - sounddevice
-  - soundfile

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -46,6 +46,7 @@ dependencies:
 - setuptools
 - sip
 - six
+- pyglet>=1.3
 - pytables
 - urllib3
 - wheel
@@ -63,6 +64,5 @@ dependencies:
   - esprima
   - freetype-py
   - pygame
-  - pyglet==1.3.0b1
   - pyparallel
   - python-gitlab

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -34,9 +34,11 @@ dependencies:
 - pyosf
 - pyqt
 - pyserial
+- pysoundfile
 - pytest
 - pytest-cov
 - python-bidi
+- python-sounddevice
 - pyyaml
 - pyzmq
 - requests
@@ -64,5 +66,3 @@ dependencies:
   - pyglet
   - pyparallel
   - python-gitlab
-  - sounddevice
-  - soundfile

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -46,6 +46,7 @@ dependencies:
 - setuptools
 - sip
 - six
+- pyglet>=1.3
 - pytables
 - urllib3
 - wheel
@@ -63,6 +64,5 @@ dependencies:
   - esprima
   - freetype-py
   - pygame
-  - pyglet
   - pyparallel
   - python-gitlab

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -3,7 +3,7 @@ wheel  # Allow us to install binary wheels e.g. for opencv-python
 matplotlib
 soundfile
 sounddevice
-pyglet==1.3.0b1
+pyglet>=1.3
 pillow
 opencv-python
 moviepy

--- a/travis/20_install_miniconda_python.sh
+++ b/travis/20_install_miniconda_python.sh
@@ -16,5 +16,5 @@ ls -la ./conda/environment-$PYTHON_VERSION.yml
 conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml
 conda env list
 source activate psychopy-conda
-if [ -n "$WXPYTHON" ]; then conda install wxpython=$WXPYTHON; fi
-if [ -n "$OPENPYXL" ]; then conda install openpyxl=$OPENPYXL; fi
+if [ -n "$WXPYTHON" ]; then conda install -c conda-forge wxpython=$WXPYTHON; fi
+if [ -n "$OPENPYXL" ]; then conda install -c conda-forge openpyxl=$OPENPYXL; fi


### PR DESCRIPTION
- SoundFile and Sounddevice are available from `conda-forge`, we don't need to install via `pip`
- We now explicitly install `wxpython` & `openpyxl` via `conda-forge` (previously the `defaults` channel could have been used, leading to potential binary incompatibilities). This seems to fix recent issues with Travis (builds segfaulting).
- Install `pyglet` from `conda-forge`, and bump min. version to 1.3.0 (used to be a 1.3 beta)