### PR TITLE
RF/DOCS: Misc fixes to 'viewtools', window, and docs.

### DIFF
--- a/docs/source/api/tools/viewtools.rst
+++ b/docs/source/api/tools/viewtools.rst
@@ -12,6 +12,7 @@
     orthoProjectionMatrix
     perspectiveProjectionMatrix
     lookAt
+    pointToNdc
     
 Function details
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -21,3 +22,4 @@ Function details
 .. autofunction:: orthoProjectionMatrix
 .. autofunction:: perspectiveProjectionMatrix
 .. autofunction:: lookAt
+.. autofunction:: pointToNdc

--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -64,3 +64,4 @@ Helper functions:
   * :mod:`~psychopy.tools.unittools` to convert deg<->radians
   * :mod:`~psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
   * :mod:`psychopy.tools.colorspacetools` to convert between supported color spaces
+  * :mod:`psychopy.tools.viewtools` to work with view projections

--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -60,8 +60,8 @@ Meta stimuli (stimuli that operate on other stimuli):
 Helper functions:
 
   * :ref:`psychopy.visual.filters` for creating grating textures and Gaussian masks etc.
-  * :ref:`visualhelperfunctions` for tests about whether one stimulus contains another
-  * :mod:`~psychopy.tools.unittools` to convert deg<->radians
-  * :mod:`~psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
+  * :ref:`psychopy.tools.visualhelperfunctions` for tests about whether one stimulus contains another
+  * :mod:`psychopy.tools.unittools` to convert deg<->radians
+  * :mod:`psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
   * :mod:`psychopy.tools.colorspacetools` to convert between supported color spaces
   * :mod:`psychopy.tools.viewtools` to work with view projections

--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -61,7 +61,7 @@ Helper functions:
 
   * :ref:`psychopy.visual.filters` for creating grating textures and Gaussian masks etc.
   * :ref:`psychopy.tools.visualhelperfunctions` for tests about whether one stimulus contains another
-  * :mod:`psychopy.tools.unittools` to convert deg<->radians
-  * :mod:`psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
-  * :mod:`psychopy.tools.colorspacetools` to convert between supported color spaces
-  * :mod:`psychopy.tools.viewtools` to work with view projections
+  * :mod:`~psychopy.tools.unittools` to convert deg<->radians
+  * :mod:`~psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
+  * :mod:`~psychopy.tools.colorspacetools` to convert between supported color spaces
+  * :mod:`~psychopy.tools.viewtools` to work with view projections

--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -14,7 +14,7 @@ Windows and and display devices:
 
     * :class:`.Window` is the main class to display objects
     * :class:`.Warper` for non-flat projection screens
-    * :class:`.ProjectorFramePacker` for handling displays with
+    * :class:`.ProjectorFramePacker` for handling displays with 'structured light mode' to achieve high framerates
     * :class:`.Rift` for Oculus Rift support (Windows 64bit only)
 
 Commonly used:

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -290,8 +290,7 @@ def lookAt(eyePos, centerPos, upVec):
     rotMat[2, :3] = -f
     rotMat[3, 3] = 1.0
 
-    transMat = np.zeros((4, 4), np.float32)
-    np.fill_diagonal(transMat, 1.0)
+    transMat = np.identity(4, np.float32)
     transMat[:3, 3] = -eyePos
 
     return np.matmul(rotMat, transMat)
@@ -358,8 +357,8 @@ def pointToNDC(wcsPos, viewMatrix, projectionMatrix):
 
     clipCoords = viewProjMatrix.dot(wcsVec)  # convert to clipping space
 
-    # handle the singularity case when the point falls on the eye
-    if np.isclose(clipCoords[3], 0.0):
+    # handle the singularity where perspective division will fail
+    if clipCoords[3] < 0.0001:
         clipCoords[3] = np.finfo(np.float32).eps
 
     return clipCoords[:3] / clipCoords[3]  # xyz / w

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -65,6 +65,37 @@ def computeFrustum(scrWidth,
     for screen distance. These offsets MUST be applied to the MODELVIEW matrix,
     not the PROJECTION matrix! Doing so may break lighting calculations.
 
+    Examples
+    --------
+
+    Creating a frustum and setting a window's projection matrix::
+
+        scrWidth = 0.5  # screen width in meters
+        scrAspect = win.size[0] / win.size[1]
+        scrDist = win.scrDistCM * 100.0  # monitor setting, can be anything
+        frustum = viewtools.computeFrustum(scrWidth, scrAspect, scrDist)
+        # convert frustum to projection matrix
+        win.projectionMatrix = viewtools.perspectiveProjectionMatrix(*frustum)
+        # set your view matrix to account for the screen distance!!!
+        win.applyEyeTransform()  # call before drawing
+
+    Off-axis frustums for stereo rendering::
+
+        # compute view matrix for each eye, these value usually don't change
+        eyeOffset = (-0.035, 0.035)  # +/- IOD / 2.0
+        leftProjMatrix = viewtools.perspectiveProjectionMatrix(
+            viewtools.computeFrustum(
+                scrWidth, scrAspect, scrDist, eyeOffset[0]))
+        rightProjMatrix = viewtools.computeFrustum(
+            viewtools.computeFrustum(
+                scrWidth, scrAspect, scrDist, eyeOffset[1]))
+        # ... after calling 'setBuffer('left')' ...
+        win.projectionMatrix = leftProjMatrix
+        # setup your view matrix accordingly, must account for screen distance
+        # and eye offset
+        win.applyViewTransform()  # call before drawing
+        # do the same for 'setBuffer('right')' using the other matrix ...
+
     """
     d = scrWidth * (convergeOffset + scrDist)
     ratio = nearClip / float((convergeOffset + scrDist))

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -154,8 +154,7 @@ def generalizedPerspectiveProjection(posBottomLeft,
     rotMat[2, :3] = vn
     rotMat[3, 3] = 1.0
 
-    transMat = np.zeros((4, 4), np.float32)
-    np.fill_diagonal(transMat, 1.0)
+    transMat = np.identity(4, np.float32)
     transMat[:3, 3] = -eyePos
 
     return projMat, np.matmul(rotMat, transMat)

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -295,7 +295,7 @@ def lookAt(eyePos, centerPos, upVec):
     return np.matmul(rotMat, transMat)
 
 
-def pointToNDC(wcsPos, viewMatrix, projectionMatrix):
+def pointToNdc(wcsPos, viewMatrix, projectionMatrix):
     """Map the position of a point in world space to normalized device
     coordinates/space.
 

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -330,13 +330,13 @@ def pointToNdc(wcsPos, viewMatrix, projectionMatrix):
     --------
     Determine if a point is visible::
         point = (0.0, 0.0, 10.0)  # behind the observer
-        ndc = pointToNDC(point, win.viewMatrix, win.projectionMatrix)
+        ndc = pointToNdc(point, win.viewMatrix, win.projectionMatrix)
         isVisible = not np.any((ndc > 1.0) | (ndc < -1.0))
 
     Convert NDC to viewport (or pixel) coordinates::
         scrRes = (1920, 1200)
         point = (0.0, 0.0, -5.0)  # forward -5.0 from eye
-        x, y, z = pointToNDC(point, win.viewMatrix, win.projectionMatrix)
+        x, y, z = pointToNdc(point, win.viewMatrix, win.projectionMatrix)
         pixelX = ((x + 1.0) / 2.0) * scrRes[0])
         pixelY = ((y + 1.0) / 2.0) * scrRes[1])
         # object at point will appear at (pixelX, pixelY)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1050,8 +1050,7 @@ class Window(object):
         self._projectionMatrix = viewtools.perspectiveProjectionMatrix(*frustum)
 
         # translate away from screen
-        self._viewMatrix = numpy.zeros((4, 4), dtype=numpy.float32)
-        numpy.fill_diagonal(self._viewMatrix, 1.0)  # identity matrix
+        self._viewMatrix = numpy.identity(4, dtype=numpy.float32)
         self._viewMatrix[2, 3] = -scrDistM  # displace scene away from viewer
 
         if applyTransform:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -126,12 +126,16 @@ openWindows = core.openWindows = OpenWinList()  # core needs this for wait()
 
 class Window(object):
     """Used to set up a context in which to draw objects,
-    using either `pyglet <http://www.pyglet.org>`_ or
-    `pygame <http://www.pygame.org>`_
+    using either `pyglet <http://www.pyglet.org>`_,
+    `pygame <http://www.pygame.org>`_, or `glfw <https://www.glfw.org/>_`.
 
     The pyglet backend allows multiple windows to be created, allows the user
     to specify which screen to use (if more than one is available, duh!) and
     allows movies to be rendered.
