### PR TITLE
ENH: remove deprecated method: SetToolTipString()

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -285,9 +285,9 @@ class PreferencesDlg(wx.Dialog):
             if len(hints):
                 # use only one comment line, from right above the pref
                 hint = hints[-1].lstrip().lstrip('#').lstrip()
-                ctrls.valueCtrl.SetToolTipString(_translate(hint))
+                ctrls.valueCtrl.SetToolTip(wx.ToolTip(_translate(hint)))
             else:
-                ctrls.valueCtrl.SetToolTipString('')
+                ctrls.valueCtrl.SetToolTip(wx.ToolTip(''))
 
             vertBox.Add(ctrlSizer)
         # size the panel and setup scrolling


### PR DESCRIPTION
SetToolTipString() raises following warning message when the Preference dialog is opened.

```
C:\Program Files (x86)\PsychoPy3\lib\site-packages\psychopy\app\preferencesDlg.py:288: wxPyDeprecationWarning: Call to deprecated item. Use SetToolTip instead.
  ctrls.valueCtrl.SetToolTipString(_translate(hint))
```

SetToolTip() has already been used at other places (e.g. coder\coder.py, pavlovia_ui\_base.py,...) and seems to work fine.  I tested my fix on Windows Python2.7, Python3.6 and Ubuntu Python3. There was no problem.