### PR TITLE
NF: Add Experiment.requireImport() method

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -40,7 +40,12 @@ from psychopy.localization import _translate
 import locale
 
 # standard_library.install_aliases()
-from collections import OrderedDict
+
+from collections import OrderedDict, namedtuple
+RequiredImport = namedtuple('RequiredImport',
+                            field_names=('importName',
+                                         'importFrom',
+                                         'importAs'))
 
 
 class Experiment(object):
@@ -70,9 +75,13 @@ class Experiment(object):
         # this can be checked by the builder that this is an experiment and a
         # compatible version
         self.psychopyVersion = __version__
+
         # What libs are needed (make sound come first)
-        self.psychopyLibs = ['sound', 'gui', 'visual', 'core',
-                             'data', 'event', 'logging', 'clock']
+        self.requiredImports = []
+        libs = ('sound', 'gui', 'visual', 'core', 'data', 'event',
+                'logging', 'clock')
+        self.requirePsychopyLibs(libs=libs)
+
         _settingsComp = getComponents(fetchIcons=False)['SettingsComponent']
         self.settings = _settingsComp(parentName='', exp=self)
         # this will be the xml.dom.minidom.doc object for saving
@@ -93,12 +102,34 @@ class Experiment(object):
     def requirePsychopyLibs(self, libs=()):
         """Add a list of top-level psychopy libs that the experiment
         will need. e.g. [visual, event]
+
+        Notes
+        -----
+        This is a convenience method for `requireImport()`.
         """
-        if not isinstance(libs, list):
-            libs = list(libs)
         for lib in libs:
-            if lib not in self.psychopyLibs:
-                self.psychopyLibs.append(lib)
+            self.requireImport(importName=lib,
+                               importFrom='psychopy')
+
+    def requireImport(self, importName, importFrom='', importAs=''):
+        """
+        Add a top-level import to the experiment.
+
+        Parameters
+        ----------
+        importName : str
+            Name of the package or module to import.
+        importFrom : str
+            Where to import ``from``.
+        importAs : str
+            Import ``as`` this name.
+        """
+        import_ = RequiredImport(importName=importName,
+                                 importFrom=importFrom,
+                                 importAs=importAs)
+
+        if import_ not in self.requiredImports:
+            self.requiredImports.append(import_)
 
     def addRoutine(self, routineName, routine=None):
         """Add a Routine to the current list of them.

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -474,8 +474,7 @@ class BaseVisualComponent(BaseComponent):
             startType=startType, startVal=startVal,
             stopType=stopType, stopVal=stopVal,
             startEstim=startEstim, durationEstim=durationEstim)
-
-        self.psychopyLibs = ['visual']  # needs this psychopy lib to operate
+        self.exp.requirePsychopyLibs(['visual'])  # needs this psychopy lib to operate
 
         msg = _translate("Units of dimensions for this stimulus")
         self.params['units'] = Param(

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -373,9 +373,17 @@ class SettingsComponent(object):
 
         self.writeUseVersion(buff)
 
+        psychopyImports = []
+        customImports = []
+        for import_ in self.exp.requiredImports:
+            if import_.importFrom == 'psychopy':
+                psychopyImports.append(import_.importName)
+            else:
+                customImports.append(import_)
+
         buff.write(
             "from psychopy import locale_setup, "
-            "%s\n" % ', '.join(self.exp.psychopyLibs) +
+            "%s\n" % ', '.join(psychopyImports) +
             "from psychopy.constants import (NOT_STARTED, STARTED, PLAYING,"
             " PAUSED,\n"
             "                                STOPPED, FINISHED, PRESSED, "
@@ -388,6 +396,26 @@ class SettingsComponent(object):
             "import os  # handy system and path functions\n" +
             "import sys  # to get file system encoding\n"
             "\n")
+
+        for import_ in customImports:
+            # Write custom import statements, line by line.
+            importName = import_.importName
+            importFrom = import_.importFrom
+            importAs = import_.importAs
+
+            statement = ''
+            if importFrom:
+                statement += "from %s " % importFrom
+
+            statement += "import %s" % importName
+
+            if importAs:
+                statement += " as %s" % importAs
+
+            statement += "\n"
+            buff.write(statement)
+
+        buff.write("\n")
 
     def prepareResourcesJS(self):
         """Sets up the resources folder and writes the info.php file for PsychoJS
@@ -668,7 +696,12 @@ class SettingsComponent(object):
         code = code.rstrip(', \n') + ')\n'
         buff.writeIndentedLines(code % self.params)
 
