### PR TITLE
ENH, RF: New "hardware" prefs tab

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -20,7 +20,7 @@ from psychopy.localization import _translate
 from pkg_resources import parse_version
 
 # this will be overridden by the size of the scrolled panel making the prefs
-dlgSize = (520, 600)
+dlgSize = (600, 600)
 
 # labels mappings for display:
 _localized = {
@@ -29,6 +29,7 @@ _localized = {
     'app': _translate('App'),
     'builder': "Builder",  # not localized
     'coder': "Coder",  # not localized
+    'hardware': _translate('Hardware'),
     'connections': _translate('Connections'),
     'keyBindings': _translate('Key bindings'),
     # pref labels:
@@ -172,7 +173,7 @@ class PreferencesDlg(wx.Dialog):
 
         self.ctrls = {}
         sectionOrdering = ['general', 'app', 'builder', 'coder',
-                           'connections', 'keyBindings']
+                           'hardware', 'connections', 'keyBindings']
         for section in sectionOrdering:
             prefsPage = self.makePrefPage(parent=self.nb,
                                           sectionName=section,
@@ -475,6 +476,7 @@ class PrefCtrls(object):
         else:
             l = errmsg
         return l
+
 
 if __name__ == '__main__':
     from psychopy import preferences

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -20,7 +20,7 @@ from psychopy.localization import _translate
 from pkg_resources import parse_version
 
 # this will be overridden by the size of the scrolled panel making the prefs
-dlgSize = (600, 600)
+dlgSize = (600, 500)
 
 # labels mappings for display:
 _localized = {

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -48,7 +48,7 @@ class ParallelOutComponent(BaseComponent):
         self.order = ['address', 'startData', 'stopData']
 
         # main parameters
-        addressOptions = prefs.general['parallelPorts'] + [u'LabJack U3']
+        addressOptions = prefs.hardware['parallelPorts'] + [u'LabJack U3']
         if not address:
             address = addressOptions[0]
 

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -38,16 +38,8 @@
     version = string(default='')
     # Add paths here to your custom Python modules
     paths=list(default=list())
-    # choice of audio library
-    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
-    # audio driver to use
-    audioDriver = list(default=list('coreaudio', 'portaudio'))
-    # audio device to use (if audioLib allows control)
-    audioDevice = list(default=list('default'))
     # path to flac (lossless audio compression) on this operating system
     flac = string(default='')
-    # a list of parallel ports
-    parallelPorts = list(default=list('0x0378', '0x03BC', '/dev/parport0', '/dev/parport1'))
     # Shutdown keys, following the pyglet naming scheme.
     shutdownKey = string(default='')
     # Modifier keys for shutdown keys
@@ -115,6 +107,16 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+
+[hardware]
+    # choice of audio library
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
+    # audio driver to use
+    audioDriver = list(default=list('coreaudio', 'portaudio'))
+    # audio device to use (if audioLib allows control)
+    audioDevice = list(default=list('default'))
+    # a list of parallel ports
+    parallelPorts = list(default=list('0x0378', '0x03BC', '/dev/parport0', '/dev/parport1'))
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -38,16 +38,8 @@
     version = string(default='')
     # Add paths here to your custom Python modules
     paths=list(default=list())
-    # choice of audio library
-    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
-    # audio driver to use
-    audioDriver = list(default=list('portaudio'))
-    # audio device to use (if audioLib allows control)
-    audioDevice = list(default=list('default'))
     # path to flac (lossless audio compression) on this operating system
     flac = string(default='')
-    # a list of parallel ports
-    parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
     # Shutdown keys, following the pyglet naming scheme.
     shutdownKey = string(default='')
     # Modifier keys for shutdown keys
@@ -115,6 +107,16 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+
+[hardware]
+    # choice of audio library
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
+    # audio driver to use
+    audioDriver = list(default=list('portaudio'))
+    # audio device to use (if audioLib allows control)
+    audioDevice = list(default=list('default'))
+    # a list of parallel ports
+    parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -38,16 +38,8 @@
     version = string(default='')
     # Add paths here to your custom Python modules
     paths=list(default=list())
-    # choice of audio library
-    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
-    # audio driver to use
-    audioDriver = list(default=list('portaudio'))
-    # audio device to use (if audioLib allows control)
-    audioDevice = list(default=list('default'))
     # path to flac (lossless audio compression) on this operating system
     flac = string(default='')
-    # a list of parallel ports
-    parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
     # Shutdown keys, following the pyglet naming scheme.
     shutdownKey = string(default='')
     # Modifier keys for shutdown keys
@@ -115,6 +107,16 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+
+[hardware]
+    # choice of audio library
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
+    # audio driver to use
+    audioDriver = list(default=list('portaudio'))
+    # audio device to use (if audioLib allows control)
+    audioDevice = list(default=list('default'))
+    # a list of parallel ports
+    parallelPorts = list(default=list('/dev/parport0', '/dev/parport1'))
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -38,16 +38,8 @@
     version = string(default='')
     # Add paths here to your custom Python modules
     paths=list(default=list())
-    # choice of audio library
-    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
-    # audio driver to use
-    audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
-    # audio device to use (if audioLib allows control)
-    audioDevice = list(default=list('default'))
     # path to flac (lossless audio compression) on this operating system
     flac = string(default='')
-    # a list of parallel ports
-    parallelPorts = list(default=list('0x0378', '0x03BC'))
     # Shutdown keys, following the pyglet naming scheme.
     shutdownKey = string(default='')
     # Modifier keys for shutdown keys
@@ -115,6 +107,16 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+
+[hardware]
+    # choice of audio library
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
+    # audio driver to use
+    audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
+    # audio device to use (if audioLib allows control)
+    audioDevice = list(default=list('default'))
+    # a list of parallel ports
+    parallelPorts = list(default=list('0x0378', '0x03BC'))
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -34,16 +34,8 @@
     version = string(default='')
     # Add paths here to your custom Python modules
     paths=list(default=list())
-    # choice of audio library
-    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
-    # audio driver to use
-    audioDriver = list(default=list('portaudio'))
-    # audio device to use (if audioLib allows control)
-    audioDevice = list(default=list('default'))
     # path to flac (lossless audio compression) on this operating system
     flac = string(default='')
-    # a list of parallel ports
-    parallelPorts = list(default=list('0x0378', '0x03BC'))
     # Shutdown keys, following the pyglet naming scheme.
     shutdownKey = string(default='')
     # Modifier keys for shutdown keys
@@ -111,6 +103,16 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+
+[hardware]
+    # choice of audio library
+    audioLib = list(default=list('sounddevice', 'pyo', 'pygame'))
+    # audio driver to use
+    audioDriver = list(default=list('portaudio'))
+    # audio device to use (if audioLib allows control)
+    audioDevice = list(default=list('default'))
+    # a list of parallel ports
+    parallelPorts = list(default=list('0x0378', '0x03BC'))
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -24,7 +24,7 @@ class Preferences(object):
     or, within a script, preferences can be controlled like this::
 
         import psychopy
-        psychopy.prefs.general['audioLib'] = ['pyo','pygame']
+        psychopy.prefs.hardware['audioLib'] = ['pyo','pygame']
         print(prefs)
         # prints the location of the user prefs file and all the current vals
 
@@ -154,6 +154,7 @@ class Preferences(object):
         self.app = self.userPrefsCfg['app']
         self.coder = self.userPrefsCfg['coder']
         self.builder = self.userPrefsCfg['builder']
+        self.hardware = self.userPrefsCfg['hardware']
         self.connections = self.userPrefsCfg['connections']
         self.keys = self.userPrefsCfg['keyBindings']
         self.appData = self.appDataCfg

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -5,7 +5,7 @@
 
 By default PsychoPy will try to use the following Libs, in this order, for
 sound reproduction but you can alter the order in
-preferences > general > audioLib:
+preferences > hardware > audioLib:
     ['sounddevice', 'pygame', 'pyo']
 For portaudio-based backends (all except for pygame) there is also a
 choice of the underlying sound driver (e.g. ASIO, CoreAudio etc).
@@ -65,9 +65,9 @@ _audioLibs = ['sounddevice', 'pyo', 'pysoundcard', 'pygame']
 travisCI = bool(str(os.environ.get('TRAVIS')).lower() == 'true')
 if travisCI:
     # for sounddevice we built in some TravisCI protection but not in pyo
-    prefs.general['audioLib'] = ['sounddevice']
+    prefs.hardware['audioLib'] = ['sounddevice']
 
-for thisLibName in prefs.general['audioLib']:
+for thisLibName in prefs.hardware['audioLib']:
 
     try:
         if thisLibName == 'pyo':
@@ -104,7 +104,7 @@ if audioLib is None:
     raise exceptions.DependencyError(
             "No sound libs could be loaded. Tried: {}\n"
             "Check whether the necessary sound libs are installed"
-            .format(prefs.general['audioLib']))
+            .format(prefs.hardware['audioLib']))
 
 # function to set the device (if current lib allows it)
 def setDevice(dev, kind=None):
@@ -133,14 +133,14 @@ def setDevice(dev, kind=None):
 
 # Set the device according to user prefs (if current lib allows it)
 if hasattr(backend, 'defaultOutput'):
-    pref = prefs.general['audioDevice']
+    pref = prefs.hardware['audioDevice']
     # is it a list or a simple string?
-    if type(prefs.general['audioDevice'])==list:
+    if type(prefs.hardware['audioDevice'])==list:
         # multiple options so use zeroth
-        dev = prefs.general['audioDevice'][0]
+        dev = prefs.hardware['audioDevice'][0]
     else:
         # a single option
-        dev = prefs.general['audioDevice']
+        dev = prefs.hardware['audioDevice']
     # is it simply "default" (do nothing)
     if dev=='default' or travisCI:
         pass  # do nothing

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -31,7 +31,7 @@ audioDriver = None
 def _bestDriver(devNames, devIDs):
     """Find ASIO or Windows sound drivers
     """
-    preferredDrivers = prefs.general['audioDriver']
+    preferredDrivers = prefs.hardware['audioDriver']
     outputID = None
     audioDriver = None
     for prefDriver in preferredDrivers:
@@ -216,7 +216,7 @@ def init(rate=44100, stereo=True, buffer=128):
                 duplex = False
         # for other platforms set duplex to True (if microphone is available)
         else:
-            audioDriver = prefs.general['audioDriver'][0]
+            audioDriver = prefs.hardware['audioDriver'][0]
             maxInputChnls = pyo.pa_get_input_max_channels(
                 pyo.pa_get_default_input())
             maxOutputChnls = pyo.pa_get_output_max_channels(

--- a/psychopy/tests/test_sound/test_sound_pygame.py
+++ b/psychopy/tests/test_sound/test_sound_pygame.py
@@ -5,7 +5,7 @@ from __future__ import division
 from builtins import object
 from past.utils import old_div
 from psychopy import prefs, core
-prefs.general['audioLib'] = ['pygame']
+prefs.hardware['audioLib'] = ['pygame']
 
 import pytest
 from scipy.io import wavfile

--- a/psychopy/tests/test_sound/test_sound_pyo.py
+++ b/psychopy/tests/test_sound/test_sound_pyo.py
@@ -19,7 +19,7 @@ from psychopy.constants import PY3
 if PY3:
     from importlib import reload
 
-origSoundPref = prefs.general['audioLib']
+origSoundPref = prefs.hardware['audioLib']
 
 # py.test --cov-report term-missing --cov sound.py tests/test_sound/test_sound_pyo.py
 
@@ -28,7 +28,7 @@ origSoundPref = prefs.general['audioLib']
 class TestPyo(object):
     @classmethod
     def setup_class(self):
-        prefs.general['audioLib'] = ['pyo']
+        prefs.hardware['audioLib'] = ['pyo']
         reload(sound)  # to force our new preference to be used
         self.contextName='pyo'
         try:
@@ -50,7 +50,7 @@ class TestPyo(object):
 
     @classmethod
     def teardown_class(self):
-        prefs.general['audioLib'] = origSoundPref
+        prefs.hardware['audioLib'] = origSoundPref
 
         if hasattr(self, 'tmp'):
             shutil.rmtree(self.tmp, ignore_errors=True)

--- a/psychopy/tests/test_sound/test_sound_sounddevice.py
+++ b/psychopy/tests/test_sound/test_sound_sounddevice.py
@@ -18,7 +18,7 @@ from psychopy.constants import PY3
 if PY3:
     from importlib import reload
 
-origSoundPref = prefs.general['audioLib']
+origSoundPref = prefs.hardware['audioLib']
 
 # py.test --cov-report term-missing --cov sound.py tests/test_sound/test_sound_pyo.py
 
@@ -29,7 +29,7 @@ class TestSoundDevice(object):
     @classmethod
     def setup_class(self):
         self.contextName='sounddevice'
-        prefs.general['audioLib'] = ['sounddevice']
+        prefs.hardware['audioLib'] = ['sounddevice']
         reload(sound)
         self.tmp = mkdtemp(prefix='psychopy-tests-sound')
 
@@ -38,7 +38,7 @@ class TestSoundDevice(object):
 
     @classmethod
     def teardown_class(self):
-        prefs.general['audioLib'] = origSoundPref
+        prefs.hardware['audioLib'] = origSoundPref
         if hasattr(self, 'tmp'):
             shutil.rmtree(self.tmp, ignore_errors=True)
 

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -236,7 +236,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
         if self.status == PLAYING:
             self.status = PAUSED
             if self._audioStream:
-                if prefs.general['audioLib'] == ['sounddevice']:
+                if prefs.hardware['audioLib'] == ['sounddevice']:
                     self._audioStream.pause() #sounddevice has a "pause" function -JK
                 else:
                     self._audioStream.stop()
@@ -452,7 +452,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
             return  # do nothing
         #check if sounddevice  is being used. If so we can use seek. If not we have to 
         #reload the audio stream and begin at the new loc
-        if prefs.general['audioLib'] == ['sounddevice']:
+        if prefs.hardware['audioLib'] == ['sounddevice']:
             self._audioStream.seek(t)
         else:
             self._audioStream.stop()


### PR DESCRIPTION
As proposed in https://github.com/psychopy/psychopy/pull/2141#issuecomment-447287872, this PR introduces a new "hardware" section in the preferences and, likewise, a "hardware" tab in the preferences dialog. I've moved the following settings from "general" to "hardware":

   - audioLib
   - audioDriver
   - audioDevice
   - parallelPorts

![screenshot 2018-12-15 at 15 19 36](https://user-images.githubusercontent.com/2046265/50043922-e3d76680-007c-11e9-8d1a-69a718fe165d.png)
