### PR TITLE
BF: undo the attempt not to force-stop brief sounds

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -158,8 +158,7 @@ class SoundComponent(BaseComponent):
         buff.setIndentLevel(-1, relative=True)
         if not self.params['stopVal'].val in ['', None, -1, 'None']:
             self.writeStopTestCode(buff)
-            code = ("if %(stopVal)s > 0.5:  # don't force-stop brief sounds\n"
-                    "    %(name)s.stop()\n")
+            code = ("%(name)s.stop()\n")
             buff.writeIndentedLines(code % self.params)
             # because of the 'if' statement of the time test
             buff.setIndentLevel(-2, relative=True)


### PR DESCRIPTION
The issue dates back to GH-1710 with an attempt to "reduce spectral
splatter" but it also has the effect that brief sounds don't stop by
themselves (they only stop if a short file)

fixes GH-2564