### PR TITLE
BF: Code component was not using Paste method from codeEditorBase class

### DIFF
--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -289,16 +289,23 @@ class CodeBox(BaseCodeEditor):
         self.SetIndentationGuides(False)
 
         self.Bind(wx.EVT_KEY_DOWN, self.OnKeyPressed)
+
         self.setupStyles()
 
     def OnKeyPressed(self, event):
         keyCode = event.GetKeyCode()
         _mods = event.GetModifiers()
+
+        # Check combination keys
         if keyCode == ord('/') and wx.MOD_CONTROL == _mods:
-            self.toggleCommentLines(self.params['Code Type'].val)
+            if self.params is not None:
+                self.toggleCommentLines(self.params['Code Type'].val)
+        elif keyCode == ord('V') and wx.MOD_CONTROL == _mods:
+            self.Paste()
+            return  # so that we don't reach the skip line at end
 
         if keyCode == wx.WXK_RETURN and not self.AutoCompActive():
-            # prcoess end of line and then do smart indentation
+            # process end of line and then do smart indentation
             event.Skip(False)
             self.CmdKeyExecute(wx.stc.STC_CMD_NEWLINE)
             if self.params is not None:

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -85,7 +85,7 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
                               'Cut': {'id': None, 'item': '', 'method': self.onCut, 'enabled': self.CanCut},
                               'Copy': {'id': None, 'item': '', 'method': self.onCopy, 'enabled': self.CanCopy},
                               'Paste': {'id': None, 'item': '', 'method': self.onPaste, 'enabled': self.CanPaste},
-                              'Delete': {'id': None, 'item': '', 'method': self.onDelete,'enabled': self.CanCopy},
+                              'Delete': {'id': None, 'item': '', 'method': self.onDelete, 'enabled': self.CanCopy},
                               'Select All': {'id': None, 'item': '', 'method': self.onSelectAll, 'enabled': None},}
 
         if not hasattr(self, "UndoID"):

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -76,44 +76,55 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
         self.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
 
     def OnContextMenu(self, event):
-        """Sets the context menu for components using base code editor"""
-
-        if not hasattr(self, "_menuDict"):
-            # Create menu item dict
-            self._menuDict = {'Undo': {'id': None, '': '', 'method': self.onUndo, 'enabled': self.CanUndo},
-                              'Redo': {'id': None, 'item': '', 'method': self.onRedo, 'enabled': self.CanRedo},
-                              'Cut': {'id': None, 'item': '', 'method': self.onCut, 'enabled': self.CanCut},
-                              'Copy': {'id': None, 'item': '', 'method': self.onCopy, 'enabled': self.CanCopy},
-                              'Paste': {'id': None, 'item': '', 'method': self.onPaste, 'enabled': self.CanPaste},
-                              'Delete': {'id': None, 'item': '', 'method': self.onDelete, 'enabled': self.CanCopy},
-                              'Select All': {'id': None, 'item': '', 'method': self.onSelectAll, 'enabled': None},}
+        """Sets the context menu for components using code editor base class"""
 
         if not hasattr(self, "UndoID"):
-            # For each item, create a new ID
-            self._menuDict['Undo']['id'] = self.UndoID = wx.NewId()
-            self._menuDict['Redo']['id'] = self.RedoID = wx.NewId()
-            self._menuDict['Cut']['id'] = self.CutID = wx.NewId()
-            self._menuDict['Copy']['id'] = self.CopyID = wx.NewId()
-            self._menuDict['Paste']['id'] = self.PasteID = wx.NewId()
-            self._menuDict['Delete']['id'] = self.DeleteID = wx.NewId()
-            self._menuDict['Select All']['id'] = self.SelectAllID = wx.NewId()
+            # Create a new ID for all items
+            self.UndoID = wx.NewId()
+            self.RedoID = wx.NewId()
+            self.CutID = wx.NewId()
+            self.CopyID = wx.NewId()
+            self.PasteID = wx.NewId()
+            self.DeleteID = wx.NewId()
+            self.SelectAllID = wx.NewId()
 
+        # Bind items to relevant method
+        self.Bind(wx.EVT_MENU, self.onUndo, id=self.UndoID)
+        self.Bind(wx.EVT_MENU, self.onRedo, id=self.RedoID)
+        self.Bind(wx.EVT_MENU, self.onCut, id=self.CutID)
+        self.Bind(wx.EVT_MENU, self.onCopy, id=self.CopyID)
+        self.Bind(wx.EVT_MENU, self.onPaste, id=self.PasteID)
+        self.Bind(wx.EVT_MENU, self.onDelete, id=self.DeleteID)
+        self.Bind(wx.EVT_MENU, self.onSelectAll, id=self.SelectAllID)
+
+        # Create menu and menu items
         menu = wx.Menu()
