### PR TITLE
BF: Fix escape key behaviour for online experiments

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -360,6 +360,8 @@ class KeyboardComponent(BaseComponent):
                 keyList = list(keyList)
             elif isinstance(keyList, basestring):  # a single string/key
                 keyList = [keyList]
+            if self.exp.settings.params['Enable Escape'].val and 'escape' not in keyList:
+                keyList.append('escape')
             keyListStr = "{keyList:%s}" % repr(keyList)
 
         # check for keypresses
@@ -368,7 +370,7 @@ class KeyboardComponent(BaseComponent):
         if self.exp.settings.params['Enable Escape'].val:
             code = ("\n// check for quit:\n"
                     "if (theseKeys.indexOf('escape') > -1) {\n"
-                    "    psychoJS.experiment.experimentEnded = true;\n"
+                    "  psychoJS.experiment.experimentEnded = true;\n"
                     "}\n")
             buff.writeIndentedLines(code)
 

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -288,7 +288,7 @@ class Routine(list):
 
         # are we done yet?
         code = ("// check for quit (typically the Esc key)\n"
-                "if (psychoJS.experiment.experimentEnded || psychoJS.eventManager.getKeys({keyList:['escape']}).length > 0) {\n"
+                "if (psychoJS.experiment.experimentEnded) {\n"
                 "  return psychoJS.quit('The [Escape] key was pressed. Goodbye!', false);\n"
                 "}\n"
                 "\n// check if the Routine should terminate\n"


### PR DESCRIPTION
Escape to quit behaviour was hardcoded into the routine code for JS. This
fix removes hardcoded escaping using "escape" and this behaviour is now
only determined by experiment settings option.