### PR TITLE
BF:  Fix button debounce behaviour for when used in multiple routines.

### DIFF
--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -171,7 +171,6 @@ class JoystickComponent(BaseComponent):
                 "%(name)s.device = None\n"
                 "%(name)s.device_number = %(deviceNumber)s\n"
                 "%(name)s.joystickClock = core.Clock()\n"
-                "%(name)s.buttons = []\n"
                 "%(name)s.xFactor = 1\n"
                 "%(name)s.yFactor = 1\n"
                 "\n"
@@ -230,7 +229,6 @@ class JoystickComponent(BaseComponent):
                 "%(name)s.clock = core.Clock()\n"
                 "%(name)s.numButtons = %(name)s.device.getNumButtons()\n"
                 "%(name)s.getNumButtons = %(name)s.device.getNumButtons\n"
-                "%(name)s.oldButtonState = %(name)s.device.getAllButtons()[:]\n"
                 "%(name)s.getAllButtons = %(name)s.device.getAllButtons\n"
                 "%(name)s.getX = lambda: %(name)s.xFactor * %(name)s.device.getX()\n"
                 "%(name)s.getY = lambda: %(name)s.yFactor * %(name)s.device.getY()\n"
@@ -242,6 +240,9 @@ class JoystickComponent(BaseComponent):
     def writeRoutineStartCode(self, buff):
         """Write the code that will be called at the start of the routine
         """
+
+        code = ("{name}.oldButtonState = {name}.device.getAllButtons()[:]\n")
+        buff.writeIndentedLines(code.format(**self.params))
 
         allowedButtons = self.params['allowedButtons'].val.strip()
         allowedButtonsIsVar = (valid_var_re.match(str(allowedButtons)) and not


### PR DESCRIPTION
Button state was not correctly initialized at the start of every 'routine'. Causing previously read button states to be incorrectly read as new presses. Now initialized to the to current button state at the start of a routine to ignored existing presses until the state has changed back to unpressed.