### PR TITLE
ENH: When renaming Routine, display current name as default in dialog

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2179,7 +2179,7 @@ class BuilderFrame(wx.Frame):
             self.routinePanel.GetSelection()).routine
         oldName = routine.name
         msg = _translate("What is the new name for the Routine?")
-        dlg = wx.TextEntryDialog(self, message=msg,
+        dlg = wx.TextEntryDialog(self, message=msg, value=oldName,
                                  caption=_translate('Rename'))
         exp = self.exp
         if dlg.ShowModal() == wx.ID_OK:


### PR DESCRIPTION
This addresses one of the issues brought up in GH-2132.

![screen recording 2018-12-20 at 14 17 33](https://user-images.githubusercontent.com/2046265/50287231-486e3900-0462-11e9-883d-edc6400607e5.gif)
