### PR TITLE
ENH: Add pathlib dependency for Python versions < 3.4

### DIFF
--- a/requirements_travis.txt
+++ b/requirements_travis.txt
@@ -32,3 +32,4 @@ python-gitlab
 gitpython
 astunparse
 esprima
+pathlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ install_requires =
     astunparse
     esprima
     freetype-py
+    pathlib; python_version < "3.4"
     # Platform-specific dependencies.
     questplus; python_version >= "3.6"
     imageio < 2.5; python_version < "3"


### PR DESCRIPTION
Pathlib is in the Python 3.4 standard library after PEP 428 acceptance.