### PR TITLE
BF: converts EOL on opening and compiling scripts to Coder.

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -53,6 +53,7 @@ from psychopy.app import pavlovia_ui
 from psychopy.projects import pavlovia
 
 from psychopy.scripts import psyexpCompile
+from psychopy.app.coder import BaseCodeEditor
 
 canvasColor = [200, 200, 200]  # in prefs? ;-)
 routineTimeColor = wx.Colour(50, 100, 200, 200)
@@ -2311,7 +2312,8 @@ class BuilderFrame(wx.Frame):
         self.app.showCoder()  # make sure coder is visible
         self.app.coder.fileNew(filepath=fullPath)
         self.app.coder.fileReload(event=None, filename=fullPath)
-        EOL = self.app.coder.getEOL()
+        # Convert EOL of currentDoc based on prefs
+        EOL = BaseCodeEditor.getEOL(None, self.app.prefs.coder['newlineConvention'])
         if EOL is not None:
             self.app.coder.currentDoc.ConvertEOLs(EOL)
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2313,7 +2313,7 @@ class BuilderFrame(wx.Frame):
         self.app.coder.fileNew(filepath=fullPath)
         self.app.coder.fileReload(event=None, filename=fullPath)
         # Convert EOL of currentDoc based on prefs
-        EOL = BaseCodeEditor.getEOL(None, self.app.prefs.coder['newlineConvention'])
+        EOL = BaseCodeEditor.getEOL(self.app.prefs.coder['newlineConvention'])
         if EOL is not None:
             self.app.coder.currentDoc.ConvertEOLs(EOL)
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2311,6 +2311,9 @@ class BuilderFrame(wx.Frame):
         self.app.showCoder()  # make sure coder is visible
         self.app.coder.fileNew(filepath=fullPath)
         self.app.coder.fileReload(event=None, filename=fullPath)
+        EOL = self.app.coder.getEOL()
+        if EOL is not None:
+            self.app.coder.currentDoc.ConvertEOLs(EOL)
 
     def generateScript(self, experimentPath, target="PsychoPy"):
         """Generates python script from the current builder experiment"""

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -283,7 +283,11 @@ class CodeBox(BaseCodeEditor):
         # 4 means 'tabs are bad'; 1 means 'flag inconsistency'
         self.SetProperty("tab.timmy.whinge.level", "4")
         self.SetViewWhiteSpace(self.prefs.appData['coder']['showWhitespace'])
-        self.SetViewEOL(False)
+        self.SetViewEOL(self.prefs.appData['coder']['showEOLs'])
+        # Set EOL mode of editor from prefs
+        EOL = self.getEOL(self.prefs.coder['newlineConvention'])
+        if EOL is not None:
+            self.SetEOLMode(EOL)
 
         self.Bind(wx.stc.EVT_STC_MARGINCLICK, self.OnMarginClick)
         self.SetIndentationGuides(False)
@@ -413,20 +417,3 @@ class CodeBox(BaseCodeEditor):
                         self.Expand(lineClicked, True, True, 100)
                 else:
                     self.ToggleFold(lineClicked)
-
-    def Paste(self, event=None):
-        dataObj = wx.TextDataObject()
-        clip = wx.Clipboard().Get()
-        clip.Open()
-        success = clip.GetData(dataObj)
-        clip.Close()
-        if success:
-            txt = dataObj.GetText()
-            if not constants.PY3:
-                try:
-                    # if we can decode/encode to utf-8 then all is good
-                    txt.decode('utf-8')
-                except:
-                    # if not then wx conversion broke so get raw data instead
-                    txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -241,8 +241,9 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
                 newIndent = 0
             self.SetLineIndentation(lineN, newIndent)
 
