### PR TITLE
FF: fix to timing. Account for first flip tStart>0

### DIFF
--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -30,7 +30,7 @@ ADDED:
 - better timing on the keyboard responses of the JavaScript experiments due to timestamping asynchronously with your script
 - Standalone installations now provide an updated Cedrus library, pyxid2
 - support for new LabHackers TTL2USB8 device (parallel port alternative)
-- Envelope grating
+- Envelope grating now has exponent (power) option
 
 FIXED:
 
@@ -39,7 +39,6 @@ FIXED:
 - support for Pyglet 1.4 (although text scaling appears to have changed a little)
 - some serial devices (photometers) were not compatible with Python3 string/bytes
   conversion
--
 
 PsychoPy 3.1
 ----------------

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -115,12 +115,8 @@ class Routine(list):
         """This defines the code for the frames of a single routine
         """
         # create the frame loop for this routine
-        code = ('\n# ------Prepare to start Routine "%s"-------\n'
-                't = 0\n'
-                '%s.reset()  # clock\n'
-                'frameN = -1\n'
-                'continueRoutine = True\n')
-        buff.writeIndentedLines(code % (self.name, self._clockName))
+        code = ('\n# ------Prepare to start Routine "%s"-------\n')
+        buff.writeIndentedLines(code % (self.name))
         # can we use non-slip timing?
         maxTime, useNonSlip = self.getMaxTime()
         if useNonSlip:
@@ -138,15 +134,23 @@ class Routine(list):
         compStr = ', '.join([c.params['name'].val for c in self
                              if 'startType' in c.params and c.type != 'Variable'])
         buff.writeIndented('%sComponents = [%s]\n' % (self.name, compStr))
-        code = ("for thisComponent in %sComponents:\n"
+
+        code = ("for thisComponent in {name}Components:\n"
                 "    thisComponent.tStart = None\n"
                 "    thisComponent.tStop = None\n"
                 "    thisComponent.tStartRefresh = None\n"
                 "    thisComponent.tStopRefresh = None\n"
                 "    if hasattr(thisComponent, 'status'):\n"
                 "        thisComponent.status = NOT_STARTED\n"
-                '\n# -------Start Routine "%s"-------\n')
-        buff.writeIndentedLines(code % (self.name, self.name))
+                "# reset timers\n"
+                't = 0\n'
+                '_timeToFirstFrame = win.getFutureFlipTime(clock="now")\n'
+                '{clockName}.reset(-_timeToFirstFrame)  # t0 is time of first possible flip\n'
+                'frameN = -1\n'
+                'continueRoutine = True\n'
+                '\n# -------Run Routine "{name}"-------\n')
+        buff.writeIndentedLines(code.format(name=self.name,
+                                            clockName=self._clockName))
         if useNonSlip:
             code = 'while continueRoutine and routineTimer.getTime() > 0:\n'
         else:

--- a/psychopy/tests/test_all_visual/test_winFlipTiming.py
+++ b/psychopy/tests/test_all_visual/test_winFlipTiming.py
@@ -72,11 +72,10 @@ class Test_WinFlipTiming(object):
         predictedFrames = []
         print('now={:.5f}, lastFrame={:.5f}'.format(now, self.win._frameTimes[-1]))
         print('delay requestT expectT diff'.format(now, self.win._frameTimes[-1]))
-        for delay in np.arange(0, 0.04, 0.001):
-            expect = self.win.getFutureFlipTime(now+delay)
-            requested = now+delay
+        for requested in np.arange(0, 0.04, 0.001):
+            expect = self.win.getFutureFlipTime(requested)
             diff = expect-requested
-            print("{:.4f}, {:.5f} {:.5f} {:.5f}".format(delay, requested, expect, diff))
+            print("{:.4f}, {:.5f} {:.5f} {:.5f}".format(requested, requested, expect, diff))
             # should always be within 1/2 frame
             assert abs(diff) < self.win.monitorFramePeriod/2.0
 


### PR DESCRIPTION
Now reseting trialClock according to time of first known flip
so that t=0 is always the time of the first flip for all stimuli