### PR TITLE
BF: Various fixes for JS compiler for psychojs-3.0.0b12.

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -578,7 +578,7 @@ class BaseVisualComponent(BaseComponent):
         buff.writeIndented("%(name)s.setAutoDraw(true);\n" % self.params)
         # to get out of the if statement
         buff.setIndentLevel(-1, relative=True)
-        buff.writeIndented("}\n")
+        buff.writeIndented("}\n\n")
 
         # test for stop (only if there was some setting for duration or stop)
         if self.params['stopVal'].val not in ('', None, -1, 'None'):

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -318,7 +318,7 @@ class KeyboardComponent(BaseComponent):
 
         if store != 'nothing':
             if self.params['syncScreenRefresh'].val:
-                code = ("psychoJS.window.callOnFlip(%(name)s.clock.reset)"
+                code = ("psychoJS.window.callOnFlip(function(){ %(name)s.clock.reset(); });"
                         " // t = 0 on screen flip\n") % self.params
             else:
                 code = "%(name)s.clock.reset();  // now t=0\n" % self.params
@@ -329,14 +329,15 @@ class KeyboardComponent(BaseComponent):
             buff.writeIndented("psychoJS.eventManager.clearEvents({eventType:'keyboard'});\n")
         # to get out of the if statement
         buff.setIndentLevel(-1, relative=True)
-        buff.writeIndented("}\n")
+        buff.writeIndented("}\n\n")
 
         # test for stop (only if there was some setting for duration or stop)
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCodeJS(buff)
             buff.writeIndented("%(name)s.status = PsychoJS.Status.STOPPED;\n"
-                               "  }\n" % self.params)
+                               "  }\n"
+                               "\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
@@ -363,10 +364,10 @@ class KeyboardComponent(BaseComponent):
         buff.writeIndented("let theseKeys = psychoJS.eventManager.getKeys(%s);\n" % keyListStr)
 
         if self.exp.settings.params['Enable Escape'].val:
-            code = ('\n// check for quit:\n'
-                    'if ("escape" in theseKeys) {\n'
-                    '    psychoJS.experiment.experimentEnded = true;\n'
-                    '}\n')
+            code = ("\n// check for quit:\n"
+                    "if (theseKeys.indexOf('escape') > -1) {\n"
+                    "    psychoJS.experiment.experimentEnded = true;\n"
+                    "}\n")
             buff.writeIndentedLines(code)
 
         # how do we store it?
@@ -379,7 +380,7 @@ class KeyboardComponent(BaseComponent):
             dedentAtEnd += 1  # indent by 1
 
         if store == 'first key':  # then see if a key has already been pressed
-            code = ("if (%(name)s.keys.length == 0) {"
+            code = ("if (%(name)s.keys.length === 0) {"
                     "  // then this was the first keypress\n") % self.params
             buff.writeIndented(code)
 
@@ -488,11 +489,11 @@ class KeyboardComponent(BaseComponent):
             currLoop = self.exp._expHandler
 
         # write the actual code
-        code = ("// check responses\n"
+        code = ("\n// check responses\n"
                 "if (['', [], undefined].indexOf(%(name)s.keys) >= 0) {"
                 "    // No response was made\n"
                 "    %(name)s.keys = undefined;\n"
-                "}\n")
+                "}\n\n")
         buff.writeIndentedLines(code % self.params)
 
         if self.params['storeCorrect'].val:  # check for correct NON-repsonse
@@ -522,11 +523,11 @@ class KeyboardComponent(BaseComponent):
                 buff.writeIndented("psychoJS.experiment.addData('%(name)s.corr', %(name)s.corr);\n" % self.params)
 
             # only add an RT if we had a response
-            code = ("if ({name}.keys != undefined) {{  // we had a response\n"
+            code = ("if ({name}.keys !== undefined) {{  // we had a response\n"
                     "    psychoJS.experiment.addData('{name}.rt', {name}.rt);\n")
             if forceEnd:
                 code += ("    routineTimer.reset();\n"
-                         "    }}\n")
+                         "    }}\n\n")
             else:
-                code += "    }}\n"
+                code += "    }}\n\n"
             buff.writeIndentedLines(code.format(loopName=currLoop.params['name'], name=name))

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -733,9 +733,9 @@ class SettingsComponent(object):
                     "    };\n"
                     "}\n")
         buff.writeIndentedLines(recordLoopIterationFunc)
-        quitFunc = ("\nfunction quitPsychoJS(isCompleted) {\n"
+        quitFunc = ("\nfunction quitPsychoJS(message, isCompleted) {\n"
                     "  psychoJS.window.close();\n"
-                    "  psychoJS.quit({isCompleted});\n\n"
+                    "  psychoJS.quit({message, isCompleted});\n\n"
                     "  return Scheduler.Event.QUIT;\n"
                     "}")
         buff.writeIndentedLines(quitFunc)

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -167,11 +167,10 @@ class SoundComponent(BaseComponent):
         # do this EVERY frame, even before/after playing?
         self.writeParamUpdates(buff, 'set every frame')
         self.writeStartTestCodeJS(buff)
-        # if self.params['syncScreenRefresh'].val:
-        #     # TODO: Check callOnFlip for sound exists with JS
-        #     code = ("psychoJS.window.callOnFlip(%(name)s.play);  // screen flip\n") % self.params
-        # else:
-        code = "%(name)s.play();  // start the sound (it finishes automatically)\n" % self.params
+        if self.params['syncScreenRefresh'].val:
+            code = ("psychoJS.window.callOnFlip(function(){ %(name)s.play(); });  // screen flip\n") % self.params
+        else:
+            code = "%(name)s.play();  // start the sound (it finishes automatically)\n" % self.params
         buff.writeIndented(code)
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-1, relative=True)

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -316,10 +316,10 @@ class Flow(list):
                     loopStack.remove(thisEntry.loop)
             script.writeIndentedLines(code)
         # quit when all routines are finished
-        script.writeIndented("flowScheduler.add(quitPsychoJS, true);\n")
+        script.writeIndented("flowScheduler.add(quitPsychoJS, '', true);\n")
         # handled all the flow entries
         code = ("\n// quit if user presses Cancel in dialog box:\n"
-                "dialogCancelScheduler.add(quitPsychoJS, false);\n"
+                "dialogCancelScheduler.add(quitPsychoJS, '', false);\n"
                 "\npsychoJS.start({configURL: 'config.json', expInfo: expInfo});\n")
         script.writeIndentedLines(code)
         script.setIndentLevel(-1, relative=True)

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -184,7 +184,6 @@ class TrialHandler(object):
         # create the variable "thisTrial" from "trials"
         makeLoopIndex = self.exp.namespace.makeLoopIndex
         self.thisName = makeLoopIndex(self.params['name'].val)
-        inits = getInitVals(self.params)
 
         # seed might be undefined
         seed = self.params['random seed'].val or 'undefined'

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -184,12 +184,19 @@ class TrialHandler(object):
         # create the variable "thisTrial" from "trials"
         makeLoopIndex = self.exp.namespace.makeLoopIndex
         self.thisName = makeLoopIndex(self.params['name'].val)
+        inits = getInitVals(self.params)
+
         # seed might be undefined
         seed = self.params['random seed'].val or 'undefined'
-        if self.params['conditionsFile'].val == '':
+        if self.params['conditionsFile'].val in ['None', None, 'none', '']:
             trialList='undefined'
+        elif self.params['Selected rows'].val in ['None', None, 'none', '']:
+            trialList = self.params['conditionsFile']
         else:
-            trialList=self.params['conditionsFile']
+            trialList = ("TrialHandler.importConditions"
+                         "(psychoJS.serverManager, {}, {})"
+                         ).format(self.params['conditionsFile'],
+                                  self.params['Selected rows'])
 
         code = ("\nfunction {funName}LoopBegin(thisScheduler) {{\n"
                 "  // set up handler to look after randomisation of conditions etc\n"

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -286,17 +286,17 @@ class Routine(list):
                 "if (!continueRoutine) {"
                 "  // a component has requested a forced-end of Routine\n"
                 "  return Scheduler.Event.NEXT;\n"
-                "}\n"
+                "}\n\n"
                 "continueRoutine = false;"
                 "// reverts to True if at least one component still running\n"
                 "for (const thisComponent of %(name)sComponents)\n"
-                "  if ('status' in thisComponent && thisComponent.status != PsychoJS.Status.FINISHED) {\n"
+                "  if ('status' in thisComponent && thisComponent.status !== PsychoJS.Status.FINISHED) {\n"
                 "    continueRoutine = true;\n"
                 "    break;\n"
-                "  }\n"
+                "  }\n\n"
                 "// check for quit (the Esc key)\n"
                 "if (psychoJS.experiment.experimentEnded || psychoJS.eventManager.getKeys({keyList:['escape']}).length > 0) {\n"
-                "  psychoJS.quit('The [Escape] key was pressed. Goodbye!');\n"
+                "  return psychoJS.quit('The [Escape] key was pressed. Goodbye!', false);\n"
                 "}\n")
         buff.writeIndentedLines(code % self.params)
 


### PR DESCRIPTION
Corrected call to callOnFlip for sound - note, must check is supported with AP
Corrected call to callOnFlip for keyboard
Update code to include selected rows in Trial Handler
Other JS compile fixes relating to equality operators
Added extra spacing to separate conditionals and loops for readability