-    def getEOL(self, prefs='keep'):
-        """Gets EOL mode from preferences.
+    @staticmethod
+    def getEOL(prefs='keep'):
+        """Gets EOL mode from preferences for setting EOL mode in Coder and code component.
         CRLF    : Windows
         CR      : Legacy Mac
         LF      : Unix

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -70,6 +70,28 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
     def OnKeyPressed(self, event):
         pass
 
+    def Paste(self, event=None):
+        import sys
+        from pkg_resources import parse_version
+        from psychopy import constants
+
+        dataObj = wx.TextDataObject()
+        clip = wx.Clipboard().Get()
+        clip.Open()
+        success = clip.GetData(dataObj)
+        clip.Close()
+        if success:
+            txt = dataObj.GetText()
+            # dealing with unicode error in wx3 for Mac
+            if parse_version(wx.__version__) >= parse_version('3') and sys.platform == 'darwin' and not constants.PY3:
+                try:
+                    # if we can decode from utf-8 then all is good
+                    txt.decode('utf-8')
+                except Exception as err:
+                    # if not then wx conversion broke so get raw data instead
+                    txt = dataObj.GetDataHere()
+            self.ReplaceSelection(txt)
+
     def HashtagCounter(self, text, nTags=0):
         # Hashtag counter - counts lines beginning with hashtags in selected text
         for lines in text.splitlines():
@@ -219,3 +241,20 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
                 newIndent = 0
             self.SetLineIndentation(lineN, newIndent)
 
+    def getEOL(self, prefs='keep'):
+        """Gets EOL mode from preferences.
+        CRLF    : Windows
+        CR      : Legacy Mac
+        LF      : Unix
+        None    : Preferences are to be kept same.
+
+        Returns
+        -------
+        int
+            None, 0 = CRLF, 1 = CR, and  2 = LF
+        """
+        EOL = {'keep': None,
+               'dos': 0,
+               'LegacyMac': 1,
+               'unix': 2}
+        return EOL[prefs]

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2250,7 +2250,7 @@ class CoderFrame(wx.Frame):
             else:
                 self.setCurrentDoc(filename)
                 self.setFileModified(False)
-        EOL = BaseCodeEditor.getEOL(None, self.prefs['newlineConvention'])
+        EOL = BaseCodeEditor.getEOL(self.prefs['newlineConvention'])
         if EOL is not None:
             self.currentDoc.ConvertEOLs(EOL)
         self.SetStatusText('')
@@ -2641,7 +2641,7 @@ class CoderFrame(wx.Frame):
         foc = self.FindFocus()
         if hasattr(foc, 'Paste'):
             foc.Paste()
-        self.currentDoc.ConvertEOLs(BaseCodeEditor.getEOL(None, self.prefs['newlineConvention']))
+        self.currentDoc.ConvertEOLs(BaseCodeEditor.getEOL(self.prefs['newlineConvention']))
 
     def undo(self, event):
         self.currentDoc.Undo()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2240,6 +2240,21 @@ class CoderFrame(wx.Frame):
         if readonly:
             self.currentDoc.SetReadOnly(True)
 
+    def getEOL(self):
+        """Gets EOL mode from preferences.
+        CRLF    : Windows
+        CR      : Legacy Mac
+        LF      : Unix
+        None    : Preferences are to be kept same.
+
+        Returns
+        -------
+        int
+            0 = CRLF, 1 = CR, and  2 = LF, None
+        """
+        EOL = {'keep': None, 'dos': 0, 'LegacyMac': 1, 'unix': 2}
+        return EOL[self.prefs['newlineConvention']]
+
     def fileOpen(self, event=None, filename=None):
         if not filename:
             # get path of current file (empty if current file is '')
@@ -2264,7 +2279,9 @@ class CoderFrame(wx.Frame):
             else:
                 self.setCurrentDoc(filename)
                 self.setFileModified(False)
-
+        EOL = self.getEOL()
+        if EOL is not None:
+            self.currentDoc.ConvertEOLs(EOL)
         self.SetStatusText('')
         # self.fileHistory.AddFileToHistory(newPath)  # this is done by
         # setCurrentDoc
