### PR TITLE
BF: Allow user to resize sync frame

### DIFF
--- a/psychopy/app/pavlovia_ui/sync.py
+++ b/psychopy/app/pavlovia_ui/sync.py
@@ -12,7 +12,7 @@ import wx
 class SyncFrame(wx.Frame):
     def __init__(self, parent, id, project):
         title = "{} / {}".format(project.group, project.title)
-        style = wx.DEFAULT_FRAME_STYLE ^ wx.RESIZE_BORDER
+        style = wx.DEFAULT_FRAME_STYLE | wx.RESIZE_BORDER
         wx.Frame.__init__(self, parent=None, id=id, style=style,
                           title=title)
         self.parent = parent


### PR DESCRIPTION
This is useful if an error message is output into the frame (see #2262). Having a resizable frame makes it easier to read the error without having to paste into a notepad or equivalent.