### PR TITLE
BF: Reverts all commits from #2278 and #2279

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -53,7 +53,7 @@ from psychopy.app import pavlovia_ui
 from psychopy.projects import pavlovia
 
 from psychopy.scripts import psyexpCompile
-from psychopy.app.coder import BaseCodeEditor
+
 
 canvasColor = [200, 200, 200]  # in prefs? ;-)
 routineTimeColor = wx.Colour(50, 100, 200, 200)
@@ -2312,10 +2312,6 @@ class BuilderFrame(wx.Frame):
         self.app.showCoder()  # make sure coder is visible
         self.app.coder.fileNew(filepath=fullPath)
         self.app.coder.fileReload(event=None, filename=fullPath)
-        # Convert EOL of currentDoc based on prefs
-        EOL = BaseCodeEditor.getEOL(self.app.prefs.coder['newlineConvention'])
-        if EOL is not None:
-            self.app.coder.currentDoc.ConvertEOLs(EOL)
 
     def generateScript(self, experimentPath, target="PsychoPy"):
         """Generates python script from the current builder experiment"""

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -283,11 +283,7 @@ class CodeBox(BaseCodeEditor):
         # 4 means 'tabs are bad'; 1 means 'flag inconsistency'
         self.SetProperty("tab.timmy.whinge.level", "4")
         self.SetViewWhiteSpace(self.prefs.appData['coder']['showWhitespace'])
-        self.SetViewEOL(self.prefs.appData['coder']['showEOLs'])
-        # Set EOL mode of editor from prefs
-        EOL = self.getEOL(self.prefs.coder['newlineConvention'])
-        if EOL is not None:
-            self.SetEOLMode(EOL)
+        self.SetViewEOL(False)
 
         self.Bind(wx.stc.EVT_STC_MARGINCLICK, self.OnMarginClick)
         self.SetIndentationGuides(False)
@@ -417,3 +413,20 @@ class CodeBox(BaseCodeEditor):
                         self.Expand(lineClicked, True, True, 100)
                 else:
                     self.ToggleFold(lineClicked)
+
+    def Paste(self, event=None):
+        dataObj = wx.TextDataObject()
+        clip = wx.Clipboard().Get()
+        clip.Open()
+        success = clip.GetData(dataObj)
+        clip.Close()
+        if success:
+            txt = dataObj.GetText()
+            if not constants.PY3:
+                try:
+                    # if we can decode/encode to utf-8 then all is good
+                    txt.decode('utf-8')
+                except:
+                    # if not then wx conversion broke so get raw data instead
+                    txt = dataObj.GetDataHere()
+            self.ReplaceSelection(txt)

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -283,7 +283,7 @@ class CodeBox(BaseCodeEditor):
         # 4 means 'tabs are bad'; 1 means 'flag inconsistency'
         self.SetProperty("tab.timmy.whinge.level", "4")
         self.SetViewWhiteSpace(self.prefs.appData['coder']['showWhitespace'])
-        self.SetViewEOL(False)
+        self.SetViewEOL(self.prefs.appData['coder']['showEOLs'])
 
         self.Bind(wx.stc.EVT_STC_MARGINCLICK, self.OnMarginClick)
         self.SetIndentationGuides(False)
@@ -413,20 +413,3 @@ class CodeBox(BaseCodeEditor):
                         self.Expand(lineClicked, True, True, 100)
                 else:
                     self.ToggleFold(lineClicked)
-
-    def Paste(self, event=None):
-        dataObj = wx.TextDataObject()
-        clip = wx.Clipboard().Get()
-        clip.Open()
-        success = clip.GetData(dataObj)
-        clip.Close()
-        if success:
-            txt = dataObj.GetText()
-            if not constants.PY3:
-                try:
-                    # if we can decode/encode to utf-8 then all is good
-                    txt.decode('utf-8')
-                except:
-                    # if not then wx conversion broke so get raw data instead
-                    txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -14,6 +14,8 @@ import wx
 import sys
 from pkg_resources import parse_version
 from psychopy.constants import PY3
