### PR TITLE
NF/BF/TESTS: Add PsychoJS version chooser to experiment settings.

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -116,6 +116,8 @@ class ParamCtrls(object):
                 options = vc._versionFilter(vc.versionOptions(local=False))
                 versions = vc._versionFilter(vc.availableVersions(local=False))
                 param.allowedVals = (options + [''] + versions)
+        if fieldName == 'Use JS version':
+            param.allowedVals = vc.psychojsVersionOptions()
         if fieldName in ['text', 'customize_everything', 'customize']:
             # for text input we need a bigger (multiline) box
             if fieldName == 'customize_everything':

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -75,7 +75,6 @@ class Experiment(object):
         # this can be checked by the builder that this is an experiment and a
         # compatible version
         self.psychopyVersion = __version__
-
         # What libs are needed (make sound come first)
         self.requiredImports = []
         libs = ('sound', 'gui', 'visual', 'core', 'data', 'event',
@@ -197,7 +196,7 @@ class Experiment(object):
             script = script.getvalue()
         elif target == "PsychoJS":
             script.oneIndent = "  "  # use 2 spaces rather than python 4
-            self.settings.writeInitCodeJS(script, self.psychopyVersion, localDateTime, modular)
+            self.settings.writeInitCodeJS(script, localDateTime, modular)
             self.flow.writeFlowSchedulerJS(script)
             self.settings.writeExpSetupCodeJS(script, self.psychopyVersion)
 

--- a/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
+++ b/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
@@ -26,7 +26,7 @@
     <div id="root"/>
     <script type='module' src='./{name}.js'></script>
 
-    <script nomodule type="text/javascript" src="lib/psychojs-3.0.0.js"></script>
+    <script nomodule type="text/javascript" src="lib/psychojs-{version}.js"></script>
     <script nomodule type="text/javascript" src="./{name}NoModule.js"></script>
 <body>
 

--- a/psychopy/tests/test_tools/test_versionchooser.py
+++ b/psychopy/tests/test_tools/test_versionchooser.py
@@ -4,7 +4,7 @@ from builtins import object
 import os
 import psychopy
 import pytest
-from psychopy.tools.versionchooser import useVersion
+from psychopy.tools.versionchooser import useVersion, psychojsVersionOptions
 from psychopy import prefs
 from psychopy import constants
 
@@ -49,8 +49,11 @@ class Test_Incompatible_Version(_baseVersionChooser):
     def test_compatible(self):
         assert (useVersion('1.90.0'))
 
+class Test_PsychoJS_Version(_baseVersionChooser):
+    """Test available psychoJS options"""
 
-
+    def test_version_options(self):
+        assert (isinstance(psychojsVersionOptions(), list))
 """
 
 TODO: Tests to write:

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -170,6 +170,17 @@ def _switchToVersion(requestedVersion):
     sys.path = [VERSIONSDIR] + sys.path
     logging.exp('Prepended `{}` to sys.path'.format(VERSIONSDIR))
 
+def psychojsVersionOptions():
+    """
+    Generates list of PsychoJS versions
+    TODO: Retrieve list of versions from remote repo
+
+    Returns
+    -------
+    list
+        A list of available PsychoJS versions
+    """
+    return ['3.0.1', '3.0.0']
 
 def versionOptions(local=True):
     """Available major.minor versions suitable for a drop-down list.


### PR DESCRIPTION
This allows users to select which psychoJS library they want to use, and also allows correct formatting of psychoJS scripts i.e., if they are not in sync with psychopy versions. Fixes #2205.