### PR TITLE
DOCS/RF: misc documentation fixes and module organization for viewtools 

### DIFF
--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -19,49 +19,49 @@ Windows and and display devices:
 
 Commonly used:
 
-	* :class:`.ImageStim` to show images
-	* :class:`.TextStim` to show text
-	* :class:`.TextBox` rewrite of TextStim (faster/better but only monospace fonts)
+    * :class:`.ImageStim` to show images
+    * :class:`.TextStim` to show text
+    * :class:`.TextBox` rewrite of TextStim (faster/better but only monospace fonts)
 
 Shapes (all special classes of :class:`ShapeStim`):
 
 	* :class:`.ShapeStim` to draw shapes with arbitrary numbers of vertices
-	* :class:`.Rect` to show rectangles
-	* :class:`.Circle` to show circles
-	* :class:`.Polygon` to show polygons
-	* :class:`.Line` to show a line
+    * :class:`.Rect` to show rectangles
+    * :class:`.Circle` to show circles
+    * :class:`.Polygon` to show polygons
+    * :class:`.Line` to show a line
 
 Images and patterns:
 
-	* :class:`.ImageStim` to show images
-	* :class:`.SimpleImageStim` to show images without bells and whistles
-	* :class:`.GratingStim` to show gratings
-	* :class:`.RadialStim` to show annulus, a rotating wedge, a checkerboard etc
-	* :class:`.NoiseStim` to show filtered noise patterns of various forms
-	* :class:`.EnvelopeGrating` to generate second-order stimuli (gratings that can have a carrier and envelope)
+    * :class:`.ImageStim` to show images
+    * :class:`.SimpleImageStim` to show images without bells and whistles
+    * :class:`.GratingStim` to show gratings
+    * :class:`.RadialStim` to show annulus, a rotating wedge, a checkerboard etc
+    * :class:`.NoiseStim` to show filtered noise patterns of various forms
+    * :class:`.EnvelopeGrating` to generate second-order stimuli (gratings that can have a carrier and envelope)
 
 Multiple stimuli:
 
-	* :class:`.ElementArrayStim` to show many stimuli of the same type
-	* :class:`.DotStim` to show and control movement of dots
+    * :class:`.ElementArrayStim` to show many stimuli of the same type
+    * :class:`.DotStim` to show and control movement of dots
 
 Other stimuli:
 
-	* :class:`.MovieStim` to show movies
-	* :class:`.Slider` a new improved class to collect ratings
-	* :class:`.RatingScale` to collect ratings
-	* :class:`.CustomMouse` to change the cursor in windows with GUI. OBS: will be deprecated soon
+    * :class:`.MovieStim` to show movies
+    * :class:`.Slider` a new improved class to collect ratings
+    * :class:`.RatingScale` to collect ratings
+    * :class:`.CustomMouse` to change the cursor in windows with GUI. OBS: will be deprecated soon
 
 Meta stimuli (stimuli that operate on other stimuli):
 
-	* :class:`.BufferImageStim` to make a faster-to-show "screenshot" of other stimuli
-	* :class:`.Aperture` to restrict visibility area of other stimuli
+    * :class:`.BufferImageStim` to make a faster-to-show "screenshot" of other stimuli
+    * :class:`.Aperture` to restrict visibility area of other stimuli
 
 Helper functions:
 
