### PR TITLE
BF: filters version chooser for wx compatibility.

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -113,8 +113,8 @@ class ParamCtrls(object):
             # settings. If remote info has become available in the meantime,
             # now populate with that as well
             if vc._remoteVersionsCache:
-                options = vc._versionFilter(vc.versionOptions(local=False))
-                versions = vc._versionFilter(vc.availableVersions(local=False))
+                options = vc._versionFilter(vc.versionOptions(local=False), wx.__version__)
+                versions = vc._versionFilter(vc.availableVersions(local=False), wx.__version__)
                 param.allowedVals = (options + [''] + versions)
         if fieldName in ['text', 'customize_everything', 'customize']:
             # for text input we need a bigger (multiline) box

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -7,10 +7,11 @@ from builtins import str
 from builtins import object
 import os
 import re
+import wx.__version__
 import psychopy
 from psychopy import logging
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.tools.versionchooser import versionOptions, availableVersions
+from psychopy.tools.versionchooser import versionOptions, availableVersions, _versionFilter
 from psychopy.constants import PY3
 
 # for creating html output folders:
@@ -150,7 +151,9 @@ class SettingsComponent(object):
         self.params['Use version'] = Param(
             useVersion, valType='str',
             # search for options locally only by default, otherwise sluggish
-            allowedVals=versionOptions() + [''] + availableVersions(),
+            allowedVals=_versionFilter(versionOptions(), wx.__version__)
+                        + ['']
+                        + _versionFilter(availableVersions(), wx.__version__),
             hint=_translate("The version of PsychoPy to use when running "
                             "the experiment."),
             label=_localized["Use version"], categ='Basic')

--- a/psychopy/tests/test_tools/test_versionchooser.py
+++ b/psychopy/tests/test_tools/test_versionchooser.py
@@ -3,10 +3,8 @@
 from builtins import object
 import os
 import psychopy
-import pytest
 from psychopy.tools.versionchooser import useVersion
 from psychopy import prefs
-from psychopy import constants
 
 USERDIR = prefs.paths['userPrefsDir']
 VER_SUBDIR = 'versions'
@@ -37,8 +35,6 @@ class Test_Older_Version(_baseVersionChooser):
 
     def test_older_version(self):
         assert(useVersion(self.requested))
-
-
 
 
 """

--- a/psychopy/tests/test_tools/test_versionchooser.py
+++ b/psychopy/tests/test_tools/test_versionchooser.py
@@ -39,16 +39,6 @@ class Test_Older_Version(_baseVersionChooser):
         assert(useVersion(self.requested))
 
 
-class Test_Incompatible_Version(_baseVersionChooser):
-    "Test for incompatibility with PY3"
-    def test_raise_error(self):
-        if constants.PY3:
-            with pytest.raises(RuntimeError):
-                useVersion('1.80.0')
-
-    def test_compatible(self):
-        assert (useVersion('1.90.0'))
-
 
 
 """


### PR DESCRIPTION
PsychoPy versions < 1.85.4 are incompatible with wx >=4.0.0. This fix filters those versions using the version filter. Also improves error handling of py3 compatibility.