### PR TITLE
 ENH: Use utf-8-sig instead of utf-8 encoding

### DIFF
--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -369,7 +369,7 @@ class _BaseTrialHandler(_ComparisonMixin):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8-sig',
+                   encoding='utf-8',
                    fileCollisionMethod='rename'):
         """
         Serialize the object to the JSON format.

--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -151,7 +151,7 @@ class _BaseTrialHandler(_ComparisonMixin):
                    appendFile=True,
                    summarised=True,
                    fileCollisionMethod='rename',
-                   encoding='utf-8'):
+                   encoding='utf-8-sig'):
         """
         Write a text file with the data and various chosen stimulus attributes
 
@@ -190,7 +190,7 @@ class _BaseTrialHandler(_ComparisonMixin):
             :func:`~psychopy.tools.fileerrortools.handleFileCollision`
 
         encoding:
-            The encoding to use when saving a the file. Defaults to `utf-8`.
+            The encoding to use when saving a the file. Defaults to `utf-8-sig`.
 
         """
         fileName = pathToString(fileName)
@@ -369,7 +369,7 @@ class _BaseTrialHandler(_ComparisonMixin):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8',
+                   encoding='utf-8-sig',
                    fileCollisionMethod='rename'):
         """
         Serialize the object to the JSON format.
@@ -382,9 +382,7 @@ class _BaseTrialHandler(_ComparisonMixin):
             in-memory JSON object.
 
         encoding : string, optional
-            The encoding to use when writing the file. This parameter will be
-            ignored if `append` is `False` and `fileName` ends with `.psydat`
-            or `.npy` (i.e. if a binary file is to be written).
+            The encoding to use when writing the file.
 
         fileCollisionMethod : string
             Collision method passed to
@@ -440,7 +438,7 @@ class _BaseTrialHandler(_ComparisonMixin):
                                   "inspect.getouterframes")
                 return '', ''
         if os.path.isfile(originPath):  # do we NOW have a path?
-            origin = codecs.open(originPath, "r", encoding="utf-8").read()
+            origin = codecs.open(originPath, "r", encoding="utf-8-sig").read()
         else:
             origin = None
         return originPath, origin

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -251,7 +251,7 @@ class ExperimentHandler(_ComparisonMixin):
                        delim=None,
                        matrixOnly=False,
                        appendFile=False,
-                       encoding='utf-8',
+                       encoding='utf-8-sig',
                        fileCollisionMethod='rename',
                        sortColumns=False):
         """Saves a long, wide-format text file, with one line representing
@@ -286,7 +286,7 @@ class ExperimentHandler(_ComparisonMixin):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
             fileCollisionMethod:
                 Collision method passed to

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -425,7 +425,7 @@ class StairHandler(_BaseTrialHandler):
                    delim=None,
                    matrixOnly=False,
                    fileCollisionMethod='rename',
-                   encoding='utf-8'):
+                   encoding='utf-8-sig'):
         """Write a text file with the data
 
         :Parameters:
@@ -448,7 +448,7 @@ class StairHandler(_BaseTrialHandler):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
         """
 
@@ -1648,7 +1648,7 @@ class MultiStairHandler(_BaseTrialHandler):
                    delim=None,
                    matrixOnly=False,
                    fileCollisionMethod='rename',
-                   encoding='utf-8'):
+                   encoding='utf-8-sig'):
         """Write out text files with the data.
 
         For MultiStairHandler this will output one file for each staircase
@@ -1676,7 +1676,7 @@ class MultiStairHandler(_BaseTrialHandler):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
         """
         if self.totalTrials < 1:

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -565,7 +565,7 @@ class TrialHandler(_BaseTrialHandler):
                        delim=None,
                        matrixOnly=False,
                        appendFile=True,
-                       encoding='utf-8',
+                       encoding='utf-8-sig',
                        fileCollisionMethod='rename'):
         """Write a text file with the session, stimulus, and data values
         from each trial in chronological order. Also, return a
