### PR TITLE
TESTS: Recent releases of pip should work for us again

### DIFF
--- a/conda/environment-2.7.yml
+++ b/conda/environment-2.7.yml
@@ -31,7 +31,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip<19.0
+- pip!=19.0,!=19.0.1,!=19.0.2
 - pixman
 - prompt_toolkit
 - psutil

--- a/conda/environment-3.6.yml
+++ b/conda/environment-3.6.yml
@@ -32,7 +32,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip<19.0
+- pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyopengl
 - pyosf

--- a/conda/environment-3.7.yml
+++ b/conda/environment-3.7.yml
@@ -32,7 +32,7 @@ dependencies:
 - openpyxl
 - pandas
 - pillow
-- pip<19.0
+- pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyopengl
 - pyosf


### PR DESCRIPTION
Remove the `pip <19.0` restriction.