### PR TITLE
BF: Check whether EOL is not None on paste

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2643,7 +2643,7 @@ class CoderFrame(wx.Frame):
             foc.Paste()
         EOL = BaseCodeEditor.getEOL(self.prefs['newlineConvention'])
         if EOL is not None:
-            self.currentDoc.ConvertEOLs()
+            self.currentDoc.ConvertEOLs(EOL)
 
     def undo(self, event):
         self.currentDoc.Undo()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2641,7 +2641,9 @@ class CoderFrame(wx.Frame):
         foc = self.FindFocus()
         if hasattr(foc, 'Paste'):
             foc.Paste()
-        self.currentDoc.ConvertEOLs(BaseCodeEditor.getEOL(self.prefs['newlineConvention']))
+        EOL = BaseCodeEditor.getEOL(self.prefs['newlineConvention'])
+        if EOL is not None:
+            self.currentDoc.ConvertEOLs()
 
     def undo(self, event):
         self.currentDoc.Undo()


### PR DESCRIPTION
This prevents a NoneType error.

Signed-off-by: dvbridges <david-bridges@hotmail.co.uk>