### PR TITLE
BF: Misc iohub fixes

### DIFF
--- a/psychopy/demos/coder/iohub/keyboardreactiontime.py
+++ b/psychopy/demos/coder/iohub/keyboardreactiontime.py
@@ -8,7 +8,6 @@ Keyboard Reaction Time Calculation shown within a line length matching task.
 
 Initial Version: May 6th, 2013, Sol Simpson
 """
-
 from __future__ import absolute_import, division, print_function
 
 from psychopy import  core,  visual
@@ -18,8 +17,7 @@ from math import fabs
 io = launchHubServer(psychopy_monitor_name='default')
 display = io.devices.display
 win = visual.Window(display.getPixelResolution(), monitor='default',
-    units='pix', #color=[128, 128, 128], colorSpace='rgb255',
-    fullscr=True, allowGUI=False)
+    units='pix', fullscr=True, allowGUI=False)
 
 # save some 'dots' during the trial loop
 keyboard = io.devices.keyboard
@@ -66,11 +64,8 @@ while spacebar_rt == 0.0 or last_len >=  win.size[0]:
 
     for s in stim:
         s.draw()
-    # Clear all events from the ioHub Global event buffer only.
-    io.clearEvents()
+        
     win.flip()
-
-io.clearEvents('all')
 
 results = "Did you Forget to Press the Spacebar?\n"
 if spacebar_rt > 0.0:
@@ -86,10 +81,7 @@ for s in stim:
     s.draw()
 win.flip()
 
-io.clearEvents('all')
-while not keyboard.getPresses():
-    io.wait(0.05)
-    io.clearEvents()
+keyboard.waitForPresses(maxWait=10.0)
 
 win.close()
 core.quit()

--- a/psychopy/iohub/client/keyboard.py
+++ b/psychopy/iohub/client/keyboard.py
@@ -88,10 +88,9 @@ class KeyboardEvent(ioEvent):
         return self._modifiers
 
     def __str__(self):
-        return '%s, key: %s char: %s, modifiers: %s' % (
-            ioEvent.__str__(self), unicode(self.key, 'utf-8'),
-            unicode(self.char, 'utf-8'),
-            unicode(self.modifiers, 'utf-8'))
+        pstr = ioEvent.__str__(self)
+        return '{}, key: {} char: {}, modifiers: {}'.format(pstr, self.key,
+                self.char, self.modifiers)
 
     def __eq__(self, v):
         if isinstance(v, KeyboardEvent):

--- a/psychopy/iohub/datastore/__init__.py
+++ b/psychopy/iohub/datastore/__init__.py
@@ -336,8 +336,6 @@ class DataStoreFile(object):
             data = temp
             try:
                 etable = self.TABLES['EXP_CV']
-                #print2err('data: ',data,' ',type(data))
-
                 for i, d in enumerate(data):
                     if isinstance(d, (list, tuple)):
                         data[i] = tuple(d)
@@ -409,7 +407,6 @@ class DataStoreFile(object):
                 np_events.append(tuple(event))
 
             np_array = np.array(np_events, dtype=eventClass.NUMPY_DTYPE)
-            #ioHub.print2err('np_array:',np_array)
             etable.append(np_array)
             self.bufferedFlush(len(np_events))
         except ioHubError as e:
@@ -503,48 +500,3 @@ class SessionMetaData(tables.IsDescription):
     comments  = StringCol(256, pos=5)
     user_variables = StringCol(2048, pos=6) # will hold json encoded version of user variable dict for session
 
-
-"""
-# NEEDS TO BE COMPLETED
-class ParticipantMetaData(IsDescription):
-    participant_id = UInt32Col(pos=1)
-    participant_code = StringCol(8,pos=2)
-
-# NEEDS TO BE COMPLETED
-class SiteMetaData(IsDescription):
-    site_id = UInt32Col(pos=1)
-    site_code = StringCol(8,pos=2)
-
-# NEEDS TO BE COMPLETED
-class MemberMetaData(IsDescription):
-    member_id =UInt32Col(pos=1)
-    username = StringCol(16,pos=2)
-    password = StringCol(16,pos=3)
-    email = StringCol(32,pos=4)
-    secretPhrase = StringCol(64,pos=5)
-    dateAdded = Int64Col(pos=6)
-
-# NEEDS TO BE COMPLETED
-class DeviceInformation(IsDescription):
-    device_id = UInt32Col(pos=1)
-    device_code = StringCol(7,pos=2)
-    name =StringCol(32,pos=3)
-    manufacturer =StringCol(32,pos=3)
-
-# NEEDS TO BE COMPLETED
-class CalibrationAreaInformation(IsDescription):
-    cal_id = UInt32Col(pos=1)
-
-# NEEDS TO BE COMPLETED
-class EyeTrackerInformation(IsDescription):
-    et_id = UInt32Col(pos=1)
-
-# NEEDS TO BE COMPLETED
-class EyeTrackerSessionConfiguration(IsDescription):
-    et_config_id = UInt32Col(pos=1)
-
-# NEEDS TO BE COMPLETED
-class ApparatusSetupMetaData(IsDescription):
-    app_setup_id = UInt32Col(pos=1)
-
-"""

--- a/psychopy/iohub/devices/__init__.py
+++ b/psychopy/iohub/devices/__init__.py
@@ -173,33 +173,33 @@ class Device(ioObject):
     _baseDataTypes = ioObject._baseDataTypes
     _newDataTypes = [
         # The name given to this device instance. User Defined. Should be
-        ('name', np.str, 24),
+        ('name', '|S24'),
         # unique within all devices of the same type_id for a given experiment.
         # For devices that support multiple connected to the computer at once,
         # with some devices the device_number can be used to select which
         # device ot use.
         ('device_number', np.uint8),
         # The name of the manufacturer for the device being used.
-        ('manufacturer_name', np.str_, 64),
+        ('manufacturer_name', '|S64'),
         # The string name of the device model being used. Some devices support
         # different models.
-        ('model_name', np.str_, 32),
+        ('model_name', '|S32'),
         # The device model number being used. Some devices support different
         # models.
-        ('model_number', np.str_, 32),
+        ('model_number', '|S32'),
         # Used to optionally store the devices software / API version being
         # used by the ioHub Device
-        ('software_version', np.str_, 8),
+        ('software_version', '|S8'),
         # Used to optionally store the devices hardware version
-        ('hardware_version', np.str_, 8),
+        ('hardware_version', '|S8'),
         # Used to optionally store the devices firmware
-        ('firmware_version', np.str_, 8),
+        ('firmware_version', '|S8'),
         # The serial number for the device being used. Serial numbers 'should'
         # be unique across all devices of the same brand and model.
-        ('serial_number', np.str_, 32),
+        ('serial_number', '|S32'),
         # The serial number for the device being used. Serial numbers 'should'
         # be unique across all devices of the same brand and model.
-        ('manufacture_date', np.str_, 10),
+        ('manufacture_date', '|S10'),
         # The maximum size of the device level event buffer for this
         ('event_buffer_length', np.uint16)
         # device instance. If the buffer becomes full, when a new event

--- a/psychopy/iohub/devices/experiment/__init__.py
+++ b/psychopy/iohub/devices/experiment/__init__.py
@@ -122,8 +122,8 @@ class MessageEvent(DeviceEvent):
 
     _newDataTypes = [
         ('msg_offset', N.float32),
-        ('category', N.str, 32),
-        ('text', N.str, 128)
+        ('category','|S32'),
+        ('text', '|S128')
     ]
     __slots__ = [e[0] for e in _newDataTypes]
 
@@ -244,7 +244,7 @@ class LogEvent(DeviceEvent):
 
     _newDataTypes = [
         ('log_level', N.uint8),
-        ('text', N.str, 128)
+        ('text', '|S128')
     ]
     __slots__ = [e[0] for e in _newDataTypes]
 

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -142,7 +142,7 @@ class KeyboardInputEvent(DeviceEvent):
 
                      # a string representation of what key was pressed. This
                      # will be based on a mapping table
-                     ('key', N.str, 12),
+                     ('key', '|S12'),
 
                      # indicates what modifier keys were active when the key
                      # was pressed.
@@ -155,7 +155,7 @@ class KeyboardInputEvent(DeviceEvent):
                      # Holds the unicode char value of the key, if available.
                      # Only keys that also have a visible glyph will be set for
                      # this field.
-                     ('char', N.str, 4),
+                     ('char', '|S4'),
 
                      # for keyboard release events, the duration from key press
                      # event (if one was registered)

--- a/psychopy/iohub/devices/mcu/iosync/__init__.py
+++ b/psychopy/iohub/devices/mcu/iosync/__init__.py
@@ -79,7 +79,7 @@ getTime = Computer.getTime
 class MCU(Device):
     """"""
     DEVICE_TIMEBASE_TO_SEC = 1.0
-    _newDataTypes = [('serial_port', np.str, 32),
+    _newDataTypes = [('serial_port', '|S32'),
                      ('time_sync_interval', np.float32)]
     EVENT_CLASS_NAMES = [
         'AnalogInputEvent',

--- a/psychopy/iohub/devices/serial/__init__.py
+++ b/psychopy/iohub/devices/serial/__init__.py
@@ -41,7 +41,7 @@ class Serial(Device):
     }
 
     DEVICE_TIMEBASE_TO_SEC = 1.0
-    _newDataTypes = [('port', N.str, 32), ('baud', N.str, 32), ]
+    _newDataTypes = [('port', '|S32'), ('baud', '|S32'), ]
     EVENT_CLASS_NAMES = ['SerialInputEvent', 'SerialByteChangeEvent']
     DEVICE_TYPE_ID = DeviceConstants.SERIAL
     DEVICE_TYPE_STRING = 'SERIAL'
@@ -723,8 +723,8 @@ class Pstbox(Serial):
 
 class SerialInputEvent(DeviceEvent):
     _newDataTypes = [
-        ('port', N.str, 32),
-        ('data', N.str, 256)
+        ('port', '|S32'),
+        ('data', '|S256')
     ]
     PARENT_DEVICE = Serial
     EVENT_TYPE_ID = EventConstants.SERIAL_INPUT
@@ -738,7 +738,7 @@ class SerialInputEvent(DeviceEvent):
 
 class SerialByteChangeEvent(DeviceEvent):
     _newDataTypes = [
-        ('port', N.str, 32),
+        ('port', '|S32'),
         ('prev_byte', N.uint8),
         ('current_byte', N.uint8)
     ]
@@ -755,11 +755,11 @@ class SerialByteChangeEvent(DeviceEvent):
 class PstboxButtonEvent(DeviceEvent):
     # Add new fields for PstboxButtonEvent
     _newDataTypes = [
-        ('port', N.str, 32),  # could be needed to identify events
+        ('port', '|S32'),  # could be needed to identify events
                               # from >1 connected button box; if that is
                               # ever supported.
         ('button', N.uint8),
-        ('button_event', N.str, 7)
+        ('button_event', '|S7')
     ]
 
     PARENT_DEVICE = Pstbox

--- a/psychopy/iohub/devices/serial/default_pstbox.yaml
+++ b/psychopy/iohub/devices/serial/default_pstbox.yaml
@@ -50,7 +50,7 @@ serial.Pstbox:
     #   attribute of events that have a parent device that is polled often can be used to
     #   determine the actual polling rate being achieved by the ioHub Process.
     device_timer:
-        interval: 0.0005
+        interval: 0.001
 
     # enable: Specifies if the device should be enabled by ioHub and monitored
     #   for events.

--- a/psychopy/iohub/devices/touch/hw/elo/__init__.py
+++ b/psychopy/iohub/devices/touch/hw/elo/__init__.py
@@ -177,8 +177,8 @@ class Touch(TouchDevice):
         self._tx(qpkt._packet_bytes)
         return qpkt
 
-    def _rx(self, async=False, num_bytes=10):
-        if async:
+    def _rx(self, rasync=False, num_bytes=10):
+        if rasync:
             while self._serial_port_hw.inWaiting() > 0:
                 self._rx_data += self._serial_port_hw.read(
                     self._serial_port_hw.inWaiting())

--- a/psychopy/iohub/devices/xinput/__init__.py
+++ b/psychopy/iohub/devices/xinput/__init__.py
@@ -689,7 +689,7 @@ class GamepadStateChangeEvent(DeviceEvent):
         # Use buttons to get a list of the text representation for
         # each button that was pressed in list form
         # placeholder for button name list when event is viewed as NamedTuple
-        ('buttons', N.str, 1),
+        ('buttons', '|S1'),
 
         # Thumbsticks are represented in normalized units between 0.0 and 1.0 for x direction, y direction
         # and magnitude of the thumbstick. x and y are the horizontal and vertical position of the stick

--- a/psychopy/iohub/removed/util/targetpositionsequence.py
+++ b/psychopy/iohub/removed/util/targetpositionsequence.py
@@ -472,9 +472,9 @@ class TargetPosSequenceStim(object):
     binocular_sample_message_element = [
         ('targ_pos_ix', np.int),
         ('last_msg_time', np.float32),
-        ('last_msg_type', np.str, max_msg_type_length),
+        ('last_msg_type', '|S%d'%(max_msg_type_length)),
         ('next_msg_time', np.float32),
-        ('next_msg_type', np.str, max_msg_type_length),
+        ('next_msg_type', '|S%d'%(max_msg_type_length)),
         ('targ_pos_x', np.float32),
         ('targ_pos_y', np.float32),
         ('targ_state', np.int),
@@ -491,9 +491,9 @@ class TargetPosSequenceStim(object):
     monocular_sample_message_element = [
         ('targ_pos_ix', np.int),
         ('last_msg_time', np.float32),
-        ('last_msg_type', np.str, max_msg_type_length),
+        ('last_msg_type', '|S%d'%(max_msg_type_length)),
         ('next_msg_time', np.float32),
-        ('next_msg_type', np.str, max_msg_type_length),
+        ('next_msg_type', '|S%d'%(max_msg_type_length)),
         ('targ_pos_x', np.float32),
         ('targ_pos_y', np.float32),
         ('targ_state', np.int),

--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -486,10 +486,10 @@ class DeviceMonitor(Greenlet):
             stime = ctime()
             self.device._poll()
             i = self.sleep_interval - (ctime() - stime)
-            if i > 0.0:
+            if i > 0.001:
                 gevent.sleep(i)
             else:
-                gevent.sleep(0.0)
+                gevent.sleep(0.001)
 
     def __del__(self):
         self.device = None
@@ -625,7 +625,7 @@ class ioServer(object):
                 self._running = False
                 break
             dur = sleep_interval - (Computer.getTime() - stime)
-            gevent.sleep(max(0.0, dur))
+            gevent.sleep(max(0.001, dur))
 
     def createNewMonitoredDevice(self, dev_cls_name, dev_conf):
         self._all_dev_conf_errors = dict()
@@ -869,7 +869,7 @@ class ioServer(object):
             stime = Computer.getTime()
             self.processDeviceEvents()
             dur = sleep_interval - (Computer.getTime() - stime)
-            gevent.sleep(max(0.0, dur))
+            gevent.sleep(max(0.001, dur))
 
     def processDeviceEvents(self):
         for device in self.devices:


### PR DESCRIPTION
Fixes iohub.datastore errors for records that had a string column.

The demos demo/coder/iohub/launchHub.py, keyboard.py, and mouse.py should now run on Windows 7 / 10 using Python 2.7 or 3.6. 

Note: due to changes in the gevent pkg implementation,  the smallest iohub device poll interval on windows is apparently 1 msec. If you put anything small than 0.001 in an iohub device interval field you get a warning from gevent and it is set to 1 msec. Devices that use callbacks are not affected by this. 
