### PR TITLE
BF: add spacebar to the valid keys

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -990,7 +990,7 @@ class _GlobalEventKeys(MutableMapping):
 
     _valid_keys = set(string.ascii_lowercase + string.digits
                       + string.punctuation + ' \t')
-    _valid_keys.update(['escape', 'left', 'right', 'up', 'down', 'space']) # add spacebar here to valid_keys
+    _valid_keys.update(['escape', 'left', 'right', 'up', 'down', 'space'])
 
     _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock',
                         'scrolllock', 'command', 'option', 'windows'}

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -990,7 +990,7 @@ class _GlobalEventKeys(MutableMapping):
 
     _valid_keys = set(string.ascii_lowercase + string.digits
                       + string.punctuation + ' \t')
-    _valid_keys.update(['escape', 'left', 'right', 'up', 'down'])
+    _valid_keys.update(['escape', 'left', 'right', 'up', 'down', 'space']) # add spacebar here to valid_keys
 
     _valid_modifiers = {'shift', 'ctrl', 'alt', 'capslock',
                         'scrolllock', 'command', 'option', 'windows'}


### PR DESCRIPTION
I found the spacebar is missing 
```
Traceback (most recent call last):
  File "stimulus_show.py", line 40, in <module>
    event.globalKeys.add(key='space', func=pause)
  File "/usr/local/lib/python3.6/site-packages/psychopy/event.py", line 1090, in add
    raise ValueError('Unknown key specified: %s' % key)
ValueError: Unknown key specified: space

```

And adding the spacebar to the valid keys can fix this.