### PR TITLE
ENH: Adds new keyboard code to Builder!

### DIFF
--- a/psychopy/experiment/components/cedrusBox/__init__.py
+++ b/psychopy/experiment/components/cedrusBox/__init__.py
@@ -61,6 +61,12 @@ class cedrusButtonBoxComponent(KeyboardComponent):
 
         self.type = 'cedrusButtonBox'
         self.url = "http://www.psychopy.org/builder/components/cedrusButtonBox.html"
+
+        # Remove inherited import from keyboard
+        for idx, imports in enumerate(self.exp.requiredImports):
+            if imports.importName == 'keyboard':
+                del self.exp.requiredImports[idx]
+
         self.exp.requirePsychopyLibs(['hardware'])
 
         self.params['correctAns'].hint = _translate(

--- a/psychopy/experiment/components/ioLabs/__init__.py
+++ b/psychopy/experiment/components/ioLabs/__init__.py
@@ -57,6 +57,12 @@ class ioLabsButtonBoxComponent(KeyboardComponent):
 
         self.type = 'ioLabsButtonBox'
         self.url = "http://www.psychopy.org/builder/components/ioLabs.html"
+
+        # Remove inherited import from keyboard
+        for idx, imports in enumerate(self.exp.requiredImports):
+            if imports.importName == 'keyboard':
+                del self.exp.requiredImports[idx]
+
         self.exp.requirePsychopyLibs(['hardware'])
         del self.params['allowedKeys']
 

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -243,7 +243,7 @@ class KeyboardComponent(BaseComponent):
 
         if self.exp.settings.params['Enable Escape'].val:
             code = ('\n# check for quit:\n'
-                    'if "escape" in theseKeys.name:\n'
+                    'if "escape" in theseKeys:\n'
                     '    endExpNow = True\n')
             buff.writeIndentedLines(code)
 

--- a/psychopy/experiment/exports.py
+++ b/psychopy/experiment/exports.py
@@ -122,7 +122,7 @@ class NameSpace(object):
         self.keywords = keyword.kwlist + dir(__builtins__)
         # these are based on a partial test, known to be incomplete:
         self.psychopy = psychopy.__all__ + ['psychopy', 'os'] + dir(constants)
-        self.builder = ['KeyResponse', 'key_resp', 'buttons',
+        self.builder = ['KeyResponse', 'keyboard', 'buttons',
                         'continueRoutine', 'expInfo', 'expName', 'thisExp',
                         'filename', 'logFile', 'paramName',
                         't', 'frameN', 'currentLoop', 'dlg', '_thisDir',

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -130,9 +130,8 @@ class Keyboard:
             name = event.getKeys(keyList, modifiers, timeStamped)
             rt = self.clock.getTime()
             if len(name):
-                # create response object on the fly
-                thisKey = type('thisKey', (), {'name': name[0], 'rt': rt})
-                keys.append(thisKey())
+                thisKey = KeyPress(code=None, tDown=rt, name=name[0])
+                keys.append(thisKey)
         return keys
 
     def waitKeys(maxWait=None, keyList=None, waitRelease=True, clear=True):
@@ -149,21 +148,26 @@ class Keyboard:
 class KeyPress(object):
     """Class to store key"""
 
-    def __init__(self, code, tDown):
+    def __init__(self, code, tDown, name=None):
         self.code = code
-        if code not in keyNames:
-            self.name = 'n/a'
-            logging.warning("Got keycode {} but that code isn't yet known")
+
+        if name is not None:  # we have event.getKeys()
+            self.name = name
+            self.rt = tDown
         else:
-            self.name = keyNames[code]
+            if code not in keyNames:
+                self.name = 'n/a'
+                logging.warning("Got keycode {} but that code isn't yet known")
+            else:
+                self.name = keyNames[code]
+            if code not in keyNames:
+                logging.warning('Keypress was given unknown key code ({})'.format(code))
+                self.name = 'unknown'
+            else:
+                self.name = keyNames[code]
+            self.rt = None  # can only be assigned by the keyboard object on return
         self.tDown = tDown
         self.duration = None
-        if code not in keyNames:
-            logging.warning('Keypress was given unknown key code ({})'.format(code))
-            self.name = 'unknown'
-        else:
-            self.name = keyNames[code]
-        self.rt = None  # can only be assigned by the keyboard object on return
 
     def __eq__(self, other):
         return self.name == other

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -20,8 +20,16 @@ import psychopy.clock
 from psychopy import logging
 from psychopy.constants import NOT_STARTED
 
-import psychtoolbox as ptb
-from psychtoolbox import hid
+try:
+    import psychtoolbox as ptb
+    from psychtoolbox import hid
+    havePTB = True
+except ImportError as err:
+    logging.warning(("Import Error: "
+                     + err.args[0]
+                     + ". Using event module for keyboard component."))
+    from psychopy import event
+    havePTB = False
 
 defaultBufferSize = 10000
 
@@ -62,34 +70,41 @@ class Keyboard:
 
         """
         self.status = NOT_STARTED
+        # Initiate containers for storing responses
+        self.keys = []  # the key(s) pressed
+        self.corr = 0  # was the resp correct this trial? (0=no, 1=yes)
+        self.rt = []  # response time(s)
+        self.time = []  # Epoch
+
         if clock:
             self.clock = clock
         else:
             self.clock = psychopy.clock.Clock()
 
-        # get the necessary keyboard buffer(s)
-        if sys.platform=='win32':
-            self._ids = [-1]  # no indexing possible so get the combo keyboard
-        else:
-            allInds, allNames, allKBs = hid.get_keyboard_indices()
-            if device==-1:
-                self._ids = allInds
-            elif type(device) in [list, tuple]:
-                self._ids = device
+        if havePTB:
+            # get the necessary keyboard buffer(s)
+            if sys.platform=='win32':
+                self._ids = [-1]  # no indexing possible so get the combo keyboard
             else:
-                self._ids = [device]
+                allInds, allNames, allKBs = hid.get_keyboard_indices()
+                if device==-1:
+                    self._ids = allInds
+                elif type(device) in [list, tuple]:
+                    self._ids = device
+                else:
+                    self._ids = [device]
 
-        # now create the buffers for those IDs
-        for devId in self._ids:
-            self._buffers = {}
-            self._devs = {}
-            if devId==-1 or devId in allInds:
-                buffer = _keyBuffers.getBuffer(devId, bufferSize)
-                self._buffers[devId] = buffer
-                self._devs[devId] = buffer.dev
+            for devId in self._ids:
+                # now we have a list of device IDs to monitor
+                self._buffers = {}
+                self._devs = {}
+                if devId==-1 or devId in allInds:
+                    buffer = _keyBuffers.getBuffer(devId, bufferSize)
+                    self._buffers[devId] = buffer
+                    self._devs[devId] = buffer.dev
 
-        if not waitForStart:
-            self.start()
+            if not waitForStart:
+                self.start()
 
     def start(self):
         """Start recording with any unstarted key buffers"""
@@ -102,38 +117,34 @@ class Keyboard:
         for buffer in self._buffers.values():
             buffer.stop()
 
-    def getKeys(self, keyList=None, waitRelease=True, clear=True):
-        keyList = []
-        for buffer in self._buffers.values():
-            for origKey in buffer.getKeys(keyList, waitRelease, clear):
-                # calculate rt from time and self.timer
-                thisKey = copy.copy(origKey)  # don't alter the original
-                thisKey.rt = thisKey.tDown - self.clock.getLastResetTime()
-                keyList.append(thisKey)
-        return keyList
+    def getKeys(self, keyList=None, modifiers=False, timeStamped=False, waitRelease=True, clear=True):
+        keys = []
+        if havePTB:
+            for buffer in self._buffers.values():
+                for origKey in buffer.getKeys(keyList, waitRelease, clear):
+                    # calculate rt from time and self.timer
+                    thisKey = copy.copy(origKey)  # don't alter the original
+                    thisKey.rt = thisKey.tDown - self.clock.getLastResetTime()
+                    keys.append(thisKey)
+        else:
+            name = event.getKeys(keyList, modifiers, timeStamped)
+            rt = self.clock.getTime()
+            if len(name):
+                # create response object on the fly
+                thisKey = type('thisKey', (), {'name': name[0], 'rt': rt})
+                keys.append(thisKey())
+        return keys
 
     def waitKeys(maxWait=None, keyList=None, waitRelease=True, clear=True):
         keys = []
         raise NotImplementedError
 
-    def clear(self):
-        self.evtBuffer.clearAll()
-
-
-class BuilderKeyResponse(object):
-    """Used in scripts created by the builder to keep track of a clock and
-    the current status (whether or not we are currently checking the keyboard)
-    """
-
-    def __init__(self):
-        super(BuilderKeyResponse, self).__init__()
-        self.status = NOT_STARTED
-        self.keys = []  # the key(s) pressed
-        self.corr = 0  # was the resp correct this trial? (0=no, 1=yes)
-        self.rt = []  # response time(s)
-        self.time = []
-        self.clock = psychopy.core.Clock()  # we'll use this to measure the rt
-
+    def clearEvents(self, eventType):
+        if havePTB:
+            for buffer in self._buffers.values():
+                buffer._clearEvents()
+        else:
+            event.clearEvents(eventType)
 
 class KeyPress(object):
     """Class to store key"""
@@ -220,7 +231,7 @@ class _KeyBuffer(object):
 
         Parameters
         ----------
-        keys : list of key(name)s of interest
+        keyList : list of key(name)s of interest
         waitRelease : if True then only process keys that are also released
         clear : clear any keys (that have been returned in this call)
 

--- a/psychopy/tests/data/correctScript/correctKeyboardComponent.py
+++ b/psychopy/tests/data/correctScript/correctKeyboardComponent.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 This experiment was created using PsychoPy3 Experiment Builder (v3.0.6),
-    on March 13, 2019, at 13:27
+    on March 19, 2019, at 15:06
 If you publish work using this script please cite the PsychoPy publications:
     Peirce, JW (2007) PsychoPy - Psychophysics software in Python.
         Journal of Neuroscience Methods, 162(1-2), 8-13.
@@ -21,6 +21,7 @@ from numpy.random import random, randint, normal, shuffle
 import os  # handy system and path functions
 import sys  # to get file system encoding
 
+from psychopy.hardware import keyboard
 
 # Ensure that relative paths start from the same directory as this script
 _thisDir = os.path.dirname(os.path.abspath(__file__))
@@ -81,7 +82,7 @@ trialClock.reset()  # clock
 frameN = -1
 continueRoutine = True
 # update component parameters for each repeat
-key_resp = event.BuilderKeyResponse()
+key_resp = keyboard.Keyboard()
 # keep track of which components have finished
 trialComponents = [key_resp]
 for thisComponent in trialComponents:
@@ -108,16 +109,17 @@ while continueRoutine:
         key_resp.status = STARTED
         # keyboard checking is just starting
         win.callOnFlip(key_resp.clock.reset)  # t=0 on next screen flip
-        event.clearEvents(eventType='keyboard')
+        key_resp.clearEvents(eventType='keyboard')
     if key_resp.status == STARTED:
-        theseKeys = event.getKeys(keyList=['y', 'n', 'left', 'right', 'space'])
-        
-        # check for quit:
-        if "escape" in theseKeys:
-            endExpNow = True
-        if len(theseKeys) > 0:  # at least one key was pressed
-            key_resp.keys = theseKeys[-1]  # just the last key pressed
-            key_resp.rt = key_resp.clock.getTime()
+        theseKeys = key_resp.getKeys(keyList=['y', 'n', 'left', 'right', 'space'], waitRelease=False)
+        if len(theseKeys):
+            theseKeys = theseKeys[0]  # at least one key was pressed
+            
+            # check for quit:
+            if "escape" in theseKeys.name:
+                endExpNow = True
+            key_resp.keys = theseKeys.name  # just the last key pressed
+            key_resp.rt = theseKeys.rt
             # a response ends the routine
             continueRoutine = False
     
@@ -144,7 +146,7 @@ for thisComponent in trialComponents:
         thisComponent.setAutoDraw(False)
 # check responses
 if key_resp.keys in ['', [], None]:  # No response was made
-    key_resp.keys=None
+    key_resp.keys = None
 thisExp.addData('key_resp.keys',key_resp.keys)
 if key_resp.keys != None:  # we had a response
     thisExp.addData('key_resp.rt', key_resp.rt)

--- a/psychopy/tests/data/correctScript/correctKeyboardComponent.py
+++ b/psychopy/tests/data/correctScript/correctKeyboardComponent.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 This experiment was created using PsychoPy3 Experiment Builder (v3.0.6),
-    on March 19, 2019, at 15:06
+    on March 19, 2019, at 16:29
 If you publish work using this script please cite the PsychoPy publications:
     Peirce, JW (2007) PsychoPy - Psychophysics software in Python.
         Journal of Neuroscience Methods, 162(1-2), 8-13.
@@ -116,7 +116,7 @@ while continueRoutine:
             theseKeys = theseKeys[0]  # at least one key was pressed
             
             # check for quit:
-            if "escape" in theseKeys.name:
+            if "escape" in theseKeys:
                 endExpNow = True
             key_resp.keys = theseKeys.name  # just the last key pressed
             key_resp.rt = theseKeys.rt

--- a/psychopy/tests/data/correctScript/correctcedrusButtonBoxComponent.py
+++ b/psychopy/tests/data/correctScript/correctcedrusButtonBoxComponent.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 This experiment was created using PsychoPy3 Experiment Builder (v3.0.6),
-    on March 13, 2019, at 13:27
+    on March 19, 2019, at 15:32
 If you publish work using this script please cite the PsychoPy publications:
     Peirce, JW (2007) PsychoPy - Psychophysics software in Python.
         Journal of Neuroscience Methods, 162(1-2), 8-13.
@@ -177,7 +177,7 @@ for thisComponent in trialComponents:
         thisComponent.setAutoDraw(False)
 # check responses
 if buttonBox.keys in ['', [], None]:  # No response was made
-    buttonBox.keys=None
+    buttonBox.keys = None
 thisExp.addData('buttonBox.keys',buttonBox.keys)
 if buttonBox.keys != None:  # we had a response
     thisExp.addData('buttonBox.rt', buttonBox.rt)

--- a/psychopy/tests/data/correctScript/correctioLabsButtonBoxComponent.py
+++ b/psychopy/tests/data/correctScript/correctioLabsButtonBoxComponent.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 """
 This experiment was created using PsychoPy3 Experiment Builder (v3.0.6),
-    on March 13, 2019, at 13:27
+    on March 19, 2019, at 15:30
 If you publish work using this script please cite the PsychoPy publications:
     Peirce, JW (2007) PsychoPy - Psychophysics software in Python.
         Journal of Neuroscience Methods, 162(1-2), 8-13.
@@ -163,7 +163,7 @@ if bbox.btns != None:  # add RTs if there are responses
     thisExp.addData('bbox.rt', bbox.rt)
 # check responses
 if bbox.keys in ['', [], None]:  # No response was made
-    bbox.keys=None
+    bbox.keys = None
 thisExp.addData('bbox.keys',bbox.keys)
 if bbox.keys != None:  # we had a response
     thisExp.addData('bbox.rt', bbox.rt)


### PR DESCRIPTION
- New keyboard code is written dependent on the existence of the
psychtoolbox module (PTB). If PTB does not exist, then keyboard
reverts to using event module code.

- The new keyboard module will make different calls depending
on whether PTB exists. Currently, only getKeys is implemented. If no PTB,
then a new response object is created from the event.getKeys output
containing the key name and the response time. This differs from previous
calls to event.getKeys, which returned a list of key names.

- BuilderKeyResponse container class is now redundant and replaced with
keyboard attributes. These are refreshed on every repeat of the
routine, because a new keyboard object is instantiated on each repeat.

- To smooth call signature to new getKeys methods, the event.getKeys
kwargs are added to the new getKeys method.

- clear method in new Keyboard renamed to clearEvents (like event module).
Also added code to clear buffer - @peircej to check. Also adds kwargs to
make compatible with calls to event.clearEvents method.

## Other changes:
- key_resp is the first name of the first keyboard, but because it is in
reserved namespace, all new keyboards are called "key_resp_2". Replaced
with 'keyboard', because overwriting keyboard will
potentially cause new keyboard module to fail.