-        if 'microphone' in self.exp.psychopyLibs:  # need a pyo Server
+        # Import here to avoid circular dependency!
+        from psychopy.experiment._experiment import RequiredImport
+        microphoneImport = RequiredImport(importName='microphone',
+                                          importFrom='psychopy',
+                                          importAs='')
+        if microphoneImport in self.exp.requiredImports:  # need a pyo Server
             buff.writeIndentedLines("\n# Enable sound input/output:\n"
                                     "microphone.switchOn()\n")
 

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -3,6 +3,7 @@ from past.builtins import execfile
 from builtins import object
 
 import psychopy.experiment
+from psychopy.experiment._experiment import RequiredImport
 from os import path
 import os, shutil, glob, sys
 import py_compile
@@ -370,3 +371,87 @@ class TestExpt(object):
         assert namespace.makeLoopIndex('trials_2') == 'thisTrial_2'
         assert namespace.makeLoopIndex('stimuli') == 'thisStimulus'
 
+
+class TestExpImports(object):
+    def setup(self):
+        self.exp = psychopy.experiment.Experiment()
+        self.exp.requiredImports = []
+
+    def test_requireImportName(self):
+        import_ = RequiredImport(importName='foo', importFrom='',
+                                 importAs='')
+        self.exp.requireImport(importName='foo')
+
+        assert import_ in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'import foo\n' in script
+
+    def test_requireImportFrom(self):
+        import_ = RequiredImport(importName='foo', importFrom='bar',
+                                 importAs='')
+        self.exp.requireImport(importName='foo', importFrom='bar')
+
+        assert import_ in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'from bar import foo\n' in script
+
+    def test_requireImportAs(self):
+        import_ = RequiredImport(importName='foo', importFrom='',
+                                 importAs='baz')
+        self.exp.requireImport(importName='foo', importAs='baz')
+
+        assert import_ in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'import foo as baz\n' in script
+
+    def test_requireImportFromAs(self):
+        import_ = RequiredImport(importName='foo', importFrom='bar',
+                                 importAs='baz')
+        self.exp.requireImport(importName='foo', importFrom='bar',
+                               importAs='baz')
+
+        assert import_ in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'from bar import foo as baz\n' in script
+
+    def test_requirePsychopyLibs(self):
+        import_ = RequiredImport(importName='foo', importFrom='psychopy',
+                                 importAs='')
+        self.exp.requirePsychopyLibs(['foo'])
+
+        assert import_ in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'from psychopy import locale_setup, foo\n' in script
+
+    def test_requirePsychopyLibs2(self):
+        import_0 = RequiredImport(importName='foo', importFrom='psychopy',
+                                  importAs='')
+        import_1 = RequiredImport(importName='foo', importFrom='psychopy',
+                                  importAs='')
+        self.exp.requirePsychopyLibs(['foo', 'bar'])
+
+        assert import_0 in self.exp.requiredImports
+        assert import_1 in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'from psychopy import locale_setup, foo, bar\n' in script
+
+    def test_requireImportAndPsychopyLib(self):
+        import_0 = RequiredImport(importName='foo', importFrom='psychopy',
+                                  importAs='')
+        import_1 = RequiredImport(importName='bar', importFrom='',
+                                  importAs='')
+        self.exp.requirePsychopyLibs(['foo'])
+        self.exp.requireImport('bar')
+
+        assert import_0 in self.exp.requiredImports
+        assert import_1 in self.exp.requiredImports
+
+        script = self.exp.writeScript()
+        assert 'from psychopy import locale_setup, foo\n' in script
+        assert 'import bar\n' in script


### PR DESCRIPTION
This is a more generic way to add import statements to a Builder-generated experiment. (See https://github.com/psychopy/psychopy/pull/2141#issuecomment-447287872 for a first short discussion)
Previously, only `requirePsychopyLibs()` was available, which would only `from psychopy import xxx`; whereas the new `requireImport()` can import `from` and `as` arbitrary packages/modules/names.

`requirePsychopyLibs()` was modified such that it now acts as a convenience method for `requireImport()`.

Example:
```python
Experiment.requireImport(importName='matplotlib.pyplot', importAs='plt')
# Would generate
import matplotlib.pyplot as plt


Experiment.requireImport(importFrom='psychopy.preferences', importName='prefs', importAs='p')
# Would generate
from psychopy.preferences import prefs as p
```

I first wanted to create an "execute arbitrary code here"-like method, but then thought it would be cleaner to provide a dedicated way to do generic imports. Might add the arbitrary-code thingy later though?? (as a separate method)