### PR TITLE
Fix windows NSIS installer to work in CurrentUser mode

### DIFF
--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -83,16 +83,26 @@ Function multiuser_pre_func
 
 FunctionEnd
 
-;if previous version installed then remove
 Function .onInit
   !insertmacro MULTIUSER_INIT
 
   ${If} $MultiUser.InstallMode == "CurrentUser"
     StrCpy $InstDir "$LOCALAPPDATA\${PRODUCT_NAME}"
+    StrCpy $PRODUCT_REGISTRY_ROOT "HKCU"
+    IfFileExists $SYSDIR\avbin.dll continue_init 0
+    MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
+    "You do not have admin privileges, which are needed to install AVBin. \
+    $\n$\nPlease cancel the install and run with admin \
+    privileges, or manually install AVBin later." \
+    IDOK continue_init
+    Abort
   ${Else}
     StrCpy $InstDir "$PROGRAMFILES\${PRODUCT_NAME}"
   ${EndIf}
 
+  continue_init:
+
+  ;if previous version installed then remove
   ReadRegStr $R0 SHELL_CONTEXT \
   "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
   "UninstallString"

--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -93,7 +93,7 @@ Function .onInit
     StrCpy $InstDir "$PROGRAMFILES\${PRODUCT_NAME}"
   ${EndIf}
 
-  ReadRegStr $R0 HKLM \
+  ReadRegStr $R0 SHELL_CONTEXT \
   "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_NAME}" \
   "UninstallString"
   StrCmp $R0 "" done
@@ -142,8 +142,8 @@ Section "PsychoPy" SEC01
 
 ; Update Windows Path
   ;add to path variable
