### PR TITLE
BF: Shader log returned as bytes causing string operations fail.

### DIFF
--- a/psychopy/visual/shaders.py
+++ b/psychopy/visual/shaders.py
@@ -24,7 +24,7 @@ def print_log(shader):
     if length.value > 0:
         log = create_string_buffer(length.value)
         GL.glGetShaderInfoLog(shader, length, byref(length), log)
-        sys.stderr.write(log.value + '\n')
+        sys.stderr.write(log.value.decode('UTF-8') + '\n')
 
 
 def compileProgram(vertexSource=None, fragmentSource=None):


### PR DESCRIPTION
Log from shader compilation needs to be converted to UTF-8 string first before printing to console.