### PR TITLE
BF: Fixes py2js tuple to list conversion using ast transformer.

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -239,8 +239,7 @@ def toList(val):
     """
     # we really just need to check if they need parentheses
     stripped = val.strip()
-
-    if (stripped.startswith('(') and stripped.endswith(')')) and utils.scriptTarget == "PsychoJS":
+    if utils.scriptTarget == "PsychoJS":
         return py2js.expression2js(stripped)
     elif not ((stripped.startswith('(') and stripped.endswith(')')) \
               or ((stripped.startswith('[') and stripped.endswith(']')))):

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -178,5 +178,3 @@ if __name__ == '__main__':
                  '[-.7, -.7]',  # A list with unary operators returns list with nested tuple
                  '[-.7, (-.7 * 7)]']:  # List with unary operators and nested tuple with operations returns list + tuple
         print("{} -> {}".format(repr(expr), repr(expression2js(expr))))
-
-#'("string", [1,2],3,-4, (1,2,3,4), 1, 2, 3,)'

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -37,6 +37,17 @@ namesJS['rand'] = 'Math.random'
 namesJS['random'] = 'Math.random'
 
 
+class TupleTransformer(ast.NodeTransformer):
+    """ An ast subclass that walks the abstract syntax tree and
+    allows modification of nodes.
+
+    This class transforms a tuple to a list.
+
+    :returns node
+    """
+    def visit_Tuple(self, node):
+        return ast.List(node.elts, node.ctx)
+
 class Unparser(astunparse.Unparser):
     """astunparser had buried the future_imports option underneath its init()
     so we need to override that method and change it."""
@@ -59,9 +70,25 @@ def unparse(tree):
 
 def expression2js(expr):
     """Convert a short expression (e.g. a Component Parameter) Python to JS"""
+
+    # if the code contains a tuple (anywhere), convert parenths to be list.
+    # This now works for compounds like `(2*(4, 5))` where the inner
+    # parenths becomes a list and the outer parens indicate priority.
+    # This works by running an ast transformer class to swap the contents of the tuple
+    # into a list for the number of tuples in the expression.
+
+    tups = 0
     syntaxTree = ast.parse(expr)
-    wasTuple = wasList = False
-    onlyUnary = []
+    for node in ast.walk(syntaxTree):
+        if isinstance(node, ast.Tuple):
+            tups += 1
+    for tup in range(tups):
+        syntaxTree = ast.parse(expr)
+        TupleTransformer().visit(syntaxTree)
+        syntaxTree = ast.fix_missing_locations(syntaxTree)
+        expr = unparse(syntaxTree).strip()
+
+    syntaxTree = ast.parse(expr)
     for node in ast.walk(syntaxTree):
         if isinstance(node, ast.Str) and node.s.startswith("u'"):
             node.s = node.s[1:]
@@ -70,33 +97,8 @@ def expression2js(expr):
             if node.id == 'undefined':
                 continue
             node.id = namesJS[node.id]
-        if isinstance(node, ast.Tuple):
-            wasTuple = True
-        if isinstance(node, ast.List):
-            wasList = True
-        if isinstance(node, ast.UnaryOp):
-            onlyUnary.append(True)
-        if not PY3:
-            if isinstance(node, ast.Num):
-                if node.n < 0:  # If unary operator not identified by ast parse
-                    onlyUnary.append(True)
-        if isinstance(node, ast.BinOp):
-            onlyUnary.append(False)
-
     jsStr = unparse(syntaxTree).strip()
-    # if the code contained a tuple (anywhere) convert parenths to be list
-    # NB this won't be good for compounds like `(2*(4, 5))` where the inner
-    # parenths are a list and the outer parens are indicating priority.
-    # Would be better to convert a Tuple node into a List node with same
-    # and then the JS would work fine!
-    # Further, numbers with unary operators are converted to tuples, inconsistent with
-    # numbers in tuples with unary operators existing as lists. Now, elements of list/tuple with unary operators
-    # are converted to nested list, unless a binary operator exists.
-    if wasTuple:
-        jsStr = jsStr.replace('(', '[').replace(')', ']')
-    if wasList:
-        if len(onlyUnary) and all(onlyUnary):
-            jsStr = jsStr.replace('(', '[').replace(')', ']')
+
     return jsStr
 
 
@@ -176,3 +178,5 @@ if __name__ == '__main__':
                  '[-.7, -.7]',  # A list with unary operators returns list with nested tuple
                  '[-.7, (-.7 * 7)]']:  # List with unary operators and nested tuple with operations returns list + tuple
         print("{} -> {}".format(repr(expr), repr(expression2js(expr))))
+
+#'("string", [1,2],3,-4, (1,2,3,4), 1, 2, 3,)'

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -77,19 +77,9 @@ def expression2js(expr):
     # This works by running an ast transformer class to swap the contents of the tuple
     # into a list for the number of tuples in the expression.
 
-    tups = 0
     syntaxTree = ast.parse(expr)
     for node in ast.walk(syntaxTree):
-        if isinstance(node, ast.Tuple):
-            tups += 1
-    for tup in range(tups):
-        syntaxTree = ast.parse(expr)
-        TupleTransformer().visit(syntaxTree)
-        syntaxTree = ast.fix_missing_locations(syntaxTree)
-        expr = unparse(syntaxTree).strip()
-
-    syntaxTree = ast.parse(expr)
-    for node in ast.walk(syntaxTree):
+        TupleTransformer().visit(node)  # Transform tuples to list
         if isinstance(node, ast.Str) and node.s.startswith("u'"):
             node.s = node.s[1:]
             print(node.s)
@@ -98,9 +88,7 @@ def expression2js(expr):
                 continue
             node.id = namesJS[node.id]
     jsStr = unparse(syntaxTree).strip()
-
     return jsStr
-
 
 def snippet2js(expr):
     """Convert several lines (e.g. a Code Component) Python to JS"""
@@ -171,7 +159,7 @@ def addVariableDeclarations(inputProgram):
 if __name__ == '__main__':
     for expr in ['sin(t)', 't*5',
                  '(3, 4)', '(5*-2)',  # tuple and not tuple
-                 '(1,(2,3))', '2*(2, 3)',  # combinations
+                 '(1,(2,3), (1,2,3), (-4,-5,-6))', '2*(2, 3)',  # combinations
                  '[1, (2*2)]',  # List with nested operations returns list + nested tuple
                  '(.7, .7)',  # A tuple returns list
                  '(-.7, .7)',  # A tuple with unary operators returns nested lists

--- a/psychopy/tests/test_psychojs/test_py2js.py
+++ b/psychopy/tests/test_psychojs/test_py2js.py
@@ -38,16 +38,14 @@ class Test_PY2JS_Compile(object):
                   '[3, 4]',
                   '(5 * (- 2))',
                   '[1, [2, 3]]',
-                  '[2 * [2, 3]]',
+                  '(2 * [2, 3])',
                   '[1, (2 * 2)]',
                   '[0.7, 0.7]',
-                  '[[- 0.7], 0.7]',
-                  '[[- 0.7], [- 0.7]]',
+                  '[(- 0.7), 0.7]',
+                  '[(- 0.7), (- 0.7)]',
                   '[(- 0.7), ((- 0.7) * 7)]']
 
         for idx, expr in enumerate(input):
             # check whether direct match or at least a match when spaces removed
-
             assert (py2js.expression2js(expr) == output[idx] or
             py2js.expression2js(expr).replace(" ", "") == output[idx].replace(" ", ""))
-


### PR DESCRIPTION
The previous fix converted lists with unary operations to nested lists,
which failed when JS color functions expected "an array of numbers of length 3".
The new fix now converts only tuples, and maintains parenthesis in order
to uphold order of operations. Unary operations are treated with
parenthesis by default to preserve that order and the numbers contained
are treated as numbers, not arrays. Thus ```[(-1), (-1), (-1)]``` is a valid color.