### PR TITLE
NF/DOCS: Advanced VBO and VAO features

### DIFF
--- a/docs/source/api/tools/gltools.rst
+++ b/docs/source/api/tools/gltools.rst
@@ -37,8 +37,20 @@
     createTexImage2D
     createTexImage2DMultisample
     deleteTexture
-    createVBO
+    VertexArrayInfo
     createVAO
+    drawVAO
+    deleteVAO
+    VertexBufferInfo
+    createVBO
+    bindVBO
+    unbindVBO
+    mapBuffer
+    unmapBuffer
+    deleteVBO
+    setVertexAttribPointer
+    enableVertexAttribArray
+    disableVertexAttribArray
     drawVAO
     deleteVBO
     deleteVAO
@@ -87,11 +99,20 @@ Function details
 .. autofunction:: createTexImage2D
 .. autofunction:: createTexImage2DMultisample
 .. autofunction:: deleteTexture
-.. autofunction:: createVBO
+.. autofunction:: VertexArrayInfo
 .. autofunction:: createVAO
 .. autofunction:: drawVAO
-.. autofunction:: deleteVBO
 .. autofunction:: deleteVAO
+.. autofunction:: VertexBufferInfo
+.. autofunction:: createVBO
+.. autofunction:: bindVBO
+.. autofunction:: unbindVBO
+.. autofunction:: mapBuffer
+.. autofunction:: unmapBuffer
+.. autofunction:: deleteVBO
+.. autofunction:: setVertexAttribPointer
+.. autofunction:: enableVertexAttribArray
+.. autofunction:: disableVertexAttribArray
 .. autofunction:: createMaterial
 .. autofunction:: useMaterial
 .. autofunction:: createLight

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -2152,7 +2152,7 @@ class MapBufferContext(object):
             self.vboDesc.target,
             GL.GLintptr(0),
             GL.GLintptr(self.vboDesc.size),
-            GL.GL_MAP_WRITE_BIT)
+            GL.GL_MAP_WRITE_BIT | GL.GL_MAP_UNSYNCHRONIZED_BIT)
         self.bufferArray = np.ctypeslib.as_array(
             ctypes.cast(self.bufferPtr, ctypes.POINTER(ctypes.c_float)),
             shape=vbo.shape)

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -19,6 +19,29 @@ import numpy as np
 import os, sys
 import itertools
 
+# compatible Numpy and OpenGL types for common GL type enums
+GL_COMPAT_TYPES = {
+    GL.GL_FLOAT: (np.float32, GL.GLfloat),
+    GL.GL_DOUBLE: (np.float64, GL.GLdouble),
+    GL.GL_UNSIGNED_SHORT: (np.uint16, GL.GLushort),
+    GL.GL_UNSIGNED_INT: (np.uint32, GL.GLuint),
+    GL.GL_INT: (np.int32, GL.GLint),
+    GL.GL_SHORT: (np.int16, GL.GLshort),
+    GL.GL_HALF_FLOAT: (np.float16, GL.GLhalfARB),
+    GL.GL_UNSIGNED_BYTE: (np.uint8, GL.GLubyte),
+    GL.GL_BYTE: (np.int8, GL.GLbyte),
+    np.float32: (GL.GL_FLOAT, GL.GLfloat),
+    np.float64: (GL.GL_DOUBLE, GL.GLdouble),
+    np.uint16: (GL.GL_UNSIGNED_SHORT, GL.GLushort),
+    np.uint32: (GL.GL_UNSIGNED_INT, GL.GLuint),
+    np.int32: (GL.GL_INT, GL.GLint),
+    np.int16: (GL.GL_SHORT, GL.GLshort),
+    np.float16: (GL.GL_HALF_FLOAT, GL.GLhalfARB),
+    np.uint8: (GL.GL_UNSIGNED_BYTE, GL.GLubyte),
+    np.int8: (GL.GL_BYTE, GL.GLbyte)
+}
+
+
 # -------------------------------
 # Shader Program Helper Functions
 # -------------------------------
