### PR TITLE
BF: Print errors to stdoutFrame

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -124,7 +124,9 @@ class OutputThread(threading.Thread):
             # then check if the process ended
             # self.exit
         for line in self.proc.stderr.readlines():
-            sys.stdout.write(line)
+            self.queue.put(line)
+            if not line:
+                break
         return True
 
     def getBuffer(self):


### PR DESCRIPTION
Trackback error messages were starting on the StdOutFrame and finishing
on the console. Also, an error occured randomly causing psychopy to crash.
The crash would happen when printing whilst a traceback was printed.
With this fix, the crash has not reoccurred.