### PR TITLE
ENH/BF: Workaround for stderr confusion after importing sounddevice

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -18,6 +18,7 @@ from ._base import _SoundBase, HammingWindow
 
 try:
     import sounddevice as sd
+    import readline  # Work around GH-2230.
 except Exception:
     raise DependencyError("sounddevice not working")
 try:


### PR DESCRIPTION
Fixes GH-2230.

Old behavior:
```python
In [1]: from psychopy.sound import Sound
pygame 1.9.4
Hello from the pygame community. https://www.pygame.org/contribute.html

In [2]: input('foo> ')
bar.
Out[2]: 'bar.'
```

New behavior:
```python
In [1]: from psychopy.sound import Sound
pygame 1.9.4
Hello from the pygame community. https://www.pygame.org/contribute.html

In [2]: input('foo> ')
foo> bar.
Out[2]: 'bar.'
```