@@ -613,7 +613,7 @@ class TrialHandler(_BaseTrialHandler):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
         """
         if self.thisTrialN < 1 and self.thisRepN < 1:
@@ -725,7 +725,7 @@ class TrialHandler(_BaseTrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8',
+                   encoding='utf-8-sig',
                    fileCollisionMethod='rename'):
         raise NotImplementedError('Not implemented for TrialHandler.')
 
@@ -1047,7 +1047,7 @@ class TrialHandler2(_BaseTrialHandler):
                        delim=None,
                        matrixOnly=False,
                        appendFile=True,
-                       encoding='utf-8',
+                       encoding='utf-8-sig',
                        fileCollisionMethod='rename'):
         """Write a text file with the session, stimulus, and data values
         from each trial in chronological order. Also, return a
@@ -1095,7 +1095,7 @@ class TrialHandler2(_BaseTrialHandler):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
         """
         if self.thisTrialN < 1 and self.thisRepN < 1:
@@ -1125,7 +1125,7 @@ class TrialHandler2(_BaseTrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8',
+                   encoding='utf-8-sig',
                    fileCollisionMethod='rename'):
         """
         Serialize the object to the JSON format.
@@ -1138,9 +1138,7 @@ class TrialHandler2(_BaseTrialHandler):
             in-memory JSON object.
 
         encoding : string, optional
-            The encoding to use when writing the file. This parameter will be
-            ignored if `append` is `False` and `fileName` ends with `.psydat`
-            or `.npy` (i.e. if a binary file is to be written).
+            The encoding to use when writing the file.
 
         fileCollisionMethod : string
             Collision method passed to
@@ -1741,7 +1739,7 @@ class TrialHandlerExt(TrialHandler):
                        delim='\t',
                        matrixOnly=False,
                        appendFile=True,
-                       encoding='utf-8',
+                       encoding='utf-8-sig',
                        fileCollisionMethod='rename'):
         """Write a text file with the session, stimulus, and data values
         from each trial in chronological order.
@@ -1788,7 +1786,7 @@ class TrialHandlerExt(TrialHandler):
 
             encoding:
                 The encoding to use when saving a the file.
-                Defaults to `utf-8`.
+                Defaults to `utf-8-sig`.
 
         """
         if self.thisTrialN < 1 and self.thisRepN < 1:
@@ -1896,6 +1894,6 @@ class TrialHandlerExt(TrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8',
+                   encoding='utf-8-sig',
                    fileCollisionMethod='rename'):
         raise NotImplementedError('Not implemented for TrialHandlerExt.')

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -725,7 +725,7 @@ class TrialHandler(_BaseTrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8-sig',
+                   encoding='utf-8',
                    fileCollisionMethod='rename'):
         raise NotImplementedError('Not implemented for TrialHandler.')
 
