### PR TITLE
NF/RF/DOCS: embedShaderSourceDefs, shader source lists, and doc fixes

### DIFF
--- a/docs/source/api/tools/gltools.rst
+++ b/docs/source/api/tools/gltools.rst
@@ -16,6 +16,7 @@
     useProgram
     createProgramObjectARB
     compileShaderObjectARB
+    embedShaderSourceDefs
     deleteObjectARB
     attachObjectARB
     detachObjectARB

--- a/docs/source/api/tools/mathtools.rst
+++ b/docs/source/api/tools/mathtools.rst
@@ -81,6 +81,8 @@ Overview
     distance
     angleTo
     surfaceNormal
+    surfaceBitangent
+    surfaceTangent
     slerp
     quatToAxisAngle
     quatFromAxisAngle
@@ -112,6 +114,8 @@ Details
 .. autofunction:: distance
 .. autofunction:: angleTo
 .. autofunction:: surfaceNormal
+.. autofunction:: surfaceBitangent
+.. autofunction:: surfaceTangent
 .. autofunction:: slerp
 .. autofunction:: quatToAxisAngle
 .. autofunction:: quatFromAxisAngle

--- a/docs/source/api/tools/mathtools.rst
+++ b/docs/source/api/tools/mathtools.rst
@@ -83,6 +83,7 @@ Overview
     surfaceNormal
     surfaceBitangent
     surfaceTangent
+    vertexNormal
     slerp
     quatToAxisAngle
     quatFromAxisAngle
@@ -116,6 +117,7 @@ Details
 .. autofunction:: surfaceNormal
 .. autofunction:: surfaceBitangent
 .. autofunction:: surfaceTangent
+.. autofunction:: vertexNormal
 .. autofunction:: slerp
 .. autofunction:: quatToAxisAngle
 .. autofunction:: quatFromAxisAngle

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -133,7 +133,7 @@ def compileShader(shaderSrc, shaderType):
 
     Parameters
     ----------
