### PR TITLE
DOC: enable sphinx.ext.viewcode

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ import sys, os, psychopy
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.autosummary', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-    'sphinx.ext.imgmath', 'sphinx.ext.napoleon', 'sphinx.ext.intersphinx']
+    'sphinx.ext.imgmath', 'sphinx.ext.napoleon', 'sphinx.ext.intersphinx', 'sphinx.ext.viewcode']
 autoclass_content='both'
 
 intersphinx_mapping = {'pathlib': ('https://docs.python.org/3/', None)}


### PR DESCRIPTION
With [`sphinx.ext.viewcode`](https://www.sphinx-doc.org/en/master/usage/extensions/viewcode.html), users can click on a very subtle "source" link next to each function/method/... in the API docs and that link leads them ... to the source :-)

For example, I was just inspecting [`getActualFramRate` in the API docs](https://www.psychopy.org/api/visual/window.html#psychopy.visual.Window.getActualFrameRate) and wanted to learn a bit more about it ... `sphinx.ext.viewcode` would have made that easier than going to GitHub and clicking on lots of different folders and files, or using a search function in an editor etc.