### PR TITLE
BF/RF: Fixes sync problem occuring when user was not actively logged in.

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -384,7 +384,7 @@ class PavloviaSession:
         projs = []
         projIDs = []
         for proj in own + group:
-            if proj.id and proj.id not in projIDs:
+            if proj.id not in projIDs and proj.id not in projs:
                 projs.append(PavloviaProject(proj))
                 projIDs.append(proj.id)
         return projs
@@ -424,14 +424,14 @@ class PavloviaSession:
                         "Trying to login with token {} which is shorter "
                         "than expected length ({} not 64) for gitlab token"
                             .format(repr(token), len(token)))
-            self.gitlab = gitlab.Gitlab(rootURL, oauth_token=token, timeout=2)
+            self.gitlab = gitlab.Gitlab(rootURL, oauth_token=token, timeout=2, per_page=100)
             self.gitlab.auth()
             self.username = self.user.username
             self.userID = self.user.id  # populate when token property is set
             self.userFullName = self.user.name
             self.authenticated = True
         else:
-            self.gitlab = gitlab.Gitlab(rootURL, timeout=1)
+            self.gitlab = gitlab.Gitlab(rootURL, timeout=1, per_page=100)
 
     @property
     def user(self):
@@ -1058,28 +1058,34 @@ def getProject(filename):
                     namespaceName = url.split('gitlab.pavlovia.org/')[1]
                     namespaceName = namespaceName.replace('.git', '')
                     pavSession = getCurrentSession()
+                    if not pavSession.user:
+                        nameSpace = namespaceName.split('/')[0]
+                        if nameSpace in knownUsers:  # Log in if user is known
+                            login(nameSpace, rememberMe=True)
+                        else:  # Check whether project repo is found in any of the known users accounts
+                            for user in knownUsers:
+                                login(user)
+                                foundProject = False
+                                for repo in pavSession.findUserProjects():
+                                    if namespaceName in repo['id']:
+                                        foundProject = True
+                                        logging.info("Logging in as {}".format(user))
+                                        break
+                                if not foundProject:
+                                    logging.warning("Could not find {namespace} in your Pavlovia accounts. "
+                                                    "Logging in as {user}.".format(namespace=namespaceName,
+                                                                                   user=user))
                     if pavSession.user:
                         proj = pavSession.getProject(namespaceName,
                                                      repo=localRepo)
                         if proj.pavlovia == 0:
-                            logging.warning(
-                                    _translate(
-                                            "We found a repository pointing to {} "
-                                            "but ") +
-                                    _translate("no project was found there ("
-                                               "deleted?)")
-                                    .format(url))
-
+                            logging.warning(_translate("We found a repository pointing to {} "
+                                                       "but no project was found there (deleted?)").format(url))
                     else:
-                        logging.warning(
-                                _translate(
-                                        "We found a repository pointing to {} "
-                                        "but ") +
-                                _translate(
-                                        "no user is logged in for us to check "
-                                        "it")
-                                .format(url))
+                        logging.warning(_translate("We found a repository pointing to {} "
+                                                   "but no user is logged in for us to check it".format(url)))
                     return proj
+
         if proj == None:
             logging.warning("We found a repository at {} but it "
                             "doesn't point to gitlab.pavlovia.org. "


### PR DESCRIPTION
If a project was opened, but the user had not logged in, and tried to sync,
the user was asked to create a project, even though the project existed.
The failed sync then resulted in the user being logged in and the sync
working on the next attempt. This fix attempts to log the user in on a sync
if the user is known, or in the case of multiple users where the namespace
is not indicative of the user account, uses the project name to determine
membership to known user and which known user should be logged in. Also
increases number of items listed to 100 when retrieving user projects from
Pavlovia. Fixes and refactors warning messages.