-    shaderSrc : str
+    shaderSrc : str or list of str
         GLSL shader source code.
     shaderType : GLenum
         Shader program type (eg. GL_VERTEX_SHADER, GL_FRAGMENT_SHADER,
@@ -166,10 +166,17 @@ def compileShader(shaderSrc, shaderType):
     """
     shaderId = GL.glCreateShader(shaderType)
 
-    shaderSrc = shaderSrc.encode()
-    srcPtr = ctypes.c_char_p(shaderSrc)
+    if isinstance(shaderSrc, (list, tuple,)):
+        nSources = len(shaderSrc)
+        srcPtr = (ctypes.c_char_p * nSources)()
+        srcPtr[:] = [i.encode() for i in shaderSrc]
+    else:
+        nSources = 1
+        srcPtr = ctypes.c_char_p(shaderSrc.encode())
+
     GL.glShaderSource(
-        shaderId, 1,
+        shaderId,
+        nSources,
         ctypes.cast(
             ctypes.byref(srcPtr),
             ctypes.POINTER(ctypes.POINTER(ctypes.c_char))),
@@ -210,10 +217,17 @@ def compileShaderObjectARB(shaderSrc, shaderType):
     """
     shaderId = GL.glCreateShaderObjectARB(shaderType)
 
-    shaderSrc = shaderSrc.encode()
-    srcPtr = ctypes.c_char_p(shaderSrc)
+    if isinstance(shaderSrc, (list, tuple,)):
+        nSources = len(shaderSrc)
+        srcPtr = (ctypes.c_char_p * nSources)()
+        srcPtr[:] = [i.encode() for i in shaderSrc]
+    else:
+        nSources = 1
+        srcPtr = ctypes.c_char_p(shaderSrc.encode())
+
     GL.glShaderSourceARB(
-        shaderId, 1,
+        shaderId,
+        nSources,
         ctypes.cast(
             ctypes.byref(srcPtr),
             ctypes.POINTER(ctypes.POINTER(ctypes.c_char))),

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -136,8 +136,8 @@ def compileShader(shaderSrc, shaderType):
     shaderSrc : str, list of str
         GLSL shader source code.
     shaderType : GLenum
-        Shader program type (eg. GL_VERTEX_SHADER, GL_FRAGMENT_SHADER,
-        GL_GEOMETRY_SHADER, etc.)
+        Shader program type (eg. `GL_VERTEX_SHADER`, `GL_FRAGMENT_SHADER`,
+        `GL_GEOMETRY_SHADER`, etc.)
 
     Returns
     -------
@@ -205,8 +205,8 @@ def compileShaderObjectARB(shaderSrc, shaderType):
     shaderSrc : str, list of str
         GLSL shader source code text.
     shaderType : GLenum
-        Shader program type. Must be *_ARB enums such as GL_VERTEX_SHADER_ARB,
-        GL_FRAGMENT_SHADER_ARB, GL_GEOMETRY_SHADER_ARB, etc.
+        Shader program type. Must be *_ARB enums such as `GL_VERTEX_SHADER_ARB`,
+        `GL_FRAGMENT_SHADER_ARB`, `GL_GEOMETRY_SHADER_ARB`, etc.
 
     Returns
     -------
@@ -508,7 +508,7 @@ def linkProgram(program):
     result = GL.GLint()
     GL.glGetProgramiv(program, GL.GL_LINK_STATUS, ctypes.byref(result))
 
-    if result.value == GL.GL_FALSE:  # failed to compile for whatever reason
+    if result.value == GL.GL_FALSE:  # failed to link for whatever reason
         sys.stderr.write(getInfoLog(program) + '\n')
         raise RuntimeError(
             'Failed to link shader program. Check log output.')
@@ -545,7 +545,7 @@ def linkProgramObjectARB(program):
         GL.GL_OBJECT_LINK_STATUS_ARB,
         ctypes.byref(result))
 
-    if result.value == GL.GL_FALSE:  # failed to compile for whatever reason
+    if result.value == GL.GL_FALSE:  # failed to link for whatever reason
         sys.stderr.write(getInfoLog(program) + '\n')
         raise RuntimeError(
             'Failed to link shader program. Check log output.')
@@ -608,7 +608,7 @@ def useProgram(program):
     program : int
         Handle of program to use. Must have originated from a
         :func:`createProgram` or `glCreateProgram` call and was successfully
-        linked.
+        linked. Passing `0` or `None` disables shader programs.
 
     Examples
     --------
@@ -621,6 +621,9 @@ def useProgram(program):
         useProgram(0)
 
     """
+    if program is None:
+        program = 0
+
     if GL.glIsProgram(program) or program == 0:
         GL.glUseProgram(program)
     else:
@@ -640,7 +643,7 @@ def useProgramObjectARB(program):
     program : int
         Handle of program object to use. Must have originated from a
         :func:`createProgramObjectARB` or `glCreateProgramObjectARB` call and
-        was successfully linked.
+        was successfully linked. Passing `0` or `None` disables shader programs.
 
     Examples
     --------
@@ -658,6 +661,9 @@ def useProgramObjectARB(program):
     :func:`createProgramObjectARB` or `glCreateProgramObjectARB`.
 
     """
+    if program is None:
+        program = 0
+
     if GL.glIsProgram(program) or program == 0:
         GL.glUseProgramObjectARB(program)
     else:
@@ -695,16 +701,15 @@ def getInfoLog(obj):
     if GL.glIsShader(obj) == GL.GL_TRUE:
         GL.glGetShaderiv(
             obj, GL.GL_INFO_LOG_LENGTH, ctypes.byref(logLength))
-        logBuffer = ctypes.create_string_buffer(logLength.value)
-        GL.glGetShaderInfoLog(obj, logLength, None, logBuffer)
     elif GL.glIsProgram(obj) == GL.GL_TRUE:
         GL.glGetProgramiv(
             obj, GL.GL_INFO_LOG_LENGTH, ctypes.byref(logLength))
-        logBuffer = ctypes.create_string_buffer(logLength.value)
-        GL.glGetProgramInfoLog(obj, logLength, None, logBuffer)
     else:
         raise ValueError(
             "Specified value of `obj` is not a shader or program.")
+
+    logBuffer = ctypes.create_string_buffer(logLength.value)
+    GL.glGetShaderInfoLog(obj, logLength, None, logBuffer)
 
     return logBuffer.value.decode('UTF-8')
 

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -285,10 +285,10 @@ def genShaderPreprocDefs(defs):
             [glslHeader, fragSrc], GL_FRAGMENT_SHADER_ARB)
 
     Code paths can be selected depending on the requirements of the material
