### PR TITLE
ENH: Better handling of error capture and reporting when compiling scripts

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2402,7 +2402,6 @@ class BuilderFrame(wx.Frame):
             sys.stdout = sys.stdoutOrig
             sys.stderr = sys.stderrOrig
 
-
     def generateScript(self, experimentPath, target="PsychoPy"):
         """Generates python script from the current builder experiment"""
         # Set stdOut for error capture

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2448,6 +2448,8 @@ class BuilderFrame(wx.Frame):
                 self.stdoutFrame.write(stderr)
             else:
                 psyexpCompile.compileScript(infile=self.exp, version=None, outfile=experimentPath)
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
         finally:
             self.stdoutFrame.Show()
             self.setStandardStream(False)

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -12,6 +12,7 @@ to JS (ES6/PsychoJS)
 import ast
 import astunparse
 import esprima
+import sys
 from os import path
 from psychopy.constants import PY3
 from psychopy import logging
@@ -143,7 +144,7 @@ def addVariableDeclarations(inputProgram, fileName):
     try:
         ast = esprima.parseScript(inputProgram, {'range': True, 'tolerant': True})
     except esprima.error_handler.Error as err:
-        logging.error("{} in {}".format(err, path.split(fileName)[1]))
+        sys.stderr.write("ERROR: {} in {}\n".format(err, path.split(fileName)[1]))
         return inputProgram  # So JS can be written to file
 
     # find undeclared vars in functions and declare them before the function


### PR DESCRIPTION
This enhancement ensures that all errors related to the script compiler captured and printed to the stdOutFrame so the use can see what errors have occurred. This does mean though, that the stdOutFrame appears more frequently e.g., when syncing and exporting html. This is only the first step to better error handling. The stdOutFrame as an error message target will be replaced in the new global error handling enhancement, but for now this is better than what is currently in use and so may be useful for the next release.