### PR TITLE
ENH/NF: Add Experiment.runOnce() method 

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -82,6 +82,8 @@ class Experiment(object):
                 'logging', 'clock')
         self.requirePsychopyLibs(libs=libs)
 
+        self._runOnce = []
+
         _settingsComp = getComponents(fetchIcons=False)['SettingsComponent']
         self.settings = _settingsComp(parentName='', exp=self)
         # this will be the xml.dom.minidom.doc object for saving
@@ -112,8 +114,7 @@ class Experiment(object):
                                importFrom='psychopy')
 
     def requireImport(self, importName, importFrom='', importAs=''):
-        """
-        Add a top-level import to the experiment.
+        """Add a top-level import to the experiment.
 
         Parameters
         ----------
@@ -130,6 +131,29 @@ class Experiment(object):
 
         if import_ not in self.requiredImports:
             self.requiredImports.append(import_)
+
+    def runOnce(self, code):
+        """Add code to the experiment that is only run exactly once, after
+        all `import`s were done.
+
+        Parameters
+        ----------
+        code : str
+            The code to run. May include newline characters to wrtie several
+            lines of code at once.
+
+        Notes
+        -----
+        For running an `import`, use meth:~`Experiment.requireImport` or
+        :meth:~`Experiment.requirePsychopyLibs` instead.
+
+        See also
+        --------
+        :meth:~`Experiment.requireImport`,
+        :meth:~`Experiment.requirePsychopyLibs`
+        """
+        if code not in self._runOnce:
+            self._runOnce.append(code)
 
     def addRoutine(self, routineName, routine=None):
         """Add a Routine to the current list of them.

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -93,18 +93,20 @@ class BaseComponent(object):
 
         self.order = ['name']  # name first, then timing, then others
 
+    def writeInitCode(self, buff):
+        """Write any code that a component needs that should only ever be done
+        at start of an experiment, BEFORE window creation.
+        """
+        pass
+
     def writeStartCode(self, buff):
         """Write any code that a component needs that should only ever be done
-        at start of an experiment (done once only)
+        at start of an experiment, AFTER window creation.
         """
         # e.g., create a data subdirectory unique to that component type.
         # Note: settings.writeStartCode() is done first, then
         # Routine.writeStartCode() will call this method for each component in
         # each routine
-        pass
-
-    def writeInitCode(self, buff):
-        """Doesn't seem to do much of anything"""
         pass
 
     def writeFrameCode(self, buff):

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -418,8 +418,9 @@ class SettingsComponent(object):
         buff.write("\n")
 
         # Write "run once" code.
-        buff.write("\n".join(self.exp._runOnce))
-        buff.write("\n\n")
+        if self.exp._runOnce:
+            buff.write("\n".join(self.exp._runOnce))
+            buff.write("\n\n")
 
     def prepareResourcesJS(self):
         """Sets up the resources folder and writes the info.php file for PsychoJS

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -397,8 +397,8 @@ class SettingsComponent(object):
             "import sys  # to get file system encoding\n"
             "\n")
 
+        # Write custom import statements, line by line.
         for import_ in customImports:
-            # Write custom import statements, line by line.
             importName = import_.importName
             importFrom = import_.importFrom
             importAs = import_.importAs
@@ -416,6 +416,10 @@ class SettingsComponent(object):
             buff.write(statement)
 
         buff.write("\n")
+
+        # Write "run once" code.
+        buff.write("\n".join(self.exp._runOnce))
+        buff.write("\n\n")
 
     def prepareResourcesJS(self):
         """Sets up the resources folder and writes the info.php file for PsychoJS

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -455,3 +455,37 @@ class TestExpImports(object):
         script = self.exp.writeScript()
         assert 'from psychopy import locale_setup, foo\n' in script
         assert 'import bar\n' in script
+
+
+class TestRunOnce(object):
+    def setup(self):
+        self.exp = psychopy.experiment.Experiment()
+
+    def test_runOnceSingleLine(self):
+        code = 'foo bar baz'
+        self.exp.runOnce(code)
+        assert code in self.exp._runOnce
+
+        script = self.exp.writeScript()
+        assert code + '\n' in script
+
+    def test_runOnceMultiLine(self):
+        code = 'foo bar baz\nbla bla bla'
+        self.exp.runOnce(code)
+        assert code in self.exp._runOnce
+
+        script = self.exp.writeScript()
+        assert code + '\n' in script
+
+    def test_runOnceMultipleStatements(self):
+        code_0 = 'foo bar baz'
+        self.exp.runOnce(code_0)
+
+        code_1 = 'bla bla bla'
+        self.exp.runOnce(code_1)
+
+        assert code_0 in self.exp._runOnce
+        assert code_1 in self.exp._runOnce
+
+        script = self.exp.writeScript()
+        assert (code_0 + '\n' + code_1 + '\n') in script


### PR DESCRIPTION
The new `Experiment.runOnce()` method allows to add arbitrary code to the beginning of the experiment script (directly below the imports) which will only be executed a single time. This is for example useful if a Component requires a certain initialization routine, e.g. activation of hardware, and this procedure shall be executed only once even if the Component appears multiple times in the experimental flow. See https://github.com/psychopy/psychopy/pull/2141#issuecomment-447295089

Also update some docstrings.