### PR TITLE
NF: Allow routines to be disabled

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2288,6 +2288,12 @@ class BuilderFrame(wx.Frame):
         """
         self.routinePanel.createNewRoutine()
 
+    def toggleRoutineDisabled(self):
+        routine = (self.routinePanel.GetPage(self.routinePanel.GetSelection())
+                   .routine)
+        routine.params['disabled'] = not routine.params['disabled']
+        return routine.params['disabled']
+
     def renameRoutine(self, name, event=None, returnName=True):
         """Defines ability to rename routine in the routine panel
         """

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2289,6 +2289,13 @@ class BuilderFrame(wx.Frame):
         self.routinePanel.createNewRoutine()
 
     def toggleRoutineDisabled(self):
+        """Toggle the `disabled` parameter of a routine.
+
+        Returns
+        -------
+        bool
+            The new state of the `disabled` paramter after toggling.
+        """
         routine = (self.routinePanel.GetPage(self.routinePanel.GetSelection())
                    .routine)
         routine.params['disabled'] = not routine.params['disabled']

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -185,9 +185,28 @@ class Experiment(object):
         else:
             localDateTime = data.getDateStr(format="%B %d, %Y, at %H:%M")
 
-        # Remove disabled components, but leave original experiment unchanged.
+        # Remove disabled routines and components, but leave original
+        # experiment unchanged.
         self_copy = deepcopy(self)
-        for _, routine in list(self_copy.routines.items()):  # PY2/3 compat
+        for routine_name, routine in list(self_copy.routines.items()):  # PY2/3 compat
+            if routine.params['disabled']:
+                # We remove all occurrences of this routine from the flow --
+                # there might be multiple ones!
+                #
+                # First, get all routines from the flow except the current
+                # (disabled) one.
+                routines = list(filter(lambda routine_:
+                                       routine_.name != routine_name,
+                                       self_copy.flow))
+
+                # We now replace the list of routines in the flow with the
+                # "cleaned" list of routines.
+                self_copy.flow[:] = routines
+
+                # We dropped an entire routine -- no need to look at individual
+                # components here anymore!
+                break
+
             for component in routine:
                 try:
                     if component.params['disabled'].val:
@@ -282,8 +301,15 @@ class Experiment(object):
         routinesNode = xml.SubElement(self.xmlRoot, 'Routines')
         # routines is a dict of routines
         for routineName, routine in self.routines.items():
-            routineNode = self._setXMLparam(
-                parent=routinesNode, param=routine, name=routineName)
+            routineNode = self._setXMLparam(parent=routinesNode,
+                                            param=routine,
+                                            name=routineName)
+
+            self._setXMLparam(parent=routineNode,
+                              param=Param(val=routine.params['disabled'],
+                                          valType='bool'),
+                              name='disabled')
+
             # a routine is based on a list of components
             for component in routine:
                 componentNode = self._setXMLparam(
@@ -569,12 +595,27 @@ class Experiment(object):
             if routineGoodName != routineNode.get('name'):
                 modifiedNames.append(routineNode.get('name'))
             self.namespace.user.append(routineGoodName)
+
             routine = Routine(name=routineGoodName, exp=self)
+
             # self._getXMLparam(params=routine.params, paramNode=routineNode)
             self.routines[routineNode.get('name')] = routine
-            for componentNode in routineNode:
 
+            for componentNode in routineNode:
                 componentType = componentNode.tag
+                if componentType == 'Param':
+                    # This is a top-level "Param" node in this routine node,
+                    # not an actual component!
+                    #
+                    # We can retrieve the `disabled` parameter of this routine
+                    # from here.
+                    params = dict()
+                    self._getXMLparam(params=params,
+                                      paramNode=componentNode)
+                    routine.params['disabled'] = params['disabled'].val
+                    del params
+                    break
+
                 if componentType in allCompons:
                     # create an actual component of that type
                     component = allCompons[componentType](
@@ -585,6 +626,7 @@ class Experiment(object):
                     component = allCompons['UnknownComponent'](
                         name=componentNode.get('name'),
                         parentName=routineNode.get('name'), exp=self)
+
                 # check for components that were absent in older versions of
                 # the builder and change the default behavior
                 # (currently only the new behavior of choices for RatingScale,

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -26,7 +26,8 @@ class Routine(list):
 
     def __init__(self, name, exp, components=()):
         super(Routine, self).__init__()
-        self.params = {'name': name}
+        self.params = {'name': name,
+                       'disabled': False}
         self.name = name
         self.exp = exp
         self._clockName = None  # for scripts e.g. "t = trialClock.GetTime()"
@@ -40,6 +41,7 @@ class Routine(list):
     @property
     def name(self):
         return self.params['name']
+
     @name.setter
     def name(self, name):
         self.params['name'] = name

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -110,7 +110,25 @@ def compileScript(infile=None, version=None, outfile=None):
         # Leave original experiment unchanged.
         exp = deepcopy(exp)
 
-        for _, routine in list(exp.routines.items()):  # PY2/3 compat
+        for routine_name, routine in list(exp.routines.items()):  # PY2/3 compat
+            if routine.params['disabled']:
+                # We remove all occurrences of this routine from the flow --
+                # there might be multiple ones!
+                #
+                # First, get all routines from the flow except the current
+                # (disabled) one.
+                routines = list(filter(lambda routine_:
+                                       routine_.name != routine_name,
+                                       exp.flow))
+
+                # We now replace the list of routines in the flow with the
+                # "cleaned" list of routines.
+                exp.flow[:] = routines
+
+                # We dropped an entire routine -- no need to look at individual
+                # components here anymore!
+                break
+
             for component in routine:
                 try:
                     if component.params['disabled'].val:

--- a/psychopy/tests/data/routine_disabled.psyexp
+++ b/psychopy/tests/data/routine_disabled.psyexp
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" ?>
+<PsychoPy2experiment encoding="utf-8" version="3.0.5">
+  <Settings>
+    <Param name="Completed URL" updates="None" val="" valType="str"/>
+    <Param name="Data filename" updates="None" val="u'data/%s_%s_%s' % (expInfo['participant'], expName, expInfo['date'])" valType="code"/>
+    <Param name="Enable Escape" updates="None" val="True" valType="bool"/>
+    <Param name="Experiment info" updates="None" val="{'participant':'', 'session':'001'}" valType="code"/>
+    <Param name="Force stereo" updates="None" val="True" valType="bool"/>
+    <Param name="Full-screen window" updates="None" val="True" valType="bool"/>
+    <Param name="HTML path" updates="None" val="html" valType="str"/>
+    <Param name="Incomplete URL" updates="None" val="" valType="str"/>
+    <Param name="JS libs" updates="None" val="packaged" valType="str"/>
+    <Param name="Monitor" updates="None" val="testMonitor" valType="str"/>
+    <Param name="Save csv file" updates="None" val="False" valType="bool"/>
+    <Param name="Save excel file" updates="None" val="False" valType="bool"/>
+    <Param name="Save log file" updates="None" val="True" valType="bool"/>
+    <Param name="Save psydat file" updates="None" val="True" valType="bool"/>
+    <Param name="Save wide csv file" updates="None" val="True" valType="bool"/>
+    <Param name="Screen" updates="None" val="1" valType="num"/>
+    <Param name="Show info dlg" updates="None" val="True" valType="bool"/>
+    <Param name="Show mouse" updates="None" val="False" valType="bool"/>
+    <Param name="Units" updates="None" val="height" valType="str"/>
+    <Param name="Use version" updates="None" val="" valType="str"/>
+    <Param name="Window size (pixels)" updates="None" val="(1024, 768)" valType="code"/>
+    <Param name="blendMode" updates="None" val="avg" valType="str"/>
+    <Param name="color" updates="None" val="$[0,0,0]" valType="str"/>
+    <Param name="colorSpace" updates="None" val="rgb" valType="str"/>
+    <Param name="expName" updates="None" val="routine_disabled" valType="str"/>
+    <Param name="exportHTML" updates="None" val="on Sync" valType="str"/>
+    <Param name="logging level" updates="None" val="exp" valType="code"/>
+  </Settings>
+  <Routines>
+    <Routine name="testRoutine">
+      <Param name="disabled" updates="None" val="True" valType="bool"/>
+    </Routine>
+  </Routines>
+  <Flow>
+    <Routine name="testRoutine"/>
+  </Flow>
+</PsychoPy2experiment>

--- a/psychopy/tests/data/routine_not_disabled.psyexp
+++ b/psychopy/tests/data/routine_not_disabled.psyexp
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" ?>
+<PsychoPy2experiment encoding="utf-8" version="3.0.5">
+  <Settings>
+    <Param name="Completed URL" updates="None" val="" valType="str"/>
+    <Param name="Data filename" updates="None" val="u'data/%s_%s_%s' % (expInfo['participant'], expName, expInfo['date'])" valType="code"/>
+    <Param name="Enable Escape" updates="None" val="True" valType="bool"/>
+    <Param name="Experiment info" updates="None" val="{'participant':'', 'session':'001'}" valType="code"/>
+    <Param name="Force stereo" updates="None" val="True" valType="bool"/>
+    <Param name="Full-screen window" updates="None" val="True" valType="bool"/>
+    <Param name="HTML path" updates="None" val="html" valType="str"/>
+    <Param name="Incomplete URL" updates="None" val="" valType="str"/>
+    <Param name="JS libs" updates="None" val="packaged" valType="str"/>
+    <Param name="Monitor" updates="None" val="testMonitor" valType="str"/>
+    <Param name="Save csv file" updates="None" val="False" valType="bool"/>
+    <Param name="Save excel file" updates="None" val="False" valType="bool"/>
+    <Param name="Save log file" updates="None" val="True" valType="bool"/>
+    <Param name="Save psydat file" updates="None" val="True" valType="bool"/>
+    <Param name="Save wide csv file" updates="None" val="True" valType="bool"/>
+    <Param name="Screen" updates="None" val="1" valType="num"/>
+    <Param name="Show info dlg" updates="None" val="True" valType="bool"/>
+    <Param name="Show mouse" updates="None" val="False" valType="bool"/>
+    <Param name="Units" updates="None" val="height" valType="str"/>
+    <Param name="Use version" updates="None" val="" valType="str"/>
+    <Param name="Window size (pixels)" updates="None" val="(1024, 768)" valType="code"/>
+    <Param name="blendMode" updates="None" val="avg" valType="str"/>
+    <Param name="color" updates="None" val="$[0,0,0]" valType="str"/>
+    <Param name="colorSpace" updates="None" val="rgb" valType="str"/>
+    <Param name="expName" updates="None" val="routine_not_disabled" valType="str"/>
+    <Param name="exportHTML" updates="None" val="on Sync" valType="str"/>
+    <Param name="logging level" updates="None" val="exp" valType="code"/>
+  </Settings>
+  <Routines>
+    <Routine name="testRoutine">
+      <Param name="disabled" updates="None" val="False" valType="bool"/>
+    </Routine>
+  </Routines>
+  <Flow>
+    <Routine name="testRoutine"/>
+  </Flow>
+</PsychoPy2experiment>

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -528,3 +528,33 @@ class TestDisabledComponents(object):
 
         # Original routine should be unchanged.
         assert self.text in self.routine
+
+
+class TestDisabledRoutines(object):
+    def setup(self):
+        self.exp = psychopy.experiment.Experiment()
+        self.exp.addRoutine(routineName='Test Routine')
+        self.routine = self.exp.routines['Test Routine']
+        self.exp.flow.addRoutine(self.routine, 0)
+
+    def test_routine_not_disabled_by_default(self):
+        assert self.routine.params['disabled'] is False
+
+    def test_routine_is_written_to_script(self):
+        script = self.exp.writeScript()
+        assert 'Test Routine' in script
+
+    def test_disabled_routine_is_not_written_to_script(self):
+        self.routine.params['disabled'] = True
+        script = self.exp.writeScript()
+        assert 'Test Routine' not in script
+
+    def test_disabling_routine_does_not_remove_it_from_original_experiment(self):
+        self.routine.params['disabled'] = True
+
+        # This drops the disabled routine -- if working correctly, only from
+        # a copy though, leaving the original unchanged!
+        self.exp.writeScript()
+
+        # Original routine should be unchanged.
+        assert self.routine in self.exp.flow

--- a/psychopy/tests/test_scripts/test_psyexpCompile.py
+++ b/psychopy/tests/test_scripts/test_psyexpCompile.py
@@ -32,3 +32,31 @@ class TestDisabledComponents(object):
         with io.open(outfile, mode='r', encoding='utf-8-sig') as f:
             script = f.read()
             assert 'visual.TextStim' not in script
+
+
+class TestDisabledRoutines(object):
+    def setup(self):
+        self.temp_dir = mkdtemp()
+
+    def teardown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_routine_is_written_to_script(self):
+        psyexp_file = os.path.join(TESTS_DATA_PATH,
+                                   'routine_not_disabled.psyexp')
+        outfile = os.path.join(self.temp_dir, 'outfile.py')
+        psyexpCompile.compileScript(infile=psyexp_file, outfile=outfile)
+
+        with io.open(outfile, mode='r', encoding='utf-8-sig') as f:
+            script = f.read()
+            assert 'testRoutine' in script
+
+    def test_disabled_component_is_not_written_to_script(self):
+        psyexp_file = os.path.join(TESTS_DATA_PATH,
+                                   'routine_disabled.psyexp')
+        outfile = os.path.join(self.temp_dir, 'outfile.py')
+        psyexpCompile.compileScript(infile=psyexp_file, outfile=outfile)
+
+        with io.open(outfile, mode='r', encoding='utf-8-sig') as f:
+            script = f.read()
+            assert 'testRoutine' not in script


### PR DESCRIPTION
This PR allows routines to be disabled via a context menu entry.

Note that because of the  way PsychoPy adds routines to the flow, there is currently no easy way to allow users to disable individual representations of the same routine. If a routine is
placed in the flow multiple times, disabling one of them will disable _all_ occurrences.

More background info on this:
When adding a routine to the flow, PsychoPy simply adds this routine to a list. When adding another representation of the same routine to the flow, effectively the very same object will get added again -- they both point to the same routine object in memory. Modifying one will automatically alter the other too (since, well, it is not "another", but "the same" routine). To fix this, we'd have to come up with a solution to store metadata for each representation of a routine in the flow individually.

![screenrecording20190301at1](https://user-images.githubusercontent.com/2046265/53638501-bbe0b380-3c26-11e9-9c8c-c960e2434220.gif)

cc @m-macaskill 