### PR TITLE
FF: Creates Psychopy version class for handling version formatting

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2339,7 +2339,7 @@ class BuilderFrame(wx.Frame):
         cmd = [pythonExec, '-m', compiler, filename,
                '-o', experimentPath]
         # if version is not specified then don't touch useVersion at all
-        version = self.exp.settings.params['Use version'].val
+        version = self.exp.psychopyVersion.requested()
         if version not in [None, 'None', '', __version__]:
             cmd.extend(['-v', version])
             logging.info(' '.join(cmd))

--- a/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
+++ b/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
@@ -27,7 +27,7 @@
     <div id="root"/>
     <script type='module' src='./{name}.js'></script>
 
-    <script nomodule type="text/javascript" src="lib/psychojs-{version}.js"></script>
+    <script nomodule type="text/javascript" src="lib/psychojs{version}.js"></script>
     <script nomodule type="text/javascript" src="./{name}NoModule.js"></script>
 </body>
 

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -86,6 +86,7 @@ thisFolder = os.path.split(__file__)[0]
 #     def allowedVals(self, allowed):
 #         pass
 
+
 class SettingsComponent(object):
     """This component stores general info about how to run the experiment
     """
@@ -107,7 +108,6 @@ class SettingsComponent(object):
         self.exp.requirePsychopyLibs(['visual', 'gui'])
         self.parentName = parentName
         self.url = "http://www.psychopy.org/builder/settings.html"
-
         # if filename is the default value fetch the builder pref for the
         # folder instead
         if filename is None:
@@ -348,11 +348,11 @@ class SettingsComponent(object):
             saveToDir = os.path.dirname(self.params['Data filename'].val)
         return saveToDir or u'data'
 
-    def writeUseVersion(self, buff):
+    def writeUseVersion(self, buff, version):
         if self.params['Use version'].val:
             code = ('\nimport psychopy\n'
                     'psychopy.useVersion({})\n\n')
-            val = repr(self.params['Use version'].val)
+            val = repr(version.requested)
             buff.writeIndentedLines(code.format(val))
 
     def writeInitCode(self, buff, version, localDateTime):
@@ -362,7 +362,7 @@ class SettingsComponent(object):
             '# -*- coding: utf-8 -*-\n'
             '"""\nThis experiment was created using PsychoPy3 Experiment '
             'Builder (v%s),\n'
-            '    on %s\n' % (version, localDateTime) +
+            '    on %s\n' % (version.current, localDateTime) +
             'If you publish work using this script please cite the PsychoPy '
             'publications:\n'
             '    Peirce, JW (2007) PsychoPy - Psychophysics software in '
@@ -374,7 +374,7 @@ class SettingsComponent(object):
             'neuro.11.010.2008\n"""\n'
             "\nfrom __future__ import absolute_import, division\n")
 
-        self.writeUseVersion(buff)
+        self.writeUseVersion(buff, version)
 
         psychopyImports = []
         customImports = []
@@ -500,7 +500,7 @@ class SettingsComponent(object):
         template = readTextFile("JS_htmlHeader.tmpl")
         header = template.format(
             name=jsFilename,
-            version=version,
+            version=version.htmlVersion(),
             params=self.params)
         jsFile = self.exp.expPath
         folder = os.path.dirname(jsFile)
@@ -519,14 +519,14 @@ class SettingsComponent(object):
 
         # Write imports if modular
         if modular:
-            code = ("import {{ PsychoJS }} from './lib/core-{version}.js';\n"
-                    "import * as core from './lib/core-{version}.js';\n"
-                    "import {{ TrialHandler }} from './lib/data-{version}.js';\n"
-                    "import {{ Scheduler }} from './lib/util-{version}.js';\n"
-                    "import * as util from './lib/util-{version}.js';\n"
-                    "import * as visual from './lib/visual-{version}.js';\n"
-                    "import {{ Sound }} from './lib/sound-{version}.js';\n"
-                    "\n").format(version=version)
+            code = ("import {{ PsychoJS }} from './lib/core{version}.js';\n"
+                    "import * as core from './lib/core{version}.js';\n"
+                    "import {{ TrialHandler }} from './lib/data{version}.js';\n"
+                    "import {{ Scheduler }} from './lib/util{version}.js';\n"
+                    "import * as util from './lib/util{version}.js';\n"
+                    "import * as visual from './lib/visual{version}.js';\n"
+                    "import {{ Sound }} from './lib/sound{version}.js';\n"
+                    "\n").format(version=version.htmlVersion())
             buff.writeIndentedLines(code)
 
         # Write window code
@@ -559,7 +559,7 @@ class SettingsComponent(object):
                         name=self.params['expName'].val,
                         loggingLevel=self.params['logging level'].val.upper(),
                         setRedirectURL=setRedirectURL,
-                        version=version,
+                        version=version.current,
                         )
         buff.writeIndentedLines(code)
 
@@ -576,7 +576,7 @@ class SettingsComponent(object):
                 "os.chdir(_thisDir)\n\n"
                 "# Store info about the experiment session\n"
                 "psychopyVersion = '{version}'\n".format(decoding=decodingInfo,
-                                                         version=version))
+                                                         version=version.current))
         buff.writeIndentedLines(code)
 
         if self.params['expName'].val in [None, '']:

--- a/psychopy/tests/data/correctScript/js/correctCodeComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctCodeComponent.js
@@ -2,13 +2,13 @@
  * Codecomponent Test *
  **********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctImageComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctImageComponent.js
