### PR TITLE
DOCS: Change to object-style calls in all parallel port API examples

### DIFF
--- a/psychopy/parallel/__init__.py
+++ b/psychopy/parallel/__init__.py
@@ -71,6 +71,7 @@ else:
 
             from psychopy import parallel
             port = parallel.ParallelPort(address=0x0378)
+
             port.setData(4)
             port.readPin(2)
             port.setPin(2, 1)
@@ -93,15 +94,18 @@ else:
 
             Examples::
 
-                parallel.setData(0)  # sets all pins low
-                parallel.setData(255)  # sets all pins high
-                parallel.setData(2)  # sets just pin 3 high (pin2 = bit0)
-                parallel.setData(3)  # sets just pins 2 and 3 high
+                from psychopy import parallel
+                port = parallel.ParallelPort(address=0x0378)
+
+                port.setData(0)  # sets all pins low
+                port.setData(255)  # sets all pins high
+                port.setData(2)  # sets just pin 3 high (pin2 = bit0)
+                port.setData(3)  # sets just pins 2 and 3 high
 
             You can also convert base 2 to int easily in python::
 
-                parallel.setData( int("00000011", 2) )  # pins 2 and 3 high
-                parallel.setData( int("00000101", 2) )  # pins 2 and 4 high
+                port.setData( int("00000011", 2) )  # pins 2 and 3 high
+                port.setData( int("00000101", 2) )  # pins 2 and 4 high
             """
             sys.stdout.flush()
             raise NotImplementedError("Parallel ports don't work on a Mac")


### PR DESCRIPTION
Some of the API examples for the parallel port still give the impression of needing to call functions of the `parallel` module itself, rather than of a specific instance of the `parallel` class. To avoid confusion  for users (particularly those who are still finding old code examples around), have amended the examples to refer to a named instance `port`, and duplicate showing how it is created within each function's example. 