### PR TITLE
BF: Fixes version formatting by using string value of version Param

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -499,7 +499,7 @@ class SettingsComponent(object):
 
         # decide if we need anchored useVersion or leave plain
         if self.params['Use version'].val not in ['', 'latest']:
-            versionStr = "-{}".format(self.params['Use version'])
+            versionStr = '-{}'.format(self.params['Use version'].val)
         else:
             versionStr = ''
 


### PR DESCRIPTION
The version Param was not formatting correctly in the JS and HTML
because the string representation of the value was not being used. This fix
uses the val attribute of version Param to format JS and html.