### PR TITLE
ENH: Flip at the very end of a Builder experiment

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -747,6 +747,11 @@ class SettingsComponent(object):
     def writeEndCode(self, buff):
         """Write code for end of experiment (e.g. close log file).
         """
+        code = ('\n# Flip one final time so any remaining win.callOnFlip() \n'
+                '# and win.timeOnFlip() tasks get executed before quitting\n'
+                'win.flip()\n\n')
+        buff.writeIndentedLines(code)
+
         buff.writeIndented("# these shouldn't be strictly necessary "
                            "(should auto-save)\n")
         if self.params['Save wide csv file'].val:

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -162,3 +162,11 @@ class TestComponents(object):
                             print(mismatch.encode('utf8'))
 
         assert not err
+
+
+@pytest.mark.components
+def test_flip_before_shutdown_in_settings_component():
+    exp = experiment.Experiment()
+    script = exp.writeScript()
+
+    assert 'Flip one final time' in script


### PR DESCRIPTION
By flipping one last time after the very last routine of an experiment has finished execution, we ensure that `win.callOnFlip()` and `win.timeOnFlip()` calls will take effect even at the end of an experiment (they used to have no effect as we simply didn't flip, see GH-2169).