### PR TITLE
TESTS: Remove freetype pinning

### DIFF
--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype<2.10.0
+- freetype
 - freetype-py
 - future
 - gevent


### PR DESCRIPTION
Latest releases of `freetype-py` support recent `freetype`, so no need to restrict `freetype` versions anymore.