### PR TITLE
NF: psychopy pathlib support

### DIFF
--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -23,7 +23,7 @@ from pkg_resources import parse_version
 import psychopy
 from psychopy import logging
 from psychopy.tools.filetools import (openOutputFile, genDelimiter,
-                                      genFilenameFromDelimiter)
+                                      genFilenameFromDelimiter, path_to_string)
 from psychopy.tools.fileerrortools import handleFileCollision
 from psychopy.tools.arraytools import extendArr
 from .utils import _getExcelCellName
@@ -125,6 +125,8 @@ class _BaseTrialHandler(_ComparisonMixin):
             fileCollisionMethod: Collision method passed to
             :func:`~psychopy.tools.fileerrortools.handleFileCollision`
         """
+        fileName = path_to_string(fileName)
+
         if self.thisTrialN < 1 and self.thisRepN < 1:
             # if both are < 1 we haven't started
             if self.autoLog:
@@ -191,6 +193,8 @@ class _BaseTrialHandler(_ComparisonMixin):
             The encoding to use when saving a the file. Defaults to `utf-8`.
 
         """
+        fileName = path_to_string(fileName)
+
         if stimOut is None:
             stimOut = []
 
@@ -301,6 +305,8 @@ class _BaseTrialHandler(_ComparisonMixin):
                 This is ignored if ``append`` is ``True``.
 
         """
+        fileName = path_to_string(fileName)
+
         if stimOut is None:
             stimOut = []
 
@@ -392,6 +398,8 @@ class _BaseTrialHandler(_ComparisonMixin):
         because loading the created JSON file would sometimes fail otherwise.
 
         """
+        fileName = path_to_string(fileName)
+
         self_copy = copy.deepcopy(self)
         self_copy.origin = ''
         msg = ('Setting attribute .origin to empty string during JSON '

--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -23,7 +23,7 @@ from pkg_resources import parse_version
 import psychopy
 from psychopy import logging
 from psychopy.tools.filetools import (openOutputFile, genDelimiter,
-                                      genFilenameFromDelimiter, path_to_string)
+                                      genFilenameFromDelimiter, pathToString)
 from psychopy.tools.fileerrortools import handleFileCollision
 from psychopy.tools.arraytools import extendArr
 from .utils import _getExcelCellName
@@ -125,7 +125,7 @@ class _BaseTrialHandler(_ComparisonMixin):
             fileCollisionMethod: Collision method passed to
             :func:`~psychopy.tools.fileerrortools.handleFileCollision`
         """
-        fileName = path_to_string(fileName)
+        fileName = pathToString(fileName)
 
         if self.thisTrialN < 1 and self.thisRepN < 1:
             # if both are < 1 we haven't started
@@ -193,7 +193,7 @@ class _BaseTrialHandler(_ComparisonMixin):
             The encoding to use when saving a the file. Defaults to `utf-8`.
 
         """
-        fileName = path_to_string(fileName)
+        fileName = pathToString(fileName)
 
         if stimOut is None:
             stimOut = []
@@ -305,7 +305,7 @@ class _BaseTrialHandler(_ComparisonMixin):
                 This is ignored if ``append`` is ``True``.
 
         """
-        fileName = path_to_string(fileName)
+        fileName = pathToString(fileName)
 
         if stimOut is None:
             stimOut = []
@@ -398,7 +398,7 @@ class _BaseTrialHandler(_ComparisonMixin):
         because loading the created JSON file would sometimes fail otherwise.
 
         """
-        fileName = path_to_string(fileName)
+        fileName = pathToString(fileName)
 
         self_copy = copy.deepcopy(self)
         self_copy.origin = ''

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -21,6 +21,7 @@ from pkg_resources import parse_version
 
 from psychopy import logging
 from psychopy.constants import PY3
+from psychopy.tools.filetools import path_to_string
 
 try:
     import openpyxl
@@ -208,6 +209,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         """screens a list of names as candidate variable names. if all
         names are OK, return silently; else raise  with msg
         """
+        fileName = path_to_string(fileName)
         if not all(fieldNames):
             msg = ('Conditions file %s: Missing parameter name(s); '
                    'empty cell(s) in the first row?')

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -21,7 +21,7 @@ from pkg_resources import parse_version
 
 from psychopy import logging
 from psychopy.constants import PY3
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 
 try:
     import openpyxl