@@ -1652,8 +1675,8 @@ class VertexBufferInfo(object):
         `userData` will be initialized as an empty dictionary.
 
     """
-    __slots__ = [
-        'name', 'target', 'usage', 'dataType', 'size', 'stride', 'shape', 'userData']
+    __slots__ = ['name', 'target', 'usage', 'dataType',
+                 'size', 'stride', 'shape', 'userData']
 
     def __init__(self,
                  name=0,
@@ -1665,7 +1688,7 @@ class VertexBufferInfo(object):
                  shape=(0,),
                  userData=None):
 
-        self.name = GL.GLuint(name)
+        self.name = name
         self.target = target
         self.usage = usage
         self.dataType = dataType
@@ -1689,7 +1712,7 @@ class VertexBufferInfo(object):
         return self.name != other.name
 
     @property
-    def isBuffer(self):
+    def hasBuffer(self):
         """Check if the VBO assigned to name is a buffer."""
         if self.name != 0 and GL.glIsBuffer(self.name):
             return True
@@ -1745,28 +1768,14 @@ class VertexBufferInfo(object):
         return isValid
 
 
-VertexArrayObject = namedtuple(
-    'VertexArrayObject',
-    ['id',
-     'indices',
-     'isIndexed',
-     'userData']
-)
-
-
-GL_COMPAT_TYPES = {GL.GL_FLOAT: (np.float32, GL.GLfloat),
-                   GL.GL_DOUBLE: (np.float64, GL.GLdouble),
-                   GL.GL_UNSIGNED_SHORT: (np.uint16, GL.GLushort),
-                   GL.GL_UNSIGNED_INT: (np.uint32, GL.GLuint),
-                   GL.GL_INT: (np.int32, GL.GLint),
-                   GL.GL_SHORT: (np.int16, GL.GLshort)}
-
-
 def createVBO(data,
               target=GL.GL_ARRAY_BUFFER,
               dataType=GL.GL_FLOAT,
               usage=GL.GL_STATIC_DRAW):
-    """Create an array buffer, often referred to as Vertex Buffer Object (VBO).
+    """Create an array buffer object (VBO).
+
+    Creates a VBO using input data, usually as a `ndarray` or `list`. Attributes
+    common to one vertex should occupy a single row of the `data` array.
 
     Parameters
     ----------
@@ -1775,9 +1784,10 @@ def createVBO(data,
         VBO is inferred by the type of the array. If the input is a Python
         `list` or `tuple` type, the data type of the array will be `GL_FLOAT`.
     target : :obj:`int`
-        Target used when binding the buffer (e.g. GL_VERTEX_ARRAY)
+        Target used when binding the buffer (e.g. `GL_VERTEX_ARRAY` or
+        `GL_ELEMENT_ARRAY_BUFFER`). Default is `GL_VERTEX_ARRAY`.
     dataType : Glenum, optional
-        Data type of array. Input data will be recast to the appropriate type if
+        Data type of array. Input data will be recast to an appropriate type if
         necessary. Default is `GL_FLOAT`.
     usage : GLenum or int, optional
         Usage type for the array (i.e. `GL_STATIC_DRAW`).
@@ -1793,19 +1803,40 @@ def createVBO(data,
 
         # vertices of a triangle
         verts = [[ 1.0,  1.0, 0.0],   # v0
-                   0.0, -1.0, 0.0],   # v1
-                  -1.0,  1.0, 0.0]]   # v2
+                 [ 0.0, -1.0, 0.0],   # v1
+                 [-1.0,  1.0, 0.0]]   # v2
 
         # load vertices to graphics device, return a descriptor
         vboDesc = createVBO(verts)
 
-    Drawing triangles using vertex buffer data::
+    Drawing triangles or quads using vertex buffer data::
 
-        GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vboDesc.name)
-        GL.glVertexPointer(vboDesc.vertexSize, vboDesc.dataType, 0, None)
-        GL.glEnableClientState(vboDesc.bufferType)
-        GL.glDrawArrays(GL.GL_TRIANGLES, 0, vboDesc.indices)
-        GL.glFlush()
+        nIndices, vSize = vboDesc.shape  # element size
+
+        glBindBuffer(GL_ARRAY_BUFFER, vboDesc.name)
+        glVertexPointer(vSize, vboDesc.dataType, 0, None)
+        glEnableClientState(GL_VERTEX_ARRAY)
+
+        if vSize == 3:
+            drawMode = GL_TRIANGLES
+        elif vSize == 4:
+            drawMode = GL_QUADS
+
+        glDrawArrays(drawMode, 0, nIndices)
+        glFlush()
+
+    Custom data can be associated with this vertex buffer by specifying
+    `userData`::
+
+        myVBO = createVBO(data)
+        myVBO.userData['startIdx'] = 14  # first index to draw with
+
+        # use it later
+        nIndices, vSize = vboDesc.shape  # element size
+        startIdx = myVBO.userData['startIdx']
+        endIdx = nIndices - startIdx
+        glDrawArrays(GL_TRIANGLES, startIdx, endIdx)
+        glFlush()
 
     """
     # build input array
@@ -1836,6 +1867,111 @@ def createVBO(data,
         data.shape)  # leave userData empty
 
     return vboInfo
