### PR TITLE
BF: No longer assume user account to log-in

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2398,6 +2398,11 @@ class BuilderFrame(wx.Frame):
             return True
 
     def onPavloviaSync(self, evt=None):
+        user = self.getPavloviaUser()
+        if not user:
+            logging.error("Log in to sync a project from Builder.")
+            return
+
         if self._getExportPref('on sync'):
             self.fileExport(htmlPath=self._getHtmlPath(self.filename))
 
@@ -2408,7 +2413,13 @@ class BuilderFrame(wx.Frame):
         finally:
             self.enablePavloviaButton(['pavloviaSync', 'pavloviaRun'], True)
 
+
     def onPavloviaRun(self, evt=None):
+        user = self.getPavloviaUser()
+        if not user:
+            logging.error("Log in to run a project from Builder.")
+            return
+
         if self._getExportPref('on save'):
             self.fileSave()
             pavlovia_ui.syncProject(parent=self, project=self.project,
@@ -2449,6 +2460,24 @@ class BuilderFrame(wx.Frame):
             buttons = buttons.split(',')
         for button in buttons:
             self.toolbar.EnableTool(self.btnHandles[button.strip(' ')].GetId(), enable)
+
+    def getPavloviaUser(self):
+        """Check user is logged in. If not, create dlg for user to log in.
+
+        Returns
+        -------
+        bool
+            True if session exists or log in successful, False otherwise
+        """
+        pavSession = pavlovia.getCurrentSession()
+        if not pavSession.user:
+            userDlg = pavlovia_ui.user.UserEditor()
+            if userDlg.user:
+                logging.info("Logged in as: {}".format(userDlg.user.username))
+                return True
+            return False
+        logging.info("Logged in as: {}".format(pavSession.username))
+        return True
 
     def setPavloviaUser(self, user):
         # TODO: update user icon on button to user avatar

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2813,6 +2813,11 @@ class CoderFrame(wx.Frame):
 
     def onPavloviaSync(self, evt=None):
         """Push changes to project repo, or create new proj if proj is None"""
+        user = self.getPavloviaUser()
+        if not user:
+            logging.error("Log in to sync a project from Coder.")
+            return
+
         self.project = pavlovia.getProject(self.currentDoc.filename)
         self.fileSave(self.currentDoc.filename)  # Must save on sync else changes not pushed
         pavlovia_ui.syncProject(parent=self, project=self.project)
@@ -2821,6 +2826,25 @@ class CoderFrame(wx.Frame):
         # TODO: Allow user to run project from coder
         pass
 
+    def getPavloviaUser(self):
+        """Check user is logged in. If not, create dlg for user to log in.
+
+        Returns
+        -------
+        bool
+            True if session exists or log in successful, False otherwise
+        """
+        pavSession = pavlovia.getCurrentSession()
+        if not pavSession.user:
+            userDlg = pavlovia_ui.user.UserEditor()
+            if userDlg.user:
+                logging.info("Logged in as: {}".format(userDlg.user.username))
+                return True
+            return False
+        logging.info("Logged in as: {}".format(pavSession.username))
+        return True
+
     def setPavloviaUser(self, user):
         # TODO: update user icon on button to user avatar
         pass
+

--- a/psychopy/app/pavlovia_ui/__init__.py
+++ b/psychopy/app/pavlovia_ui/__init__.py
@@ -19,4 +19,4 @@ from psychopy.projects import pavlovia
 from .functions import *
 from .project import ProjectEditor, syncProject
 from ._base import PavloviaMiniBrowser
-from . import menu, project, search, toolbar
+from . import menu, project, search, toolbar, user

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1026,7 +1026,6 @@ class PavloviaProject(dict):
             perms = None  # not sure if this ever occurs when logged in
         return perms
 
-
 def getGitRoot(p):
     """Return None or the root path of the repository"""
     if not haveGit:
@@ -1045,6 +1044,8 @@ def getGitRoot(p):
         out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"],
                                       cwd=p)
         return out.strip().decode('utf-8')
+
+
 
 def getProject(filename):
     """Will try to find (locally synced) pavlovia Project for the filename
@@ -1067,23 +1068,7 @@ def getProject(filename):
                     namespaceName = url.split('gitlab.pavlovia.org/')[1]
                     namespaceName = namespaceName.replace('.git', '')
                     pavSession = getCurrentSession()
-                    if not pavSession.user:
-                        nameSpace = namespaceName.split('/')[0]
-                        if nameSpace in knownUsers:  # Log in if user is known
-                            login(nameSpace, rememberMe=True)
-                        else:  # Check whether project repo is found in any of the known users accounts
-                            for user in knownUsers:
-                                login(user)
-                                foundProject = False
-                                for repo in pavSession.findUserProjects():
-                                    if namespaceName in repo['id']:
-                                        foundProject = True
-                                        logging.info("Logging in as {}".format(user))
-                                        break
-                                if not foundProject:
-                                    logging.warning("Could not find {namespace} in your Pavlovia accounts. "
-                                                    "Logging in as {user}.".format(namespace=namespaceName,
-                                                                                   user=user))
+
                     if pavSession.user:
                         proj = pavSession.getProject(namespaceName,
                                                      repo=localRepo)


### PR DESCRIPTION
Following #2258, this fix now raises a user log-in dialog to make user
log-in if they are not logged in but want to sync or run a study from
PsychoPy. Previously in #2258, we attempted to make this non-intrusive
by finding usernames associated with projects, and make the log-in attempt
for them. This can cause problems when multiple user accounts exist
that contain forks/clones of the same projects - see discourse issue
https://discourse.psychopy.org/t/6955