### PR TITLE
ENH/RF: Changes how commit dialog works, ensuring commit message given.

### DIFF
--- a/psychopy/app/pavlovia_ui/_base.py
+++ b/psychopy/app/pavlovia_ui/_base.py
@@ -170,7 +170,6 @@ class PavloviaCommitDialog(wx.Dialog):
     def setBindings(self):
         """Set the bindings for the dialog widgets"""
         # Bind button event to textbox
-        self.commitTitleCtrl.Bind(wx.EVT_CHAR, self.enableButton)
         self.commitTitleCtrl.Bind(wx.EVT_UPDATE_UI, self.enableButton)
 
     def setToolTips(self):

--- a/psychopy/app/pavlovia_ui/_base.py
+++ b/psychopy/app/pavlovia_ui/_base.py
@@ -7,7 +7,6 @@
 
 import wx
 import wx.html2
-import wx.lib.agw.balloontip as BT
 
 from psychopy.localization import _translate
 from psychopy.projects import pavlovia
@@ -147,25 +146,30 @@ class PavloviaCommitDialog(wx.Dialog):
     """This class will be used to brings up a commit dialog
     (if there is anything to commit)"""
 
-    def __init__(self, *args, initMsg='Write your commit message here...', changeInfo='', **kwargs):
+    def __init__(self, *args, **kwargs):
+
+        # pop kwargs for Py2 compatibility
+        changeInfo = kwargs.pop('changeInfo', '')
+        initMsg = kwargs.pop('initMsg', 'Write your commit message here...')
+
         super(PavloviaCommitDialog, self).__init__(*args, **kwargs)
 
         # Set Text widgets
-        self.dlg = wx.Dialog(None, id=wx.ID_ANY, title="Committing changes")
-        self.updatesInfo = wx.StaticText(self.dlg, label=changeInfo)
-        self.commitTitleLbl = wx.StaticText(self.dlg, label='Summary of changes')
-        self.commitTitleCtrl = wx.TextCtrl(self.dlg, size=(500, -1), value=initMsg)
-        self.commitDescrLbl = wx.StaticText(self.dlg, label='Details of changes\n (optional)')
-        self.commitDescrCtrl = wx.TextCtrl(self.dlg, size=(500, 200), style=wx.TE_MULTILINE | wx.TE_AUTO_URL)
+        wx.Dialog(None, id=wx.ID_ANY, title="Committing changes")
+        self.updatesInfo = wx.StaticText(self, label=changeInfo)
+        self.commitTitleLbl = wx.StaticText(self, label='Summary of changes')
+        self.commitTitleCtrl = wx.TextCtrl(self, size=(500, -1), value=initMsg)
+        self.commitDescrLbl = wx.StaticText(self, label='Details of changes\n (optional)')
+        self.commitDescrCtrl = wx.TextCtrl(self, size=(500, 200), style=wx.TE_MULTILINE | wx.TE_AUTO_URL)
 
         # Set buttons
-        self.btnOK = wx.Button(self.dlg, wx.ID_OK)
-        self.btnCancel = wx.Button(self.dlg, wx.ID_CANCEL)
+        self.btnOK = wx.Button(self, wx.ID_OK)
+        self.btnCancel = wx.Button(self, wx.ID_CANCEL)
 
         # Format elements
         self.setBindings()
         self.setToolTips()
-        self.setSizers()
+        self.setDlgSizers()
 
     def setBindings(self):
         """Set the bindings for the dialog widgets"""
@@ -181,7 +185,7 @@ class PavloviaCommitDialog(wx.Dialog):
             wx.ToolTip(
                 _translate("Optional further details about the changes you're making in these files")))
 
-    def setSizers(self):
+    def setDlgSizers(self):
         """
         Set the commit dialog sizers and layout.
         """
@@ -199,8 +203,8 @@ class PavloviaCommitDialog(wx.Dialog):
         mainSizer.Add(self.updatesInfo, 0, wx.ALL | wx.EXPAND, border=5)
         mainSizer.Add(commitSizer, 1, wx.ALL | wx.EXPAND, border=5)
         mainSizer.Add(buttonSizer, 0, wx.ALL | wx.ALIGN_RIGHT, border=5)
-        self.dlg.SetSizerAndFit(mainSizer)
-        self.dlg.Layout()
+        self.SetSizerAndFit(mainSizer)
+        self.Layout()
 
     def ShowCommitDlg(self):
         """Show the commit application-modal dialog
@@ -209,7 +213,7 @@ class PavloviaCommitDialog(wx.Dialog):
         -------
         wx event
         """