+
+
+def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=True):
+    """Define an array of vertex attribute data with a VBO descriptor.
+
+    Parameters
+    ----------
+    index : int
+        Index of the attribute to modify.
+    vboInfo : VertexBufferInfo
+        VBO descriptor.
+    offset : int
+        Starting index of the attribute in the buffer.
+    normalize : bool
+        Normalize fixed-point format values when accessed.
+    enable : bool
+        Enable the vertex attribute array after defining it. Note that you must
+        call `glDisableVertexAttribArray` with `index` when done (unless this is
+        being called within a presently bound VAO).
+
+    Examples
+    --------
+    Define a generic attribute from a vertex buffer descriptor::
+
+        # set the vertex location attribute
+        setVertexAttribPointer(0, vboDesc)  # 0 is vertex in our shader
+        GL.glColor3f(1.0, 0.0, 0.0)  # red triangle
+
+        # draw the triangle
+        nIndices, vSize = vboDesc.shape  # element size
+        GL.glDrawArrays(GL.GL_TRIANGLES, 0, nIndices)
+
+    If our VBO has interleaved attributes, we can specify `offset` to account
+    for this::
+
+        # define vertex attributes
+        verts = [[ -1.0, -1.0, 0.0],
+                 [ -1.0,  1.0, 0.0],
+                 [  1.0,  1.0, 0.0],
+                 [  1.0, -1.0, 0.0]]
+        texCoords = [[0.0, 0.0],
+                     [0.0, 1.0],
+                     [1.0, 1.0],
+                     [1.0, 0.0]]
+        normals = [[ 0.0, 0.0, 1.0],
+                   [ 0.0, 0.0, 1.0],
+                   [ 0.0, 0.0, 1.0],
+                   [ 0.0, 0.0, 1.0]]
+
+        # create interleaved array
+        vertexAttribs = np.hstack([
+            np.asarray(verts, dtype=np.float32),      # starts at 0
+            np.asarray(texCoords, dtype=np.float32),  # starts at 3
+            np.asarray(normals, dtype=np.float32)])   # starts at 5
+
+        # create VBO
+        vboInterleaved = createVBO(vertexAttribs)
+
+        # ... before rendering, set the attribute pointers
+        setVertexAttribPointer(0, vboInterleaved, offset=0)  # vertex pointer
+        setVertexAttribPointer(1, vboInterleaved, offset=3)  # texture pointer
+        setVertexAttribPointer(2, vboInterleaved, offset=5)  # normals pointer
+
+        # draw the triangles
+        nIndices, vSize = vboDesc.shape  # element size
+        GL.glDrawArrays(GL.GL_TRIANGLES, 0, nIndices)
+
+        # call these when done if `enable=True`
+        glDisableVertexAttribArray(0)
+        glDisableVertexAttribArray(1)
+        glDisableVertexAttribArray(2)
+
+    """
+    if vboInfo.target != GL.GL_ARRAY_BUFFER:
+        raise ValueError('VBO must have `target` type `GL_ARRAY_BUFFER`.')
+
+    _, glType = GL_COMPAT_TYPES[vboInfo.dataType]
+
+    GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vboInfo.name)
+    if enable:
+        GL.glEnableVertexAttribArray(index)
+
+    GL.glVertexAttribPointer(
+        index,
+        vboInfo.shape[1],
+        vboInfo.dataType,
+        GL.GL_TRUE if normalize else GL.GL_FALSE,
+        vboInfo.stride,
+        offset * ctypes.sizeof(glType))
+
+    GL.glBindBuffer(GL.GL_ARRAY_BUFFER, 0)
+
+
+def deleteVBO(vbo):
+    """Delete a vertex buffer object (VBO).
+
+    Parameters
+    ----------
+    vbo : VertexBufferInfo
+        Descriptor of VBO to delete.
+
+    """
+    if GL.glIsBuffer(vbo.name):
+        GL.glDeleteBuffers(1, vbo.name)
+        vbo.name = GL.GLuint(0)
 
 
 def createVAO(vertexBuffers, indexBuffer=None):
@@ -1955,17 +2091,6 @@ def drawVAO(vao, mode=GL.GL_TRIANGLES, flush=False):
 
     # reset
     GL.glBindVertexArray(0)
-
-
-def deleteVBO(vbo):
-    """Delete a Vertex Buffer Object (VBO).
-
-    Returns
-    -------
-    :obj:`None'
-
-    """
-    GL.glDeleteBuffers(1, vbo.id)
 
 
 def deleteVAO(vao):

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1713,9 +1713,17 @@ class VertexBufferInfo(object):
 
     @property
     def hasBuffer(self):
-        """Check if the VBO assigned to name is a buffer."""
+        """Check if the VBO assigned to `name` is a buffer."""
         if self.name != 0 and GL.glIsBuffer(self.name):
             return True
+
+        return False
+
+    @property
+    def isIndex(self):
+        """`True` if the buffer referred to by this object is an index array."""
+        if self.name != 0 and GL.glIsBuffer(self.name):
+            return self.target == GL.GL_ELEMENT_ARRAY_BUFFER
 
         return False
 
@@ -1734,16 +1742,17 @@ class VertexBufferInfo(object):
         if self.name == 0 or GL.glIsBuffer(self.name) != GL.GL_TRUE:
             return False
 
-        # get current binding so we don't disturb the current state
-        currentVBO = GL.GLint()
-
-        if self.target == GL.GL_VERTEX_ARRAY:
-            bindTarget = GL.GL_VERTEX_ARRAY_BINDING
+        if self.target == GL.GL_ARRAY_BUFFER:
+            bindTarget = GL.GL_VERTEX_ARRAY_BUFFER_BINDING
         elif self.target == GL.GL_ELEMENT_ARRAY_BUFFER:
             bindTarget = GL.GL_ELEMENT_ARRAY_BUFFER_BINDING
         else:
-            raise ValueError('Invalid `target` type.')
+            raise ValueError(
+                'Invalid `target` type, must be `GL_ARRAY_BUFFER` or '
+                '`GL_ELEMENT_ARRAY_BUFFER`.')
 
+        # get current binding so we don't disturb the current state
+        currentVBO = GL.GLint()
         GL.glGetIntegerv(bindTarget, ctypes.byref(currentVBO))
 
         # bind buffer at name to validate
