### PR TITLE
RF: Updates to Builder Components

### DIFF
--- a/psychopy/experiment/components/cedrusBox/__init__.py
+++ b/psychopy/experiment/components/cedrusBox/__init__.py
@@ -206,7 +206,7 @@ class cedrusButtonBoxComponent(KeyboardComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
             buff.setIndentLevel(-1, True)
 
         buff.writeIndented("if %(name)s.status == STARTED:\n" % self.params)

--- a/psychopy/experiment/components/eyetracker/__init__.py
+++ b/psychopy/experiment/components/eyetracker/__init__.py
@@ -142,15 +142,15 @@ class EyetrackerComponent(BaseComponent):
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
 
-            code = ("%(name)s.status = STOPPED\n"
+            code = ("%(name)s.status = FINISHED\n"
                     "%(name)s.setRecordingState(False)\n")
             buff.writeIndentedLines(code % self.params)
 
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
-        # if STARTED and not STOPPED!
-        code = "if %(name)s.status == STARTED:  # only update if started and not stopped!\n" % self.params
+        # if STARTED and not FINISHED!
+        code = "if %(name)s.status == STARTED:  # only update if started and not finished!\n" % self.params
         buff.writeIndented(code)
 
         buff.setIndentLevel(1, relative=True)  # to get out of the if statement
@@ -199,7 +199,7 @@ class EyetrackerComponent(BaseComponent):
                     "%s.addData('%s.%s', %s.%s)\n" %
                     (currLoop.params['name'], name, property, name, property))
 
-        # make sure eyetracking stops recording (in case it hsn't stopped
+        # make sure eyetracking stops recording (in case it hasn't stopped
         # already)
         buff.writeIndented("eyetracker.setRecordingState(False)\n")
 

--- a/psychopy/experiment/components/ioLabs/__init__.py
+++ b/psychopy/experiment/components/ioLabs/__init__.py
@@ -166,7 +166,7 @@ class ioLabsButtonBoxComponent(KeyboardComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
             buff.setIndentLevel(-1, True)
 
         buff.writeIndented("if %(name)s.status == STARTED:\n" % self.params)

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -363,13 +363,13 @@ class JoystickComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
-        # if STARTED and not STOPPED!
+        # if STARTED and not FINISHED!
         code = ("if %(name)s.status == STARTED:  "
-                "# only update if started and not stopped!\n") % self.params
+                "# only update if started and not finished!\n") % self.params
         buff.writeIndented(code)
         buff.setIndentLevel(1, relative=True)  # to get out of if statement
         dedentAtEnd = 1  # keep track of how far to dedent later

--- a/psychopy/experiment/components/joystick/mouseJoystick.py
+++ b/psychopy/experiment/components/joystick/mouseJoystick.py
@@ -12,7 +12,8 @@
 from __future__ import absolute_import, division, print_function
 from psychopy import event
 
-class Joystick:
+
+class Joystick(object):
     def __init__(self, device_number):
         self.device_number = device_number
         self.numberKeys = ['0','1','2','3','4','5','6','7','8','9']

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -199,7 +199,7 @@ class KeyboardComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
@@ -335,7 +335,7 @@ class KeyboardComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCodeJS(buff)
-            buff.writeIndented("%(name)s.status = PsychoJS.Status.STOPPED;\n"
+            buff.writeIndented("%(name)s.status = PsychoJS.Status.FINISHED;\n"
                                "  }\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -272,13 +272,13 @@ class MouseComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
-        # if STARTED and not STOPPED!
+        # if STARTED and not FINISHED!
         code = ("if %(name)s.status == STARTED:  "
-                "# only update if started and not stopped!\n") % self.params
+                "# only update if started and not finished!\n") % self.params
         buff.writeIndented(code)
         buff.setIndentLevel(1, relative=True)  # to get out of if statement
         dedentAtEnd = 1  # keep track of how far to dedent later
@@ -399,14 +399,14 @@ class MouseComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCodeJS(buff)
-            buff.writeIndented("%(name)s.status = PsychoJS.Status.STOPPED;\n"
+            buff.writeIndented("%(name)s.status = PsychoJS.Status.FINISHED;\n"
                                "  }\n" % self.params)
             # to get out of the if statement
             buff.setIndentLevel(-1, relative=True)
 
-        # if STARTED and not STOPPED!
+        # if STARTED and not FINISHED!
         code = ("if (%(name)s.status === PsychoJS.Status.STARTED) {  "
-                "// only update if started and not stopped!\n")
+                "// only update if started and not finished!\n")
         buff.writeIndented(code % self.params)
         buff.setIndentLevel(1, relative=True)  # to get out of if statement
         dedentAtEnd = 1  # keep track of how far to dedent later

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -114,7 +114,7 @@ class ParallelOutComponent(BaseComponent):
         if self.params['stopVal'].val not in ['', None, -1, 'None']:
             # writes an if statement to determine whether to draw etc
             self.writeStopTestCode(buff)
-            buff.writeIndented("%(name)s.status = STOPPED\n" % self.params)
+            buff.writeIndented("%(name)s.status = FINISHED\n" % self.params)
 
             if not self.params['syncScreen'].val:
                 code = "%(name)s.setData(int(%(stopData)s))\n" % self.params


### PR DESCRIPTION
- Set status to `FINISHED` instead of `STOPPED` when components stop (#2132).
- `mouseJoystick.Joystick` should be new-style class. Closes #2151.