+
+    The glfw backend is a new addition which provides most of the same features
+    as pyglet, but provides greater flexibility for complex display
+    configurations.
 
     Pygame may still work for you but it's officially deprecated in this
     project (we won't be fixing pygame-specific bugs).

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -725,9 +725,17 @@ class Window(object):
         frame. (This replaces the win.update() method, better reflecting what
         is happening underneath).
 
-        win.flip(clearBuffer=True)  # results in a clear screen after flipping
-        win.flip(clearBuffer=False)  # the screen is not cleared (so represent
-                                     # the previous screen)
+        Examples
+        --------
+
+        Results in a clear screen after flipping::
+
+            win.flip(clearBuffer=True)
+
+        The screen is not cleared (so represent the previous screen)::
+
+            win.flip(clearBuffer=False)
+
         """
         for thisStim in self._toDraw:
             thisStim.draw()

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -341,8 +341,7 @@ class Window(object):
         # being used.
         # NB - attribute checks needed for Rift compatibility
         if not hasattr(self, '_viewMatrix'):
-            self._viewMatrix = numpy.zeros((4,4,), numpy.float32)
-            numpy.fill_diagonal(self._viewMatrix, 1.0)  # identity
+            self._viewMatrix = numpy.identity(4, dtype=numpy.float32)
 
         if not hasattr(self, '_projectionMatrix'):
             self._projectionMatrix = viewtools.orthoProjectionMatrix(-1, 1, -1, 1, -1, 1)
@@ -1077,15 +1076,15 @@ class Window(object):
         # apply the projection and view transformations
         GL.glMatrixMode(GL.GL_PROJECTION)
         GL.glLoadIdentity()
-        projMat = numpy.asfortranarray(self._projectionMatrix).ctypes.data_as(
+        projMat = self._projectionMatrix.T.ctypes.data_as(
             ctypes.POINTER(ctypes.c_float))
-        GL.glMultMatrixf(projMat)
+        GL.glLoadMatrixf(projMat)
 
         GL.glMatrixMode(GL.GL_MODELVIEW)
         GL.glLoadIdentity()
-        viewMat = numpy.asfortranarray(self._viewMatrix).ctypes.data_as(
+        viewMat = self._viewMatrix.T.ctypes.data_as(
             ctypes.POINTER(ctypes.c_float))
-        GL.glMultMatrixf(viewMat)
+        GL.glLoadMatrixf(viewMat)
 
         if clearDepth:
             #GL.glDepthMask(GL.GL_TRUE)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1075,13 +1075,13 @@ class Window(object):
 
         # apply the projection and view transformations
         GL.glMatrixMode(GL.GL_PROJECTION)
-        GL.glLoadIdentity()
+        #GL.glLoadIdentity()
         projMat = self._projectionMatrix.T.ctypes.data_as(
             ctypes.POINTER(ctypes.c_float))
         GL.glLoadMatrixf(projMat)
 
         GL.glMatrixMode(GL.GL_MODELVIEW)
-        GL.glLoadIdentity()
+        #GL.glLoadIdentity()
         viewMat = self._viewMatrix.T.ctypes.data_as(
             ctypes.POINTER(ctypes.c_float))
         GL.glLoadMatrixf(viewMat)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1737,12 +1737,12 @@ class Window(object):
         They may vary in appearance and hot spot location across platforms. The
         following names are valid on most platforms:
 
-                'arrow' : Default pointer
-                'ibeam' : Indicates text can be edited
-            'crosshair' : Crosshair with hot-spot at center
-                 'hand' : A pointing hand
-              'hresize' : Double arrows pointing horizontally
-              'vresize' : Double arrows pointing vertically
+        - 'arrow' : Default pointer
+        - 'ibeam' : Indicates text can be edited
+        - 'crosshair' : Crosshair with hot-spot at center
+        - 'hand' : A pointing hand
+        - 'hresize' : Double arrows pointing horizontally
+        - 'vresize' : Double arrows pointing vertically
 
         Requires the GLFW backend, otherwise this function does nothing! Note,
         on Windows the 'crosshair' option is XORed with the background color. It


### PR DESCRIPTION
Some small changes to 'viewtools' including documentation/examples. 

- Added 'pointToNdc' to the viewtools index. 
- Some changes to attributes in the window class which viewtools works with. Mostly to reduce redundant numpy and GL calls.
- I also added viewtools to the documentation index for 'visual' for discoverability. 

I also went through and fixed up some mangled docstrings not related to viewtools which make the API reference look ugly.