@@ -1759,11 +1768,11 @@ class VertexBufferInfo(object):
 
         # check values against those in this object
         isValid = False
-        if self.usage == actualUsage and self.size == actualSize:
+        if self.usage == actualUsage.value and self.size == actualSize.value:
             isValid = True
 
         # return to the original binding
-        GL.glBindBuffer(self.target, currentVBO)
+        GL.glBindBuffer(self.target, currentVBO.value)
 
         return isValid
 

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1944,9 +1944,10 @@ def createVBO(data,
 
         nIndices, vSize = vboDesc.shape  # element size
 
-        glBindBuffer(GL_ARRAY_BUFFER, vboDesc.name)
-        glVertexPointer(vSize, vboDesc.dataType, 0, None)
-        glEnableClientState(GL_VERTEX_ARRAY)
+        bindVBO(vboDesc)
+        setVertexAttribPointer(
+            GL_VERTEX_ARRAY, vSize, vboDesc.dataType, legacy=True)
+        enableVertexAttribArray(GL_VERTEX_ARRAY, legacy=True)
 
         if vSize == 3:
             drawMode = GL_TRIANGLES
@@ -1955,6 +1956,9 @@ def createVBO(data,
 
         glDrawArrays(drawMode, 0, nIndices)
         glFlush()
+
+        disableVertexAttribArray(GL_VERTEX_ARRAY, legacy=True)
+        unbindVBO()
 
     Custom data can be associated with this vertex buffer by specifying
     `userData`::
@@ -2191,7 +2195,6 @@ def setVertexAttribPointer(index,
                            size=None,
                            offset=0,
                            normalize=False,
-                           bind=False,
                            legacy=False):
     """Define an array of vertex attribute data with a VBO descriptor.
 
@@ -2259,9 +2262,6 @@ def setVertexAttribPointer(index,
         Starting index of the attribute in the buffer.
     normalize : bool, optional
         Normalize fixed-point format values when accessed.
-    bind : bool, optional
-        Bind/unbind the vertex buffer before and after defining attributes. If
-        `False`, `vbo` must be bound and unbound by other means.
     legacy : bool, optional
         Use legacy vertex attributes (ie. `GL_VERTEX_ARRAY`,
         `GL_TEXTURE_COORD_ARRAY`, etc.) for backwards compatibility.

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1645,13 +1645,15 @@ class VertexBufferInfo(object):
     stride : int, optional
         Number of bytes between adjacent attributes. If `0`, values are assumed
         to be tightly packed.
+    shape : tuple or list, optional
+        Shape of the array used to create this VBO.
     userData : dict, optional
         Optional user defined data associated with the VBO. If `None`,
         `userData` will be initialized as an empty dictionary.
 
     """
     __slots__ = [
-        'name', 'target', 'usage', 'dataType', 'size', 'stride', 'userData']
+        'name', 'target', 'usage', 'dataType', 'size', 'stride', 'shape', 'userData']
 
     def __init__(self,
                  name=0,
@@ -1660,6 +1662,7 @@ class VertexBufferInfo(object):
                  dataType=GL.GL_FLOAT,
                  size=0,
                  stride=0,
+                 shape=(0,),
                  userData=None):
 
         self.name = GL.GLuint(name)
@@ -1668,6 +1671,7 @@ class VertexBufferInfo(object):
         self.dataType = dataType
         self.size = size
         self.stride = stride
+        self.shape = shape
 
         if userData is None:
             self.userData = {}
@@ -1703,6 +1707,7 @@ class VertexBufferInfo(object):
             OpenGL state.
 
         """
+        # fail automatically if these conditions are true
         if self.name == 0 or GL.glIsBuffer(self.name) != GL.GL_TRUE:
             return False
 
@@ -1749,24 +1754,26 @@ VertexArrayObject = namedtuple(
 )
 
 
-GL_COMPAT_TYPES = {np.float32: (GL.GL_FLOAT, GL.GLfloat),
-                   np.float64: (GL.GL_DOUBLE, GL.GLdouble),
-                   np.float: (GL.GL_DOUBLE, GL.GLdouble),
-                   np.uint16: (GL.GL_UNSIGNED_SHORT, GL.GLushort),
-                   np.uint32: (GL.GL_UNSIGNED_INT, GL.GLuint),
-                   np.int32: (GL.GL_INT, GL.GLint),
-                   np.int16: (GL.GL_SHORT, GL.GLshort)}
+GL_COMPAT_TYPES = {GL.GL_FLOAT: (np.float32, GL.GLfloat),
+                   GL.GL_DOUBLE: (np.float64, GL.GLdouble),
+                   GL.GL_UNSIGNED_SHORT: (np.uint16, GL.GLushort),
+                   GL.GL_UNSIGNED_INT: (np.uint32, GL.GLuint),
+                   GL.GL_INT: (np.int32, GL.GLint),
+                   GL.GL_SHORT: (np.int16, GL.GLshort)}
 
 
-def createVBO(data, target=GL.GL_ARRAY_BUFFER, dataType=GL.GL_FLOAT, usage=GL.GL_STATIC_DRAW):
+def createVBO(data,
+              target=GL.GL_ARRAY_BUFFER,
+              dataType=GL.GL_FLOAT,
+              usage=GL.GL_STATIC_DRAW):
     """Create an array buffer, often referred to as Vertex Buffer Object (VBO).
 
     Parameters
     ----------
     data : array_like
-        Coordinates as a 2D array of values. The data type of the VBO is
-        inferred by the type of the array. If the input is a Python `list` or
-        `tuple` type, the data type of the array will be `GL_FLOAT`.
+        A 2D array of values to write to the array buffer. The data type of the
+        VBO is inferred by the type of the array. If the input is a Python
+        `list` or `tuple` type, the data type of the array will be `GL_FLOAT`.
     target : :obj:`int`
         Target used when binding the buffer (e.g. GL_VERTEX_ARRAY)
     dataType : Glenum, optional
@@ -1785,49 +1792,50 @@ def createVBO(data, target=GL.GL_ARRAY_BUFFER, dataType=GL.GL_FLOAT, usage=GL.GL
     Creating a vertex buffer object with vertex data::
 
         # vertices of a triangle
-        verts = [ 1.0,  1.0, 0.0,   # v0
-                  0.0, -1.0, 0.0,   # v1
-                 -1.0,  1.0, 0.0]   # v2
+        verts = [[ 1.0,  1.0, 0.0],   # v0
+                   0.0, -1.0, 0.0],   # v1
+                  -1.0,  1.0, 0.0]]   # v2
 
         # load vertices to graphics device, return a descriptor
