### PR TITLE
BF: Set name of Windows 'num enter' and 'return' to 'return'

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -414,7 +414,7 @@ keyNamesWin = {
     37: 'left', 40: 'down', 38: 'up', 39: 'right', 27: 'escape',
     144: 'numlock', 111: 'num_divide', 106: 'num_multiply',
     8: 'backspace', 109: 'num_subtract', 107: 'num_add',
-    13: 'num_enter', 222: 'pound', 161: 'lshift', 163: 'rctrl',
+    13: 'return', 222: 'pound', 161: 'lshift', 163: 'rctrl',
     92: 'rwindows', 32: 'space', 164: 'lalt', 165: 'ralt',
     91: 'lwindows', 93: 'menu', 162: 'lctrl', 160: 'lshift',
     20: 'capslock', 9: 'tab', 223: 'quoteleft', 220: 'backslash',


### PR DESCRIPTION
The windows OS does not differentiate between 'num enter' and 'return'
and so the same keycode is returned for keyboard. Changed name to 'return'
because that is (probably) more commonly used.