### PR TITLE
BF: Return keys if maxWait <= 0

### DIFF
--- a/psychopy/iohub/client/keyboard.py
+++ b/psychopy/iohub/client/keyboard.py
@@ -394,7 +394,7 @@ class Keyboard(ioHubDeviceView):
         Returned events are sorted by time.
 
         :param maxWait: Maximum seconds method waits for >=1 matching event.
-                        If 0.0, method functions the same as getKeys().
+                        If <=0.0, method functions the same as getKeys().
                         If None, the methods blocks indefinitely.
         :param keys: Include events where .key in keys.
         :param chars: Include events where .char in chars.
@@ -425,6 +425,11 @@ class Keyboard(ioHubDeviceView):
             if key:
                 return key
             win32MessagePump()
+            return key
+
+        # Don't wait if maxWait is <= 0
+        if maxWait <= 0:
+            key = pumpKeys()
             return key
 
         while getTime() < (timeout - checkInterval * 2):


### PR DESCRIPTION
This fix ensures that `waitForKeys` still returns the current set of queued events if `maxWait` is a number but not greater than 0. Previous behavior was to return an empty list.

Fixes #2454 