### PR TITLE
BF: Creates row beneath selected row in exp. settings expInfo

### DIFF
--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -399,14 +399,13 @@ class GlobSizer(wx.GridBagSizer):
         if startCol is None:
             startCol = 0
         for c in range(startCol, endCol):
-            for r in range(endRow, startRow - 1, -1):
-                if r != startRow:  # Do not move startRow down
-                    item = self.FindItemAtPosition((r, c))
-                    if item:
-                        w = item.GetWindow()
-                        if w:
-                            self.SetItemPosition(w, (r + 1, c))
-                            w.Refresh()
+            for r in range(endRow, startRow, -1):
+                item = self.FindItemAtPosition((r, c))
+                if item:
+                    w = item.GetWindow()
+                    if w:
+                        self.SetItemPosition(w, (r + 1, c))
+                        w.Refresh()
 
     def ShiftColsLeft(self, startCol, endCol=None, startRow=None,
                       endRow=None):

--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -387,6 +387,7 @@ class GlobSizer(wx.GridBagSizer):
 
     def ShiftRowsDown(self, startRow, endRow=None, startCol=None,
                       endCol=None):
+
         if endCol is None:
             endCol = self.GetCols()
         else:
@@ -399,12 +400,13 @@ class GlobSizer(wx.GridBagSizer):
             startCol = 0
         for c in range(startCol, endCol):
             for r in range(endRow, startRow - 1, -1):
-                item = self.FindItemAtPosition((r, c))
-                if item:
-                    w = item.GetWindow()
-                    if w:
-                        self.SetItemPosition(w, (r + 1, c))
-                        w.Refresh()
+                if r != startRow:  # Do not move startRow down
+                    item = self.FindItemAtPosition((r, c))
+                    if item:
+                        w = item.GetWindow()
+                        if w:
+                            self.SetItemPosition(w, (r + 1, c))
+                            w.Refresh()
 
     def ShiftColsLeft(self, startCol, endCol=None, startRow=None,
                       endRow=None):
@@ -565,7 +567,7 @@ class ListWidget(GlobSizer):
         newEntry = {}
         for fieldName in self.fieldNames:
             newEntry[fieldName] = ""
-        self.addEntryCtrls(row, newEntry)
+        self.addEntryCtrls(row + 1, newEntry)
         self.Layout()
         self.parent.Fit()
 


### PR DESCRIPTION
Previously, if you wanted to add extra fields to exp info in experiment
settings, the new row would be added above the selected field. This fix
changes this behaviour so that rows are appended beneath the current row.