### PR TITLE
NF: pathlib support

### DIFF
--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -23,7 +23,7 @@ from pkg_resources import parse_version
 import psychopy
 from psychopy import logging
 from psychopy.tools.filetools import (openOutputFile, genDelimiter,
-                                      genFilenameFromDelimiter)
+                                      genFilenameFromDelimiter, path_to_string)
 from psychopy.tools.fileerrortools import handleFileCollision
 from psychopy.tools.arraytools import extendArr
 from .utils import _getExcelCellName
@@ -125,6 +125,8 @@ class _BaseTrialHandler(_ComparisonMixin):
             fileCollisionMethod: Collision method passed to
             :func:`~psychopy.tools.fileerrortools.handleFileCollision`
         """
+        fileName = path_to_string(fileName)
+
         if self.thisTrialN < 1 and self.thisRepN < 1:
             # if both are < 1 we haven't started
             if self.autoLog:
@@ -191,6 +193,8 @@ class _BaseTrialHandler(_ComparisonMixin):
             The encoding to use when saving a the file. Defaults to `utf-8`.
 
         """
+        fileName = path_to_string(fileName)
+
         if stimOut is None:
             stimOut = []
 
@@ -301,6 +305,8 @@ class _BaseTrialHandler(_ComparisonMixin):
                 This is ignored if ``append`` is ``True``.
 
         """
+        fileName = path_to_string(fileName)
+
         if stimOut is None:
             stimOut = []
 
@@ -392,6 +398,8 @@ class _BaseTrialHandler(_ComparisonMixin):
         because loading the created JSON file would sometimes fail otherwise.
 
         """
+        fileName = path_to_string(fileName)
+
         self_copy = copy.deepcopy(self)
         self_copy.origin = ''
         msg = ('Setting attribute .origin to empty string during JSON '

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -21,6 +21,7 @@ from pkg_resources import parse_version
 
 from psychopy import logging
 from psychopy.constants import PY3
+from psychopy.tools.filetools import path_to_string
 
 try:
     import openpyxl
@@ -220,6 +221,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                 raise ValueError('Conditions file %s: %s%s"%s"' %
                                   (fileName, msg, os.linesep * 2, name))
 
+    filename = path_to_string(filename)
     if fileName in ['None', 'none', None]:
         if returnFieldNames:
             return [], []

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -42,6 +42,7 @@ import numpy as np
 from scipy.io import wavfile
 from psychopy import core, logging, sound, web, prefs
 from psychopy.constants import NOT_STARTED, PLAYING, PSYCHOPY_USERAGENT
+from psychopy.tools.filetools import path_to_string
 # import pyo is done within switchOn to better encapsulate it, can be very
 # slow and don't want to delay up to 3 sec when importing microphone
 # downside: to make this work requires some trickiness with globals
@@ -109,6 +110,7 @@ class AudioCapture(object):
 
         def run(self, filename, sec, sampletype=0, buffering=16,
                 chnl=0, chnls=2):
+            filename = path_to_string(filename)
             self.running = True
             # chnl from psychopy.sound.backend.get_input_devices()
             inputter = pyo.Input(chnl=chnl, mul=1)
@@ -151,6 +153,7 @@ class AudioCapture(object):
                                   ' before AudioCapture or AdvancedCapture')
         self.name = name
         self.saveDir = saveDir
+        filename = path_to_string(filename)
         if filename:
             self.wavOutFilename = filename
         else:
@@ -219,6 +222,7 @@ class AudioCapture(object):
         return self._record(sec, filename=filename, block=block)
 
     def _record(self, sec, filename='', block=True, log=True):
+        filename = path_to_string(filename)
         while self.recorder.running:
             pass
         self.duration = float(sec)
@@ -396,7 +400,7 @@ class AdvAudioCapture(AudioCapture):
     def setFile(self, filename):
         """Sets the name of the file to work with.
         """
