### PR TITLE
BF: sounddevice backend raises exception in Python2

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -189,7 +189,7 @@ class _SoundStream(object):
         t0 = time.time()
         self.frameN += 1
         toSpk.fill(0)
-        for thisSound in self.sounds.copy():
+        for thisSound in list(self.sounds): # copy (Py2 doesn't have list.copy)
             dat = thisSound._nextBlock()  # fetch the next block of data
             dat *= thisSound.volume  # Set the volume block by block
             if self.channels == 2 and len(dat.shape) == 2:


### PR DESCRIPTION
sounddevice backend raises exception in Python2 because `list` object in Python2 doesn't have `copy() `method.
Please see #2214 for detail.

