### PR TITLE
RF: Get rid of NumPy deprecation warning

### DIFF
--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -702,7 +702,7 @@ class RatingScale(MinimalStim):
                     int(self.tickMarks) % 10 == 0):
                 self.autoRescaleFactor = 10
                 self.tickMarks /= self.autoRescaleFactor
-            tickMarkPositions = numpy.linspace(0, 1, self.tickMarks + 1)
+            tickMarkPositions = numpy.linspace(0, 1, int(self.tickMarks) + 1)
         self.scaledPrecision = float(self.precision * self.autoRescaleFactor)
 
         # how far a left or right key will move the marker, in tick units:


### PR DESCRIPTION
We used to receive: `DeprecationWarning: object of type <type 'float'> cannot be safely interpreted as an integer.`