-        self.filename = filename
+        self.filename = path_to_string(filename)
 
     def setMarker(self, tone=19000, secs=0.015, volume=0.03, log=True):
         """Sets the onset marker, where `tone` is either in hz or a custom
@@ -562,6 +566,7 @@ def getMarkerOnset(filename, chunk=128, secs=0.5, marker_hz=19000,
 def readWavFile(filename):
     """Return (data, sampleRate) as read from a wav file, expects int16 data.
     """
+    filename = path_to_string(filename)
     try:
         sampleRate, data = wavfile.read(filename)
     except Exception:
@@ -884,6 +889,7 @@ class Speech2Text(object):
                     flac compression level (0 less compression but fastest)
         """
         # set up some key parameters:
+        filename = path_to_string(filename)
         results = 5  # how many words wanted
         self.timeout = timeout
         useragent = PSYCHOPY_USERAGENT
@@ -1061,6 +1067,7 @@ def flac2wav(path, keep=True):
 
     `keep` to retain the original .flac file(s), default `True`.
     """
+    path = path_to_string(path)
     flac_path = _getFlacPath()
     flac_files = []
     if path.endswith('.flac'):
@@ -1097,6 +1104,7 @@ def wav2flac(path, keep=True, level=5):
     `level` is compression level: 0 is fastest but larger,
         8 is slightly smaller but much slower.
     """
+    path = path_to_string(path)
     flac_path = _getFlacPath()
     wav_files = []
     if path.endswith('.wav'):

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -16,6 +16,7 @@ from os import path
 from psychopy import logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
+from psychopy.tools.filetools import path_to_string
 from sys import platform
 
 
@@ -158,6 +159,8 @@ class _SoundBase(object):
         # Re-init sound to ensure bad values will raise error during setting:
         self._snd = None
 
+        # Coerces pathlib obj to string, else returns inputted value
+        value = path_to_string(value)
         try:
             # could be '440' meaning 440
             value = float(value)

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -57,12 +57,13 @@ def fromFile(filename):
             # We also need to remove the 'temporary' ._rng_state attribute that
             # was saved with it.
             from psychopy.data import TrialHandler2
+
             if isinstance(contents, TrialHandler2):
                 contents._rng = np.random.RandomState(seed=contents.seed)
                 contents._rng.set_state(contents._rng_state)
                 del contents._rng_state
     else:
-        msg = "Don't know how to handle this file type, aborting."
+        msg = 'Don't know how to handle this file type, aborting.'
         raise ValueError(msg)
 
     return contents
@@ -91,8 +92,9 @@ def mergeFolder(src, dst, pattern=None):
                 print(why)
 
 
-def openOutputFile(fileName=None, append=False, fileCollisionMethod='rename',
-                   encoding='utf-8'):
+def openOutputFile(
+    fileName=None, append=False, fileCollisionMethod='rename', encoding='utf-8'
+):
     """Open an output file (or standard output) for writing.
 
     :Parameters:
@@ -136,8 +138,8 @@ def openOutputFile(fileName=None, append=False, fileCollisionMethod='rename',
         # and it should not be appended.
         if os.path.exists(fileName) and not append:
             fileName = handleFileCollision(
-                fileName,
-                fileCollisionMethod=fileCollisionMethod)
+                fileName, fileCollisionMethod=fileCollisionMethod
+            )
 
     # Do not use encoding when writing a binary file.
     if 'b' in mode:
@@ -179,9 +181,21 @@ def genDelimiter(fileName):
 def genFilenameFromDelimiter(filename, delim):
     # If no known filename extension was specified, derive a one from the
     # delimiter.
-    if not filename.endswith(('.dlm', '.DLM', '.tsv', '.TSV', '.txt',
-                              '.TXT', '.csv', '.CSV', '.psydat', '.npy',
-                              '.json')):
+    if not filename.endswith(
+        (
+            '.dlm',
+            '.DLM',
+            '.tsv',
+            '.TSV',
+            '.txt',
+            '.TXT',
+            '.csv',
+            '.CSV',
+            '.psydat',
+            '.npy',
+            '.json',
+        )
+    ):
         if delim == ',':
             filename += '.csv'
         elif delim == '\t':
@@ -214,9 +228,10 @@ class DictStorage(dict):
                 try:
                     self.update(json.load(f))
                 except ValueError:
-                    logging.error("Tried to load %s but it wasn't valid "
-                                  "JSON format"
-                                  %filename)
+                    logging.error(
+                        'Tried to load %s but it wasn't valid '
+                        'JSON format' % filename
+                    )
 
     def save(self, filename=None):
         """Save all tokens from a given filename
