### PR TITLE
BF: Fixes how EOL are converted in XML Builder file

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -128,6 +128,7 @@ class ParamCtrls(object):
             self.valueCtrl = CodeBox(parent, -1, pos=wx.DefaultPosition,
                                      size=wx.Size(sx, sy), style=0,
                                      prefs=appPrefs)
+            self.valueCtrl.SetEOLMode(wx.stc.STC_EOL_LF)  # Because text uses \n EOLs (also resets for rating scale)
             if len(param.val):
                 self.valueCtrl.AddText(str(param.val))
             if fieldName == 'text':

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -326,7 +326,10 @@ class Experiment(object):
         thisChild = xml.SubElement(parent, thisType)
         thisChild.set('name', name)
         if hasattr(param, 'val'):
-            thisChild.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
+            if hasattr(parent, 'tag') and parent.tag == 'CodeComponent':  # set EOLs for CodeComponent
+                thisChild.set('val', u"{}".format(param.val).replace("\r", "&#13;").replace("\n", "&#10;"))
+            else:
+                thisChild.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
         if hasattr(param, 'valType'):
             thisChild.set('valType', param.valType)
         if hasattr(param, 'updates'):
@@ -344,8 +347,10 @@ class Experiment(object):
         val = paramNode.get('val')
         # many components need web char newline replacement
         if not name == 'advancedParams':
-            val = val.replace("&#10;", "\n")
-
+            if hasattr(componentNode, 'tag') and componentNode.tag == 'CodeComponent':  # set EOLs for CodeComponent
+                val = val.replace("&#13;", "\r").replace("&#10;", "\n")
+            else:
+                val = val.replace("&#10;", "\n")
         # custom settings (to be used when
         if valType == 'fixedList':  # convert the string to a list
             params[name].val = eval('list({})'.format(val))


### PR DESCRIPTION
Previous problems with EOLS were found when legacy Mac EOLs were used in
code components, because PsychoPy could not convert those EOLs into the
correct XML format. This fix now also checks for legacy Mac EOLS in code
components only, but in doing so, covers three EOL styles (\\r, \\n and \\r\\n for legacy Mac, Unix
and Windows). The previous fix for controlling and converting EOLs using
preferences may still be useful, because it creates uniform EOLs in the
PsychoPy when it is compiled from Builder.

The prefs for newline convention were causing a global reconfig of EOLS
in components that use CodeBox class e.g., text and RatingScale.
This fix also keeps the EOLs as standard UNIX in components that
use CodeBox, but are not code components. This way, there are no
differences presenting text locally or online that may be caused by
newline prefs.