### PR TITLE
BF: Convert NoneTypes to undefined for HTML export, and Pavlovia gui fix

### DIFF
--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -434,7 +434,7 @@ def syncProject(parent, project=None, closeFrameWhenDone=False):
         # project didn't exist at Pavlovia (deleted?)
         recreatorDlg = ProjectRecreator(parent=parent, project=project)
         ok = recreatorDlg.ShowModal()
-        if ok is not None:
+        if ok > 0:
             project = recreatorDlg.project
         else:
             logging.error("Failed to recreate project to sync with")
@@ -578,5 +578,7 @@ class ProjectRecreator(wx.Dialog):
             elif choice == 2:
                 raise NotImplementedError("Deleting the local git repo is not "
                                           "yet implemented")
+            elif choice == 3:
+                return -1  # user aborted
         else:
             return -1

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -434,7 +434,7 @@ def syncProject(parent, project=None, closeFrameWhenDone=False):
         # project didn't exist at Pavlovia (deleted?)
         recreatorDlg = ProjectRecreator(parent=parent, project=project)
         ok = recreatorDlg.ShowModal()
-        if ok > 0:
+        if ok is not None:
             project = recreatorDlg.project
         else:
             logging.error("Failed to recreate project to sync with")

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -545,20 +545,23 @@ class ProjectRecreator(wx.Dialog):
         choices = [_translate("(Re)create a project"),
                    "{} ({})".format(_translate("Point to an different location"),
                                     _translate("not yet supported")),
-                   _translate("Forget the local git repository (deletes history keeps files)"),
-                   _translate("Do nothing and abort the sync")]
+                   _translate("Forget the local git repository (deletes history keeps files)")]
         self.radioCtrl = wx.RadioBox(self, label='RadioBox', choices=choices,
                                      majorDimension=1)
         self.radioCtrl.EnableItem(1, False)
         self.radioCtrl.EnableItem(2, False)
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)
-        mainSizer.Add(msg, 1, wx.ALL, 5)
-        mainSizer.Add(self.radioCtrl, 1, wx.ALL, 5)
-        mainSizer.Add(wx.Button(self, id=wx.ID_OK, label=_translate("OK")),
+        buttonSizer = wx.BoxSizer(wx.HORIZONTAL)
+        buttonSizer.Add(wx.Button(self, id=wx.ID_OK, label=_translate("OK")),
                       1, wx.ALL | wx.ALIGN_RIGHT, 5)
+        buttonSizer.Add(wx.Button(self, id=wx.ID_CANCEL, label=_translate("Cancel")),
+                      1, wx.ALL | wx.ALIGN_RIGHT, 5)
+        mainSizer.Add(msg, 1, wx.ALL, 5)
+        mainSizer.Add(self.radioCtrl, 1, wx.ALL | wx.ALIGN_CENTER_HORIZONTAL, 5)
+        mainSizer.Add(buttonSizer, 1, wx.ALL | wx.ALIGN_RIGHT, 1)
 
-        self.SetSizerAndFit(mainSizer)
+        self.SetSizer(mainSizer)
         self.Layout()
 
     def ShowModal(self):
@@ -578,7 +581,5 @@ class ProjectRecreator(wx.Dialog):
             elif choice == 2:
                 raise NotImplementedError("Deleting the local git repo is not "
                                           "yet implemented")
-            elif choice == 3:
-                return -1  # user aborted
         else:
             return -1

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -143,10 +143,12 @@ class TextComponent(BaseVisualComponent):
         # replaces variable params with sensible defaults
         inits = getInitVals(self.params, 'PsychoJS')
 
-        if self.params['wrapWidth'].val in ['', None, 'None', 'none']:
-            inits['wrapWidth'] = 'undefined'
-        if self.params['text'].val in ['', None, 'None', 'none']:
-            inits['text'] = "''"
+        # check for NoneTypes
+        for param in inits:
+            if inits[param] in [None, 'None', '']:
+                inits[param].val = 'undefined'
+                if param == 'text':
+                    inits[param].val = "''"
 
         code = ("%(name)s = new visual.TextStim({\n"
                 "  win: psychoJS.window,\n"
@@ -158,6 +160,7 @@ class TextComponent(BaseVisualComponent):
                 "  color: new util.Color(%(color)s),"
                 "  opacity: %(opacity)s,")
         buff.writeIndentedLines(code % inits)
+
         flip = self.params['flip'].val.strip()
         if flip == 'horiz':
             flipStr = 'flipHoriz : true, '


### PR DESCRIPTION
--For textstim, this changes any NoneTypes to 'undefined', except actual text,
where NoneTypes become empty string (as with Python).
--The Pavlovia sync project function was throwing a TypeError if the user
chose not to recreate project on sync, if the exp was pointing to a remote
that doesn't exist. Error thrown because the line was comparing Int and None
if the user aborted.