### PR TITLE
Remove pygame requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     pandas
     pillow
     pyglet
-    pygame
     pyopengl
     soundfile
     sounddevice


### PR DESCRIPTION
I noticed that the most recent version on PyPI still requires lots of packages, including the deprecated `pygame`. I've fixed that in this PR, but maybe it would be a good idea to do some more cleaning (especially since the [install docs now mention a minimal setup](https://www.psychopy.org/installation.html), which currently cannot be installed because all requirements get pulled in). Let me know if you want me to do that.