-    being used. For instance, a shader program can enable/disable sampling
-    diffuse color from texture conditionally by defining ``DIFFUSE`` and
-    surrounding texture related code paths with ``#ifdef`` and ``#endif``
-    preprocessor directives::
+    being used. For instance, a shader program can be built to sample diffuse
+    color from texture conditionally by defining ``DIFFUSE`` and surrounding
+    texture related code paths with ``#ifdef`` and ``#endif`` preprocessor
+    directives::
 
         #ifdef DIFFUSE
             uniform sampler2D diffuseTexture;

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -337,19 +337,16 @@ def embedShaderSourceDefs(shaderSrc, defs):
         if not isinstance(varName, str):
             raise ValueError("Definition name must be type `str`.")
 
-        if isinstance(varValue, (int, float,)):
-            if isinstance(varValue, bool):
-                varValue = int(varValue)
-            defStmt = '#define {n} {v}\n'.format(n=varName, v=str(varValue))
-        elif isinstance(varValue, str):
-            defStmt = '#define {n} {v}\n'.format(n=varName, v=varValue)
+        if isinstance(varValue, (int, bool, float,)):
+            varValue = str(int(varValue))
         elif isinstance(varValue, bytes):
             varValue = varValue.decode('UTF-8')
-            defStmt = '#define {n} "{v}"\n'.format(n=varName, v=varValue)
+        elif isinstance(varValue, str):
+            pass  # nop
         else:
             raise TypeError("Invalid type for value of `{}`.".format(varName))
 
-        glslDefSrc += defStmt
+        glslDefSrc += '#define {n} "{v}"\n'.format(n=varName, v=varValue)
 
     # find where the `#version` directive occurs
     versionDirIdx = shaderSrc.find("#version")

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -1678,10 +1678,7 @@ def posOriToMatrix(pos, ori, out=None, dtype=None):
     transMat = translationMatrix(pos, dtype=dtype)
     rotMat = quatToMatrix(ori, dtype=dtype)
 
-    if out is not None:
-        return np.matmul(rotMat, transMat, out=toReturn)
-
-    return np.matmul(rotMat, transMat)
+    return np.matmul(rotMat, transMat, out=toReturn)
 
 
 def transform(pos, ori, points, out=None, dtype=None):

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -2009,13 +2009,3 @@ def transform(pos, ori, points, out=None, dtype=None):
 
     return toReturn
 
-
-if __name__ == "__main__":
-    vertices = [[[1., 0., 0.], [0., 1., 0.], [-1, 0, 0]],  # 2x3x3
-                [[1., 0., 0.], [0., 1., 0.], [-1, 0, 0]]]
-    normals = np.zeros((2, 3))  # normals from two triangles triangles
-    faceNorms = surfaceNormal(vertices, out=normals)
-
-    print(faceNorms)
-
-    print(vertexNormal([[1., 0., 0.], [0., 1., 0.]]))

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -1383,8 +1383,8 @@ def translationMatrix(t, out=None, dtype=None):
         output if `out` was not specified.
     dtype : dtype or str, optional
         Data type for arrays, can either be 'float32' or 'float64'. If `None` is
