### PR TITLE
BF: Apply STENCIL_TEST only if enabled

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -687,7 +687,8 @@ class Window(object):
             # NB - check if we need these
             GL.glActiveTexture(GL.GL_TEXTURE0)
             GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
-            GL.glEnable(GL.GL_STENCIL_TEST)
+            if GL.glIsEnabled(GL.GL_STENCIL_TEST):
+                GL.glEnable(GL.GL_STENCIL_TEST)
 
         # setup retina display if applicable
         global retinaContext


### PR DESCRIPTION
This fixes an error where Apertures created in Forms were enabled in
following routines when Sliders are used, trimming any stim that did
not fall within the stencil area.