### PR TITLE
TESTS: Remove freetype dependency

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype<2.10.0
+- freetype
 - freetype-py
 - future
 - gevent

--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -13,7 +13,6 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype
 - freetype-py
 - future
 - gevent

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype<2.10.0
+- freetype
 - freetype-py
 - future
 - gevent

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -13,7 +13,6 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype
 - freetype-py
 - future
 - gevent

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -13,7 +13,7 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype<2.10.0
+- freetype
 - freetype-py
 - future
 - gevent

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -13,7 +13,6 @@ dependencies:
 - esprima-python
 - gitpython
 - ffmpeg
-- freetype
 - freetype-py
 - future
 - gevent


### PR DESCRIPTION
Latest releases of `freetype-py` support recent `freetype`, so no need to restrict `freetype` versions anymore.

**Edit** We don't need an explicit `freetype` dependency as it gets installed along with `freetype-py`.