### PR TITLE
TESTS, PKG Updates

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
- needs_sound: requires sound hw, thus should not be excercised e.g. on travis-ci

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,8 @@ classifiers =
     Programming Language :: Python :: 3.7
 
 [options]
+python_requires =
+    >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 install_requires =
     requests[security]
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,3 +73,7 @@ style = pep440
 versionfile_source = psychopy/_version.py
 versionfile_build =
 tag_prefix = ''
+
+[tool:pytest]
+markers =
+    needs_sound: requires sound hw, thus should not be excercised e.g. on travis-ci


### PR DESCRIPTION
- Move `pytest` configuration to `setup.cfg` for more consistency ("everything in one place")
- Use `python_requires` config option to restrict supported Python interpreter versions