### PR TITLE
TESTS: Updates to conda environment setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,13 @@ before_install:
 
   # Install & activate conda environment, if requested; otherwise,
   # install system Python dependencies.
-  - if [ -n "$CONDA" ]; then
-      ./travis/20_install_miniconda_python.sh;
-      source ~/miniconda/etc/profile.d/conda.sh; # Initialize shell.
-      conda activate psychopy-conda;
+  - |
+    if [ -n "$CONDA" ]; then
+      ./travis/20_install_miniconda_python.sh
+      source ~/miniconda/etc/profile.d/conda.sh # Initialize shell.
+      conda activate psychopy-conda
     else
-      ./travis/20_install_system_python.sh;
+      ./travis/20_install_system_python.sh
     fi
 
   - echo $PATH
@@ -70,8 +71,9 @@ install:
   - rm -rf build/ dist/
 
 before_script:
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset;
+  - |
+    if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+       /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1024x768x24 -ac +extension GLX +extension RANDR +render -noreset
     fi
 
   # To enable core.rush() functionality, we need to set capabilities on the Python

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   # install system Python dependencies.
   - if [ -n "$CONDA" ]; then
       ./travis/20_install_miniconda_python.sh;
-      source ~/miniconda/etc/profile.d/conda.sh # Initialize shell.
+      source ~/miniconda/etc/profile.d/conda.sh; # Initialize shell.
       conda activate psychopy-conda;
     else
       ./travis/20_install_system_python.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,12 @@ before_install:
   - ./travis/00_set_up_packaging_system.sh
   - ./travis/10_install_system_dependencies.sh
 
-  # Install & activate conda environment if requested; otherwise,
+  # Install & activate conda environment, if requested; otherwise,
   # install system Python dependencies.
   - if [ -n "$CONDA" ]; then
       ./travis/20_install_miniconda_python.sh;
-      source ~/miniconda/bin/activate psychopy-conda;
+      source ~/miniconda/etc/profile.d/conda.sh # Initialize shell.
+      conda activate psychopy-conda;
     else
       ./travis/20_install_system_python.sh;
     fi

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -1,7 +1,6 @@
 name: conda-py2.7
 channels:
 - conda-forge
-- defaults
 dependencies:
 - python=2.7
 - arabic_reshaper

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -1,7 +1,6 @@
 name: conda-py3.6
 channels:
 - conda-forge
-- defaults
 dependencies:
 - python=3.6
 - arabic_reshaper

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -1,7 +1,6 @@
 name: conda-py3.7
 channels:
 - conda-forge
-- defaults
 dependencies:
 - python=3.7
 - arabic_reshaper

--- a/travis/20_install_miniconda_python.sh
+++ b/travis/20_install_miniconda_python.sh
@@ -7,7 +7,7 @@ set -ev
 echo "Installing Miniconda environment..."
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
 bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+source ~/miniconda/etc/profile.d/conda.sh # Initialize shell.
 hash -r
 conda config --set always_yes yes --set changeps1 no
 conda update -q conda
@@ -15,7 +15,7 @@ conda info -a
 ls -la ./conda/environment-$PYTHON_VERSION.yml
 conda env create -n psychopy-conda -f ./conda/environment-$PYTHON_VERSION.yml
 conda env list
-source activate psychopy-conda
+conda activate psychopy-conda
 if [ -n "$WXPYTHON" ]; then conda install --freeze-installed -c conda-forge wxpython=$WXPYTHON; fi
 if [ -n "$OPENPYXL" ]; then conda install --freeze-installed -c conda-forge openpyxl=$OPENPYXL; fi
 conda list # Display all installed packages.

--- a/travis/20_install_miniconda_python.sh
+++ b/travis/20_install_miniconda_python.sh
@@ -18,3 +18,4 @@ conda env list
 source activate psychopy-conda
 if [ -n "$WXPYTHON" ]; then conda install --freeze-installed -c conda-forge wxpython=$WXPYTHON; fi
 if [ -n "$OPENPYXL" ]; then conda install --freeze-installed -c conda-forge openpyxl=$OPENPYXL; fi
+conda list # Display all installed packages.


### PR DESCRIPTION
- slightly change how `conda` environment gets activated (to match recommended procedure for newer `conda` versions)
- ensure all dependencies listed in the environment files are installed from `conda-forge` only; this will avoid future mixups of `conda-forge` and `defaults`, which can lead to unexpected behavior as seen in #2239
- provide a list of all `conda` packages installed  in the testing environment to simplify future debugging