@@ -241,3 +256,26 @@ class DictStorage(dict):
             self.save()
         self._deleted = True
 
+
+def path_to_string(filepath):
+    """
+    Coerces pathlib Path objects to a string (only python version 3.6+)
+    any other objects passed to this function will be returned as is.
+    This WILL NOT work with on Python 3.4, 3.5 since the __fspath__ dunder
+    method did not exist in those verisions, however psychopy does not support
+    these versions of python anyways.
+
+    :Parameters:
+
+    filepath : string or pathlib Path object
+        file system path that needs to be coerced into a string to
+        use by Psychopy's internals
+
+    :Returns:
+    
+    filepath : string or same as passed object
+        file system path coerced into a string type
+    """
+    if hasattr(filepath, '__fspath__'):
+        return filepath.__fspath__()
+    return filepath

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -22,6 +22,7 @@ from psychopy import logging, colors
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import setAttribute
+from psychopy.tools.filetools import path_to_string
 
 import numpy as np
 
@@ -322,6 +323,7 @@ def findImageFile(filename):
     alternatives (e.g. extensions .jpg .tif...)
     """
     # if user supplied correct path then reutnr quickly
+    filename = path_to_string(filename)
     isfile = os.path.isfile
     if isfile(filename):
         return filename

--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -51,6 +51,7 @@ import psychopy.event
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
+from psychopy.tools.filetools import path_to_string
 
 if sys.platform == 'win32' and not haveAvbin:
     logging.warning("avbin.dll failed to load. "
@@ -144,7 +145,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
             # pyglet 1.1.4?
             self._player_default_on_eos = self._player._on_eos
 
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.duration = None
         self.loop = loop
         if loop and pyglet.version >= '1.2':
@@ -199,6 +200,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         try:
             self._movie = pyglet.media.load(filename, streaming=True)
         except Exception as e:

--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -88,6 +88,7 @@ from psychopy import core, logging
 
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
 from psychopy.clock import Clock
 from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED
@@ -233,7 +234,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
             logging.warning("FrameRate could not be supplied by psychopy; "
                             "defaulting to 60.0")
             self._retracerate = 60.0
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -325,6 +326,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         self._unload()
         self._reset()
         if self._no_audio is False:

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -38,6 +38,7 @@ import os
 from psychopy import logging, prefs #adding prefs to be able to check sound lib -JK
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin, TextureMixin
 
 from moviepy.video.io.VideoFileClip import VideoFileClip
@@ -112,7 +113,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
                             "defaulting to 60.0")
             retraceRate = 60.0
         self._retraceInterval = 1.0/retraceRate
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -173,6 +174,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         self.reset()  # set status and timestamps etc
 
         # Create Video Stream stuff

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -29,6 +29,7 @@ from psychopy import core, logging
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.monitorunittools import convertToPix
 from psychopy.tools.attributetools import setAttribute, attributeSetter
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import MinimalStim, WindowMixin
 from . import globalVars
 
@@ -255,6 +256,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         can be any format that the Python Imaging Library can import
         (almost any). Can also be an image already loaded by PIL.
         """
+        filename = path_to_string(filename)
         self.__dict__['image'] = filename
         if isinstance(filename, basestring):
             # is a string - see if it points to a file
@@ -289,4 +291,5 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         """Usually you can use 'stim.attribute = value' syntax instead,
         but use this method if you need to suppress the log message.
         """
+        filename = path_to_string(filename)
         setAttribute(self, 'image', filename, log)


### PR DESCRIPTION
* Added `path_to_string` function under tools/filetools which will coerce pathlib objects (or any object that utilizes the `__fspath__` dunder method). 

* Added support for pathlib to:
  * microphone
  * data/utils.py
  * data/base.py
  * visual/movie*.py
  * visual/helpers.py
  * sound/_base.py

Wasn't sure if tests for the new `path_to_string` function were needed. I think I covered most of the important areas where users will supply their own paths, but if you think of any others please let me know.

see #1817 