-        specified, the data type is inferred by `out`. If `out` is not
-        specified, the default is 'float64'.
+        specified, the data type is inferred by `out`. If `out` is not provided,
+        the default is 'float64'.
 
     Returns
     -------
@@ -1442,6 +1442,7 @@ def invertMatrix(m, homogeneous=False, out=None, dtype=None):
         toReturn.fill(0.0)
 
     m = np.asarray(m, dtype=dtype)  # input as array
+    assert m.shape == (4, 4,)
 
     if not homogeneous:
         toReturn[:, :] = np.linalg.inv(m)
@@ -1588,8 +1589,8 @@ def applyMatrix(m, points, out=None, dtype=None):
         output if `out` was not specified.
     dtype : dtype or str, optional
         Data type for arrays, can either be 'float32' or 'float64'. If `None` is
-        specified, the data type is inferred by `out`. If `out` is not
-        specified, the default is 'float64'.
+        specified, the data type is inferred by `out`. If `out` is not provided,
+        the default is 'float64'.
 
     Returns
     -------
@@ -1659,8 +1660,8 @@ def posOriToMatrix(pos, ori, out=None, dtype=None):
         output if `out` was not specified.
     dtype : dtype or str, optional
         Data type for arrays, can either be 'float32' or 'float64'. If `None` is
-        specified, the data type is inferred by `out`. If `out` is not
-        specified, the default is 'float64'.
+        specified, the data type is inferred by `out`. If `out` is not provided,
+        the default is 'float64'.
 
     Returns
     -------

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -662,7 +662,7 @@ def surfaceNormal(tri, norm=False, out=None, dtype=None):
 
         vertices = [[[-1., 0., 0.], [0., 1., 0.], [1, 0, 0]],  # 2x3x3
                     [[1., 0., 0.], [0., 1., 0.], [-1, 0, 0]]]
