### PR TITLE
Fix and add links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ platform independent.
 
 There is a range of documentation at:
 
-* (PsychoPy Homepage)[https://www.psychopy.org]
-* (Youtube)[https://www.youtube.com/playlist?list=PLFB5A1BE51964D587]
-* The textbook, (Building Experiments in PsychoPy)[https://uk.sagepub.com/en-gb/eur/building-experiments-in-psychopy/book253480]
-* (The discourse user forum)[https://discourse.psychopy.org]
+* [PsychoPy Homepage](https://www.psychopy.org)
+* [Youtube](https://www.youtube.com/playlist?list=PLFB5A1BE51964D587)
+* The textbook, [Building Experiments in PsychoPy](https://uk.sagepub.com/en-gb/eur/building-experiments-in-psychopy/book253480)
+* [The discourse user forum](https://discourse.psychopy.org)
 
 ## Contributions
 
 To contribute, please fork the repository, hack in a feature branch, and send a
-pull request.  For more, see and the developers documentation at
-http://www.psychopy.org/developers
+pull request.  For more, see [CONTRIBUTING.md](CONTRIBUTING.md)
+and the developers documentation at http://www.psychopy.org/developers/developers.html
 
 ## More information
 


### PR DESCRIPTION
Minor README tweaks.

The developers link was 404'ing, so I fixed it, made your other links correct Markdown, and added a link to CONTRIBUTING.md.