### PR TITLE
WIP - BF/EN: Fixed drawing on multi-window displays with heterogeneous configurations.

### DIFF
--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -447,6 +447,9 @@ class GLFWBackend(BaseBackend):
                 GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
                 GL.glEnable(GL.GL_STENCIL_TEST)
 
+                GL.glViewport(0, 0, win.size[0], win.size[1])
+                GL.glScissor(0, 0, win.size[0], win.size[1])
+
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)
 

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -403,19 +403,21 @@ class GLFWBackend(BaseBackend):
         They may vary in appearance and hot spot location across platforms. The
         following names are valid on most platforms:
 
-        - 'arrow' : Default pointer
-        - 'ibeam' : Indicates text can be edited
-        - 'crosshair' : Crosshair with hot-spot at center
-        - 'hand' : A pointing hand
-        - 'hresize' : Double arrows pointing horizontally
-        - 'vresize' : Double arrows pointing vertically
+        * ``arrow`` : Default pointer
+        * ``ibeam`` : Indicates text can be edited
+        * ``crosshair`` : Crosshair with hot-spot at center
+        * ``hand`` : A pointing hand
+        * ``hresize`` : Double arrows pointing horizontally
+        * ``vresize`` : Double arrows pointing vertically
 
         Requires the GLFW backend, otherwise this function does nothing! Note,
-        on Windows the 'crosshair' option is XORed with the background color. It
-        will not be visible when placed over 50% grey fields.
+        on Windows the ``crosshair`` option is negated with the background
+        color. It will not be visible when placed over 50% grey fields.
 
-        :param name: str, type of standard cursor to use
-        :return:
+        Parameters
+        ----------
+        name : str
+            Type of standard cursor to use.
 
         """
         try:

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -403,15 +403,16 @@ class GLFWBackend(BaseBackend):
         They may vary in appearance and hot spot location across platforms. The
         following names are valid on most platforms:
 
-                'arrow' : Default pointer
-                'ibeam' : Indicates text can be edited
-            'crosshair' : Crosshair with hot-spot at center
-                 'hand' : A pointing hand
-              'hresize' : Double arrows pointing horizontally
-              'vresize' : Double arrows pointing vertically
+        - 'arrow' : Default pointer
+        - 'ibeam' : Indicates text can be edited
+        - 'crosshair' : Crosshair with hot-spot at center
+        - 'hand' : A pointing hand
+        - 'hresize' : Double arrows pointing horizontally
+        - 'vresize' : Double arrows pointing vertically
 
-        Note, on Windows the 'crosshair' option is XORed with the background
-        color. It will not be visible when placed over 50% grey fields.
+        Requires the GLFW backend, otherwise this function does nothing! Note,
+        on Windows the 'crosshair' option is XORed with the background color. It
+        will not be visible when placed over 50% grey fields.
 
         :param name: str, type of standard cursor to use
         :return:
@@ -427,17 +428,23 @@ class GLFWBackend(BaseBackend):
     def setCurrent(self):
         """Sets this window to be the current rendering target.
 
-        :return: None
+        Returns
+        -------
+        bool
+            ``True`` if the context was switched from another. ``False`` is
+            returned if ``setCurrent`` was called on an already current window.
 
         """
         if self != globalVars.currWindow:
             glfw.make_context_current(self.winHandle)
             globalVars.currWindow = self
 
+            return True
+
+        return False
+
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)
-
-        :return:
         """
         pass
 

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -434,22 +434,6 @@ class GLFWBackend(BaseBackend):
             glfw.make_context_current(self.winHandle)
             globalVars.currWindow = self
 
-            win = self.win  # it's a weakref so faster to call just once
-            # if we are using an FBO, bind it
-            if hasattr(win, 'frameBuffer'):
-                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT,
-                                        win.frameBuffer)
-                GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-                GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-
-                # NB - check if we need these
-                GL.glActiveTexture(GL.GL_TEXTURE0)
-                GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
-                GL.glEnable(GL.GL_STENCIL_TEST)
-
-                GL.glViewport(0, 0, win.size[0], win.size[1])
-                GL.glScissor(0, 0, win.size[0], win.size[1])
-
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)
 

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -269,35 +269,22 @@ class PygletBackend(BaseBackend):
         self.winHandle.set_mouse_visible(visibility)
 
     def setCurrent(self):