-        normals = np.zeros((2, 3, 3))
+        normals = np.zeros((2, 3))  # normals from two triangles triangles
         surfaceNormal(vertices, out=normals)
 
     """
@@ -685,8 +685,8 @@ def surfaceNormal(tri, norm=False, out=None, dtype=None):
 
     # from https://www.khronos.org/opengl/wiki/Calculating_a_Surface_Normal
     nr = np.atleast_2d(toReturn)
-    u = (tris[:, 1, :] - tris[:, 0, :])
-    v = (tris[:, 2, :] - tris[:, 1, :])
+    u = tris[:, 1, :] - tris[:, 0, :]
+    v = tris[:, 2, :] - tris[:, 1, :]
     nr[:, 0] = u[:, 1] * v[:, 2] - u[:, 2] * v[:, 1]
     nr[:, 1] = u[:, 2] * v[:, 0] - u[:, 0] * v[:, 2]
     nr[:, 2] = u[:, 0] * v[:, 1] - u[:, 1] * v[:, 0]
@@ -1181,7 +1181,7 @@ def applyQuat(q, points, out=None, dtype=None):
 #
 
 def quatToMatrix(q, out=None, dtype=None):
-    """Create a rotation matrix from a quaternion.
+    """Create a 4x4 rotation matrix from a quaternion.
 
     Parameters
     ----------
@@ -1541,8 +1541,8 @@ def concatenate(matrices, out=None, dtype=None):
         MV = np.asarray(MV, dtype='float32')
         GL.glLoadTransposeMatrixf(MV)
 
-    Furthermore, you can go from model-space to homogeneous clip-space by
-    concatenating the projection, view, and model matrices::
+    Furthermore, you can convert a point from model-space to homogeneous
+    clip-space by concatenating the projection, view, and model matrices::
 
         # compute projection matrix, functions here are from 'viewtools'
         screenWidth = 0.52
@@ -1552,7 +1552,7 @@ def concatenate(matrices, out=None, dtype=None):
         P = perspectiveProjectionMatrix(*frustum)
 
         # multiply model-space points by MVP to convert them to clip-space
-        MVP = concatenate(M, V, P)
+        MVP = concatenate([M, V, P])
         pointModel = np.array([0., 1., 0., 1.])
         pointClipSpace = np.matmul(MVP, pointModel.T)
 

--- a/psychopy/visual/shaders.py
+++ b/psychopy/visual/shaders.py
@@ -19,7 +19,7 @@ def compileProgram(vertexSource=None, fragmentSource=None):
 
     Parameters
     ----------
-    vertexSource, fragmentSource : str
+    vertexSource, fragmentSource : str or list of str
         Vertex and fragment shader GLSL sources.
 
     Returns


### PR DESCRIPTION
Added function `embedShaderSourceDefs` to `gltools`. This function generates and inserts ``#define`` statements into existing GLSL source code, allowing one to use GLSL preprocessor statements to alter program source at compile time. Using this feature, it is possible to have vertex and fragment shader code in the same source text. It also allows for constants to be defined and render code paths to be pruned at compile time. 

Shader code can be formatted in a file like so (here is the combined code for PsychoPy's FBO blit shader):

```
    #ifdef VERTEX
    void main() {
            gl_FrontColor = gl_Color;
            gl_TexCoord[0] = gl_MultiTexCoord0;
            gl_TexCoord[1] = gl_MultiTexCoord1;
            gl_TexCoord[2] = gl_MultiTexCoord2;
            gl_Position =  ftransform();
    }
    #endif
    #ifdef FRAGMENT
    uniform sampler2D texture;

    float rand(vec2 seed){
        return fract(sin(dot(seed.xy ,vec2(12.9898,78.233))) * 43758.5453);
    }

    void main() {
        vec4 textureFrag = texture2D(texture,gl_TexCoord[0].st);
        gl_FragColor.rgb = textureFrag.rgb;
        //! if too high then show red/black noise
        if ( gl_FragColor.r>1.0 || gl_FragColor.g>1.0 || gl_FragColor.b>1.0) {
            gl_FragColor.rgb = vec3 (rand(gl_TexCoord[0].st), 0, 0);
        }
        //! if too low then show red/black noise
        else if ( gl_FragColor.r<0.0 || gl_FragColor.g<0.0 || gl_FragColor.b<0.0) {
            gl_FragColor.rgb = vec3 (0, 0, rand(gl_TexCoord[0].st));
        }
    }
    #endif
```

Using `embedShaderSourceDefs`, you can define either `VERTEX` or `FRAGMENT` as `True` to select which code to compile.

```
        vertexShader = gltools.compileShaderObjectARB(
            gltools.embedShaderSourceDefs(glslSource, {'VERTEX': True}),
            GL.GL_VERTEX_SHADER_ARB)
        fragmentShader = gltools.compileShaderObjectARB(
            gltools.embedShaderSourceDefs(glslSource, {'FRAGMENT': True}),
            GL.GL_FRAGMENT_SHADER_ARB)
```
This function also allows you to prune rendering code paths to accommodate various lighting and material properties without needing to write separate shaders. For instance, the same fragment shader source can handle cases where sampling diffuse colour from a texture is or isn't used as seen here:

```
        #ifdef DIFFUSE_TEXTURE
            uniform sampler2D diffuseTexture;
        #endif
        ...
        #ifdef DIFFUSE_TEXTURE
            // sample color from texture
            vec4 diffuseColor = texture2D(diffuseTexture, gl_TexCoord[0].st);
        #else
            // code path for no textures, just output material color
            vec4 diffuseColor = gl_FrontMaterial.diffuse;
        #endif
```
Simply use `gltools.embedShaderSourceDefs(glslSource, {'DIFFUSE_TEXTURE': True})` to enable the texturing code path at compile time. This functionality becomes very handy when creating shader to handle many permutations of lighting and material properties (which was my primary motivation to write this function because the 3D mesh class called for that).

I also fixed some documenation and added the ability to pass lists of shader sources to `compileShader` and `compileShaderObjectARB` as is permitted by those functions. Nothing has changed otherwise to how PsychoPy compiles shaders. 