-        return self.dlg.ShowModal()
+        return self.ShowModal()
 
     def enableButton(self, evt):
         """

--- a/psychopy/app/pavlovia_ui/functions.py
+++ b/psychopy/app/pavlovia_ui/functions.py
@@ -38,11 +38,9 @@ def setLocalPath(parent, project=None, path=""):
     else:
         origPath = ""
     # create the dialog
-    dlg = wx.DirDialog(
-            parent,
-            defaultPath=origPath,
-            message=_translate(
-                    "Choose/create the root location for the synced project"))
+    dlg = wx.DirDialog(parent,
+                       defaultPath=origPath,
+                       message=_translate("Choose/create the root location for the synced project"))
     if dlg.ShowModal() == wx.ID_OK:
         newPath = dlg.GetPath()
         if os.path.isfile(newPath):
@@ -107,11 +105,14 @@ def showCommitDialog(parent, project, initMsg=""):
             changeInfo += "\t{}: {} files\n".format(categ.title(), len(changes))
     
     dlg = PavloviaCommitDialog(parent, id=wx.ID_ANY, title="Committing changes", changeInfo=changeInfo)
+
     retVal = dlg.ShowCommitDlg()
+    commitMsg = dlg.getCommitMsg()
+    dlg.Destroy()
+
     if retVal == wx.ID_CANCEL:
         return -1
 
-    commitMsg = dlg.getCommitMsg()
     project.stageFiles(changeList)  # NB not needed in dulwich
     project.commit(commitMsg)
     return 1

--- a/psychopy/app/pavlovia_ui/functions.py
+++ b/psychopy/app/pavlovia_ui/functions.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, print_function
 import os
 import wx
 
-from ._base import PavloviaMiniBrowser
+from ._base import PavloviaMiniBrowser, PavloviaCommitDialog
 from psychopy.projects import pavlovia  # NB pavlovia will set gitpython path
 from psychopy.localization import _translate
 
@@ -98,58 +98,23 @@ def showCommitDialog(parent, project, initMsg=""):
     if not changeList:
         return 0
 
-    infoStr = "Changes to commit:\n"
+    changeInfo = "Changes to commit:\n"
     for categ in ['untracked', 'changed', 'deleted', 'renamed']:
         changes = changeDict[categ]
         if categ == 'untracked':
             categ = 'New'
         if changes:
-            infoStr += "\t{}: {} files\n".format(categ.title(), len(changes))
+            changeInfo += "\t{}: {} files\n".format(categ.title(), len(changes))
     
-    dlg = wx.Dialog(parent, id=wx.ID_ANY, title="Committing changes")
-    
-    updatesInfo = wx.StaticText(dlg, label=infoStr)
-    
-    commitTitleLbl = wx.StaticText(dlg, label='Summary of changes')
-    commitTitleCtrl = wx.TextCtrl(dlg, size=(500, -1), value=initMsg)
-    commitTitleCtrl.SetToolTip(wx.ToolTip(_translate(
-        "A title summarizing the changes you're making in these files"
-        )))
-    commitDescrLbl = wx.StaticText(dlg, label='Details of changes\n (optional)')
-    commitDescrCtrl = wx.TextCtrl(dlg, size=(500, 200),
-                                  style=wx.TE_MULTILINE | wx.TE_AUTO_URL)
-    commitDescrCtrl.SetToolTip(wx.ToolTip(_translate(
-        "Optional further details about the changes you're making in these files"
-        )))
-    commitSizer = wx.FlexGridSizer(cols=2, rows=2, vgap=5, hgap=5)
-    commitSizer.AddMany([(commitTitleLbl, 0, wx.ALIGN_RIGHT),
-                       commitTitleCtrl,
-                       (commitDescrLbl, 0, wx.ALIGN_RIGHT),
-                       commitDescrCtrl
-                       ])
-
-    btnOK  = wx.Button(dlg, wx.ID_OK)
-    btnCancel  = wx.Button(dlg, wx.ID_CANCEL)
-    buttonSizer = wx.BoxSizer(wx.HORIZONTAL)
-    buttonSizer.AddMany([btnCancel, btnOK])
-
-    # main sizer and layout
-    mainSizer = wx.BoxSizer(wx.VERTICAL)
-    mainSizer.Add(updatesInfo, 0, wx.ALL, border=5)
-    mainSizer.Add(commitSizer, 1, wx.ALL | wx.EXPAND, border=5)
-    mainSizer.Add(buttonSizer, 0, wx.ALL | wx.ALIGN_RIGHT, border=5)
-    dlg.SetSizerAndFit(mainSizer)
-    dlg.Layout()
-    if dlg.ShowModal() == wx.ID_CANCEL:
+    dlg = PavloviaCommitDialog(parent, id=wx.ID_ANY, title="Committing changes", changeInfo=changeInfo)
+    retVal = dlg.ShowCommitDlg()
+    if retVal == wx.ID_CANCEL:
         return -1
 
-    commitMsg = commitTitleCtrl.GetValue()
-    if commitDescrCtrl.GetValue():
-        commitMsg += "\n\n" + commitDescrCtrl.GetValue()
+    commitMsg = dlg.getCommitMsg()
     project.stageFiles(changeList)  # NB not needed in dulwich
     project.commit(commitMsg)
     return 1
-
 
 def noGitWarning(parent):
     """Raise a simpler warning dialog that the user needs to install git first"""


### PR DESCRIPTION
This fix creates a new dialog class for committing changes.
The dialog checks for user input in the commit summary.
The OK button is disabled when the text box is empty, however
a default message is inplace and highlighted by default as a reminder,
and to ensure the the OK button can still be clicked.
Deleting the default message leaving the summary text empty will disable
the OK button, thus preventing errors caused by having an empty commit message.