### PR TITLE
BF: fixed mic for pyo backend when prefs did not give pyo as preferred

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -13,11 +13,14 @@ from sys import platform
 from psychopy import core, logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
+import os
+travisCI = bool(str(os.environ.get('TRAVIS')).lower() == 'true')
 try:
     import pyo
 except ImportError as err:
-    # convert this import error to our own, pyo probably not installed
-    raise exceptions.DependencyError(repr(err))
+    if not travisCI:
+        # convert this import error to our own, pyo probably not installed
+        raise exceptions.DependencyError(repr(err))
 
 from ._base import _SoundBase
 import sounddevice

--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -264,7 +264,7 @@ class SoundDeviceSound(_SoundBase):
                         to force sounds to stereo or mono
         :param volume: float 0-1
         :param loops: number of loops to play (-1=forever, 0=single repeat)
-        :param sampleRate: sample rate for synthesized tones
+        :param sampleRate: sample rate (for synthesized tones)
         :param blockSize: the size of the buffer on the sound card
                          (small for low latency, large for stability)
         :param preBuffer: integer to control streaming/buffering


### PR DESCRIPTION
Mic is currently ONLY supported under pyo backend so, if another backend
is set as the default, we should initialise the pyo engine anyway and give
a warning that the mic and the preferred output lib may clash