### PR TITLE
RF, ENH, TESTS for QuestPlusHandler

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1318,6 +1318,12 @@ class QuestPlusHandler(StairHandler):
         QUEST+ implementation. Currently only supports parameter estimation of
         a Weibull-shaped psychometric function.
 
+        The parameter estimates can be retrieved via the `.paramEstimate`
+        attribute, which returns a dictionary whose keys correspond to the
+        names of the estimated parameters
+        (i.e., `QuestPlusHandler.paramEstimate['threshold']` will provide the
+         threshold estimate).
+
         Parameters
         ----------
         nTrials : int
@@ -1524,8 +1530,23 @@ class QuestPlusHandler(StairHandler):
             self.finished = False
 
     @property
-    def paramEstimates(self):
-        return self._qp.param_estimate
+    def paramEstimate(self):
+        """
+        The estimated parameters of the psychometric function.
+
+        Returns
+        -------
+        dict
+            A dictionary whose keys correspond to the names of the estimated
+            parameters.
+
+        """
+        qp_estimate = self._qp.param_estimate
+        estimate = dict(threshold=qp_estimate['threshold'],
+                        slope=qp_estimate['slope'],
+                        lowerAsymptote=qp_estimate['lower_asymptote'],
+                        lapseRate=qp_estimate['lapse_rate'])
+        return estimate
 
     def saveAsJson(self,
                    fileName=None,

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1322,7 +1322,8 @@ class QuestPlusHandler(StairHandler):
         attribute, which returns a dictionary whose keys correspond to the
         names of the estimated parameters
         (i.e., `QuestPlusHandler.paramEstimate['threshold']` will provide the
-         threshold estimate).
+         threshold estimate). Retrieval of the marginal posterior distributions
+         works similarly: they can be accessed via the `.posterior` dictionary.
 
         Parameters
         ----------
@@ -1536,7 +1537,7 @@ class QuestPlusHandler(StairHandler):
 
         Returns
         -------
-        dict
+        dict of floats
             A dictionary whose keys correspond to the names of the estimated
             parameters.
 
@@ -1547,6 +1548,31 @@ class QuestPlusHandler(StairHandler):
                         lowerAsymptote=qp_estimate['lower_asymptote'],
                         lapseRate=qp_estimate['lapse_rate'])
         return estimate
+
+    @property
+    def posterior(self):
+        """
+        The marginal posterior distributions.
+
+        Returns
+        -------
+        dict of np.ndarrays
+            A dictionary whose keys correspond to the names of the estimated
+            parameters.
+
+        """
+        qp_posterior = self._qp.posterior
+
+        threshold = qp_posterior.sum(dim=('slope', 'lower_asymptote', 'lapse_rate'))
+        slope = qp_posterior.sum(dim=('threshold', 'lower_asymptote', 'lapse_rate'))
+        lowerAsymptote = qp_posterior.sum(dim=('threshold', 'slope', 'lapse_rate'))
+        lapseRate = qp_posterior.sum(dim=('threshold', 'slope', 'lower_asymptote'))
+
+        posterior = dict(threshold=threshold.values,
+                         slope=slope.values,
+                         lowerAsymptote=lowerAsymptote.values,
+                         lapseRate=lapseRate.values)
+        return posterior
 
     def saveAsJson(self,
                    fileName=None,

--- a/psychopy/tests/test_data/test_MultiStairHandler.py
+++ b/psychopy/tests/test_data/test_MultiStairHandler.py
@@ -103,10 +103,10 @@ class TestMultiStairHandler(object):
             response = np.random.choice(['Correct', 'Incorrect'])
             stairs.addResponse(response)
 
-        stairs.saveAsExcel(os.path.join(self.temp_dir, 'multiQuestOut'))
+        stairs.saveAsExcel(os.path.join(self.temp_dir, 'multiQuestPlusOut'))
 
         # contains more info
-        stairs.saveAsPickle(os.path.join(self.temp_dir, 'multiQuestOut'))
+        stairs.saveAsPickle(os.path.join(self.temp_dir, 'multiQuestPlusOut'))
         exp.close()
 
 

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -990,6 +990,34 @@ def test_QuestPlusHandler_paramEstimate_weibull():
     assert 'lapseRate' in q.paramEstimate.keys()
 
 
+def test_QuestPlusHandler_posterior_weibull():
+    import sys
+    if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        pytest.skip('QUEST+ only works on Python 3.6+')
+
+    from psychopy.data.staircase import QuestPlusHandler
+
+    thresholds = np.arange(-40, 0 + 1)
+    slope, guess, lapse = 3.5, 0.5, 0.02
+    contrasts = thresholds.copy()
+    response_vals = ['Correct', 'Incorrect']
+    func = 'weibull'
+
+    q = QuestPlusHandler(nTrials=20,
+                         intensityVals=contrasts,
+                         thresholdVals=thresholds,
+                         slopeVals=slope,
+                         lowerAsymptoteVals=guess,
+                         lapseRateVals=lapse,
+                         responseVals=response_vals,
+                         psychometricFunc=func)
+
+    assert 'threshold' in q.posterior.keys()
+    assert 'slope' in q.posterior.keys()
+    assert 'lowerAsymptote' in q.posterior.keys()
+    assert 'lapseRate' in q.posterior.keys()
+
+
 if __name__ == '__main__':
     # test_QuestPlusHandler()
     # test_QuestPlusHandler_startIntensity()

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -869,7 +869,7 @@ def test_QuestPlusHandler():
         assert next_contrast == expected_contrasts[trial_index]
         q.addResponse(response=responses[trial_index])
 
-    assert np.allclose(q.paramEstimates['threshold'],
+    assert np.allclose(q.paramEstimate['threshold'],
                        expected_mode_threshold)
 
 
@@ -960,6 +960,34 @@ def test_QuestPlusHandler_saveAsJson():
     q.addResponse(response='Correct')
 
     shutil.rmtree(temp_dir)
+
+
+def test_QuestPlusHandler_paramEstimate_weibull():
+    import sys
+    if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        pytest.skip('QUEST+ only works on Python 3.6+')
+
+    from psychopy.data.staircase import QuestPlusHandler
+
+    thresholds = np.arange(-40, 0 + 1)
+    slope, guess, lapse = 3.5, 0.5, 0.02
+    contrasts = thresholds.copy()
+    response_vals = ['Correct', 'Incorrect']
+    func = 'weibull'
+
+    q = QuestPlusHandler(nTrials=20,
+                         intensityVals=contrasts,
+                         thresholdVals=thresholds,
+                         slopeVals=slope,
+                         lowerAsymptoteVals=guess,
+                         lapseRateVals=lapse,
+                         responseVals=response_vals,
+                         psychometricFunc=func)
+
+    assert 'threshold' in q.paramEstimate.keys()
+    assert 'slope' in q.paramEstimate.keys()
+    assert 'lowerAsymptote' in q.paramEstimate.keys()
+    assert 'lapseRate' in q.paramEstimate.keys()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Parameter estimates must now be retrieved via `.paramEstimate` attribute (used to be `.paramEstimates`)
* Posterior PDFs can now be retrieved via `.posterior` attribute
* tiny changes to tests
