### PR TITLE
BF: Find and save orphaned data at end of online task

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -813,6 +813,10 @@ class SettingsComponent(object):
                     "}\n")
         buff.writeIndentedLines(recordLoopIterationFunc)
         quitFunc = ("\nfunction quitPsychoJS(message, isCompleted) {\n"
+                    "  // Check for and save orphaned data\n"
+                    "  if (Object.keys(psychoJS.experiment._thisEntry).length > 0) {\n"
+                    "    psychoJS.experiment.nextEntry();\n"
+                    "  }\n"
                     "  psychoJS.window.close();\n"
                     "  psychoJS.quit({message: message, isCompleted: isCompleted});\n\n"
                     "  return Scheduler.Event.QUIT;\n"


### PR DESCRIPTION
This fix solves a problem where routine data was not saved
if no loops came after that routine (because nextEntry was not called).

This current implementation will not work until PsychoJS
Experiment Handler attributes of `_trialsData` and `thisCurrentTrial`
are changed  to `entries` and `thisEntry`, respectively.