-        vboDesc = createVBO(verts, 3)
+        vboDesc = createVBO(verts)
 
     Drawing triangles using vertex buffer data::
 
-        GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vboDesc.id)
-        GL.glVertexPointer(vboDesc.vertexSize, vboDesc.dtype, 0, None)
+        GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vboDesc.name)
+        GL.glVertexPointer(vboDesc.vertexSize, vboDesc.dataType, 0, None)
         GL.glEnableClientState(vboDesc.bufferType)
         GL.glDrawArrays(GL.GL_TRIANGLES, 0, vboDesc.indices)
         GL.glFlush()
 
     """
+    # build input array
+    npType, glType = GL_COMPAT_TYPES[dataType]
+    data = np.asarray(data, dtype=npType)
 
-    if dataType == GL.GL_FLOAT:
-        data = np.asarray(data, dtype=np.float32)
-    elif dataType == GL.GL_DOUBLE:
-        data = np.asarray(data, dtype=np.float64)
-    elif dataType == GL.GL_UNSIGNED_INT:
-        data = np.asarray(data, dtype=np.uint32)
-    elif dataType == GL.GL_UNSIGNED_SHORT:
-        data = np.asarray(data, dtype=np.uint16)
-    elif dataType == GL.GL_INT:
-        data = np.asarray(data, dtype=np.int32)
-    elif dataType == GL.GL_SHORT:
-        data = np.asarray(data, dtype=np.int16)
+    # get buffer size and pointer
+    bufferSize = data.size * ctypes.sizeof(glType)
+    bufferStride = data.shape[1] * ctypes.sizeof(glType)
+    bufferPtr = data.ctypes.data_as(ctypes.POINTER(glType))
 
-    # # create a vertex buffer ID
-    # vboInfo = VertexBufferInfo()
-    # GL.glGenBuffers(1, ctypes.byref(vboInfo.name))
-    #
-    # # bind and upload
-    # GL.glBindBuffer(target, vboInfo.name)
-    # GL.glBufferData(target,
-    #                 ctypes.sizeof(c_array),
-    #                 c_array,
-    #                 GL.GL_STATIC_DRAW)
-    # GL.glBindBuffer(target, 0)
+    # create a vertex buffer ID
+    bufferName = GL.GLuint()
+    GL.glGenBuffers(1, ctypes.byref(bufferName))
 
-    return vboDesc
+    # bind and upload
+    GL.glBindBuffer(target, bufferName)
+    GL.glBufferData(target, bufferSize, bufferPtr, usage)
+    GL.glBindBuffer(target, 0)
+
+    vboInfo = VertexBufferInfo(
+        bufferName,
+        target,
+        usage,
+        dataType,
+        bufferSize,
+        bufferStride,
+        data.shape)  # leave userData empty
+
+    return vboInfo
 
 
 def createVAO(vertexBuffers, indexBuffer=None):

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1611,16 +1611,134 @@ def deleteTexture(texture):
 # ---------------------------
 
 
-VertexBufferObject = namedtuple(
-    'VertexBufferObject',
-    ['id',
-     'size',
-     'count',
-     'indices',
-     'usage',
-     'dtype',
-     'userData']
-)
+#VertexBufferObject = namedtuple(
+#    'VertexBufferObject',
+#    ['id',
+#     'size',
+#     'count',
+#     'indices',
+#     'usage',
+#     'dtype',
+#     'userData']
+#)
+
+class VertexBufferInfo(object):
+    """Vertex buffer object (VBO) descriptor.
+
+    This class only stores information about the VBO it refers to, it does not
+    contain any actual array data associated with the VBO. Calling
+    :func:`createVBO` returns instances of this class.
+
+    Parameters
+    ----------
+    name : GLuint or int
+        OpenGL handle for the buffer.
+    target : GLenum or int, optional
+        Target used when binding the buffer (e.g. `GL_VERTEX_ARRAY` or
+        `GL_ELEMENT_ARRAY_BUFFER`). Default is `GL_VERTEX_ARRAY`)
+    usage : GLenum or int, optional
+        Usage type for the array (i.e. `GL_STATIC_DRAW`).
+    dataType : Glenum, optional
+        Data type of array. Default is `GL_FLOAT`.
+    size : int, optional
+        Size of the buffer in bytes.
+    stride : int, optional
+        Number of bytes between adjacent attributes. If `0`, values are assumed
+        to be tightly packed.
+    userData : dict, optional
+        Optional user defined data associated with the VBO. If `None`,
+        `userData` will be initialized as an empty dictionary.
+
+    """
+    __slots__ = [
+        'name', 'target', 'usage', 'dataType', 'size', 'stride', 'userData']
+
+    def __init__(self,
+                 name=0,
+                 target=GL.GL_ARRAY_BUFFER,
+                 usage=GL.GL_STATIC_DRAW,
+                 dataType=GL.GL_FLOAT,
+                 size=0,
+                 stride=0,
+                 userData=None):
+
+        self.name = GL.GLuint(name)
+        self.target = target
+        self.usage = usage
+        self.dataType = dataType
+        self.size = size
+        self.stride = stride
+
+        if userData is None:
+            self.userData = {}
+        elif isinstance(userData, dict):
+            self.userData = userData
+        else:
+            raise TypeError('Invalid type for `userData`.')
+
+    def __eq__(self, other):
+        """Equality test between VBO object names."""
+        return self.name == other.name
+
+    def __ne__(self, other):
+        """Inequality test between VBO object names."""
+        return self.name != other.name
+
+    @property
+    def isBuffer(self):
+        """Check if the VBO assigned to name is a buffer."""
+        if self.name != 0 and GL.glIsBuffer(self.name):
+            return True
+
+        return False
+
+    def validate(self):
+        """Check if the data contained in this descriptor matches what is
+        actually present in the OpenGL state.
+
+        Returns
+        -------
+        bool
+            `True` if the information contained in this descriptor matches the
+            OpenGL state.
+
+        """
+        if self.name == 0 or GL.glIsBuffer(self.name) != GL.GL_TRUE:
+            return False
+
+        # get current binding so we don't disturb the current state
+        currentVBO = GL.GLint()
+
+        if self.target == GL.GL_VERTEX_ARRAY:
+            bindTarget = GL.GL_VERTEX_ARRAY_BINDING
+        elif self.target == GL.GL_ELEMENT_ARRAY_BUFFER:
+            bindTarget = GL.GL_ELEMENT_ARRAY_BUFFER_BINDING
+        else:
+            raise ValueError('Invalid `target` type.')
+
+        GL.glGetIntegerv(bindTarget, ctypes.byref(currentVBO))
+
+        # bind buffer at name to validate
+        GL.glBindBuffer(self.target, self.name)
+
+        # get buffer parameters
+        actualSize = GL.GLint()
+        GL.glGetBufferParameteriv(
+            self.target, GL.GL_BUFFER_SIZE, ctypes.byref(actualSize))
+        actualUsage = GL.GLint()
+        GL.glGetBufferParameteriv(
+            self.target, GL.GL_BUFFER_USAGE, ctypes.byref(actualUsage))
+
+        # check values against those in this object
+        isValid = False
+        if self.usage == actualUsage and self.size == actualSize:
+            isValid = True
+
+        # return to the original binding
+        GL.glBindBuffer(self.target, currentVBO)
+
+        return isValid
+
 
 VertexArrayObject = namedtuple(
     'VertexArrayObject',
@@ -1631,31 +1749,36 @@ VertexArrayObject = namedtuple(
 )
 
 
-def createVBO(data, size=3, dtype=GL.GL_FLOAT, target=GL.GL_ARRAY_BUFFER):
-    """Create a single-storage array buffer, often referred to as Vertex Buffer
-    Object (VBO).
+GL_COMPAT_TYPES = {np.float32: (GL.GL_FLOAT, GL.GLfloat),
+                   np.float64: (GL.GL_DOUBLE, GL.GLdouble),
+                   np.float: (GL.GL_DOUBLE, GL.GLdouble),
+                   np.uint16: (GL.GL_UNSIGNED_SHORT, GL.GLushort),
+                   np.uint32: (GL.GL_UNSIGNED_INT, GL.GLuint),
+                   np.int32: (GL.GL_INT, GL.GLint),
+                   np.int16: (GL.GL_SHORT, GL.GLshort)}
+
+
+def createVBO(data, target=GL.GL_ARRAY_BUFFER, dataType=GL.GL_FLOAT, usage=GL.GL_STATIC_DRAW):
+    """Create an array buffer, often referred to as Vertex Buffer Object (VBO).
 
     Parameters
     ----------
-    data : :obj:`list` or :obj:`tuple` of :obj:`float` or :obj:`int`
-        Coordinates as a 1D array of floats (e.g. [X0, Y0, Z0, X1, Y1, Z1, ...])
-    size : :obj:`int`
-        Number of coordinates per-vertex, default is 3.
-    dtype : :obj:`int`
-        Data type OpenGL will interpret that data as, should be compatible with
-        the type of 'data'.
+    data : array_like
+        Coordinates as a 2D array of values. The data type of the VBO is
+        inferred by the type of the array. If the input is a Python `list` or
+        `tuple` type, the data type of the array will be `GL_FLOAT`.
     target : :obj:`int`
         Target used when binding the buffer (e.g. GL_VERTEX_ARRAY)
+    dataType : Glenum, optional
+        Data type of array. Input data will be recast to the appropriate type if
+        necessary. Default is `GL_FLOAT`.
+    usage : GLenum or int, optional
+        Usage type for the array (i.e. `GL_STATIC_DRAW`).
 
     Returns
     -------
-    VertexBufferObject
+    VertexBufferInfo
         A descriptor with vertex buffer information.
-
-    Notes
-    -----
-    Creating vertex buffers is a computationally expensive operation. Be sure to
-    load all resources before entering your experiment's main loop.
 
     Examples
     --------
@@ -1678,47 +1801,31 @@ def createVBO(data, size=3, dtype=GL.GL_FLOAT, target=GL.GL_ARRAY_BUFFER):
         GL.glFlush()
 
     """
