### PR TITLE
BF: JS outputs should be the version of current psychopy if not useVe…

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -170,6 +170,7 @@ class Experiment(object):
     def writeScript(self, expPath=None, target="PsychoPy", modular=True):
         """Write a PsychoPy script for the experiment
         """
+        self.psychopyVersion = psychopy.__version__  # make sure is current
         # set this so that params write for approp target
         utils.scriptTarget = target
         self.flow._prescreenValues()
@@ -248,6 +249,7 @@ class Experiment(object):
         return script
 
     def saveToXML(self, filename):
+        self.psychopyVersion = psychopy.__version__  # make sure is current
         # create the dom object
         self.xmlRoot = xml.Element("PsychoPy2experiment")
         self.xmlRoot.set('version', __version__)


### PR DESCRIPTION
…rsion

It was accidentally being set to the version that the experimernt was
*first created* in rather than the current version of the app