### PR TITLE
BF: Make waitBlanking set the GLFW window's swap interval.

### DIFF
--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -144,8 +144,6 @@ class GLFWBackend(BaseBackend):
             Framebuffer (back buffer) depth bits.
         stencilBits : int
             Framebuffer (back buffer) stencil bits.
-        swapInterval : int
-            Screen updates before swapping buffers.
         winTitle : str
             Optional window title string.
         *args
@@ -180,7 +178,7 @@ class GLFWBackend(BaseBackend):
         win.refreshHz = int(kwargs.get('refreshHz', 60))
         win.depthBits = int(kwargs.get('depthBits', 8))
         win.stencilBits = int(kwargs.get('stencilBits', 8))
-        win.swapInterval = int(kwargs.get('swapInterval', 1))  # vsync ON if 1
+        # win.swapInterval = int(kwargs.get('swapInterval', 1))  # vsync ON if 1
 
         # get monitors, with GLFW the primary display is ALWAYS at index 0
         allScrs = glfw.get_monitors()
@@ -341,7 +339,7 @@ class GLFWBackend(BaseBackend):
         glfw.set_char_mods_callback(self.winHandle, event._onGLFWText)
 
         # set swap interval to manual setting, independent of waitBlanking
-        self.setSwapInterval(win.swapInterval)
+        self.setSwapInterval(int(kwargs.get('swapInterval', 1)))
 
         # give the window class GLFW specific methods
         win.setMouseType = self.setMouseType

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -142,6 +142,8 @@ class GLFWBackend(BaseBackend):
             Refresh rate in Hertz.
         depthBits : int,
             Framebuffer (back buffer) depth bits.
+        swapInterval : int
+            Swap interval for the current OpenGL context.
         stencilBits : int
             Framebuffer (back buffer) stencil bits.
         winTitle : str

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -180,8 +180,6 @@ class GLFWBackend(BaseBackend):
         win.refreshHz = int(kwargs.get('refreshHz', 60))
         win.depthBits = int(kwargs.get('depthBits', 8))
         win.stencilBits = int(kwargs.get('stencilBits', 8))
-
-        # TODO - make waitBlanking set this too, independent right now
         win.swapInterval = int(kwargs.get('swapInterval', 1))  # vsync ON if 1
 
         # get monitors, with GLFW the primary display is ALWAYS at index 0
@@ -342,9 +340,8 @@ class GLFWBackend(BaseBackend):
         glfw.set_key_callback(self.winHandle, event._onGLFWKey)
         glfw.set_char_mods_callback(self.winHandle, event._onGLFWText)
 
-        # Enable vsync, GLFW has additional setting for this that might be
-        # useful.
-        glfw.swap_interval(win.swapInterval)
+        # set swap interval to manual setting, independent of waitBlanking
+        self.setSwapInterval(win.swapInterval)
 
         # give the window class GLFW specific methods
         win.setMouseType = self.setMouseType
@@ -355,6 +352,10 @@ class GLFWBackend(BaseBackend):
         #self.winHandle.on_resize = _onResize  # avoid circular reference
 
         # TODO - handle window resizing
+
+    def setSwapInterval(self, interval):
+        """Set the swap interval for the current GLFW context."""
+        glfw.swap_interval(interval)
 
     @property
     def shadersSupported(self):

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -462,6 +462,11 @@ class Window(object):
 
         self.lastFrameT = core.getTime()
         self.waitBlanking = waitBlanking
+
+        # set the swap interval if using GLFW
+        if self.winType == 'glfw':
+            self.backend.setSwapInterval(int(waitBlanking))
+
         self.refreshThreshold = 1.0  # initial val needed by flip()
 
         # over several frames with no drawing


### PR DESCRIPTION
Enabling vertical sync when using the GLFW backend requires additional configuration other than setting waitBlanking=True in some cases. This patch sets the GLFW swap interval accordingly depending on the value of waitBlanking. 
