### PR TITLE
RF/TESTS: Changes py2js conversion of params and adds py2js tests

### DIFF
--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -156,7 +156,7 @@ class ImageComponent(BaseVisualComponent):
                 "  name : '{inits[name]}', {units}\n"
                 "  image : {inits[image]}, mask : {inits[mask]},\n"
                 "  ori : {inits[ori]}, pos : {inits[pos]}, size : {inits[size]},\n"
-                "  color : new util.Color ({inits[color]}), opacity : {inits[opacity]},\n"
+                "  color : new util.Color({inits[color]}), opacity : {inits[opacity]},\n"
                 "  flipHoriz : {inits[flipHoriz]}, flipVert : {inits[flipVert]},\n"
                 # no newline - start optional parameters
                 "  texRes : {inits[texture resolution]}"

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -239,8 +239,11 @@ def toList(val):
     """
     # we really just need to check if they need parentheses
     stripped = val.strip()
-    if not ((stripped.startswith('(') and stripped.endswith(')')) \
-            or ((stripped.startswith('[') and stripped.endswith(']')))):
+
+    if (stripped.startswith('(') and stripped.endswith(')')):  # If tuple, return list
+        return py2js.expression2js(stripped)
+    elif not ((stripped.startswith('(') and stripped.endswith(')')) \
+              or ((stripped.startswith('[') and stripped.endswith(']')))):
         return "[{}]".format(stripped)
     else:
         return stripped

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -240,7 +240,7 @@ def toList(val):
     # we really just need to check if they need parentheses
     stripped = val.strip()
 
-    if (stripped.startswith('(') and stripped.endswith(')')):  # If tuple, return list
+    if (stripped.startswith('(') and stripped.endswith(')')) and utils.scriptTarget == "PsychoJS":
         return py2js.expression2js(stripped)
     elif not ((stripped.startswith('(') and stripped.endswith(')')) \
               or ((stripped.startswith('[') and stripped.endswith(']')))):

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -76,8 +76,13 @@ def expression2js(expr):
             wasList = True
         if isinstance(node, ast.UnaryOp):
             onlyUnary.append(True)
+        if not PY3:
+            if isinstance(node, ast.Num):
+                if node.n < 0:  # If unary operator not identified by ast parse
+                    onlyUnary.append(True)
         if isinstance(node, ast.BinOp):
             onlyUnary.append(False)
+
     jsStr = unparse(syntaxTree).strip()
     # if the code contained a tuple (anywhere) convert parenths to be list
     # NB this won't be good for compounds like `(2*(4, 5))` where the inner

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -85,7 +85,7 @@ def expression2js(expr):
     # Would be better to convert a Tuple node into a List node with same
     # and then the JS would work fine!
     # Further, numbers with unary operators are converted to tuples, inconsistent with
-    # numbers without unary operators existing as lists. Now, elements of list/tuple with unary operators
+    # numbers in tuples with unary operators existing as lists. Now, elements of list/tuple with unary operators
     # are converted to nested list, unless a binary operator exists.
     if wasTuple:
         jsStr = jsStr.replace('(', '[').replace(')', ']')

--- a/psychopy/tests/test_psychojs/test_py2js.py
+++ b/psychopy/tests/test_psychojs/test_py2js.py
@@ -46,5 +46,8 @@ class Test_PY2JS_Compile(object):
                   '[(- 0.7), ((- 0.7) * 7)]']
 
         for idx, expr in enumerate(input):
-            assert py2js.expression2js(expr) == output[idx]
-            
+            # check whether direct match or at least a match when spaces removed
+
+            assert (py2js.expression2js(expr) == output[idx] or
+            py2js.expression2js(expr).replace(" ", "") == output[idx].replace(" ", ""))
+

--- a/psychopy/tests/test_psychojs/test_py2js.py
+++ b/psychopy/tests/test_psychojs/test_py2js.py
@@ -1,0 +1,50 @@
+
+"""Test the output of py2js conversion
+"""
+
+import psychopy.experiment.py2js as py2js
+
+class Test_PY2JS_Compile(object):
+    """
+    Test class for py2js code conversion
+    """
+
+    def test_Py2js_Expression2js(self):
+        """Test that converts a short expression (e.g. a Component Parameter) Python to JS"""
+        input = ['sin(t)',
+                 'cos(t)',
+                 'tan(t)',
+                 'pi',
+                 'rand',
+                 'random',
+                 't*5',
+                 '(3, 4)',
+                 '(5*-2)',
+                 '(1,(2,3))',
+                 '2*(2, 3)',
+                 '[1, (2*2)]',
+                 '(.7, .7)',
+                 '(-.7, .7)',
+                 '[-.7, -.7]',
+                 '[-.7, (-.7 * 7)]']
+
+        output = ['Math.sin(t)',
+                  'Math.cos(t)',
+                  'Math.tan(t)',
+                  'Math.PI',
+                  'Math.random',
+                  'Math.random',
+                  '(t * 5)',
+                  '[3, 4]',
+                  '(5 * (- 2))',
+                  '[1, [2, 3]]',
+                  '[2 * [2, 3]]',
+                  '[1, (2 * 2)]',
+                  '[0.7, 0.7]',
+                  '[[- 0.7], 0.7]',
+                  '[[- 0.7], [- 0.7]]',
+                  '[(- 0.7), ((- 0.7) * 7)]']
+
+        for idx, expr in enumerate(input):
+            assert py2js.expression2js(expr) == output[idx]
+            


### PR DESCRIPTION
Numbers in lists with unary operators were converted to tuples, numbers in tuples with unary operators were converted to  lists. Now, elements of list/tuple with unary operators are converted to nested list, unless a binary operator exists, in which case parenthesis are used to determine order of operations.
Also, some tuples were not converted to lists, and now py2js checks for tuple in params, and converts to list.
py2js tests are added to check conversions of parameters.