### PR TITLE
BF: slider.getRating() returns undefined, not 'undefined'

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -263,7 +263,7 @@ class SliderComponent(BaseVisualComponent):
         forceEnd = self.params['forceEndRoutine'].val
         if forceEnd:
             code = ("\n// Check %(name)s for response to end routine\n"
-                    "if (%(name)s.getRating() !== 'undefined' && %(name)s.status === PsychoJS.Status.STARTED) {\n"
+                    "if (%(name)s.getRating() !== undefined && %(name)s.status === PsychoJS.Status.STARTED) {\n"
                     "  continueRoutine = false; }\n")
             buff.writeIndentedLines(code % (self.params))
 


### PR DESCRIPTION
The fix changed the conditional to end the routine, as currently it
always ends routine without a response because 'undefined' !== undefined.
Note, you cannot see the actual marker if you ask the Slider to end the
routine. The routine will end without a marker being drawn.