@@ -1125,7 +1125,7 @@ class TrialHandler2(_BaseTrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8-sig',
+                   encoding='utf-8',
                    fileCollisionMethod='rename'):
         """
         Serialize the object to the JSON format.
@@ -1894,6 +1894,6 @@ class TrialHandlerExt(TrialHandler):
 
     def saveAsJson(self,
                    fileName=None,
-                   encoding='utf-8-sig',
+                   encoding='utf-8',
                    fileCollisionMethod='rename'):
         raise NotImplementedError('Not implemented for TrialHandlerExt.')

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -259,7 +259,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                         # val = eval('%s' %unicode(val.decode('utf8')))
                         val = eval(val)
                 elif type(val) == np.string_:
-                    val = str(val.decode('utf-8'))
+                    val = str(val.decode('utf-8-sig'))
                     # if it looks like a list, convert it:
                     if val.startswith('[') and val.endswith(']'):
                         # val = eval('%s' %unicode(val.decode('utf8')))
@@ -270,19 +270,15 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             trialList.append(thisTrial)
         return trialList, fieldNames
 
-    if fileName.endswith('.csv'):
-        with open(fileName, 'rU') as fileUniv:
-            # use pandas reader, which can handle commas in fields, etc
-            trialsArr = pd.read_csv(fileUniv, encoding='utf-8')
+    if fileName.endswith('.csv') or (fileName.endswith(('.xlsx','.xls'))
+                                     and haveXlrd):
+        if fileName.endswith('.csv'):
+            trialsArr = pd.read_csv(fileName, encoding='utf-8-sig')
             logging.debug(u"Read csv file with pandas: {}".format(fileName))
-            unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
-            trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
-            logging.debug(u"Clearing unnamed columns from {}".format(fileName))
-            trialList, fieldNames = pandasToDictList(trialsArr)
+        else:
+            trialsArr = pd.read_excel(fileName)
+            logging.debug(u"Read Excel file with pandas: {}".format(fileName))
 
-    elif fileName.endswith(('.xlsx','.xls')) and haveXlrd:
-        trialsArr = pd.read_excel(fileName)
-        logging.debug(u"Read excel file with pandas: {}".format(fileName))
         unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
         trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
         logging.debug(u"Clearing unnamed columns from {}".format(fileName))

--- a/psychopy/tests/test_data/test_ExperimentHandler.py
+++ b/psychopy/tests/test_data/test_ExperimentHandler.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from builtins import object
+import codecs
 from psychopy import data, logging
 import numpy as np
 import os, glob, shutil
@@ -94,7 +95,8 @@ class TestExperimentHandler(object):
         exp.saveAsWideText(exp.dataFileName+'.csv', delim=',')
 
         # get data file contents:
-        contents = open(exp.dataFileName+'.csv', 'rU').read()
+        contents = codecs.open(exp.dataFileName+'.csv', 'rU',
+                               encoding='utf-8-sig').read()
         assert contents == "mutable,\n[1],\n[9999],\n"
 
     def test_unicode_conditions(self):

--- a/psychopy/tests/test_data/test_TrialHandler.py
+++ b/psychopy/tests/test_data/test_TrialHandler.py
@@ -9,6 +9,7 @@ from os.path import join as pjoin
 import shutil
 from tempfile import mkdtemp, mkstemp
 import numpy as np
+import codecs
 import pytest
 
 from psychopy import data
@@ -45,10 +46,12 @@ class TestTrialHandler(object):
         # Make sure the header line is correct
         # We open the file with universal newline support (PEP-278).
         if PY3:
-            with open(data_filename, 'r', newline=None) as f:
+            with open(data_filename, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(data_filename, 'rU') as f:
+            with codecs.open(data_filename, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         expected_header = u'n,with_underscore_mean,with_underscore_raw,with_underscore_std,order\n'
@@ -230,10 +233,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -253,10 +258,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -276,10 +283,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -299,10 +308,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -320,10 +331,11 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -344,10 +356,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -367,10 +381,10 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header

--- a/psychopy/tests/test_data/test_TrialHandler2.py
+++ b/psychopy/tests/test_data/test_TrialHandler2.py
@@ -8,6 +8,7 @@ from os.path import join as pjoin
 import shutil
 from tempfile import mkdtemp, mkstemp
 import numpy as np
+import codecs
 import json_tricks
 import pytest
 
@@ -47,10 +48,12 @@ class TestTrialHandler2(object):
         # Make sure the header line is correct
         # We open the file with universal newline support (PEP-278).
         if PY3:
-            with open(data_filename, 'r', newline=None) as f:
+            with open(data_filename, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(data_filename, 'rU') as f:
+            with codecs.open(data_filename, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         expected_header = u'n,with_underscore_mean,with_underscore_raw,with_underscore_std,order\n'
@@ -297,10 +300,12 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -318,10 +323,12 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -339,10 +346,12 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -360,10 +369,12 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -379,10 +390,10 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -401,10 +412,12 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -422,10 +435,10 @@ class TestTrialHandler2Output(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header

--- a/psychopy/tests/test_data/test_TrialHandlerExt.py
+++ b/psychopy/tests/test_data/test_TrialHandlerExt.py
@@ -13,6 +13,7 @@ from os.path import join as pjoin
 import shutil
 from tempfile import mkdtemp, mkstemp
 import numpy as np
+import codecs
 import pytest
 
 from psychopy import data
@@ -49,10 +50,11 @@ class TestTrialHandlerExt(object):
         # Make sure the header line is correct
         # We open the file with universal newline support (PEP-278).
         if PY3:
-            with open(data_filename, 'r', newline=None) as f:
+            with open(data_filename, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(data_filename, 'rU') as f:
+            with codecs.open(data_filename, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         expected_header = u'n,with_underscore_mean,with_underscore_raw,with_underscore_std,order\n'
@@ -254,10 +256,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -277,10 +281,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -300,10 +306,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -323,10 +331,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -344,10 +354,10 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -368,10 +378,12 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path + expected_suffix, 'r', newline=None) as f:
+            with open(path + expected_suffix, 'r', newline=None,
+                      encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path + expected_suffix, 'rU') as f:
+            with codecs.open(path + expected_suffix, 'rU',
+                             encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header
@@ -391,10 +403,10 @@ class TestTrialHandlerOutput(object):
 
         # Universal newline support.
         if PY3:
-            with open(path, 'r', newline=None) as f:
+            with open(path, 'r', newline=None, encoding='utf-8-sig') as f:
                 header = f.readline()
         else:
-            with open(path, 'rU') as f:
+            with codecs.open(path, 'rU', encoding='utf-8-sig') as f:
                 header = f.readline()
 
         assert header == expected_header

--- a/psychopy/tests/test_tools/test_filetools.py
+++ b/psychopy/tests/test_tools/test_filetools.py
@@ -51,14 +51,14 @@ class TestOpenOutputFile(object):
 
     def test_default_parameters(self):
         f = openOutputFile(self.baseFileName)
-        assert f.encoding == 'utf-8'
+        assert f.encoding == 'utf-8-sig'
         assert f.closed is False
         assert f.stream.mode == 'wb'
         f.close()
 
     def test_append(self):
         f = openOutputFile(self.baseFileName, append=True)
-        assert f.encoding == 'utf-8'
+        assert f.encoding == 'utf-8-sig'
         assert f.closed is False
         assert f.stream.mode == 'ab'
         f.close()

--- a/psychopy/tests/test_tools/test_filetools.py
+++ b/psychopy/tests/test_tools/test_filetools.py
@@ -78,31 +78,7 @@ class TestFromFile(object):
     def teardown(self):
         shutil.rmtree(self.tmp_dir)
 
-    def test_text(self):
-        _, path = mkstemp(dir=self.tmp_dir, suffix='.txt')
-
-        test_data = 'Test'
-        with open(path, 'w') as f:
-            f.write(test_data)
-
-        with open(path, 'r') as f:
-            loaded_data = f.read()
-
-        assert test_data == loaded_data
-
-    def test_json(self):
-        _, path = mkstemp(dir=self.tmp_dir, suffix='.json')
-
-        test_data = 'Test'
-        with open(path, 'w') as f:
-            json.dump(test_data, f)
-
-        with open(path, 'r') as f:
-            loaded_data = json.load(f)
-
-        assert test_data == loaded_data
-
-    def test_json_encoding(self):
+    def test_json_with_encoding(self):
         _, path_0 = mkstemp(dir=self.tmp_dir, suffix='.json')
         _, path_1 = mkstemp(dir=self.tmp_dir, suffix='.json')
         encoding_0 = 'utf-8'
@@ -131,10 +107,7 @@ class TestFromFile(object):
         with open(path, 'wb') as f:
             pickle.dump(test_data, f)
 
-        with open(path, 'rb') as f:
-            loaded_data = pickle.load(f)
-
-        assert test_data == loaded_data
+        assert test_data == fromFile(path)
 
     def test_cPickle(self):
         if PY3:
@@ -148,10 +121,7 @@ class TestFromFile(object):
         with open(path, 'wb') as f:
             cPickle.dump(test_data, f)
 
-        with open(path, 'rb') as f:
-            loaded_data = cPickle.load(f)
-
-        assert test_data == loaded_data
+        assert test_data == fromFile(path)
 
 
 if __name__ == '__main__':

--- a/psychopy/tests/utils.py
+++ b/psychopy/tests/utils.py
@@ -6,6 +6,7 @@ from os.path import abspath, basename, dirname, isfile, join as pjoin
 import os.path
 import shutil
 import numpy as np
+import codecs
 from psychopy import logging
 
 try:
@@ -66,8 +67,10 @@ def compareScreenshot(fileName, win, crit=5.0):
             "RMS=%.3g at threshold=%.3g. Local copy in %s" % (rms, crit, filenameLocal)
 
 
-def compareTextFiles(pathToActual, pathToCorrect, delim=None):
-    """Compare the text of two files, ignoring EOL differences, and save a copy if they differ
+def compareTextFiles(pathToActual, pathToCorrect, delim=None,
+                     encoding='utf-8-sig'):
+    """Compare the text of two files, ignoring EOL differences,
+    and save a copy if they differ
     """
     if not os.path.isfile(pathToCorrect):
         logging.warning('There was no comparison ("correct") file available, saving current file as the comparison:%s' %pathToCorrect)