-  ${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR"
-  ${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR\DLLs"
+  ${EnvVarUpdate} $0 "PATH" "A" "SHELL_CONTEXT" "$INSTDIR"
+  ${EnvVarUpdate} $0 "PATH" "A" "SHELL_CONTEXT" "$INSTDIR\DLLs"
 
 SectionEnd
 
@@ -162,7 +162,7 @@ SectionEnd
 
 Section -Post
   WriteUninstaller "$INSTDIR\uninst.exe"
-  ;WriteRegStr HKLM "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\AppMainExe.exe"
+  ;WriteRegStr SHELL_CONTEXT "${PRODUCT_DIR_REGKEY}" "" "$INSTDIR\AppMainExe.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayName" "$(^Name)"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "UninstallString" "$INSTDIR\uninst.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion" "${PRODUCT_VERSION}"
@@ -186,9 +186,9 @@ Section Uninstall
   RMDir /r "$SMPROGRAMS\$ICONS_GROUP"
 
   DeleteRegKey ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}"
-  ;DeleteRegKey HKLM "${PRODUCT_DIR_REGKEY}"
-  ${un.EnvVarUpdate} $0 "PATH" "R" "HKLM" "$INSTDIR"
-  ${un.EnvVarUpdate} $0 "PATH" "R" "HKLM" "$INSTDIR\DLLs"
+  ;DeleteRegKey SHELL_CONTEXT "${PRODUCT_DIR_REGKEY}"
+  ${un.EnvVarUpdate} $0 "PATH" "R" "SHELL_CONTEXT" "$INSTDIR"
+  ${un.EnvVarUpdate} $0 "PATH" "R" "SHELL_CONTEXT" "$INSTDIR\DLLs"
 
   SetAutoClose true
 SectionEnd

--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -127,7 +127,7 @@ Section "PsychoPy" SEC01
 
   File /r /x *.pyo /x *.chm /x Editra /x doc "${PYPATH}*.*"
 ; avbin to system32
-;  !insertmacro InstallLib DLL NOTSHARED NOREBOOT_PROTECTED avbin.dll $SYSDIR\avbin.dll $SYSDIR
+  !insertmacro InstallLib DLL NOTSHARED NOREBOOT_PROTECTED avbin.dll $SYSDIR\avbin.dll $SYSDIR
 
 ; Shortcuts
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application

--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -136,8 +136,11 @@ Section "PsychoPy" SEC01
   StrCpy $AppDir "$INSTDIR\Lib\site-packages\psychopy\app"
 
   File /r /x *.pyo /x *.chm /x Editra /x doc "${PYPATH}*.*"
-; avbin to system32
-  !insertmacro InstallLib DLL NOTSHARED NOREBOOT_PROTECTED avbin.dll $SYSDIR\avbin.dll $SYSDIR
+
+  ${If} $MultiUser.InstallMode == "AllUsers"
+  ; avbin to system32
+    !insertmacro InstallLib DLL NOTSHARED NOREBOOT_PROTECTED avbin.dll $SYSDIR\avbin.dll $SYSDIR
+  ${EndIf}
 
 ; Shortcuts
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application

--- a/buildWinDistributions.ps1
+++ b/buildWinDistributions.ps1
@@ -4,14 +4,13 @@
 # python setup.py bdist_wininst --install-script=psychopy_post_inst.py
 
 # remove editable installation
-$pyPaths = @("C:\Python27\", "C:\Python36\", "C:\Python36_64\")
-$names = @("PsychoPy3_PY2", "PsychoPy3", "PsychoPy3")
-$archs = @("win32", "win32", "win64")
+$pyPaths = @("C:\Users\Fitch\AppData\Local\Programs\Python\Python37\")
+$names = @("PsychoPy3")
+$archs = @("win64")
 
-# get PsychoPy version from import
-# $v = python -c 'import psychopy; print(psychopy.__version__)'
 # read from the version file
-$v = [Io.File]::ReadAllText("C:\Users\lpzjwp\code\psychopy\git\version").Trim()
+$versionfile = Join-Path $pwd "version"
+$v = [Io.File]::ReadAllText($versionfile).Trim()
 
 for ($i=0; $i -lt $pyPaths.Length; $i++) {
     [console]::beep(440,300); [console]::beep(880,300)
@@ -19,7 +18,7 @@ for ($i=0; $i -lt $pyPaths.Length; $i++) {
     Invoke-Expression ("{0}python.exe -m pip uninstall psychopy -y" -f $pyPaths[$i])
     # re-install the current version as editable/developer
     Invoke-Expression ("{0}python.exe -m pip install . --no-deps" -f $pyPaths[$i])
-	echo ("Installed current PsychoPy")
+    echo ("Installed current PsychoPy")
     xcopy /I /Y psychopy\*.txt $pyPaths[$i]
     if ($i -eq '0') {
         xcopy /Y C:\Windows\SysWOW64\py*27.dll C:\Python27
@@ -28,12 +27,10 @@ for ($i=0; $i -lt $pyPaths.Length; $i++) {
     $thisPath = $pyPaths[$i]
     $thisName = $names[$i]
     $thisArch = $archs[$i]
-    $cmdStr = "makensis.exe /v2 /DPRODUCT_VERSION={0} /DPRODUCT_NAME={1} /DARCH={2} /DPYPATH={3} buildCompleteInstaller.nsi" -f $v, $thisName, $thisArch, $thisPath
+    $cmdStr = "makensis.exe /v3 /DPRODUCT_VERSION={0} /DPRODUCT_NAME={1} /DARCH={2} /DPYPATH={3} buildCompleteInstaller.nsi" -f $v, $thisName, $thisArch, $thisPath
     echo $cmdStr
     Invoke-Expression $cmdStr
     # "C:\Program Files\Caphyon\Advanced Installer 13.1\bin\x86\AdvancedInstaller.com" /rebuild PsychoPy_AdvancedInstallerProj.aip
-
-    echo 'moving files to ..\dist'
 
     # try to uninstall psychopy from site-packages
     Invoke-Expression ("{0}python.exe -m pip uninstall psychopy -y" -f $pyPaths[$i])
@@ -41,6 +38,10 @@ for ($i=0; $i -lt $pyPaths.Length; $i++) {
     Invoke-Expression ("{0}python.exe -m pip install -e . --no-deps" -f $pyPaths[$i])
 
 }
+
+echo 'moving files to ..\dist'
+
+md -Force ..\dist\ | Out-Null
 
 Move-Item -Force "StandalonePsychoPy*.exe" ..\dist\
 Move-Item -Force dist\* ..\dist\

--- a/buildWinDistributions.ps1
+++ b/buildWinDistributions.ps1
@@ -4,9 +4,9 @@
 # python setup.py bdist_wininst --install-script=psychopy_post_inst.py
 
 # remove editable installation
-$pyPaths = @("C:\Users\Fitch\AppData\Local\Programs\Python\Python37\")
-$names = @("PsychoPy3")
-$archs = @("win64")
+$pyPaths = @("C:\Python27\", "C:\Python36\", "C:\Python36_64\")
+$names = @("PsychoPy3_PY2", "PsychoPy3", "PsychoPy3")
+$archs = @("win32", "win32", "win64")
 
 # read from the version file
 $versionfile = Join-Path $pwd "version"
@@ -27,10 +27,12 @@ for ($i=0; $i -lt $pyPaths.Length; $i++) {
     $thisPath = $pyPaths[$i]
     $thisName = $names[$i]
     $thisArch = $archs[$i]
-    $cmdStr = "makensis.exe /v3 /DPRODUCT_VERSION={0} /DPRODUCT_NAME={1} /DARCH={2} /DPYPATH={3} buildCompleteInstaller.nsi" -f $v, $thisName, $thisArch, $thisPath
+    $cmdStr = "makensis.exe /v2 /DPRODUCT_VERSION={0} /DPRODUCT_NAME={1} /DARCH={2} /DPYPATH={3} buildCompleteInstaller.nsi" -f $v, $thisName, $thisArch, $thisPath
     echo $cmdStr
     Invoke-Expression $cmdStr
     # "C:\Program Files\Caphyon\Advanced Installer 13.1\bin\x86\AdvancedInstaller.com" /rebuild PsychoPy_AdvancedInstallerProj.aip
+
+    echo 'moving files to ..\dist'
 
     # try to uninstall psychopy from site-packages
     Invoke-Expression ("{0}python.exe -m pip uninstall psychopy -y" -f $pyPaths[$i])
@@ -38,10 +40,6 @@ for ($i=0; $i -lt $pyPaths.Length; $i++) {
     Invoke-Expression ("{0}python.exe -m pip install -e . --no-deps" -f $pyPaths[$i])
 
 }
-
-echo 'moving files to ..\dist'
-
-md -Force ..\dist\ | Out-Null
 
 Move-Item -Force "StandalonePsychoPy*.exe" ..\dist\
 Move-Item -Force dist\* ..\dist\


### PR DESCRIPTION
With these changes, the windows installer no longer requires admin. 

Fixes #2127 

- If run with admin privileges, allows user to choose "Current User" or "All Users"
- If run without admin, defaults to "Current User" and warns user about installing avbin

The main changes to the NSI file are:

- using `!include MultiUser.nsh` and its needed settings
- using LogicLib to do some conditional things on install/uninstall

I changed the .ps1 script to make it less path-dependent as well.

Likely needs testing on more bitness/platforms, but the installer is largely the same; just slightly different methods to set PATH and create shortcuts, etc.