-  * :ref:`psychopy.visual.filters` for creating grating textures and Gaussian masks etc.
-  * :ref:`psychopy.tools.visualhelperfunctions` for tests about whether one stimulus contains another
-  * :mod:`~psychopy.tools.unittools` to convert deg<->radians
-  * :mod:`~psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
-  * :mod:`~psychopy.tools.colorspacetools` to convert between supported color spaces
-  * :mod:`~psychopy.tools.viewtools` to work with view projections
+    * :mod:`~psychopy.visual.filters` for creating grating textures and Gaussian masks etc.
+    * :mod:`~psychopy.tools.visualhelperfunctions` for tests about whether one stimulus contains another
+    * :mod:`~psychopy.tools.unittools` to convert deg<->radians
+    * :mod:`~psychopy.tools.monitorunittools` to convert cm<->pix<->deg etc.
+    * :mod:`~psychopy.tools.colorspacetools` to convert between supported color spaces
+    * :mod:`~psychopy.tools.viewtools` to work with view projections

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -167,9 +167,8 @@ def generalizedPerspectiveProjection(posBottomLeft,
     Examples
     --------
 
-    Computing a projection and view matrix::
+    Computing a projection and view matrices::
 
-        # eyePos can come from motion capture data or is fixed
         projMatrix, viewMatrix = viewtools.generalizedPerspectiveProjection(
             posBottomLeft, posBottomRight, posTopLeft, eyePos)
         # set the window matrices
@@ -177,6 +176,20 @@ def generalizedPerspectiveProjection(posBottomLeft,
         win.viewMatrix = viewMatrix
         # before rendering
         win.applyEyeTransform()
+
+    Stereo-pair rendering example from Kooima (2009)::
+
+        # configuration of screen and eyes
+        posBottomLeft = [-1.5, -0.75, -18.0]
+        posBottomRight = [1.5, -0.75, -18.0]
+        posTopLeft = [-1.5, 0.75, -18.0]
+        posLeftEye = [-1.25, 0.0, 0.0]
+        posRightEye = [1.25, 0.0, 0.0]
+        # create projection and view matrices
+        leftProjMatrix, leftViewMatrix = generalizedPerspectiveProjection(
+            posBottomLeft, posBottomRight, posTopLeft, posLeftEye)
+        rightProjMatrix, rightViewMatrix = = generalizedPerspectiveProjection(
+            posBottomLeft, posBottomRight, posTopLeft, posRightEye)
 
     """
     # convert everything to numpy arrays

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -8,6 +8,10 @@
 # Copyright (C) 2018 Jonathan Peirce
 # Distributed under the terms of the GNU General Public License (GPL).
 
+__all__ = ['Frustum', 'computeFrustum', 'generalizedPerspectiveProjection',
+           'orthoProjectionMatrix', 'perspectiveProjectionMatrix', 'lookAt',
+           'pointToNdc']
+
 import numpy as np
 from collections import namedtuple
 

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -124,11 +124,11 @@ def generalizedPerspectiveProjection(posBottomLeft,
                                      nearClip=0.01,
                                      farClip=100.0):
     """Generalized derivation of projection and view matrices based on the
-    physical configuration of the display system.
+    physical configuration of the display system. This is useful for cases where
+    the screen and observer and not necessarily
 
     This implementation is based on Robert Kooima's 'Generalized Perspective
-    Projection' method
-    (see http://csc.lsu.edu/~kooima/articles/genperspective/).
+    Projection' method [1]_.
 
     Parameters
     ----------
@@ -159,6 +159,11 @@ def generalizedPerspectiveProjection(posBottomLeft,
     The resulting projection frustums are off-axis relative to the center of the
     display. The returned matrices are row-major. Values are floats with 32-bits
     of precision stored as a contiguous (C-order) array.
+
+    References
+    ----------
+    .. [1] Kooima, R. (2009). Generalized perspective projection. J. Sch.
+    Electron. Eng. Comput. Sci.
 
     """
     # convert everything to numpy arrays
@@ -367,20 +372,18 @@ def pointToNdc(wcsPos, viewMatrix, projectionMatrix):
 
     Notes
     -----
-    The point is not visible, falling outside of the viewing frustum, if the
-    returned coordinates fall outside of -1 and 1 along any dimension.
-
-    In the rare instance the point falls directly on the eye in world space
-    where the frustum converges to a point (singularity), the divisor will be
-    zero during perspective division. To avoid this, the divisor is 'bumped' to
-    machine epsilon for the 'float32' type.
-
-    This function assumes the display area is rectilinear. Any distortion or
-    warping applied in normalized device or viewport space is not considered.
+        - The point is not visible, falling outside of the viewing frustum, if
+        the returned coordinates fall outside of -1 and 1 along any dimension.
+        - In the rare instance the point falls directly on the eye in world
+        space where the frustum converges to a point (singularity), the divisor
+        will be zero during perspective division. To avoid this, the divisor is
+        'bumped' to machine epsilon for the 'float32' type.
+        - This function assumes the display area is rectilinear. Any distortion
+        or warping applied in normalized device or viewport space is not
+        considered.
 
     Examples
     --------
-
     Determine if a point is visible::
 
         point = (0.0, 0.0, 10.0)  # behind the observer

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -63,12 +63,13 @@ def computeFrustum(scrWidth,
 
     Notes
     -----
-    The view point must be transformed for objects to appear correctly. Offsets
-    in the X-direction must be applied +/- eyeOffset to account for inter-ocular
-    separation. A transformation in the Z-direction must be applied to account
-    for screen distance. These offsets MUST be applied to the GL_MODELVIEW
-    matrix, not the GL_PROJECTION matrix! Doing so may break lighting
-    calculations.
+
+    * The view point must be transformed for objects to appear correctly.
+      Offsets in the X-direction must be applied +/- eyeOffset to account for
+      inter-ocular separation. A transformation in the Z-direction must be
+      applied to accountfor screen distance. These offsets MUST be applied to
+      the GL_MODELVIEW matrix, not the GL_PROJECTION matrix! Doing so may break
+      lighting calculations.
 
     Examples
     --------
@@ -160,9 +161,11 @@ def generalizedPerspectiveProjection(posBottomLeft,
 
     Notes
     -----
-    The resulting projection frustums are off-axis relative to the center of the
-    display. The returned matrices are row-major. Values are floats with 32-bits
-    of precision stored as a contiguous (C-order) array.
+    * The resulting projection frustums are off-axis relative to the center of
+      the display.
+
+    * The returned matrices are row-major. Values are floats with 32-bits
+      of precision stored as a contiguous (C-order) array.
 
     References
     ----------
@@ -171,7 +174,6 @@ def generalizedPerspectiveProjection(posBottomLeft,
 
     Examples
     --------
-
     Computing a projection and view matrices for a window::
 
         projMatrix, viewMatrix = viewtools.generalizedPerspectiveProjection(
@@ -270,8 +272,9 @@ def orthoProjectionMatrix(left, right, bottom, top, nearClip, farClip):
 
     Notes
     -----
-    The returned matrix is row-major. Values are floats with 32-bits of
-    precision stored as a contiguous (C-order) array.
+
+    * The returned matrix is row-major. Values are floats with 32-bits of
+      precision stored as a contiguous (C-order) array.
 
     """
     projMat = np.zeros((4, 4), np.float32)
@@ -316,8 +319,9 @@ def perspectiveProjectionMatrix(left, right, bottom, top, nearClip, farClip):
 
     Notes
     -----
-    The returned matrix is row-major. Values are floats with 32-bits of
-    precision stored as a contiguous (C-order) array.
+
+    * The returned matrix is row-major. Values are floats with 32-bits of
+      precision stored as a contiguous (C-order) array.
 
     """
     projMat = np.zeros((4, 4), np.float32)
@@ -356,8 +360,9 @@ def lookAt(eyePos, centerPos, upVec=(0.0, 1.0, 0.0)):
 
     Notes
     -----
-    The returned matrix is row-major. Values are floats with 32-bits of
-    precision stored as a contiguous (C-order) array.
+
+    * The returned matrix is row-major. Values are floats with 32-bits of
+      precision stored as a contiguous (C-order) array.
 
     """
     eyePos = np.asarray(eyePos, np.float32)
@@ -403,15 +408,17 @@ def pointToNdc(wcsPos, viewMatrix, projectionMatrix):
 
     Notes
     -----
-        - The point is not visible, falling outside of the viewing frustum, if
-        the returned coordinates fall outside of -1 and 1 along any dimension.
-        - In the rare instance the point falls directly on the eye in world
-        space where the frustum converges to a point (singularity), the divisor
-        will be zero during perspective division. To avoid this, the divisor is
-        'bumped' to machine epsilon for the 'float32' type.
-        - This function assumes the display area is rectilinear. Any distortion
-        or warping applied in normalized device or viewport space is not
-        considered.
+
+    * The point is not visible, falling outside of the viewing frustum, if the
+      returned coordinates fall outside of -1 and 1 along any dimension.
+
+    * In the rare instance the point falls directly on the eye in world
+      space where the frustum converges to a point (singularity), the divisor
+      will be zero during perspective division. To avoid this, the divisor is
+      'bumped' to 1e-5.
+
+    * This function assumes the display area is rectilinear. Any distortion or
+      warping applied in normalized device or viewport space is not considered.
 
     Examples
     --------

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -195,7 +195,7 @@ def generalizedPerspectiveProjection(posBottomLeft,
         # create projection and view matrices
         leftProjMatrix, leftViewMatrix = generalizedPerspectiveProjection(
             posBottomLeft, posBottomRight, posTopLeft, posLeftEye)
-        rightProjMatrix, rightViewMatrix = = generalizedPerspectiveProjection(
+        rightProjMatrix, rightViewMatrix = generalizedPerspectiveProjection(
             posBottomLeft, posBottomRight, posTopLeft, posRightEye)
 
     """

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -331,7 +331,7 @@ def perspectiveProjectionMatrix(left, right, bottom, top, nearClip, farClip):
     return projMat
 
 
-def lookAt(eyePos, centerPos, upVec):
+def lookAt(eyePos, centerPos, upVec=(0.0, 1.0, 0.0)):
     """Create a transformation matrix to orient a view towards some point. Based
     on the same algorithm as 'gluLookAt'. This does not generate a projection
     matrix, but rather the matrix to transform the observer's view in the scene.
@@ -345,8 +345,8 @@ def lookAt(eyePos, centerPos, upVec):
         Eye position in the scene.
     centerPos : list of float or ndarray
         Position of the object center in the scene.
-    upVec : list of float or ndarray
-        Vector defining the up vector.
+    upVec : list of float or ndarray, optional
+        Vector defining the up vector. Default is +Y is up.
 
     Returns
     -------
@@ -445,7 +445,7 @@ def pointToNdc(wcsPos, viewMatrix, projectionMatrix):
     clipCoords = viewProjMatrix.dot(wcsVec)  # convert to clipping space
 
     # handle the singularity where perspective division will fail
-    if clipCoords[3] < 0.0001:
-        clipCoords[3] = np.finfo(np.float32).eps
+    if clipCoords[3] < 1e-05:
+        clipCoords[3] = 1e-05
 
     return clipCoords[:3] / clipCoords[3]  # xyz / w

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -124,8 +124,7 @@ def generalizedPerspectiveProjection(posBottomLeft,
                                      nearClip=0.01,
                                      farClip=100.0):
     """Generalized derivation of projection and view matrices based on the
-    physical configuration of the display system. This is useful for cases where
-    the screen and observer and not necessarily
+    physical configuration of the display system.
 
     This implementation is based on Robert Kooima's 'Generalized Perspective
     Projection' method [1]_.
@@ -164,6 +163,20 @@ def generalizedPerspectiveProjection(posBottomLeft,
     ----------
     .. [1] Kooima, R. (2009). Generalized perspective projection. J. Sch.
     Electron. Eng. Comput. Sci.
+
+    Examples
+    --------
+
+    Computing a projection and view matrix::
+
+        # eyePos can come from motion capture data or is fixed
+        projMatrix, viewMatrix = viewtools.generalizedPerspectiveProjection(
+            posBottomLeft, posBottomRight, posTopLeft, eyePos)
+        # set the window matrices
+        win.projectionMatrix = projMatrix
+        win.viewMatrix = viewMatrix
+        # before rendering
+        win.applyEyeTransform()
 
     """
     # convert everything to numpy arrays

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -171,7 +171,7 @@ def generalizedPerspectiveProjection(posBottomLeft,
     Examples
     --------
 
-    Computing a projection and view matrices::
+    Computing a projection and view matrices for a window::
 
         projMatrix, viewMatrix = viewtools.generalizedPerspectiveProjection(
             posBottomLeft, posBottomRight, posTopLeft, eyePos)

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -110,6 +110,7 @@ def computeFrustum(scrWidth,
         win.applyViewTransform()  # call before drawing
 
     """
+    # mdc - uses display size instead of the horizontal FOV gluPerspective needs
     d = scrWidth * (convergeOffset + scrDist)
     ratio = nearClip / float((convergeOffset + scrDist))
 


### PR DESCRIPTION
* Cleaned up the documentation for 'viewtools' to make it easier to follow. 
* Added examples for various functions showing most common use cases.
* Defined an `__all__` statement. 
* Made 'up' optional for 'lookAt'.
* More sensible handling of singularity condition in 'pointToNdc'.
* Added APA reference for 'generalizedPerspectiveProjection'.
* Added 'See also' entries for related functions. 