### PR TITLE
ENH/BF: New Experiment Setting – Flip after Routine is finished

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -49,6 +49,7 @@ _localized = {'expName': _translate("Experiment name"),
               'colorSpace':  _translate("Color space"),
               'Units':  _translate("Units"),
               'blendMode':   _translate("Blend mode"),
+              'flipAfterRoutine': _translate("Flip at Routine end"),
               'Show mouse':  _translate("Show mouse"),
               'Save log file':  _translate("Save log file"),
               'Save wide csv file':
@@ -85,6 +86,7 @@ thisFolder = os.path.split(__file__)[0]
 #     def allowedVals(self, allowed):
 #         pass
 
+
 class SettingsComponent(object):
     """This component stores general info about how to run the experiment
     """
@@ -95,7 +97,7 @@ class SettingsComponent(object):
                  expInfo="{'participant':'', 'session':'001'}",
                  units='use prefs', logging='exp',
                  color='$[0,0,0]', colorSpace='rgb', enableEscape=True,
-                 blendMode='avg',
+                 blendMode='avg', flipAfterRoutine=True,
                  saveXLSXFile=False, saveCSVFile=False,
                  saveWideCSVFile=True, savePsydatFile=True,
                  savedDataFolder='',
@@ -125,7 +127,8 @@ class SettingsComponent(object):
                       'Save log file', 'logging level',
                       'Monitor', 'Screen', 'Full-screen window',
                       'Window size (pixels)',
-                      'color', 'colorSpace', 'Units', 'HTML path']
+                      'color', 'colorSpace', 'Units', 'blendMode',
+                      'Show mouse', 'flipAfterRoutine', 'HTML path']
         # basic params
         self.params['expName'] = Param(
             expName, valType='str', allowedTypes=[],
@@ -207,6 +210,11 @@ class SettingsComponent(object):
             showMouse, valType='bool', allowedTypes=[],
             hint=_translate("Should the mouse be visible on screen?"),
             label=_localized["Show mouse"], categ='Screen')
+        self.params['flipAfterRoutine'] = Param(
+            flipAfterRoutine, valType='bool', allowedTypes=[],
+            hint=_translate('Clear (flip) the screen after the last component '
+                            'of a Routine has finished'),
+            label=_localized['flipAfterRoutine'], categ='Screen')
 
         # data params
         self.params['Data filename'] = Param(

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -188,11 +188,15 @@ class Routine(list):
                     'if endExpNow or event.getKeys(keyList=["escape"]):\n'
                     '    core.quit()\n')
             buff.writeIndentedLines(code)
+
         # update screen
-        code = ('\n# refresh the screen\n'
-                "if continueRoutine:  # don't flip if this routine is over "
-                "or we'll get a blank screen\n"
-                '    win.flip()\n')
+        if self.exp.settings.params['flipAfterRoutine'].val:
+            code = ('\n# refresh the screen\n'
+                    'win.flip()\n')
+        else:
+            code = ("\n# refresh the screen\n"
+                    "if continueRoutine:  # don't flip if this routine is over\n"
+                    "    win.flip()\n")
         buff.writeIndentedLines(code)
 
         # that's done decrement indent to end loop

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -3794,6 +3794,18 @@ SettingsComponent.exportHTML.staticUpdater:None
 SettingsComponent.exportHTML.updates:None
 SettingsComponent.exportHTML.val:on Sync
 SettingsComponent.exportHTML.valType:str
+SettingsComponent.flipAfterRoutine.default:True
+SettingsComponent.flipAfterRoutine.allowedTypes:[]
+SettingsComponent.flipAfterRoutine.allowedUpdates:None
+SettingsComponent.flipAfterRoutine.allowedVals:[]
+SettingsComponent.flipAfterRoutine.categ:Screen
+SettingsComponent.flipAfterRoutine.hint:Clear (flip) the screen after the last component of a Routine has finished
+SettingsComponent.flipAfterRoutine.label:Flip at Routine end
+SettingsComponent.flipAfterRoutine.readOnly:False
+SettingsComponent.flipAfterRoutine.staticUpdater:None
+SettingsComponent.flipAfterRoutine.updates:None
+SettingsComponent.flipAfterRoutine.val:True
+SettingsComponent.flipAfterRoutine.valType:bool
 SettingsComponent.logging level.default:exp
 SettingsComponent.logging level.allowedTypes:[]
 SettingsComponent.logging level.allowedUpdates:None

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -3,6 +3,8 @@ from past.builtins import execfile
 from builtins import object
 
 import psychopy.experiment
+from psychopy.experiment.routine import Routine
+from psychopy.experiment.flow import Flow
 from psychopy.experiment._experiment import RequiredImport
 from os import path
 import os, shutil, glob, sys
@@ -489,3 +491,32 @@ class TestRunOnce(object):
 
         script = self.exp.writeScript()
         assert (code_0 + '\n' + code_1 + '\n') in script
+
+
+class TestFlipAfterRoutine(object):
+    def setup(self):
+        self.exp = psychopy.experiment.Experiment()
+        self.routine = Routine(name='TestRoutine', exp=self.exp)
+        self.flow = Flow(self.exp)
+        self.flow.addRoutine(self.routine, pos=0)
+        self.exp.flow = self.flow
+
+    def test_default(self):
+        assert self.exp.settings.params['flipAfterRoutine'].val is True
+
+    def test_true(self):
+        self.exp.settings.params['flipAfterRoutine'].val = True
+        script = self.exp.writeScript()
+        print(script)
+        code = ('    # refresh the screen\n'
+                '    win.flip()\n')
+        assert code in script
+
+    def test_false(self):
+        self.exp.settings.params['flipAfterRoutine'].val = False
+
+        script = self.exp.writeScript()
+        code = ("    # refresh the screen\n"
+                "    if continueRoutine:  # don't flip if this routine is over\n"
+                "        win.flip()\n")
+        assert code in script

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -507,14 +507,12 @@ class TestFlipAfterRoutine(object):
     def test_true(self):
         self.exp.settings.params['flipAfterRoutine'].val = True
         script = self.exp.writeScript()
-        print(script)
         code = ('    # refresh the screen\n'
                 '    win.flip()\n')
         assert code in script
 
     def test_false(self):
         self.exp.settings.params['flipAfterRoutine'].val = False
-
         script = self.exp.writeScript()
         code = ("    # refresh the screen\n"
                 "    if continueRoutine:  # don't flip if this routine is over\n"


### PR DESCRIPTION
As described in #2169, Builder Components might have unexpected durations if they occur at the end of a Routine (or at the end of the experiment) as we currently skip the last screen flip.

This PR addresses the issue by introducing a new Experiment Setting (a checkbox `Screen -> Flip at Routine end`) which enables flipping after the last Component in a Routine has finished. The setting is **ON** by default, meaning this is a "breaking" change, if you will. Users can, however, uncheck the setting to restore previous behavior.

Closes #2169.