### PR TITLE
BF: Better handling of exceptions raised for getChanges method

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -912,9 +912,7 @@ class PavloviaProject(dict):
             elif this.change_type == 'M':
                 changeDict['changed'].append(this.b_path)
             else:
-                raise (
-                    "Found an unexpected change_type '{}' in gitpython Diff"
-                        .format(this.change_type))
+                raise ValueError("Found an unexpected change_type '{}' in gitpython Diff".format(this.change_type))
         changeList = []
         for categ in changeDict:
             changeList.extend(changeDict[categ])


### PR DESCRIPTION
Raise was emitting a TypeError: exceptions must derive from BaseException
when passed inappropriate value (in this case a 'U' was passed. This
fix handles this case as a value error. However, perhaps more general
exception handling is required.