### PR TITLE
BF: Fix basetring/unicode bugs for Py3

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -158,7 +158,7 @@ class EyeTracker(EyeTrackerDevice):
             if default_native_data_file_name:
                 if isinstance(default_native_data_file_name, (str, unicode)):
                     r = default_native_data_file_name.rfind('.')
-                    if default_native_data_file_name > 0:
+                    if r > 0:
                         if default_native_data_file_name[r:] == 'edf'.lower():
                             default_native_data_file_name = default_native_data_file_name[
                                 :r]

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -13,7 +13,17 @@ try:
     from psychopy.gui.wxgui import ProgressBarDialog
 except ImportError:
     ProgressBarDialog = None
-    
+
+try:
+    unicode
+except NameError:
+    unicode = str
+
+try:
+    basestring
+except NameError:
+    basestring = str
+
 from ......constants import EventConstants, EyeTrackerConstants
 from ...... import EXP_SCRIPT_DIRECTORY
 from ......errors import print2err, printExceptionDetailsToStdErr


### PR DESCRIPTION
This PR fixes some errors in `psychopy.iohub` occurring when running Psychopy with Python3.6. Basically catches errors when trying to use `basestring` or `unicode`, and pointing these classes to the default Python3 `str` class.

It also fixes a bug when trying to remove the extension of the `default_native_data_file_name` string.