### PR TITLE
BF: with a retina display and Window.units='pix' mouse.getPos needs /2

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -643,6 +643,7 @@ class Mouse(object):
             else:
                 lastPosPix = lastPosPix - numpy.array(self.win.size) / 2
         self.lastPos = self._pix2windowUnits(lastPosPix)
+
         return copy.copy(self.lastPos)
 
     def mouseMoved(self, distance=None, reset=False):
@@ -849,6 +850,8 @@ class Mouse(object):
 
     def _pix2windowUnits(self, pos):
         if self.win.units == 'pix':
+            if self.win.useRetina:
+                pos /= 2.0
             return pos
         elif self.win.units == 'norm':
             return pos * 2.0 / self.win.size


### PR DESCRIPTION
The (actual) coords returned by the retina display are twice the
(virtual) coords returned by the window. So mouse.getPos needs to convert
these back to virtual coords as well (by dividing by 2)