### PR TITLE
BF: Adds an empty string to text JS text component if text is None

### DIFF
--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -107,6 +107,7 @@ class TextComponent(BaseVisualComponent):
         inits = getInitVals(self.params, 'PsychoPy')
         if self.params['wrapWidth'].val in ['', 'None', 'none']:
             inits['wrapWidth'] = 'None'
+
         code = ("%(name)s = visual.TextStim(win=win, "
                 "name='%(name)s',\n"
                 "    text=%(text)s,\n"
@@ -144,6 +145,9 @@ class TextComponent(BaseVisualComponent):
 
         if self.params['wrapWidth'].val in ['', 'None', 'none']:
             inits['wrapWidth'] = 'undefined'
+        if self.params['text'].val in ['', 'None', 'none']:
+            inits['text'] = "''"
+
         code = ("%(name)s = new visual.TextStim({\n"
                 "  win : psychoJS.window,\n"
                 "  name : '%(name)s',\n"


### PR DESCRIPTION
When text is set to Blank or None in Builder, the JS output provided a Nonetype as text, which fails in JS.
Also, setting to undefined, as in JS, the user is given a Hello World string.
This fix sets the JS output text for text component to an empty string if no text is provided.