### PR TITLE
FF: Have `embedShaderSourceDefs` use proper indentation level.

### DIFF
--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -76,7 +76,7 @@ def createProgramObjectARB():
 
     This creates an *Architecture Review Board* (ARB) program variant which is
     compatible with older GLSL versions and OpenGL coding practices (eg.
-    immediate mode) on some platforms. Use *ARB variants of shader helper
+    fixed function) on some platforms. Use *ARB variants of shader helper
     functions (eg. `compileShaderObjectARB` instead of `compileShader`) when
     working with these ARB program objects. This was included for legacy support
     of existing PsychoPy shaders. However, it is recommended that you use

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -775,7 +775,7 @@ def getUniformLocations(program, builtins=False):
         # get the uniform names and locations. In the shader, we have defined
         # `uniform vec4 specularColor`.
         uniforms = getUniformLocations(myShader)
-        hasSpecularColor = 'specularColor' in uniforms
+        hasSpecularColor = 'specularColor' in uniforms.keys()
 
         if hasSpecularColor:
             glUniform4f(uniforms['specularColor'],
@@ -786,7 +786,7 @@ def getUniformLocations(program, builtins=False):
         #
         # If the shader has `uniform sampler2D diffuseTexture` defined, we
         # enable textures and bind it to the appropriate texture unit.
-        if 'diffuseTexture' in uniforms:
+        if 'diffuseTexture' in uniforms.keys():
             # enable textures if the shader calls for it
             glEnable(GL_TEXTURE_2D)
             glActiveTexture(GL_TEXTURE0)

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -23,6 +23,9 @@ import itertools
 # Shader Program Helper Functions
 # -------------------------------
 #
+# These functions simplify the creation and usage of GLSL shader programs. Both
+# legacy *ARB and recent core profile shader programs are supported.
+#
 
 
 def createProgram():


### PR DESCRIPTION
Minor fix, have embedded `#define` statements match the indentation level of the GLSL source code they are being inserted into. This make printing the modified GLSL source code appear neater. Also removed quotations from define values. 