+from psychopy import logging
+
 
 class BaseCodeEditor(wx.stc.StyledTextCtrl):
     """Provides base class for code editors
@@ -235,8 +237,8 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
                 try:
                     # if we can decode from utf-8 then all is good
                     txt.decode('utf-8')
-                except:
+                except Exception as e:
+                    logging.error(str(e))
                     # if not then wx conversion broke so get raw data instead
                     txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)
-            self.ConvertEOLs(wx.stc.STC_EOL_LF)
+            self.ReplaceSelection(txt.replace("\r\n", "\n").replace("\r", "\n"))

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -70,28 +70,6 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
     def OnKeyPressed(self, event):
         pass
 
-    def Paste(self, event=None):
-        import sys
-        from pkg_resources import parse_version
-        from psychopy import constants
-
-        dataObj = wx.TextDataObject()
-        clip = wx.Clipboard().Get()
-        clip.Open()
-        success = clip.GetData(dataObj)
-        clip.Close()
-        if success:
-            txt = dataObj.GetText()
-            # dealing with unicode error in wx3 for Mac
-            if parse_version(wx.__version__) >= parse_version('3') and sys.platform == 'darwin' and not constants.PY3:
-                try:
-                    # if we can decode from utf-8 then all is good
-                    txt.decode('utf-8')
-                except Exception as err:
-                    # if not then wx conversion broke so get raw data instead
-                    txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)
-
     def HashtagCounter(self, text, nTags=0):
         # Hashtag counter - counts lines beginning with hashtags in selected text
         for lines in text.splitlines():
@@ -240,22 +218,3 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
             if newIndent < 0:
                 newIndent = 0
             self.SetLineIndentation(lineN, newIndent)
-
-    @staticmethod
-    def getEOL(prefs='keep'):
-        """Gets EOL mode from preferences for setting EOL mode in Coder and code component.
-        CRLF    : Windows
-        CR      : Legacy Mac
-        LF      : Unix
-        None    : Preferences are to be kept same.
-
-        Returns
-        -------
-        int
-            None, 0 = CRLF, 1 = CR, and  2 = LF
-        """
-        EOL = {'keep': None,
-               'dos': 0,
-               'LegacyMac': 1,
-               'unix': 2}
-        return EOL[prefs]

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -954,24 +954,6 @@ class CodeEditor(BaseCodeEditor):
             newText = newText + lineText
         self._ReplaceSelectedLines(newText)
 
-    def Paste(self, event=None):
-        dataObj = wx.TextDataObject()
-        clip = wx.Clipboard().Get()
-        clip.Open()
-        success = clip.GetData(dataObj)
-        clip.Close()
-        if success:
-            txt = dataObj.GetText()
-            # dealing with unicode error in wx3 for Mac
-            if wx.__version__[0] == '3' and sys.platform == 'darwin':
-                try:
-                    # if we can decode from utf-8 then all is good
-                    txt.decode('utf-8')
-                except:
-                    # if not then wx conversion broke so get raw data instead
-                    txt = dataObj.GetDataHere()
-            self.ReplaceSelection(txt)
-
     def increaseFontSize(self):
         self.SetZoom(self.GetZoom() + 1)
 
@@ -2333,27 +2315,7 @@ class CoderFrame(wx.Frame):
                 if failToSave:
                     raise IOError
                 self.SetStatusText(_translate('Saving file'))
-                newlines = None  # system default, os.linesep
-                try:
-                    # this will fail when doc.newlines was not set (new file)
-                    if self.prefs['newlineConvention'] == 'keep':
-                        if doc.GetText().lstrip(u'\ufeff').startswith("#!"):
-                            # document has shebang (ignore byte-order-marker)
-                            newlines = '\n'
-                        elif doc.newlines == '\r\n':
-                            # document had '\r\n' newline on load
-                            newlines = '\r\n'
-                        else:
-                            # None, \n, tuple
-                            newlines = '\n'
-                    elif self.prefs['newlineConvention'] == 'dos':
-                        newlines = '\r\n'
-                    elif self.prefs['newlineConvention'] == 'unix':
-                        newlines = '\n'
-
-                except Exception:
-                    pass
-
+                newlines = '\n'  # system default, os.linesep
                 with io.open(filename, 'w', encoding='utf-8', newline=newlines) as f:
                     f.write(doc.GetText())
                 self.setFileModified(False)

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -63,7 +63,6 @@ _localized = {
     'showOutput': _translate('show output'),
     'reloadPrevFiles': _translate('reload previous files'),
     'preferredShell': _translate('preferred shell'),
-    'newlineConvention': _translate('newline convention'),
     'reloadPrevExp': _translate('reload previous exp'),
     'unclutteredNamespace': _translate('uncluttered namespace'),
     'componentsFolders': _translate('components folders'),

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -139,7 +139,7 @@ class Experiment(object):
         Parameters
         ----------
         code : str
-            The code to run. May include newline characters to wrtie several
+            The code to run. May include newline characters to write several
             lines of code at once.
 
         Notes

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -84,8 +84,6 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
-    # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -84,8 +84,6 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
-    # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -84,8 +84,6 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
-    # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -84,8 +84,6 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
-    # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -85,7 +85,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -81,7 +81,7 @@
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
     # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos','LegacyMac',default='keep')
+    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -80,8 +80,6 @@
     reloadPrevFiles = boolean(default=True)
     # for coder shell window, which shell to use
     preferredShell = option('ipython','pyshell',default='pyshell')
-    # newline for python files: unix = \n, dos = \r\n
-    newlineConvention = option('keep','unix','dos',default='keep')
 
 # Settings for the Builder window
 [builder]

--- a/psychopy/preferences/hints.py
+++ b/psychopy/preferences/hints.py
@@ -91,9 +91,6 @@ _translate("reload previously opened files after start")
 # baseNoArch.spec,[coder],line85
 _translate("for coder shell window, which shell to use")
 
-# baseNoArch.spec,[coder],line87
-_translate("newline for python files: unix = \\n, dos = \\r\\n")
-
 # baseNoArch.spec,[coder],line89
 _translate("whether to automatically reload a previously open experiment")
 


### PR DESCRIPTION
The original issue from Discourse appeared to be a problem with interpretting
mixed EOLs in Coder and code components. The original fix
attempted to convert EOLs to those defined in the preferences to provide
uniform EOLS. However, this did not address the problem described in
the original post.