### PR TITLE
BF: Disable Pavlovia Run when syncing.

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2373,9 +2373,11 @@ class BuilderFrame(wx.Frame):
         if self._getExportPref('on sync'):
             self.fileExport(htmlPath=self._getHtmlPath(self.filename))
 
-        self.togglePavloviaButton('pavloviaRun', 0)
-        pavlovia_ui.syncProject(parent=self, project=self.project)
-        self.togglePavloviaButton('pavloviaRun', 1)
+        self.enablePavloviaButton('pavloviaRun', False)
+        try:
+            pavlovia_ui.syncProject(parent=self, project=self.project)
+        finally:
+            self.enablePavloviaButton('pavloviaRun', True)
 
     def onPavloviaRun(self, evt=None):
         if self._getExportPref('on save'):
@@ -2401,8 +2403,18 @@ class BuilderFrame(wx.Frame):
             url = "https://pavlovia.org/run/{}/html".format(self.project.id)
             wx.LaunchDefaultBrowser(url)
 
-    def togglePavloviaButton(self, name, state):
-        self.toolbar.EnableTool(self.btnHandles[name].GetId(), state)
+    def enablePavloviaButton(self, name, enable):
+        """
+        Enables or disables Pavlovia buttons.
+
+        Parameters
+        ----------
+        name: string
+            Works for buttons 'pavloviaSync', 'pavloviaRun', 'pavloviaSearch', or 'pavloviaUser'.
+        enable: bool
+            True enables and False disables the button
+        """
+        self.toolbar.EnableTool(self.btnHandles[name].GetId(), enable)
 
     def setPavloviaUser(self, user):
         # TODO: update user icon on button to user avatar

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2372,7 +2372,10 @@ class BuilderFrame(wx.Frame):
     def onPavloviaSync(self, evt=None):
         if self._getExportPref('on sync'):
             self.fileExport(htmlPath=self._getHtmlPath(self.filename))
+
+        self.togglePavloviaButton('pavloviaRun', 0)
         pavlovia_ui.syncProject(parent=self, project=self.project)
+        self.togglePavloviaButton('pavloviaRun', 1)
 
     def onPavloviaRun(self, evt=None):
         if self._getExportPref('on save'):
@@ -2397,6 +2400,9 @@ class BuilderFrame(wx.Frame):
             self.project.pavloviaStatus = 'ACTIVATED'
             url = "https://pavlovia.org/run/{}/html".format(self.project.id)
             wx.LaunchDefaultBrowser(url)
+
+    def togglePavloviaButton(self, name, state):
+        self.toolbar.EnableTool(self.btnHandles[name].GetId(), state)
 
     def setPavloviaUser(self, user):
         # TODO: update user icon on button to user avatar


### PR DESCRIPTION
This fix disables Pavlovia Run when syncing because running too early caused a wx error. The choice to use 0 or 1 for toggle state was more intuitive than False or True. Happy to change if bool is preferred.