### PR TITLE
BF: FormComponent crashes if non-ASCII characters are used in Python2

### DIFF
--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -15,6 +15,8 @@ from psychopy.visual.basevisual import (BaseVisualStim,
                                         ColorMixin)
 from random import shuffle
 
+from psychopy.constants import PY3
+
 __author__ = 'Jon Peirce, David Bridges, Anthony Haffey'
 
 
@@ -171,8 +173,12 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 _checkHeaders(item.keys())
         # Convert options to list of strings
         for idx, item in enumerate(items):
-            if isinstance(item['options'], str):
-                items[idx]['options'] = item['options'].split(',')
+            if PY3:
+                if isinstance(item['options'], str):
+                    items[idx]['options'] = item['options'].split(',')
+            else: # Python2
+                if isinstance(item['options'], unicode):
+                    items[idx]['options'] = item['options'].split(',')
         # Check types
         [_checkTypes(item['type']) for item in items]
         # Check N options > 1
@@ -266,7 +272,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
             The width of the question bounding box as type float
         """
         if self.autoLog:
-            psychopy.logging.exp("Question text: {}".format(item['questionText']))
+            psychopy.logging.exp(u"Question text: {}".format(item['questionText']))
 
         question = psychopy.visual.TextStim(self.win,
                                             text=item['questionText'],
@@ -310,7 +316,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         if self.autoLog:
             psychopy.logging.exp("Response type: {}".format(item['type']))
             psychopy.logging.exp("Response layout: {}".format(item['layout']))
-            psychopy.logging.exp("Response options: {}".format(item['options']))
+            psychopy.logging.exp(u"Response options: {}".format(item['options']))
 
         # Create position of response object
         pos = self._getResponsePos(item, question)

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -177,7 +177,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 if isinstance(item['options'], str):
                     items[idx]['options'] = item['options'].split(',')
             else: # Python2
-                if isinstance(item['options'], unicode):
+                if isinstance(item['options'], basestring):
                     items[idx]['options'] = item['options'].split(',')
         # Check types
         [_checkTypes(item['type']) for item in items]


### PR DESCRIPTION
Form component crashes if non-ASCII characters are used in form items in Python2.
Error message is as follows:

```
Traceback (most recent call last):
  File "C:\Users\Hiroyuki\Desktop\untitled.py", line 81, in <module>
    itemPadding=0.05)
  File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\visual\form.py", line 99, in __init__
    self._doLayout()
  File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\visual\form.py", line 605, in _doLayout
    question, questionHeight, questionWidth = self._setQuestion(item)
  File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\visual\form.py", line 269, in _setQuestion
    psychopy.logging.exp("Question text: {}".format(item['questionText']))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-1: ordinal not in range(128)
```
If non-ASCII characters are included in `item['questionText']`, `u` is necessary to output this string to logfile.

In addition, in lines 174-175 for visual/form.py, type of `item['options']` is not `str` but `unicode ` in Python2.
