### PR TITLE
PKG: Add msgpack-numpy dependency

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -22,6 +22,7 @@ dependencies:
 - lxml
 - matplotlib
 - moviepy
+- msgpack-numpy
 - msgpack-python
 - numexpr
 - numpy

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -22,6 +22,7 @@ dependencies:
 - lxml
 - matplotlib
 - moviepy
+- msgpack-numpy
 - msgpack-python
 - numexpr
 - numpy

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -22,6 +22,7 @@ dependencies:
 - lxml
 - matplotlib
 - moviepy
+- msgpack-numpy
 - msgpack-python
 - numexpr
 - numpy

--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -13,6 +13,7 @@ lxml
 openpyxl
 gevent
 psutil
+msgpack-numpy
 msgpack-python
 pyserial
 pyparallel

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     pyparallel
     pyyaml
     gevent
+    msgpack-numpy
     msgpack-python
     psutil
     tables


### PR DESCRIPTION
`iohub` tries to import `msgpack-numpy` and, if that import fails, emits a warning that this "may cause issues". Therefore, adding `msgpack-numpy` to the package requirements.

NB Will rebase once #2199 has been merged.