### PR TITLE
BF: Replace loop file path separators for cross-platform compatibility

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1549,7 +1549,7 @@ class DlgLoopProperties(_BaseParamsDlg):
                 isSameFilePathAndName = bool(newFullPath == oldFullPath)
             else:
                 isSameFilePathAndName = False
-            newPath = _relpath(newFullPath, expFolder).replace('\\', '/')
+            newPath = _relpath(newFullPath, expFolder)
             self.conditionsFile = newPath
             needUpdate = False
             try:

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1549,7 +1549,7 @@ class DlgLoopProperties(_BaseParamsDlg):
                 isSameFilePathAndName = bool(newFullPath == oldFullPath)
             else:
                 isSameFilePathAndName = False
-            newPath = _relpath(newFullPath, expFolder)
+            newPath = _relpath(newFullPath, expFolder).replace('\\', '/')
             self.conditionsFile = newPath
             needUpdate = False
             try:
@@ -1626,9 +1626,9 @@ class DlgLoopProperties(_BaseParamsDlg):
             # add after self.show() in __init__:
             self.duplCondNames = duplCondNames
 
-            if (needUpdate or
-                    ('conditionsFile' in list(self.currentCtrls.keys()) and
-                     not duplCondNames)):
+            if (needUpdate
+                    or ('conditionsFile' in list(self.currentCtrls.keys())
+                        and not duplCondNames)):
                 self.currentCtrls['conditionsFile'].setValue(newPath)
                 self.currentCtrls['conditions'].setValue(
                     self.getTrialsSummary(self.conditions))

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -185,6 +185,9 @@ class TrialHandler(object):
         makeLoopIndex = self.exp.namespace.makeLoopIndex
         self.thisName = makeLoopIndex(self.params['name'].val)
 
+        # Convert filepath separator
+        conditionsFile = self.params['conditionsFile'].val
+        self.params['conditionsFile'].val = conditionsFile.replace('\\\\', '/').replace('\\', '/')
         # seed might be undefined
         seed = self.params['random seed'].val or 'undefined'
         if self.params['conditionsFile'].val in ['None', None, 'none', '']:
@@ -207,8 +210,13 @@ class TrialHandler(object):
                 "    seed: {seed}, name: '{name}'}});\n"
                 "  psychoJS.experiment.addLoop({name}); // add the loop to the experiment\n"
                 "  currentLoop = {name};  // we're now the current loop\n"
-                .format(funName=self.params['name'].val,name=self.params['name'], loopType=(self.params['loopType'].val).upper(),
-                        params=self.params, thisName=self.thisName, trialList=trialList, seed=seed))
+                .format(funName=self.params['name'].val,
+                        name=self.params['name'],
+                        loopType=(self.params['loopType'].val).upper(),
+                        params=self.params,
+                        thisName=self.thisName,
+                        trialList=trialList,
+                        seed=seed))
         buff.writeIndentedLines(code)
         # for the scheduler
         if modular:


### PR DESCRIPTION
Makes more sense to capture and replace the file path separators for JS
when compiling the script, rather than attempting to convert the actual
condition filename and path parameter. This fix also converts both double
and single backslashes. Double may be input by the user if manually
typing file path.