### PR TITLE
BF: Replaces escaped newline chars in conditions file strings

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -234,6 +234,11 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         """
         # convert the resulting dataframe to a numpy recarray
         trialsArr = dataframe.to_records(index=False)
+        # Check for new line characters in strings, and replace escaped characters
+        for record in trialsArr:
+            for idx, element in enumerate(record):
+                if isinstance(element, str):
+                    record[idx] = element.replace('\\n', '\n')
         if trialsArr.shape == ():
             # convert 0-D to 1-D with one element:
             trialsArr = trialsArr[np.newaxis]


### PR DESCRIPTION
New line characters in strings were printed not executed when
imported from a conditions file because new line characters are escaped
when the conditions file is converted from a dataframe to a numpy record
array. This fix checks for string in record after conversion to recarray,
and replaces the excaped newline with an unescaped new line.