@@ -209,7 +209,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         """screens a list of names as candidate variable names. if all
         names are OK, return silently; else raise  with msg
         """
-        fileName = path_to_string(fileName)
+        fileName = pathToString(fileName)
         if not all(fieldNames):
             msg = ('Conditions file %s: Missing parameter name(s); '
                    'empty cell(s) in the first row?')

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -20,7 +20,7 @@ import os
 import glob
 import threading
 from psychopy.constants import PY3
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 
 if PY3:
     import urllib.request
@@ -110,7 +110,7 @@ class AudioCapture(object):
 
         def run(self, filename, sec, sampletype=0, buffering=16,
                 chnl=0, chnls=2):
-            filename = path_to_string(filename)
+            filename = pathToString(filename)
             self.running = True
             # chnl from psychopy.sound.backend.get_input_devices()
             inputter = pyo.Input(chnl=chnl, mul=1)
@@ -153,7 +153,7 @@ class AudioCapture(object):
                                   ' before AudioCapture or AdvancedCapture')
         self.name = name
         self.saveDir = saveDir
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         if filename:
             self.wavOutFilename = filename
         else:
@@ -222,7 +222,7 @@ class AudioCapture(object):
         return self._record(sec, filename=filename, block=block)
 
     def _record(self, sec, filename='', block=True, log=True):
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         while self.recorder.running:
             pass
         self.duration = float(sec)
@@ -566,7 +566,7 @@ def getMarkerOnset(filename, chunk=128, secs=0.5, marker_hz=19000,
 def readWavFile(filename):
     """Return (data, sampleRate) as read from a wav file, expects int16 data.
     """
-    filename = path_to_string(filename)
+    filename = pathToString(filename)
     try:
         sampleRate, data = wavfile.read(filename)
     except Exception:
@@ -1068,7 +1068,7 @@ def flac2wav(path, keep=True):
     """
     flac_path = _getFlacPath()
     flac_files = []
-    path = path_to_string(path)
+    path = pathToString(path)
     if path.endswith('.flac'):
         flac_files = [path]
     elif type(path) == str and os.path.isdir(path):
@@ -1105,7 +1105,7 @@ def wav2flac(path, keep=True, level=5):
     """
     flac_path = _getFlacPath()
     wav_files = []
-    path = path_to_string(path)
+    path = pathToString(path)
     if path.endswith('.wav'):
         wav_files = [path]
     elif type(path) == str and os.path.isdir(path):

--- a/psychopy/microphone.py
+++ b/psychopy/microphone.py
@@ -20,6 +20,7 @@ import os
 import glob
 import threading
 from psychopy.constants import PY3
+from psychopy.tools.filetools import path_to_string
 
 if PY3:
     import urllib.request
@@ -109,6 +110,7 @@ class AudioCapture(object):
 
         def run(self, filename, sec, sampletype=0, buffering=16,
                 chnl=0, chnls=2):
+            filename = path_to_string(filename)
             self.running = True
             # chnl from psychopy.sound.backend.get_input_devices()
             inputter = pyo.Input(chnl=chnl, mul=1)
@@ -151,6 +153,7 @@ class AudioCapture(object):
                                   ' before AudioCapture or AdvancedCapture')
         self.name = name
         self.saveDir = saveDir
+        filename = path_to_string(filename)
         if filename:
             self.wavOutFilename = filename
         else:
@@ -219,6 +222,7 @@ class AudioCapture(object):
         return self._record(sec, filename=filename, block=block)
 
     def _record(self, sec, filename='', block=True, log=True):
+        filename = path_to_string(filename)
         while self.recorder.running:
             pass
         self.duration = float(sec)
