### PR TITLE
BF/RF: Window fixes 

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -822,13 +822,6 @@ class Window(object):
                 GL.glColor3f(1.0, 1.0, 1.0)  # glColor multiplies with texture
                 GL.glColorMask(True, True, True, True)
 
-                # clear the projection and modelview matrix for FBO blit
-                GL.glMatrixMode(GL.GL_PROJECTION)
-                GL.glLoadIdentity()
-                GL.glOrtho(-1, 1, -1, 1, -1, 1)
-                GL.glMatrixMode(GL.GL_MODELVIEW)
-                GL.glLoadIdentity()
-
                 self._renderFBO()
 
                 GL.glEnable(GL.GL_BLEND)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1153,13 +1153,13 @@ class Window(object):
             GL.glMatrixMode(GL.GL_PROJECTION)
             projMat = self._projectionMatrix.T.ctypes.data_as(
                 ctypes.POINTER(ctypes.c_float))
-            GL.glLoadMatrixf(projMat)
+            GL.glLoadTransposeMatrixf(projMat)
 
         if hasattr(self, '_viewMatrix'):
             GL.glMatrixMode(GL.GL_MODELVIEW)
             viewMat = self._viewMatrix.T.ctypes.data_as(
                 ctypes.POINTER(ctypes.c_float))
-            GL.glLoadMatrixf(viewMat)
+            GL.glLoadTransposeMatrixf(viewMat)
 
         if clearDepth:
             GL.glClear(GL.GL_DEPTH_BUFFER_BIT)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -822,6 +822,13 @@ class Window(object):
                 GL.glColor3f(1.0, 1.0, 1.0)  # glColor multiplies with texture
                 GL.glColorMask(True, True, True, True)
 
+                # clear the projection and modelview matrix for FBO blit
+                GL.glMatrixMode(GL.GL_PROJECTION)
+                GL.glLoadIdentity()
+                GL.glOrtho(-1, 1, -1, 1, -1, 1)
+                GL.glMatrixMode(GL.GL_MODELVIEW)
+                GL.glLoadIdentity()
+
                 self._renderFBO()
 
                 GL.glEnable(GL.GL_BLEND)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -670,7 +670,7 @@ class Window(object):
         GL.glScissor(0, 0, bufferWidth, bufferHeight)
 
         # apply the view transforms for this window
-        self.applyEyeTransform()
+        #self.applyEyeTransform()
 
     def onResize(self, width, height):
         """A default resize event handler.
@@ -1147,15 +1147,17 @@ class Window(object):
 
         """
         # apply the projection and view transformations
-        GL.glMatrixMode(GL.GL_PROJECTION)
-        projMat = self._projectionMatrix.T.ctypes.data_as(
-            ctypes.POINTER(ctypes.c_float))
-        GL.glLoadMatrixf(projMat)
+        if hasattr(self, '_projectionMatrix'):
+            GL.glMatrixMode(GL.GL_PROJECTION)
+            projMat = self._projectionMatrix.T.ctypes.data_as(
+                ctypes.POINTER(ctypes.c_float))
+            GL.glLoadMatrixf(projMat)
 
-        GL.glMatrixMode(GL.GL_MODELVIEW)
-        viewMat = self._viewMatrix.T.ctypes.data_as(
-            ctypes.POINTER(ctypes.c_float))
-        GL.glLoadMatrixf(viewMat)
+        if hasattr(self, '_viewMatrix'):
+            GL.glMatrixMode(GL.GL_MODELVIEW)
+            viewMat = self._viewMatrix.T.ctypes.data_as(
+                ctypes.POINTER(ctypes.c_float))
+            GL.glLoadMatrixf(viewMat)
 
         if clearDepth:
             GL.glClear(GL.GL_DEPTH_BUFFER_BIT)
@@ -1174,10 +1176,10 @@ class Window(object):
         """
         # should eventually have the same effect as calling _onResize(), so we
         # need to add the retina mode stuff eventually
-        if not hasattr(self, '_viewMatrix'):
+        if hasattr(self, '_viewMatrix'):
             self._viewMatrix = numpy.identity(4, dtype=numpy.float32)
 
-        if not hasattr(self, '_projectionMatrix'):
+        if hasattr(self, '_projectionMatrix'):
             self._projectionMatrix = viewtools.orthoProjectionMatrix(
                 -1, 1, -1, 1, -1, 1)
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -641,7 +641,7 @@ class Window(object):
 
         """
         # don't configure if we haven't changed context
-        if self.backend.setCurrent():
+        if not self.backend.setCurrent():
             return
 
         # if we are using an FBO, bind it

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -792,6 +792,7 @@ class Window(object):
             # set these to match the current window or buffer's settings
             GL.glViewport(0, 0, self.size[0], self.size[1])
             GL.glScissor(0, 0, self.size[0], self.size[1])
+            GL.glEnable(GL.GL_SCISSOR_TEST)
 
             # clear the projection and modelview matrix for FBO blit
             GL.glMatrixMode(GL.GL_PROJECTION)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -668,6 +668,7 @@ class Window(object):
         # set these to match the current window or buffer's settings
         GL.glViewport(0, 0, bufferWidth, bufferHeight)
         GL.glScissor(0, 0, bufferWidth, bufferHeight)
+        GL.glEnable(GL.GL_SCISSOR_TEST)
 
         # apply the view transforms for this window
         #self.applyEyeTransform()

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -810,6 +810,13 @@ class Window(object):
                 GL.glColor3f(1.0, 1.0, 1.0)  # glColor multiplies with texture
                 GL.glColorMask(True, True, True, True)
 
+                # clear the projection and modelview matrix for FBO blit
+                GL.glMatrixMode(GL.GL_PROJECTION)
+                GL.glLoadIdentity()
+                GL.glOrtho(-1, 1, -1, 1, -1, 1)
+                GL.glMatrixMode(GL.GL_MODELVIEW)
+                GL.glLoadIdentity()
+
                 self._renderFBO()
 
                 GL.glEnable(GL.GL_BLEND)


### PR DESCRIPTION
Fixes some issues where ``viewPos`` and ``viewScale`` are overwritten by the new matrix logic. Added a bunch of fixes for retina displays when switching contexts. I drew a range of stimuli and everything draws correctly now. 

I'm going to play it safe an avoid going all in with regards to the view/projection matrix system until the next major release. If anyone can test this patch out on a Mac, that would be very helpful to see if retina support is working correctly.

Also for some reason there are lots of duplicate commit entries. Seems like git is acting up a bit. 