### PR TITLE
ENH: Added Channel field to Microphone properties

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -19,7 +19,7 @@ iconFile = path.join(thisFolder, 'microphone.png')
 tooltip = _translate('Microphone: basic sound capture (fixed onset & '
                      'duration), okay for spoken words')
 
-_localized = {'stereo': _translate('Stereo')}
+_localized = {'stereo': _translate('Stereo'),'channel': _translate('Channel')}
 
 
 class MicrophoneComponent(BaseComponent):
@@ -29,7 +29,7 @@ class MicrophoneComponent(BaseComponent):
     def __init__(self, exp, parentName, name='mic_1',
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=2.0, startEstim='',
-                 durationEstim='', stereo=False):
+                 durationEstim='', stereo=False, channel=0):
         super(MicrophoneComponent, self).__init__(
             exp, parentName, name=name,
             startType=startType, startVal=startVal,
@@ -54,6 +54,9 @@ class MicrophoneComponent(BaseComponent):
             'The duration of the recording in seconds; blank = 0 sec')
         self.params['stopType'].hint = msg
 
+        msg = _translate("Enter a channel number. Default value is 0. If unsure, run 'sound.backend.get_input_devices()' to locate the system's selected device/channel.")
+
+        self.params['channel'] = Param(channel, valType='str', hint=msg, label=_localized['channel'])
     def writeStartCode(self, buff):
         # filename should have date_time, so filename_wav should be unique
         buff.writeIndented("wavDirName = filename + '_wav'\n")
@@ -64,7 +67,7 @@ class MicrophoneComponent(BaseComponent):
     def writeRoutineStartCode(self, buff):
         inits = getInitVals(self.params)
         code = ("%(name)s = microphone.AdvAudioCapture(name='%(name)s', "
-                "saveDir=wavDirName, stereo=%(stereo)s)\n")
+                "saveDir=wavDirName, stereo=%(stereo)s, chnl=%(channel)s)\n")
         buff.writeIndented(code % inits)
 
     def writeFrameCode(self, buff):

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -1980,8 +1980,9 @@ MicrophoneComponent.syncScreenRefresh.val:False
 MicrophoneComponent.syncScreenRefresh.valType:bool
 MicrophoneComponent.channel.default:0
 MicrophoneComponent.channel.allowedTypes:[]
-MicrophoneComponent.channel.allowedUpdates:[]
+MicrophoneComponent.channel.allowedUpdates:None
 MicrophoneComponent.channel.allowedVals:[]
+MicrophoneComponent.channel.categ:Basic
 MicrophoneComponent.channel.val:0
 MicrophoneComponent.channel.valType:str
 MicrophoneComponent.channel.label:Channel

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -1979,9 +1979,16 @@ MicrophoneComponent.syncScreenRefresh.updates:None
 MicrophoneComponent.syncScreenRefresh.val:False
 MicrophoneComponent.syncScreenRefresh.valType:bool
 MicrophoneComponent.channel.default:0
+MicrophoneComponent.channel.allowedTypes:[]
+MicrophoneComponent.channel.allowedUpdates:[]
+MicrophoneComponent.channel.allowedVals:[]
+MicrophoneComponent.channel.val:0
 MicrophoneComponent.channel.valType:str
 MicrophoneComponent.channel.label:Channel
+MicrophoneComponent.channel.readOnly:False
 MicrophoneComponent.channel.hint:Enter a channel number. Default value is 0. If unsure, run 'sound.backend.get_input_devices()' to locate the system's selected device/channel
+MicrophoneComponent.channel.staticUpdater:None
+MicrophoneComponent.channel.updates:None
 MouseComponent.order:['name', 'forceEndRoutineOnPress', 'saveMouseState', 'timeRelativeTo', 'newClicksOnly', 'clickable', 'saveParamsClickable']
 MouseComponent.clickable.default:
 MouseComponent.clickable.allowedTypes:[]

--- a/psychopy/tests/test_app/test_builder/componsTemplate.txt
+++ b/psychopy/tests/test_app/test_builder/componsTemplate.txt
@@ -1978,6 +1978,10 @@ MicrophoneComponent.syncScreenRefresh.staticUpdater:None
 MicrophoneComponent.syncScreenRefresh.updates:None
 MicrophoneComponent.syncScreenRefresh.val:False
 MicrophoneComponent.syncScreenRefresh.valType:bool
+MicrophoneComponent.channel.default:0
+MicrophoneComponent.channel.valType:str
+MicrophoneComponent.channel.label:Channel
+MicrophoneComponent.channel.hint:Enter a channel number. Default value is 0. If unsure, run 'sound.backend.get_input_devices()' to locate the system's selected device/channel
 MouseComponent.order:['name', 'forceEndRoutineOnPress', 'saveMouseState', 'timeRelativeTo', 'newClicksOnly', 'clickable', 'saveParamsClickable']
 MouseComponent.clickable.default:
 MouseComponent.clickable.allowedTypes:[]


### PR DESCRIPTION
This is so that the experiment builder can auto generate 'chnl' attribute for AdvAudioCapture, as not all devices share the same default '0' for input device.

**Detailed explaination of fix in below thread**
https://discourse.psychopy.org/t/potential-improvements-to-microphone-component-of-experiment-builder/6814