### PR TITLE
ENH: Don't alphabetically sort exp info dict by default in Builder

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -589,7 +589,7 @@ class SettingsComponent(object):
         buff.writeIndented("expInfo = %s\n" % repr(expInfoDict))
         if self.params['Show info dlg'].val:
             buff.writeIndentedLines(
-                "dlg = gui.DlgFromDict(dictionary=expInfo, title=expName)\n"
+                "dlg = gui.DlgFromDict(dictionary=expInfo, sortKeys=False, title=expName)\n"
                 "if dlg.OK == False:\n    core.quit()  # user pressed cancel\n")
         buff.writeIndentedLines(
             "expInfo['date'] = data.getDateStr()  # add a simple timestamp\n"


### PR DESCRIPTION
This should work on Python 3.6+, where dictionaries retain insertion order by default.

Example settings:
<img width="551" alt="Screen Shot 2019-03-15 at 11 43 52" src="https://user-images.githubusercontent.com/2046265/54426506-57d6e880-4718-11e9-94cb-1d68831fd220.png">

Old behavior – sorted alphabetically:
<img width="486" alt="Screen Shot 2019-03-15 at 11 44 44" src="https://user-images.githubusercontent.com/2046265/54426521-60c7ba00-4718-11e9-8593-c4c10c0bff7e.png">

New behavior – sorted as in Experiment Settings:
<img width="486" alt="Screen Shot 2019-03-15 at 11 44 11" src="https://user-images.githubusercontent.com/2046265/54426537-69b88b80-4718-11e9-8cbe-7f8331809db8.png">
