### PR TITLE
BF: Set new remote URL when recreating projects in existing local repo

### DIFF
--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -608,6 +608,8 @@ class ProjectRecreator(wx.Dialog):
                                        localRoot=self.project.localRoot)
                 if editor.ShowModal() == wx.ID_OK:
                     self.project = editor.project
+                    # Update git config with new remote URL
+                    self.project.repo.git.remote("set-url", "origin", "{}".format(self.project['remoteHTTPS']))
                     return 1  # success!
                 else:
                     return -1  # user cancelled


### PR DESCRIPTION
This fixes an error where remote repos were not updated when
recreating projects in an existing repo. This was causing an error where
the project was not found remotely because the URL was pointing to a
different accounts remote repo, which may or may be visible due to
privacy settings. This scenario lead to users having to
keep recreating their project locally on every sync.