-    # convert values to ctypes float array
-    if dtype == GL.GL_FLOAT:
-        useType = GL.GLfloat
-    elif dtype == GL.GL_UNSIGNED_INT:
-        useType = GL.GLuint
-    elif dtype == GL.GL_UNSIGNED_SHORT:
-        useType = GL.GLushort
-    else:
-        raise TypeError("Invalid type specified.")
 
-    if isinstance(data, array.array):
-        addr, count = data.buffer_info()
-        c_array = ctypes.cast(addr, ctypes.POINTER((useType * count)))[0]
-    else:
-        count = len(data)
-        c_array = (useType * count)(*data)
+    if dataType == GL.GL_FLOAT:
+        data = np.asarray(data, dtype=np.float32)
+    elif dataType == GL.GL_DOUBLE:
+        data = np.asarray(data, dtype=np.float64)
+    elif dataType == GL.GL_UNSIGNED_INT:
+        data = np.asarray(data, dtype=np.uint32)
+    elif dataType == GL.GL_UNSIGNED_SHORT:
+        data = np.asarray(data, dtype=np.uint16)
+    elif dataType == GL.GL_INT:
+        data = np.asarray(data, dtype=np.int32)
+    elif dataType == GL.GL_SHORT:
+        data = np.asarray(data, dtype=np.int16)
 
