### PR TITLE
BF: Call endLoopIteration when isTrials is False so loop can be broken

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -789,7 +789,7 @@ class SettingsComponent(object):
 
     def writeEndCodeJS(self, buff):
 
-        endLoopInteration = ("\nfunction endLoopIteration(thisScheduler, thisTrial) {\n"
+        endLoopInteration = ("\nfunction endLoopIteration({thisScheduler, isTrials=true}) {\n"
                     "  // ------Prepare for next entry------\n"
                     "  return function () {\n"
                     "    // ------Check if user ended loop early------\n"
@@ -799,7 +799,7 @@ class SettingsComponent(object):
                     "        psychoJS.experiment.nextEntry();\n"
                     "      }\n"
                     "      thisScheduler.stop();\n"
-                    "    } else if (typeof thisTrial === 'undefined' || !('isTrials' in thisTrial) || thisTrial.isTrials) {\n"
+                    "    } else if (isTrials) {\n"
                     "      psychoJS.experiment.nextEntry();\n"
                     "    }\n"
                     "  return Scheduler.Event.NEXT;\n"

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -255,14 +255,12 @@ class TrialHandler(object):
                     "    thisScheduler.add({name}LoopEnd);\n"
                     .format(params=self.params, name=thisChild.params['name'].val)
                     )
-        if self.params['isTrials'].val == True:
-            code += ("    thisScheduler.add(endLoopIteration(thisScheduler, "
-                     "{thisName}));\n".format(thisName=self.thisName))
 
-        code += ("  }\n"
-                "\n"
-                "  return Scheduler.Event.NEXT;\n"
-                "}\n")
+        code += ("    thisScheduler.add(endLoopIteration({{thisScheduler, isTrials : {isTrials}}}));\n"
+                 "  }}\n"
+                 "\n"
+                 "  return Scheduler.Event.NEXT;\n"
+                 "}}\n").format(isTrials=str(self.params['isTrials'].val).lower())
         buff.writeIndentedLines(code)
 
     def writeLoopEndCode(self, buff):


### PR DESCRIPTION
The endLoopIteration was not being called when isTrials was false, meaning
that the loop could not be broken using loop.finished. Adding the
endLoopIteration function to loops where isTrials is false means that the
a new arg `isTrials` must be passed, because `isTrials` never actually
exists in the `thisTrials` arg, so can not satisfy the else if statement,
and thisTrial can be both defined and undefined when isTrials is false,
meaning nextEntry could be called when it should not be. Now,
endLoopIteration will only call nextEntry if isTrials is true if not
trying to break loop manually.