-        separators = ['Redo', 'Paste']  # Add separators after these menu items
+        undoItem = wx.MenuItem(menu, self.UndoID, "Undo")
+        redoItem = wx.MenuItem(menu, self.RedoID, "Redo")
+        cutItem = wx.MenuItem(menu, self.CutID, "Cut")
+        copyItem = wx.MenuItem(menu, self.CopyID, "Copy")
+        pasteItem = wx.MenuItem(menu, self.PasteID, "Paste")
+        deleteItem = wx.MenuItem(menu, self.DeleteID, "Delete")
+        selectItem = wx.MenuItem(menu, self.SelectAllID, "Select All")
 
-        for menuItem in self._menuDict.keys():
-            # Bind each item to relevant method
-            self.Bind(wx.EVT_MENU, self._menuDict[menuItem]['method'], id=self._menuDict[menuItem]['id'])
-            # Create each menu item
-            self._menuDict[menuItem]['item'] = wx.MenuItem(menu, self._menuDict[menuItem]['id'], menuItem)
-            # Check whether item should be enabled
-            if self._menuDict[menuItem]['enabled'] is not None:
-                self._menuDict[menuItem]['item'].Enable(self._menuDict[menuItem]['enabled']())
-            # Append item to menu
-            menu.Append(self._menuDict[menuItem]['item'])
-            # Add separator if needed
-            if menuItem in separators:
-                menu.AppendSeparator()
+        # Check whether items should be enabled
+        undoItem.Enable(self.CanUndo())
+        redoItem.Enable(self.CanRedo())
+        cutItem.Enable(self.CanCut())
+        copyItem.Enable(self.CanCopy())
+        pasteItem.Enable(self.CanPaste())
+        deleteItem.Enable(self.CanCopy())
+
+        # Append items to menu
+        menu.Append(undoItem)
+        menu.Append(redoItem)
+        menu.AppendSeparator()
+        menu.Append(cutItem)
+        menu.Append(copyItem)
+        menu.Append(pasteItem)
+        menu.AppendSeparator()
+        menu.Append(deleteItem)
+        menu.Append(selectItem)
 
         self.PopupMenu(menu)
         menu.Destroy()

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -78,7 +78,6 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
     def OnContextMenu(self, event):
         """Sets the context menu for components using base code editor"""
 
-
         if not hasattr(self, "_menuDict"):
             # Create menu item dict
             self._menuDict = {'Undo': {'id': None, '': '', 'method': self.onUndo, 'enabled': self.CanUndo},

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -77,32 +77,44 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
 
     def OnContextMenu(self, event):
         """Sets the context menu for components using base code editor"""
-        menuDict = {'Undo': {'id': None, '': '', 'method': self.onUndo, 'enabled': self.CanUndo()},
-                    'Redo': {'id': None, 'item': '', 'method': self.onRedo, 'enabled': self.CanRedo()},
-                    'Cut': {'id': None, 'item': '', 'method': self.onCut, 'enabled': self.CanCut()},
-                    'Copy': {'id': None, 'item': '', 'method': self.onCopy, 'enabled': self.CanCopy()},
-                    'Paste': {'id': None, 'item': '', 'method': self.onPaste, 'enabled': self.CanPaste()},
-                    'Delete': {'id': None, 'item': '', 'method': self.onDelete, 'enabled': True},
-                    'Select All': {'id': None, 'item': '', 'method': self.onSelectAll, 'enabled': True},}
+
+
+        if not hasattr(self, "_menuDict"):
+            # Create menu item dict
+            self._menuDict = {'Undo': {'id': None, '': '', 'method': self.onUndo, 'enabled': self.CanUndo},
+                              'Redo': {'id': None, 'item': '', 'method': self.onRedo, 'enabled': self.CanRedo},
+                              'Cut': {'id': None, 'item': '', 'method': self.onCut, 'enabled': self.CanCut},
+                              'Copy': {'id': None, 'item': '', 'method': self.onCopy, 'enabled': self.CanCopy},
+                              'Paste': {'id': None, 'item': '', 'method': self.onPaste, 'enabled': self.CanPaste},
+                              'Delete': {'id': None, 'item': '', 'method': self.onDelete,'enabled': self.CanCopy},
+                              'Select All': {'id': None, 'item': '', 'method': self.onSelectAll, 'enabled': None},}
+
+        if not hasattr(self, "UndoID"):
+            # For each item, create a new ID
+            self._menuDict['Undo']['id'] = self.UndoID = wx.NewId()
+            self._menuDict['Redo']['id'] = self.RedoID = wx.NewId()
+            self._menuDict['Cut']['id'] = self.CutID = wx.NewId()
+            self._menuDict['Copy']['id'] = self.CopyID = wx.NewId()
+            self._menuDict['Paste']['id'] = self.PasteID = wx.NewId()
+            self._menuDict['Delete']['id'] = self.DeleteID = wx.NewId()
+            self._menuDict['Select All']['id'] = self.SelectAllID = wx.NewId()
 
         menu = wx.Menu()
         separators = ['Redo', 'Paste']  # Add separators after these menu items
 
-        if menuDict['Undo'].get("id") is None:
-            for menuItem in menuDict.keys():
-                # For each item, create a new ID
-                menuDict[menuItem]['id'] = wx.NewId()
-                # Bind each item to relevant method
-                self.Bind(wx.EVT_MENU, menuDict[menuItem]['method'], id=menuDict[menuItem]['id'])
-                # Create each menu item
-                menuDict[menuItem]['item'] = wx.MenuItem(menu, menuDict[menuItem]['id'], menuItem)
-                # Check whether item should be enabled
-                menuDict[menuItem]['item'].Enable(menuDict[menuItem]['enabled'])
-                # Append item to menu
-                menu.Append(menuDict[menuItem]['item'])
-                # Add separator if needed
-                if menuItem in separators:
-                    menu.AppendSeparator()
+        for menuItem in self._menuDict.keys():
+            # Bind each item to relevant method
+            self.Bind(wx.EVT_MENU, self._menuDict[menuItem]['method'], id=self._menuDict[menuItem]['id'])
+            # Create each menu item
+            self._menuDict[menuItem]['item'] = wx.MenuItem(menu, self._menuDict[menuItem]['id'], menuItem)
+            # Check whether item should be enabled
+            if self._menuDict[menuItem]['enabled'] is not None:
+                self._menuDict[menuItem]['item'].Enable(self._menuDict[menuItem]['enabled']())
+            # Append item to menu
+            menu.Append(self._menuDict[menuItem]['item'])
+            # Add separator if needed
+            if menuItem in separators:
+                menu.AppendSeparator()
 
         self.PopupMenu(menu)
         menu.Destroy()

--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -72,6 +72,83 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl):
         self.MarkerDefine(wx.stc.STC_MARKNUM_FOLDERMIDTAIL,
                           wx.stc.STC_MARK_TCORNER, "white", "#808080")
 