@@ -2352,6 +2369,8 @@ class CoderFrame(wx.Frame):
                         newlines = '\r\n'
                     elif self.prefs['newlineConvention'] == 'unix':
                         newlines = '\n'
+                    elif self.prefs['newlineConvention'] == 'LegacyMac':
+                        newlines = '\r'
                 except Exception:
                     pass
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -506,6 +506,10 @@ class CodeEditor(BaseCodeEditor):
         self.coder = frame
         self.SetViewWhiteSpace(self.coder.appData['showWhitespace'])
         self.SetViewEOL(self.coder.appData['showEOLs'])
+        # Set EOL mode of editor from prefs
+        EOL = self.getEOL(self.coder.prefs['newlineConvention'])
+        if EOL is not None:
+            self.SetEOLMode(EOL)
 
         self.Bind(wx.EVT_DROP_FILES, self.coder.filesDropped)
         self.Bind(wx.stc.EVT_STC_MODIFIED, self.onModified)
@@ -954,24 +958,6 @@ class CodeEditor(BaseCodeEditor):
                 lineText = lineText[1:]
             newText = newText + lineText
         self._ReplaceSelectedLines(newText)
-
-    def Paste(self, event=None):
-        dataObj = wx.TextDataObject()
-        clip = wx.Clipboard().Get()
-        clip.Open()
-        success = clip.GetData(dataObj)
-        clip.Close()
-        if success:
-            txt = dataObj.GetText()
-            # dealing with unicode error in wx3 for Mac
-            if wx.__version__[0] == '3' and sys.platform == 'darwin':
-                try:
-                    # if we can decode from utf-8 then all is good
-                    txt.decode('utf-8')
-                except:
-                    # if not then wx conversion broke so get raw data instead
-                    txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)
 
     def increaseFontSize(self):
         self.SetZoom(self.GetZoom() + 1)
@@ -2240,21 +2226,6 @@ class CoderFrame(wx.Frame):
         if readonly:
             self.currentDoc.SetReadOnly(True)
 
-    def getEOL(self):
-        """Gets EOL mode from preferences.
-        CRLF    : Windows
-        CR      : Legacy Mac
-        LF      : Unix
-        None    : Preferences are to be kept same.
-
-        Returns
-        -------
-        int
-            0 = CRLF, 1 = CR, and  2 = LF, None
-        """
-        EOL = {'keep': None, 'dos': 0, 'LegacyMac': 1, 'unix': 2}
-        return EOL[self.prefs['newlineConvention']]
-
     def fileOpen(self, event=None, filename=None):
         if not filename:
             # get path of current file (empty if current file is '')
@@ -2279,7 +2250,7 @@ class CoderFrame(wx.Frame):
             else:
                 self.setCurrentDoc(filename)
                 self.setFileModified(False)
-        EOL = self.getEOL()
+        EOL = BaseCodeEditor.getEOL(None, self.prefs['newlineConvention'])
         if EOL is not None:
             self.currentDoc.ConvertEOLs(EOL)
         self.SetStatusText('')
@@ -2670,6 +2641,7 @@ class CoderFrame(wx.Frame):
         foc = self.FindFocus()
         if hasattr(foc, 'Paste'):
             foc.Paste()
+        self.currentDoc.ConvertEOLs(BaseCodeEditor.getEOL(None, self.prefs['newlineConvention']))
 
     def undo(self, event):
         self.currentDoc.Undo()

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
+    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
+    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
+    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
+    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -81,7 +81,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
+    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
 
 # Settings for the Builder window
 [builder]


### PR DESCRIPTION
Should fix issue of mixed EOLs causing lines of code to disappear, see [Discourse](https://discourse.psychopy.org/t/bug-disappearing-line-breaks-in-code-cells-in-builder/6607/9).
Also, adds Legacy Mac line endings as a preference.