### PR TITLE
BF Fixes  TypeError when changing text in text component.

### DIFF
--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -301,7 +301,8 @@ class CodeBox(BaseCodeEditor):
             # prcoess end of line and then do smart indentation
             event.Skip(False)
             self.CmdKeyExecute(wx.stc.STC_CMD_NEWLINE)
-            self.smartIdentThisLine(self.params['Code Type'].val)
+            if self.params is not None:
+                self.smartIdentThisLine(self.params['Code Type'].val)
             return  # so that we don't reach the skip line at end
 
         event.Skip()


### PR DESCRIPTION
One use of params in CodeBox is to determine code type (JS or PY).
This fixes a TypeError raised when ParamCtrls creates a CodeBox for Text Component,
because ParamCtrls does not pass params to the CodeBox, resulting in params
being None. Therefore, when params are used on keypresses for smart indenting
lines, a TypeError is thrown as NoneTypes are not subscriptable.