### PR TITLE
PKG, TESTS: Exclude broken wxpython versions

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -60,7 +60,7 @@ dependencies:
 - pytest
 - pytest-cov
 - python-sounddevice
-- wxpython
+- wxpython!=4.0.2,!=4.0.3
 - zlib
 - pip:
   - arabic_reshaper

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -56,7 +56,7 @@ dependencies:
 - yaml
 - lzo
 - pytables
-- wxpython
+- wxpython!=4.0.2,!=4.0.3
 - zlib
 - pip:
   - arabic_reshaper

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ install_requires =
     freetype-py
     # Platform-specific dependencies.
     pyqt5; python_version >= "3"
-    wxPython; platform_system != "Linux"
+    wxPython!=4.0.2,!=4.0.3; platform_system != "Linux"
     pypiwin32; platform_system == "Windows"
     pyobjc-core; platform_system == "Darwin"
     pyobjc-framework-Quartz; platform_system == "Darwin"


### PR DESCRIPTION
wxpython 4.0.2 and 4.0.3 break Undo/Redo behavior in the app. Exclude these versions from requirements and conda environments. However, only 4.0.3 is available for Python 3.7 on conda-forge, so do not impose any restrictions for Python 3.7 for now. Closes GH-2119.