### PR TITLE
TESTS, PKG: Install imageio & imageio-ffmpeg; support openpyxl 2.6

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -17,7 +17,7 @@ dependencies:
 - future
 - gevent
 - greenlet
-- imageio
+- imageio<2.5
 - json_tricks
 - libffi
 - libflac

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -17,6 +17,7 @@ dependencies:
 - future
 - gevent
 - greenlet
+- imageio
 - json_tricks
 - libffi
 - libflac

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -18,6 +18,8 @@ dependencies:
 - gevent
 - greenlet
 - hdf5
+- imageio
+- imageio-ffmpeg
 - json_tricks
 - libflac
 - lxml

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -18,6 +18,8 @@ dependencies:
 - gevent
 - greenlet
 - hdf5
+- imageio
+- imageio-ffmpeg
 - json_tricks
 - libflac
 - lxml

--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -35,7 +35,7 @@ try:
         from openpyxl.utils.cell import get_column_letter
     else:
         from openpyxl.cell import get_column_letter
-    from openpyxl.reader.excel import load_workbook, Workbook
+    from openpyxl import load_workbook, Workbook
     haveOpenpyxl = True
 except ImportError:
     haveOpenpyxl = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,9 +61,9 @@ install_requires =
     astunparse
     esprima
     freetype-py
+    # Platform-specific dependencies.
     imageio < 2.5; python_version < "3"
     imageio >= 2.5; python_version >= "3"
-    # Platform-specific dependencies.
     imageio-ffmpeg; python_version >= "3"
     pyparallel; platform_system == "Linux"
     pyWinhook; platform_system == "Windows"

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,8 @@ install_requires =
     astunparse
     esprima
     freetype-py
-    imageio
+    imageio < 2.5; python_version < "3"
+    imageio >= 2.5; python_version >= "3"
     # Platform-specific dependencies.
     imageio-ffmpeg; python_version >= "3"
     pyparallel; platform_system == "Linux"

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,9 @@ install_requires =
     astunparse
     esprima
     freetype-py
+    imageio
     # Platform-specific dependencies.
+    imageio-ffmpeg; python_version >= "3"
     pyparallel; platform_system == "Linux"
     pyWinhook; platform_system == "Windows"
     pyqmix >= 2018.12.13; platform_system == "Windows"


### PR DESCRIPTION
Closes GH-2260.