-    # create a vertex buffer ID
-    vboId = GL.GLuint()
-    GL.glGenBuffers(1, ctypes.byref(vboId))
-
-    nIndices = count
-    if target != GL.GL_ELEMENT_ARRAY_BUFFER:
-        nIndices = int(nIndices / size)
-
-    # new vertex descriptor
-    vboDesc = VertexBufferObject(vboId,
-                                 size,
-                                 count,
-                                 nIndices,
-                                 GL.GL_STATIC_DRAW,
-                                 dtype,
-                                 dict())
-
-    # bind and upload
-    GL.glBindBuffer(target, vboId)
-    GL.glBufferData(target,
-                    ctypes.sizeof(c_array),
-                    c_array,
-                    GL.GL_STATIC_DRAW)
-    GL.glBindBuffer(target, 0)
+    # # create a vertex buffer ID
+    # vboInfo = VertexBufferInfo()
+    # GL.glGenBuffers(1, ctypes.byref(vboInfo.name))
+    #
+    # # bind and upload
+    # GL.glBindBuffer(target, vboInfo.name)
+    # GL.glBufferData(target,
+    #                 ctypes.sizeof(c_array),
+    #                 c_array,
+    #                 GL.GL_STATIC_DRAW)
+    # GL.glBindBuffer(target, 0)
 
     return vboDesc
 

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1645,6 +1645,35 @@ def deleteTexture(texture):
 #     'userData']
 #)
 
+class VertexArrayInfo(object):
+    """Vertex array object (VAO) descriptor.
+
+    This class only stores information about the VAO it refers to, it does not
+    contain any actual array data associated with the VAO. Calling
+    :func:`createVAO` returns instances of this class.
+
+    """
+    __slots__ = ['name', 'userData']
+
+    def __init__(self, name=0, userData=None):
+        self.name = name
+
+        if userData is None:
+            self.userData = {}
+        elif isinstance(userData, dict):
+            self.userData = userData
+        else:
+            raise TypeError('Invalid type for `userData`.')
+
+    def __eq__(self, other):
+        """Equality test between VAO object names."""
+        return self.name == other.name
+
+    def __ne__(self, other):
+        """Inequality test between VAO object names."""
+        return self.name != other.name
+
+
 class VertexBufferInfo(object):
     """Vertex buffer object (VBO) descriptor.
 
@@ -1878,23 +1907,24 @@ def createVBO(data,
     return vboInfo
 
 
-def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=True):
+def setVertexAttribPointer(index, vbo, offset=0, normalize=False, vao=None):
     """Define an array of vertex attribute data with a VBO descriptor.
 
     Parameters
     ----------
     index : int
         Index of the attribute to modify.