-        """Sets this window to be the current rendering target
+        """Sets this window to be the current rendering target.
 
-        :return: None
+        Returns
+        -------
+        bool
+            ``True`` if the context was switched from another. ``False`` is
+            returned if ``setCurrent`` was called on an already current window.
+
         """
         if self != globalVars.currWindow:
             self.winHandle.switch_to()
             globalVars.currWindow = self
 
-        win = self.win  # it's a weakref so faster to call just once
-        # if we are using an FBO, bind it
-        if hasattr(win, 'frameBuffer'):
-            GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT,
-                                    win.frameBuffer)
-            GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-            GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+            return True
 
-            # NB - check if we need these
-            GL.glActiveTexture(GL.GL_TEXTURE0)
-            GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
-            GL.glEnable(GL.GL_STENCIL_TEST)
-
-        GL.glViewport(0, 0, win.size[0], win.size[1])
-        GL.glScissor(0, 0, win.size[0], win.size[1])
-
-        GL.glMatrixMode(GL.GL_PROJECTION)
-        GL.glLoadIdentity()
-        GL.glOrtho(-1, 1, -1, 1, -1, 1)
-        GL.glMatrixMode(GL.GL_MODELVIEW)
-        GL.glLoadIdentity()
+        return False
 
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -277,21 +277,27 @@ class PygletBackend(BaseBackend):
             self.winHandle.switch_to()
             globalVars.currWindow = self
 
-            win = self.win  # it's a weakref so faster to call just once
-            # if we are using an FBO, bind it
-            if hasattr(win, 'frameBuffer'):
-                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT,
-                                        win.frameBuffer)
-                GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-                GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+        win = self.win  # it's a weakref so faster to call just once
+        # if we are using an FBO, bind it
+        if hasattr(win, 'frameBuffer'):
+            GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT,
+                                    win.frameBuffer)
+            GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+            GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
 
-                # NB - check if we need these
-                GL.glActiveTexture(GL.GL_TEXTURE0)
-                GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
-                GL.glEnable(GL.GL_STENCIL_TEST)
+            # NB - check if we need these
+            GL.glActiveTexture(GL.GL_TEXTURE0)
+            GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+            GL.glEnable(GL.GL_STENCIL_TEST)
 
-                GL.glViewport(0, 0, win.size[0], win.size[1])
-                GL.glScissor(0, 0, win.size[0], win.size[1])
+        GL.glViewport(0, 0, win.size[0], win.size[1])
+        GL.glScissor(0, 0, win.size[0], win.size[1])
+
+        GL.glMatrixMode(GL.GL_PROJECTION)
+        GL.glLoadIdentity()
+        GL.glOrtho(-1, 1, -1, 1, -1, 1)
+        GL.glMatrixMode(GL.GL_MODELVIEW)
+        GL.glLoadIdentity()
 
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -290,6 +290,9 @@ class PygletBackend(BaseBackend):
                 GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
                 GL.glEnable(GL.GL_STENCIL_TEST)
 
+                GL.glViewport(0, 0, win.size[0], win.size[1])
+                GL.glScissor(0, 0, win.size[0], win.size[1])
+
     def dispatchEvents(self):
         """Dispatch events to the event handler (typically called on each frame)
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -648,9 +648,18 @@ class Window(object):
             GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
             GL.glEnable(GL.GL_STENCIL_TEST)
 
+        # setup retina display if applicable
+        global retinaContext
+        if retinaContext is not None:
+            view = retinaContext.view()
+            bounds = view.convertRectToBacking_(view.bounds()).size
+            bufferWidth, bufferHeight = (int(bounds.width), int(bounds.height))
+        else:
+            bufferWidth, bufferHeight = self.size
+
         # set these to match the current window's settings
-        GL.glViewport(0, 0, self.size[0], self.size[1])
-        GL.glScissor(0, 0, self.size[0], self.size[1])
+        GL.glViewport(0, 0, bufferWidth, bufferHeight)
+        GL.glScissor(0, 0, bufferWidth, bufferHeight)
 
         # clear the projection and view matrix
         GL.glMatrixMode(GL.GL_PROJECTION)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1789,19 +1789,24 @@ class Window(object):
         They may vary in appearance and hot spot location across platforms. The
         following names are valid on most platforms:
 
