### PR TITLE
ENH: Use WX's built-in prompt-to-overwrite-file feature

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1622,40 +1622,27 @@ class BuilderFrame(wx.Frame):
         returnVal = False
         dlg = wx.FileDialog(
             self, message=_translate("Save file as ..."), defaultDir=initPath,
-            defaultFile=filename, style=wx.FD_SAVE, wildcard=wildcard)
+            defaultFile=filename, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+            wildcard=wildcard)
+
         if dlg.ShowModal() == wx.ID_OK:
             newPath = dlg.GetPath()
             # update exp name
-            # if the file already exists, query whether it should be
-            # overwritten (default = yes)
-            okToSave = True
-            if os.path.exists(newPath):
-                msg = _translate("File '%s' already exists.\n"
-                                 "    OK to overwrite?") % newPath
-                dg2 = dialogs.MessageDialog(self, message=msg, type='Warning')
-                ok = dg2.ShowModal()
-                if ok != wx.ID_YES:
-                    okToSave = False
-                try:
-                    dg2.destroy()
-                except Exception:
-                    pass
-            if okToSave:
-                # if user has not manually renamed experiment
-                if usingDefaultName:
-                    newShortName = os.path.splitext(
-                        os.path.split(newPath)[1])[0]
-                    self.exp.setExpName(newShortName)
-                # actually save
-                self.fileSave(event=None, filename=newPath)
-                self.filename = newPath
-                returnVal = 1
-            else:
-                print("'Save-as' cancelled; existing file NOT overwritten.\n")
+            # if user has not manually renamed experiment
+            if usingDefaultName:
+                newShortName = os.path.splitext(
+                    os.path.split(newPath)[1])[0]
+                self.exp.setExpName(newShortName)
+            # actually save
+            self.fileSave(event=None, filename=newPath)
+            self.filename = newPath
+            returnVal = 1
+
         try:  # this seems correct on PC, but not on mac
             dlg.destroy()
         except Exception:
             pass
+
         self.updateWindowTitle()
         return returnVal
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2296,31 +2296,22 @@ class CoderFrame(wx.Frame):
         else:
             wildcard = _translate("Python scripts (*.py)|*.py|Text file "
                                   "(*.txt)|*.txt|Any file (*.*)|*")
-        # open dlg
+
         dlg = wx.FileDialog(
             self, message=_translate("Save file as ..."), defaultDir=initPath,
-            defaultFile=filename, style=wx.FD_SAVE, wildcard=wildcard)
+            defaultFile=filename, style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+            wildcard=wildcard)
+
         if dlg.ShowModal() == wx.ID_OK:
             newPath = dlg.GetPath()
-            # if the file already exists, query whether it should be
-            # overwritten (default = yes)
-            msg = _translate("File '%s' already exists.\n    OK to overwrite?")
-            dlg2 = dialogs.MessageDialog(self, message=msg % newPath,
-                                         type='Warning')
-            if not os.path.exists(newPath) or dlg2.ShowModal() == wx.ID_YES:
-                doc.filename = newPath
-                self.fileSave(event=None, filename=newPath, doc=doc)
-                path, shortName = os.path.split(newPath)
-                self.notebook.SetPageText(docId, shortName)
-                self.setFileModified(False)
-                # JRG: 'doc.filename' should = newPath = dlg.getPath()
-                doc.fileModTime = os.path.getmtime(doc.filename)
-                try:
-                    dlg2.destroy()
-                except Exception:
-                    pass
-            else:
-                print("'Save-as' canceled; existing file NOT overwritten.\n")
+            doc.filename = newPath
+            self.fileSave(event=None, filename=newPath, doc=doc)
+            path, shortName = os.path.split(newPath)
+            self.notebook.SetPageText(docId, shortName)
+            self.setFileModified(False)
+            # JRG: 'doc.filename' should = newPath = dlg.getPath()
+            doc.fileModTime = os.path.getmtime(doc.filename)
+
         try:  # this seems correct on PC, but can raise errors on mac
             dlg.destroy()
         except Exception:


### PR DESCRIPTION
By adding the window style `wx.FD_OVERWRITE_PROMPT` to the `wx.FileDialog`, we don't have to manually handle the "file already exists, should we overwrite?" case anymore.

This also closes GH-2113.