### PR TITLE
Another attempted fix to incompatible freetype library

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -13,6 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
+- freetype<2.10.0
 - freetype-py<2.10.0
 - future
 - gevent

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -14,7 +14,7 @@ dependencies:
 - gitpython
 - ffmpeg
 - freetype<2.10.0
-- freetype-py<2.10.0
+- freetype-py
 - future
 - gevent
 - greenlet

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype-py
+- freetype-py<2.10.0
 - future
 - gevent
 - greenlet

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -13,6 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
+- freetype<2.10.0
 - freetype-py<2.10.0
 - future
 - gevent

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -14,7 +14,7 @@ dependencies:
 - gitpython
 - ffmpeg
 - freetype<2.10.0
-- freetype-py<2.10.0
+- freetype-py
 - future
 - gevent
 - greenlet

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype-py
+- freetype-py<2.10.0
 - future
 - gevent
 - greenlet

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -13,6 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
+- freetype<2.10.0
 - freetype-py<2.10.0
 - future
 - gevent

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -14,7 +14,7 @@ dependencies:
 - gitpython
 - ffmpeg
 - freetype<2.10.0
-- freetype-py<2.10.0
+- freetype-py
 - future
 - gevent
 - greenlet

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype-py
+- freetype-py<2.10.0
 - future
 - gevent
 - greenlet

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,8 +59,7 @@ install_requires =
     gitpython
     astunparse
     esprima
-    freetype<2.10.0
-    freetype-py<2.10.0
+    freetype-py
     # Platform-specific dependencies.
     imageio < 2.5; python_version < "3"
     imageio >= 2.5; python_version >= "3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ install_requires =
     gitpython
     astunparse
     esprima
-    freetype-py
+    freetype-py<2.10.0
     # Platform-specific dependencies.
     imageio < 2.5; python_version < "3"
     imageio >= 2.5; python_version >= "3"

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     gitpython
     astunparse
     esprima
+    freetype<2.10.0
     freetype-py<2.10.0
     # Platform-specific dependencies.
     imageio < 2.5; python_version < "3"


### PR DESCRIPTION
It seems there is a freetype and a py-freetype (and I think the former is installed by the latter) so maybe we need to fix them both to a particular version rather than just one of them?