-        - 'arrow' : Default pointer
-        - 'ibeam' : Indicates text can be edited
-        - 'crosshair' : Crosshair with hot-spot at center
-        - 'hand' : A pointing hand
-        - 'hresize' : Double arrows pointing horizontally
-        - 'vresize' : Double arrows pointing vertically
+            * ``arrow`` : Default pointer.
+            * ``ibeam`` : Indicates text can be edited.
+            * ``crosshair`` : Crosshair with hot-spot at center.
+            * ``hand`` : A pointing hand.
+            * ``hresize`` : Double arrows pointing horizontally.
+            * ``vresize`` : Double arrows pointing vertically.
 
-        Requires the GLFW backend, otherwise this function does nothing! Note,
-        on Windows the 'crosshair' option is XORed with the background color. It
-        will not be visible when placed over 50% grey fields.
+        Requires the GLFW backend, otherwise this function does nothing!
 
-        :param name: str, type of standard cursor to use
-        :return:
+        Parameters
+        ----------
+        name : str
+            Type of standard cursor to use.
+
+        Notes
+        -----
+        * On Windows the ``crosshair`` option is negated with the background
+          color. It will not be visible when placed over 50% grey fields.
 
         """
         pass

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -631,10 +631,14 @@ class Window(object):
             self.frameClock.reset()
 
     def _setCurrent(self):
-        """Make this window current. If useFBO=True, the framebuffer is bound
-        after the context switch.
+        """Make this window's OpenGL context current.
+
+        If ``useFBO=True``, the framebuffer is bound after the context switch.
+
         """
-        self.backend.setCurrent()
+        # don't configure if we haven't changed context
+        if not self.backend.setCurrent():
+            return
 
         # if we are using an FBO, bind it
         if hasattr(self, 'frameBuffer'):
@@ -657,7 +661,7 @@ class Window(object):
         else:
             bufferWidth, bufferHeight = self.size
 
-        # set these to match the current window's settings
+        # set these to match the current window or buffer's settings
         GL.glViewport(0, 0, bufferWidth, bufferHeight)
         GL.glScissor(0, 0, bufferWidth, bufferHeight)
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -633,7 +633,10 @@ class Window(object):
     def _setCurrent(self):
         """Make this window's OpenGL context current.
 
-        If ``useFBO=True``, the framebuffer is bound after the context switch.
+        If called on a window whose context is current, the function will return
+        immediately. This reduces the number of redundant calls if no context
+        switch is required. If ``useFBO=True``, the framebuffer is bound after
+        the context switch.
 
         """
         # don't configure if we haven't changed context

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1087,8 +1087,8 @@ class Window(object):
             objects.
 
         """
-        GL.glViewport(0, 0, self.size[0], self.size[1])
-        GL.glScissor(0, 0, self.size[0], self.size[1])
+        #GL.glViewport(0, 0, self.size[0], self.size[1])
+        #GL.glScissor(0, 0, self.size[0], self.size[1])
 
         # apply the projection and view transformations
         GL.glMatrixMode(GL.GL_PROJECTION)
@@ -1125,8 +1125,8 @@ class Window(object):
         """
         # should eventually have the same effect as calling _onResize(), so we
         # need to add the retina mode stuff eventually
-        GL.glViewport(0, 0, self.size[0], self.size[1])
-        GL.glScissor(0, 0, self.size[0], self.size[1])
+        #GL.glViewport(0, 0, self.size[0], self.size[1])
+        #GL.glScissor(0, 0, self.size[0], self.size[1])
         GL.glMatrixMode(GL.GL_PROJECTION)
         GL.glLoadIdentity()
         GL.glOrtho(-1, 1, -1, 1, -1, 1)


### PR DESCRIPTION
Fixes the issue posted here: https://discourse.psychopy.org/t/scaling-problems-with-multiple-windows-using-different-resolutions/7476/5

This patch fixes issues around switching windows which cause things to be incorrectly drawn in some use cases (e.g. when using windows with differing resolutions). It also makes window switches a touch more efficient by reducing redundant calls when a context change is requested on a current window. 

Also has support for properly configuring windows on retina displays. However, I don't have one to test with. 
