### PR TITLE
DOCS: Correct typo in window.py

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1875,7 +1875,7 @@ class Window(object):
     def mouseVisible(self, visibility):
         """Sets the visibility of the mouse cursor.
 
-        If Window was initialized with ``allowGUI=True`` then the mouse is
+        If Window was initialized with ``allowGUI=False`` then the mouse is
         initially set to invisible, otherwise it will initially be visible.
 
         Usage::


### PR DESCRIPTION
Addresses documentation error noted in #2524