@@ -83,8 +86,8 @@ def compareTextFiles(pathToActual, pathToCorrect, delim=None):
 
     try:
         #we have the necessary file
-        txtActual = open(pathToActual, 'r').readlines()
-        txtCorrect = open(pathToCorrect, 'r').readlines()
+        txtActual = codecs.open(pathToActual, 'r', encoding='utf-8-sig').readlines()
+        txtCorrect = codecs.open(pathToCorrect, 'r', encoding='utf-8-sig').readlines()
         assert len(txtActual)==len(txtCorrect), "The data file has the wrong number of lines"
         for lineN in range(len(txtActual)):
             if delim is None:

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -51,7 +51,7 @@ def fromFile(filename):
             if hasattr(contents, 'abort'):
                 contents.abort()
     elif filename.endswith('.json'):
-        with open(filename, 'r') as f:
+        with codecs.open(filename, 'r', encoding='utf-8-sig') as f:
             contents = json_tricks.load(f)
 
             # Restore RNG if we load a TrialHandler2 object.
@@ -93,7 +93,7 @@ def mergeFolder(src, dst, pattern=None):
 
 
 def openOutputFile(fileName=None, append=False, fileCollisionMethod='rename',
-                   encoding='utf-8'):
+                   encoding='utf-8-sig'):
     """Open an output file (or standard output) for writing.
 
     :Parameters:

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -39,8 +39,15 @@ def toFile(filename, data):
     f.close()
 
 
-def fromFile(filename):
+def fromFile(filename, encoding='utf-8'):
     """Load data from a pickle or JSON file.
+
+    Parameters
+    ----------
+    encoding : str
+        The encoding to use when reading a JSON file. This parameter will be
+        ignored for any other file type.
+
     """
     filename = pathToString(filename)
     if filename.endswith('.psydat'):
@@ -51,7 +58,7 @@ def fromFile(filename):
             if hasattr(contents, 'abort'):
                 contents.abort()
     elif filename.endswith('.json'):
-        with codecs.open(filename, 'r', encoding='utf-8') as f:
+        with codecs.open(filename, 'r', encoding=encoding) as f:
             contents = json_tricks.load(f)
 
             # Restore RNG if we load a TrialHandler2 object.

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -51,7 +51,7 @@ def fromFile(filename):
             if hasattr(contents, 'abort'):
                 contents.abort()
     elif filename.endswith('.json'):
-        with codecs.open(filename, 'r', encoding='utf-8-sig') as f:
+        with codecs.open(filename, 'r', encoding='utf-8') as f:
             contents = json_tricks.load(f)
 
             # Restore RNG if we load a TrialHandler2 object.


### PR DESCRIPTION
This allows for better support of "special" characters and improves e.g.
support of Chinese. Closes #2166.