### PR TITLE
BF: Undoing error from an auto merge at GH-2213 that left uneeded code

### DIFF
--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -302,11 +302,7 @@ class Routine(list):
                 "  if ('status' in thisComponent && thisComponent.status !== PsychoJS.Status.FINISHED) {\n"
                 "    continueRoutine = true;\n"
                 "    break;\n"
-                "  }\n\n"
-                "// check for quit (the Esc key)\n"
-                "if (psychoJS.experiment.experimentEnded || psychoJS.eventManager.getKeys({keyList:['escape']}).length > 0) {\n"
-                "  return quitPsychoJS('The [Escape] key was pressed. Goodbye!', false);\n"
-                "}\n")
+                "  }\n\n")
         buff.writeIndentedLines(code % self.params)
 
         buff.writeIndentedLines("\n// refresh the screen if continuing\n")


### PR DESCRIPTION
In commit ff5f731956a3 we had switched the order of checks to end
routine versus end experiment but in GH-2213 an auto merge resulted in
the moved code existing in both locations