### PR TITLE
DOCS/RF: Documentation fixes for colorspacetools

### DIFF
--- a/docs/source/api/tools/colorspacetools.rst
+++ b/docs/source/api/tools/colorspacetools.rst
@@ -15,6 +15,10 @@
     lms2rgb
     rgb2lms
     dkl2rgb
+    cielab2rgb
+    cielch2rgb
+    srgbTF
+    rec709TF
     
 Function details
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -26,3 +30,7 @@ Function details
 .. autofunction:: lms2rgb
 .. autofunction:: rgb2lms
 .. autofunction:: dkl2rgb
+.. autofunction:: cielab2rgb
+.. autofunction:: cielch2rgb
+.. autofunction:: srgbTF
+.. autofunction:: rec709TF

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -35,7 +35,7 @@ def unpackColors(colors):  # used internally, not exported by __all__
     Returns
     -------
     tuple
-        Nx3 ndarray of converted colors, original shape, original dims
+        Nx3 ndarray of converted colors, original shape, original dims.
 
     """
     # handle the various data types and shapes we might get as input
@@ -173,7 +173,7 @@ def cielab2rgb(lab,
         be passed by specifying them as keyword arguments. Gamma functions that
         come with PsychoPy are 'srgbTF' and 'rec709TF', see their docs for more
         information.
-    clip : boolean
+    clip : bool
         Make all output values representable by the display. However, colors
         outside of the display's gamut may not be valid!
 

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -5,7 +5,7 @@
 # Copyright (C) 2018 Jonathan Peirce
 # Distributed under the terms of the GNU General Public License (GPL).
 
-"""Functions and classes related to color space conversion
+"""Functions and classes related to color space conversion.
 """
 from __future__ import absolute_import, division, print_function
 

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -9,14 +9,16 @@
 """
 from __future__ import absolute_import, division, print_function
 
+__all__ = ['srgbTF', 'rec709TF', 'cielab2rgb', 'cielch2rgb', 'dkl2rgb',
+           'dklCart2rgb', 'rgb2dklCart', 'hsv2rgb', 'rgb2lms', 'lms2rgb']
+
 from past.utils import old_div
 import numpy
-
 from psychopy import logging
 from psychopy.tools.coordinatetools import sph2cart
 
 
-def unpackColors(colors):
+def unpackColors(colors):  # used internally, not exported by __all__
     """Reshape an array of color values to Nx3 format.
 
     Many color conversion routines operate on color data in Nx3 format, where


### PR DESCRIPTION
Just doing some documentation work on modules I've contributed to in the past. Added __all__statment to keep internal functions from gunking up the namespace.

Also, it might be helpful to consider using Colour Science for Python libraries (https://www.colour-science.org/) to handle future colorspace conversion routines. 