### PR TITLE
BF: Keyboard event keys cleared properly

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -232,7 +232,9 @@ class Keyboard:
     def clearEvents(self, eventType=None):
         if havePTB:
             for buffer in self._buffers.values():
-                buffer._clearEvents()
+                buffer._evts.clear()
+                buffer._keys.clear()
+                buffer._keysStillDown.clear()
         else:
             event.clearEvents(eventType)
 


### PR DESCRIPTION
KB was calling clearEvents to clear the key buffer, which only cleared the events list, not the
actual list of keys pressed. This means that keypresses persisted
even with the option to discard previous keypresses before KB onset
 was selected. To fix, rather than have clearEvents call _clearEvents,
which other methods also call, the events and key list are cleared
 directly.