+        # Bind context menu
+        self.Bind(wx.EVT_CONTEXT_MENU, self.OnContextMenu)
+
+    def OnContextMenu(self, event):
+        """Sets the context menu for components using base code editor"""
+        menuDict = {'Undo': {'id': None, '': '', 'method': self.onUndo, 'enabled': self.CanUndo()},
+                    'Redo': {'id': None, 'item': '', 'method': self.onRedo, 'enabled': self.CanRedo()},
+                    'Cut': {'id': None, 'item': '', 'method': self.onCut, 'enabled': self.CanCut()},
+                    'Copy': {'id': None, 'item': '', 'method': self.onCopy, 'enabled': self.CanCopy()},
+                    'Paste': {'id': None, 'item': '', 'method': self.onPaste, 'enabled': self.CanPaste()},
+                    'Delete': {'id': None, 'item': '', 'method': self.onDelete, 'enabled': True},
+                    'Select All': {'id': None, 'item': '', 'method': self.onSelectAll, 'enabled': True},}
+
+        menu = wx.Menu()
+        separators = ['Redo', 'Paste']  # Add separators after these menu items
+
+        if menuDict['Undo'].get("id") is None:
+            for menuItem in menuDict.keys():
+                # For each item, create a new ID
+                menuDict[menuItem]['id'] = wx.NewId()
+                # Bind each item to relevant method
+                self.Bind(wx.EVT_MENU, menuDict[menuItem]['method'], id=menuDict[menuItem]['id'])
+                # Create each menu item
+                menuDict[menuItem]['item'] = wx.MenuItem(menu, menuDict[menuItem]['id'], menuItem)
+                # Check whether item should be enabled
+                menuDict[menuItem]['item'].Enable(menuDict[menuItem]['enabled'])
+                # Append item to menu
+                menu.Append(menuDict[menuItem]['item'])
+                # Add separator if needed
+                if menuItem in separators:
+                    menu.AppendSeparator()
+
+        self.PopupMenu(menu)
+        menu.Destroy()
+
+    def onUndo(self, event):
+        """For context menu Undo"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'Undo'):
+            foc.Undo()
+
+    def onRedo(self, event):
+        """For context menu Redo"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'Redo'):
+            foc.Redo()
+
+    def onCut(self, event):
+        """For context menu Cut"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'Cut'):
+            foc.Cut()
+
+    def onCopy(self, event):
+        """For context menu Copy"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'Copy'):
+            foc.Copy()
+
+    def onPaste(self, event):
+        """For context menu Paste"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'Paste'):
+            foc.Paste()
+
+    def onSelectAll(self, event):
+        """For context menu Select All"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'SelectAll'):
+            foc.SelectAll()
+
+    def onDelete(self, event):
+        """For context menu Delete"""
+        foc = self.FindFocus()
+        if hasattr(foc, 'DeleteBack'):
+            foc.DeleteBack()
+
     def OnKeyPressed(self, event):
         pass
 


### PR DESCRIPTION
This fix adds a keycheck when using paste shortcut and redirects
to the codeEditorBase paste method. It also enables the
context menus for both Coder and Code Component to be directed
to the Paste function in the codeEditorBase.

Edit: The context menu **DOES** work when switching the tabs - the tab just needs
to be active. The keyboard shortcut is independent
of the context menu fixes, and can be cherry picked if the menu is not
wanted.