### PR TITLE
BF: Leave out Variable components when tracking start/stop times

### DIFF
--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -134,8 +134,9 @@ class Routine(list):
 
         code = '# keep track of which components have finished\n'
         buff.writeIndentedLines(code)
+        # Get list of components, but leave out Variable components, which may not support attributes
         compStr = ', '.join([c.params['name'].val for c in self
-                             if 'startType' in c.params])
+                             if 'startType' in c.params and c.type != 'Variable'])
         buff.writeIndented('%sComponents = [%s]\n' % (self.name, compStr))
         code = ("for thisComponent in %sComponents:\n"
                 "    thisComponent.tStart = None\n"


### PR DESCRIPTION
This fixes an issue where Variable components cause AttributeErrors
when datatypes, that do not support attribute assigment, are used in the
component. The issue has arisen following new changes that the track start and
stop times of PsychoPy components. This fix stops Variable comps from being
added to the list of routine components that need start/stop times
recording. Fixes #2499.