@@ -562,6 +566,7 @@ def getMarkerOnset(filename, chunk=128, secs=0.5, marker_hz=19000,
 def readWavFile(filename):
     """Return (data, sampleRate) as read from a wav file, expects int16 data.
     """
+    filename = path_to_string(filename)
     try:
         sampleRate, data = wavfile.read(filename)
     except Exception:
@@ -1063,6 +1068,7 @@ def flac2wav(path, keep=True):
     """
     flac_path = _getFlacPath()
     flac_files = []
+    path = path_to_string(path)
     if path.endswith('.flac'):
         flac_files = [path]
     elif type(path) == str and os.path.isdir(path):
@@ -1099,6 +1105,7 @@ def wav2flac(path, keep=True, level=5):
     """
     flac_path = _getFlacPath()
     wav_files = []
+    path = path_to_string(path)
     if path.endswith('.wav'):
         wav_files = [path]
     elif type(path) == str and os.path.isdir(path):

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -16,6 +16,7 @@ from os import path
 from psychopy import logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
+from psychopy.tools.filetools import path_to_string
 from sys import platform
 
 
@@ -158,6 +159,8 @@ class _SoundBase(object):
         # Re-init sound to ensure bad values will raise error during setting:
         self._snd = None
 
+        # Coerces pathlib obj to string, else returns inputted value
+        value = path_to_string(value)
         try:
             # could be '440' meaning 440
             value = float(value)

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -16,7 +16,7 @@ from os import path
 from psychopy import logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 from sys import platform
 
 
@@ -160,7 +160,7 @@ class _SoundBase(object):
         self._snd = None
 
         # Coerces pathlib obj to string, else returns inputted value
-        value = path_to_string(value)
+        value = pathToString(value)
         try:
             # could be '440' meaning 440
             value = float(value)

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -42,7 +42,7 @@ def toFile(filename, data):
 def fromFile(filename):
     """Load data from a pickle or JSON file.
     """
-    filename = path_to_string(filename)
+    filename = pathToString(filename)
     if filename.endswith('.psydat'):
         with open(filename, 'rb') as f:
             contents = pickle.load(f)
@@ -122,7 +122,7 @@ def openOutputFile(fileName=None, append=False, fileCollisionMethod='rename',
         A writable file handle.
 
     """
-    fileName = path_to_string(fileName)
+    fileName = pathToString(fileName)
     if (fileName is None) or (fileName == 'stdout'):
         return sys.stdout
 
@@ -170,7 +170,7 @@ def genDelimiter(fileName):
         character otherwise.
 
     """
-    fileName = path_to_string(fileName)
+    fileName = pathToString(fileName)
     if fileName.endswith(('.csv', '.CSV')):
         delim = ','
     else:
@@ -182,7 +182,7 @@ def genDelimiter(fileName):
 def genFilenameFromDelimiter(filename, delim):
     # If no known filename extension was specified, derive a one from the
     # delimiter.
-    filename = path_to_string(filename)
+    filename = pathToString(filename)
     if not filename.endswith(('.dlm', '.DLM', '.tsv', '.TSV', '.txt',
                               '.TXT', '.csv', '.CSV', '.psydat', '.npy',
                               '.json')):
@@ -245,7 +245,7 @@ class DictStorage(dict):
             self.save()
         self._deleted = True
 
-def path_to_string(filepath):
+def pathToString(filepath):
     """
     Coerces pathlib Path objects to a string (only python version 3.6+)
     any other objects passed to this function will be returned as is.

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -42,6 +42,7 @@ def toFile(filename, data):
 def fromFile(filename):
     """Load data from a pickle or JSON file.
     """
+    filename = path_to_string(filename)
     if filename.endswith('.psydat'):
         with open(filename, 'rb') as f:
             contents = pickle.load(f)
@@ -121,6 +122,7 @@ def openOutputFile(fileName=None, append=False, fileCollisionMethod='rename',
         A writable file handle.
 
     """
+    fileName = path_to_string(fileName)
     if (fileName is None) or (fileName == 'stdout'):
         return sys.stdout
 
@@ -168,6 +170,7 @@ def genDelimiter(fileName):
         character otherwise.
 
     """
+    fileName = path_to_string(fileName)
     if fileName.endswith(('.csv', '.CSV')):
         delim = ','
     else:
@@ -179,6 +182,7 @@ def genDelimiter(fileName):
 def genFilenameFromDelimiter(filename, delim):
     # If no known filename extension was specified, derive a one from the
     # delimiter.
+    filename = path_to_string(filename)
     if not filename.endswith(('.dlm', '.DLM', '.tsv', '.TSV', '.txt',
                               '.TXT', '.csv', '.CSV', '.psydat', '.npy',
                               '.json')):
@@ -248,12 +252,15 @@ def path_to_string(filepath):
     This WILL NOT work with on Python 3.4, 3.5 since the __fspath__ dunder
     method did not exist in those verisions, however psychopy does not support
     these versions of python anyways.
-     :Parameters:
-     filepath : string or pathlib Path object
+
+    :Parameters:
+
+    filepath : string or pathlib Path object
         file system path that needs to be coerced into a string to
         use by Psychopy's internals
-     :Returns:
-    
+
+    :Returns:
+
     filepath : string or same as passed object
         file system path coerced into a string type
     """

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -255,13 +255,13 @@ def pathToString(filepath):
 
     :Parameters:
 
-    filepath : string or pathlib Path object
+    filepath : str or pathlib.Path
         file system path that needs to be coerced into a string to
         use by Psychopy's internals
 
     :Returns:
 
-    filepath : string or same as passed object
+    filepath : str or same as input object
         file system path coerced into a string type
     """
     if hasattr(filepath, "__fspath__"):

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -241,3 +241,22 @@ class DictStorage(dict):
             self.save()
         self._deleted = True
 
+def path_to_string(filepath):
+    """
+    Coerces pathlib Path objects to a string (only python version 3.6+)
+    any other objects passed to this function will be returned as is.
+    This WILL NOT work with on Python 3.4, 3.5 since the __fspath__ dunder
+    method did not exist in those verisions, however psychopy does not support
+    these versions of python anyways.
+     :Parameters:
+     filepath : string or pathlib Path object
+        file system path that needs to be coerced into a string to
+        use by Psychopy's internals
+     :Returns:
+    
+    filepath : string or same as passed object
+        file system path coerced into a string type
+    """
+    if hasattr(filepath, "__fspath__"):
+        return filepath.__fspath__()
+    return filepath

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -22,7 +22,7 @@ from psychopy import logging, colors
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import setAttribute
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 
 import numpy as np
 
@@ -323,7 +323,7 @@ def findImageFile(filename):
     alternatives (e.g. extensions .jpg .tif...)
     """
     # if user supplied correct path then reutnr quickly
-    filename = path_to_string(filename)
+    filename = pathToString(filename)
     isfile = os.path.isfile
     if isfile(filename):
         return filename

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -22,6 +22,7 @@ from psychopy import logging, colors
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import setAttribute
+from psychopy.tools.filetools import path_to_string
 
 import numpy as np
 
@@ -322,6 +323,7 @@ def findImageFile(filename):
     alternatives (e.g. extensions .jpg .tif...)
     """
     # if user supplied correct path then reutnr quickly
+    filename = path_to_string(filename)
     isfile = os.path.isfile
     if isfile(filename):
         return filename

--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -51,6 +51,7 @@ import psychopy.event
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
+from psychopy.tools.filetools import path_to_string
 
 if sys.platform == 'win32' and not haveAvbin:
     logging.warning("avbin.dll failed to load. "
@@ -144,7 +145,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
             # pyglet 1.1.4?
             self._player_default_on_eos = self._player._on_eos
 
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.duration = None
         self.loop = loop
         if loop and pyglet.version >= '1.2':
@@ -199,6 +200,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         try:
             self._movie = pyglet.media.load(filename, streaming=True)
         except Exception as e:

--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -51,7 +51,7 @@ import psychopy.event
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 
 if sys.platform == 'win32' and not haveAvbin:
     logging.warning("avbin.dll failed to load. "
@@ -145,7 +145,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
             # pyglet 1.1.4?
             self._player_default_on_eos = self._player._on_eos
 
-        self.filename = path_to_string(filename)
+        self.filename = pathToString(filename)
         self.duration = None
         self.loop = loop
         if loop and pyglet.version >= '1.2':
@@ -200,7 +200,7 @@ class MovieStim(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         try:
             self._movie = pyglet.media.load(filename, streaming=True)
         except Exception as e:

--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -88,7 +88,7 @@ from psychopy import core, logging
 
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
 from psychopy.clock import Clock
 from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED
@@ -234,7 +234,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
             logging.warning("FrameRate could not be supplied by psychopy; "
                             "defaulting to 60.0")
             self._retracerate = 60.0
-        self.filename = path_to_string(filename)
+        self.filename = pathToString(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -326,7 +326,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         self._unload()
         self._reset()
         if self._no_audio is False:

--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -88,6 +88,7 @@ from psychopy import core, logging
 
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin
 from psychopy.clock import Clock
 from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED
@@ -233,7 +234,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
             logging.warning("FrameRate could not be supplied by psychopy; "
                             "defaulting to 60.0")
             self._retracerate = 60.0
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -325,6 +326,7 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         self._unload()
         self._reset()
         if self._no_audio is False:

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -38,7 +38,7 @@ import os
 from psychopy import logging, prefs #adding prefs to be able to check sound lib -JK
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin, TextureMixin
 
 from moviepy.video.io.VideoFileClip import VideoFileClip
@@ -113,7 +113,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
                             "defaulting to 60.0")
             retraceRate = 60.0
         self._retraceInterval = 1.0/retraceRate
-        self.filename = path_to_string(filename)
+        self.filename = pathToString(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -174,7 +174,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         self.reset()  # set status and timestamps etc
 
         # Create Video Stream stuff

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -38,6 +38,7 @@ import os
 from psychopy import logging, prefs #adding prefs to be able to check sound lib -JK
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import logAttrib, setAttribute
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import BaseVisualStim, ContainerMixin, TextureMixin
 
 from moviepy.video.io.VideoFileClip import VideoFileClip
@@ -112,7 +113,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
                             "defaulting to 60.0")
             retraceRate = 60.0
         self._retraceInterval = 1.0/retraceRate
-        self.filename = filename
+        self.filename = path_to_string(filename)
         self.loop = loop
         self.flipVert = flipVert
         self.flipHoriz = flipHoriz
@@ -173,6 +174,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
         After the file is loaded MovieStim.duration is updated with the movie
         duration (in seconds).
         """
+        filename = path_to_string(filename)
         self.reset()  # set status and timestamps etc
 
         # Create Video Stream stuff

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -29,6 +29,7 @@ from psychopy import core, logging
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.monitorunittools import convertToPix
 from psychopy.tools.attributetools import setAttribute, attributeSetter
+from psychopy.tools.filetools import path_to_string
 from psychopy.visual.basevisual import MinimalStim, WindowMixin
 from . import globalVars
 
@@ -255,6 +256,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         can be any format that the Python Imaging Library can import
         (almost any). Can also be an image already loaded by PIL.
         """
+        filename = path_to_string(filename)
         self.__dict__['image'] = filename
         if isinstance(filename, basestring):
             # is a string - see if it points to a file
@@ -289,4 +291,5 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         """Usually you can use 'stim.attribute = value' syntax instead,
         but use this method if you need to suppress the log message.
         """
+        filename = path_to_string(filename)
         setAttribute(self, 'image', filename, log)

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -29,7 +29,7 @@ from psychopy import core, logging
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.monitorunittools import convertToPix
 from psychopy.tools.attributetools import setAttribute, attributeSetter
-from psychopy.tools.filetools import path_to_string
+from psychopy.tools.filetools import pathToString
 from psychopy.visual.basevisual import MinimalStim, WindowMixin
 from . import globalVars
 
@@ -256,7 +256,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         can be any format that the Python Imaging Library can import
         (almost any). Can also be an image already loaded by PIL.
         """
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         self.__dict__['image'] = filename
         if isinstance(filename, basestring):
             # is a string - see if it points to a file
@@ -291,5 +291,5 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         """Usually you can use 'stim.attribute = value' syntax instead,
         but use this method if you need to suppress the log message.
         """
-        filename = path_to_string(filename)
+        filename = pathToString(filename)
         setAttribute(self, 'image', filename, log)


### PR DESCRIPTION
* Added `path_to_string` function under tools/filetools which will coerce pathlib objects (or any object that utilizes the `__fspath__` dunder method) to their corresponding filesystem representation (string or bytes). Any object that does not have an `__fspath__` dunder method will be returned as is.

* Added support for pathlib to:
  * microphone
  * data/utils
  * data/base
  * visual/movie*.py
  * visual/helpers.py
  * sound/_base

Wasn't sure if tests for the new `path_to_string` function were needed. I think I covered most of the important areas where users will supply their own paths, but if you think of any others please let me know.

see #1817 