### PR TITLE
DOC/TESTS: Fix Pump Builder demo

### DIFF
--- a/psychopy/demos/builder/pump/bubble_cycle.psyexp
+++ b/psychopy/demos/builder/pump/bubble_cycle.psyexp
@@ -187,7 +187,7 @@
       </KeyboardComponent>
     </Routine>
     <Routine name="aspirate_liquid_2">
-      <UnknownComponent name="pump_0_2">
+      <QmixPumpComponent name="pump_0_2">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -202,8 +202,8 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
-      <UnknownComponent name="pump_1_2">
+      </QmixPumpComponent>
+      <QmixPumpComponent name="pump_1_2">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -218,10 +218,10 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
+      </QmixPumpComponent>
     </Routine>
     <Routine name="aspirate_air">
-      <UnknownComponent name="pump_0_1">
+      <QmixPumpComponent name="pump_0_1">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -236,8 +236,8 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
-      <UnknownComponent name="pump_1_1">
+      </QmixPumpComponent>
+      <QmixPumpComponent name="pump_1_1">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -252,10 +252,10 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
+      </QmixPumpComponent>
     </Routine>
     <Routine name="aspirate_liquid_1">
-      <UnknownComponent name="pump_0_0">
+      <QmixPumpComponent name="pump_0_0">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -270,8 +270,8 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
-      <UnknownComponent name="pump_1_0">
+      </QmixPumpComponent>
+      <QmixPumpComponent name="pump_1_0">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -286,10 +286,10 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
+      </QmixPumpComponent>
     </Routine>
     <Routine name="empty">
-      <UnknownComponent name="pump_0_3">
+      <QmixPumpComponent name="pump_0_3">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -304,8 +304,8 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
-      <UnknownComponent name="pump_1_3">
+      </QmixPumpComponent>
+      <QmixPumpComponent name="pump_1_3">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -320,10 +320,10 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
+      </QmixPumpComponent>
     </Routine>
     <Routine name="fill">
-      <UnknownComponent name="pump_0_4">
+      <QmixPumpComponent name="pump_0_4">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -338,8 +338,8 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
-      <UnknownComponent name="pump_1_4">
+      </QmixPumpComponent>
+      <QmixPumpComponent name="pump_1_4">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -354,7 +354,7 @@
         <Param name="switchValveWhenDone" updates="None" val="True" valType="bool"/>
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
-      </UnknownComponent>
+      </QmixPumpComponent>
     </Routine>
   </Routines>
   <Flow>


### PR DESCRIPTION
For whatever reason, `bubble_cycle.psyexp` contained references to an `UnknownComponent` where it should have been `QmixPumpComponent`. Don't know how that happened, maybe committed the wrong file at some point, or mixed up stuff during a rebase.

Whatever the cause, with these changes in place, Travis should pass again, hopefully.

x-ref: GH-2192