### PR TITLE
Fix to a bug related to static component

### DIFF
--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -156,7 +156,7 @@ class StaticComponent(BaseComponent):
                     prms = compName.params  # it's already a compon so get params
                 else:
                     # it's a name so get compon and then get params
-                    prms = self.exp.getComponentFromName(bytes(compName)).params
+                    prms = self.exp.getComponentFromName(str(compName)).params
                 self.writeParamUpdate(buff, compName=compName,
                                       paramName=fieldName,
                                       val=prms[fieldName],


### PR DESCRIPTION
`bytes(compName)` does not work in Python 3 and because of that static component does not work too.
replacing it by `str(compName)` fixed the problem