-    vboInfo : VertexBufferInfo
+    vbo : VertexBufferInfo
         VBO descriptor.
-    offset : int
+    offset : int, optional
         Starting index of the attribute in the buffer.
-    normalize : bool
+    normalize : bool, optional
         Normalize fixed-point format values when accessed.
-    enable : bool
-        Enable the vertex attribute array after defining it. Note that you must
-        call `glDisableVertexAttribArray` with `index` when done (unless this is
-        being called within a presently bound VAO).
+    vao : int, optional
+        Vertex array object (VAO) to modify. The state of the VAO will be
+        changed to include the definition of the vertex attribute pointer.
+        Furthermore, access to the attribute will be enabled within the VAO
+        state.
 
     Examples
     --------
@@ -1909,7 +1939,7 @@ def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=Tru
         GL.glDrawArrays(GL.GL_TRIANGLES, 0, nIndices)
 
     If our VBO has interleaved attributes, we can specify `offset` to account
-    for this::
+    for that::
 
         # define interleaved vertex attributes
         #        |     Position    | Texture |   Normals   |
@@ -1921,7 +1951,7 @@ def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=Tru
         # create interleaved array
         vertexAttribs = np.asarray(vQuad, dtype=np.float32)
 
-        # create VBO
+        # create a VBO with interleaved attributes
         vboInterleaved = createVBO(vertexAttribs)
 
         # ... before rendering, set the attribute pointers
@@ -1939,21 +1969,21 @@ def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=Tru
         glDisableVertexAttribArray(2)
 
     """
-    if vboInfo.target != GL.GL_ARRAY_BUFFER:
+    if vbo.target != GL.GL_ARRAY_BUFFER:
         raise ValueError('VBO must have `target` type `GL_ARRAY_BUFFER`.')
 
-    _, glType = GL_COMPAT_TYPES[vboInfo.dataType]
+    _, glType = GL_COMPAT_TYPES[vbo.dataType]
 
-    GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vboInfo.name)
-    if enable:
+    GL.glBindBuffer(GL.GL_ARRAY_BUFFER, vbo.name)
+    if vao is not None:
         GL.glEnableVertexAttribArray(index)
 
     GL.glVertexAttribPointer(
         index,
-        vboInfo.shape[1],
-        vboInfo.dataType,
+        vbo.shape[1],
+        vbo.dataType,
         GL.GL_TRUE if normalize else GL.GL_FALSE,
-        vboInfo.stride,
+        vbo.stride,
         offset * ctypes.sizeof(glType))
 
     GL.glBindBuffer(GL.GL_ARRAY_BUFFER, 0)

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1911,25 +1911,15 @@ def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=Tru
     If our VBO has interleaved attributes, we can specify `offset` to account
     for this::
 
-        # define vertex attributes
-        verts = [[ -1.0, -1.0, 0.0],
-                 [ -1.0,  1.0, 0.0],
-                 [  1.0,  1.0, 0.0],
-                 [  1.0, -1.0, 0.0]]
-        texCoords = [[0.0, 0.0],
-                     [0.0, 1.0],
-                     [1.0, 1.0],
-                     [1.0, 0.0]]
-        normals = [[ 0.0, 0.0, 1.0],
-                   [ 0.0, 0.0, 1.0],
-                   [ 0.0, 0.0, 1.0],
-                   [ 0.0, 0.0, 1.0]]
+        # define interleaved vertex attributes
+        #        |     Position    | Texture |   Normals   |
+        vQuad = [[ -1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  # v0
+                 [ -1.0,  1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],  # v1
+                 [  1.0,  1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],  # v2
+                 [  1.0, -1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]]  # v3
 
         # create interleaved array
-        vertexAttribs = np.hstack([
-            np.asarray(verts, dtype=np.float32),      # starts at 0
-            np.asarray(texCoords, dtype=np.float32),  # starts at 3
-            np.asarray(normals, dtype=np.float32)])   # starts at 5
+        vertexAttribs = np.asarray(vQuad, dtype=np.float32)
 
         # create VBO
         vboInterleaved = createVBO(vertexAttribs)
@@ -1940,7 +1930,7 @@ def setVertexAttribPointer(index, vboInfo, offset=0, normalize=False, enable=Tru
         setVertexAttribPointer(2, vboInterleaved, offset=5)  # normals pointer
 
         # draw the triangles
-        nIndices, vSize = vboDesc.shape  # element size
+        nIndices, _ = vboDesc.shape
         GL.glDrawArrays(GL.GL_TRIANGLES, 0, nIndices)
 
         # call these when done if `enable=True`


### PR DESCRIPTION
Reworked the VBO and VAO functions in 'gltools' to handle interleaved buffers. Also added `mapBuffer` functions for accessing and editing GPU buffer data with numpy array pointers. This results in enormous performance gains (multiple orders of magnitude) when drawing and updating arrays over current routines used in `ElementArrayStim`. These methods work on nVidia and Intel cards with fixed-function and core pipelines. 

