### PR TITLE
TESTS: Pin pip to version <19.0 and ensure packages are not updated when installing a new conda package

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -32,7 +32,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip
+- pip<19.0
 - pixman
 - prompt_toolkit
 - psutil

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -32,7 +32,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip
+- pip<19.0
 - psutil
 - pyopengl
 - pyosf

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -32,7 +32,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip
+- pip<19.0
 - psutil
 - pyopengl
 - pyosf

--- a/travis/20_install_miniconda_python.sh
+++ b/travis/20_install_miniconda_python.sh
@@ -16,5 +16,5 @@ ls -la ./conda/environment-$PYTHON_VERSION.yml
 conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml
 conda env list
 source activate psychopy-conda
-if [ -n "$WXPYTHON" ]; then conda install -c conda-forge wxpython=$WXPYTHON; fi
-if [ -n "$OPENPYXL" ]; then conda install -c conda-forge openpyxl=$OPENPYXL; fi
+if [ -n "$WXPYTHON" ]; then conda install --freeze-installed -c conda-forge wxpython=$WXPYTHON; fi
+if [ -n "$OPENPYXL" ]; then conda install --freeze-installed -c conda-forge openpyxl=$OPENPYXL; fi


### PR DESCRIPTION
Addresses GH-2238 and ensures `conda` will not update arbitrary packages when we try to install another one.