### PR TITLE
ENH: pause BitsSharp device after sending message

### DIFF
--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -1268,6 +1268,7 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
             while msg:
                 msg=self.read(timeout=0.1)
             self.sendMessage('$VideoFrameRate\r')
+            self.pause()
             msg=self.read(timeout=0.1)
             msg2 = msg.split(b';')
             self.frameRate = float(msg2[1])


### PR DESCRIPTION
Display++ was giving an error on initialisation because the reply was not available to be read immediately - this pauses to allow the device time to respond before reading.