@@ -2,13 +2,13 @@
  * Imagecomponent Test *
  ***********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctKeyboardComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctKeyboardComponent.js
@@ -2,13 +2,13 @@
  * Keyboardcomponent Test *
  **************************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctMouseComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctMouseComponent.js
@@ -2,13 +2,13 @@
  * Mousecomponent Test *
  ***********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctMovieComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctMovieComponent.js
@@ -2,13 +2,13 @@
  * Moviecomponent Test *
  ***********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctPolygonComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctPolygonComponent.js
@@ -2,13 +2,13 @@
  * Polygoncomponent Test *
  *************************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctSliderComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctSliderComponent.js
@@ -2,13 +2,13 @@
  * Slidercomponent Test *
  ************************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctSoundComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctSoundComponent.js
@@ -2,13 +2,13 @@
  * Soundcomponent Test *
  ***********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/data/correctScript/js/correctTextComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctTextComponent.js
@@ -2,13 +2,13 @@
  * Textcomponent Test *
  **********************/
 
-import { PsychoJS } from './lib/core-3.1.0.js';
-import * as core from './lib/core-3.1.0.js';
-import { TrialHandler } from './lib/data-3.1.0.js';
-import { Scheduler } from './lib/util-3.1.0.js';
-import * as util from './lib/util-3.1.0.js';
-import * as visual from './lib/visual-3.1.0.js';
-import { Sound } from './lib/sound-3.1.0.js';
+import { PsychoJS } from './lib/core.js';
+import * as core from './lib/core.js';
+import { TrialHandler } from './lib/data.js';
+import { Scheduler } from './lib/util.js';
+import * as util from './lib/util.js';
+import * as visual from './lib/visual.js';
+import { Sound } from './lib/sound.js';
 
 // init psychoJS:
 var psychoJS = new PsychoJS({

--- a/psychopy/tests/test_tools/test_versionchooser.py
+++ b/psychopy/tests/test_tools/test_versionchooser.py
@@ -3,8 +3,9 @@
 from builtins import object
 import os
 import psychopy
-from psychopy.tools.versionchooser import useVersion
+from psychopy.tools.versionchooser import useVersion, psychopyVersion
 from psychopy import prefs
+from psychopy.experiment import params
 
 USERDIR = prefs.paths['userPrefsDir']
 VER_SUBDIR = 'versions'
@@ -36,6 +37,28 @@ class Test_Older_Version(_baseVersionChooser):
     def test_older_version(self):
         assert(useVersion(self.requested))
 
+class Test_PsychoPyVersion(object):
+    def setup(self):
+        self.current = '3.1.0'
+        self.params =  {}
+        self.params['Use version'] = params.Param(self.current, valType='str', allowedVals=[''])
+        self.psychopyVersion = psychopyVersion(self.params, self.current)
+
+    def test_html_version(self):
+        assert(self.psychopyVersion.htmlVersion() == ''.join(('-', self.current)))
+
+    def test_current_version(self):
+        assert(self.psychopyVersion.current == self.current)
+
+    def test_empty_version(self):
+        self.params['Use version'].val = ''
+        self.psychopyVersion = psychopyVersion(self.params, self.current)
+        assert(self.psychopyVersion.htmlVersion() == '')
+
+    def test_empty_latest_version(self):
+        self.params['Use version'].val = 'latest'
+        self.psychopyVersion = psychopyVersion(self.params, self.current)
+        assert(self.psychopyVersion.htmlVersion() == '')
 
 """
 

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -38,6 +38,56 @@ def _translate(string):
     return string
 
 
+class psychopyVersion(object):
+    """
+    A class for handling PsychoPy version requests from code compilers
+
+    Attributes
+    ----------
+    params : Param
+        The settings parameters holding 'Use version' param
+    current: str
+        The current version of PsychoPy
+    """
+
+    def __init__(self, params, currentVersion):
+        """
+        Parameters
+        ----------
+        params : Param
+            The settings parameters holding 'Use version' param
+        currentVersion : str
+            The current version of PsychoPy
+        """
+        self.params = params
+        self.current = currentVersion
+
+    def htmlVersion(self):
+        """
+        Returns the correctly formatted version for HTML export
+
+        Returns
+        -------
+        version : str
+            Returns empty string for latest version,
+            or version with '-' prepended for html/JS formatting
+        """
+        if self.params['Use version'].val in ['', 'latest']:
+            return ''
+        return ''.join(('-', self.current))
+
+    def requested(self):
+        """
+        Returns the reqested version of PsychoPy defined in experiment settings
+
+        Returns
+        -------
+        version : str
+            Returns the currently selected version from "Use version" parameter
+        """
+        return self.params['Use version'].val
+
+
 def useVersion(requestedVersion):
     """Manage paths and checkout psychopy libraries for requested versions
     of PsychoPy.


### PR DESCRIPTION
Version formatting varies for html exports. When no version is
requested in experiment settings, no version number is added to the JS
code meaning the latest PsychoJS version will be used for a task.
This fix handles different version formats by creating a version class
for all version string formatting. The alternative was to use a function
or if statement to convert the version string, but having a version class
keeps things tidy and object-oriented. It also adds clarity which version
is actually being requested in the version compiler e.g., current or
requested version.