### PR TITLE
TESTS: For test_scripts tests, create new files in a temp directory

### DIFF
--- a/psychopy/tests/test_scripts/test_component_compile_js.py
+++ b/psychopy/tests/test_scripts/test_component_compile_js.py
@@ -34,9 +34,9 @@ class TestComponentCompilerJS(object):
                     # correctPath = os.path.join(TESTS_DATA_PATH, "correctScript", "js", 'correct{}.js'.format(compName))
                     # Compare files, raising assertions on fails above tolerance (%)
                     # try:
-                    #     compareTextFiles('new{}.js'.format(compName), correctPath, tolerance=3)
+                    #     compareTextFiles('{}/new{}.js'.format(self.temp_dir, compName), correctPath, tolerance=3)
                     # except IOError as err:
-                    #     compareTextFiles('new{}.js'.format(compName), correctPath, tolerance=3)
+                    #     compareTextFiles('{}/new{}.js'.format(self.temp_dir, compName), correctPath, tolerance=3)
 
     def reset_experiment(self, compName):
         """Resets the exp object for each component"""
@@ -55,5 +55,5 @@ class TestComponentCompilerJS(object):
 
     def create_component_output(self, compName):
         """Create the JS script"""
-        jsFilePath = os.path.join(os.getcwd(), 'new{}.js'.format(compName))
+        jsFilePath = os.path.join(os.getcwd(), '{}/new{}.js'.format(self.temp_dir, compName))
         psyexpCompile.compileScript(infile=self.exp, outfile=jsFilePath)

--- a/psychopy/tests/test_scripts/test_component_compile_python.py
+++ b/psychopy/tests/test_scripts/test_component_compile_python.py
@@ -35,9 +35,9 @@ class TestComponentCompilerPython(object):
                 # correctPath = os.path.join(TESTS_DATA_PATH, "correctScript", "python", 'correct{}.py'.format(compName))
                 # Compare files, raising assertions on fails above tolerance (%)
                 # try:
-                #     compareTextFiles('new{}.py'.format(compName), correctPath, tolerance=5)
+                #     compareTextFiles('{}/new{}.py'.format(self.temp_dir, compName), correctPath, tolerance=5)
                 # except IOError as err:
-                #     compareTextFiles('new{}.py'.format(compName), correctPath, tolerance=5)
+                #     compareTextFiles('{}/new{}.py'.format(self.temp_dir, compName), correctPath, tolerance=5)
 
     def reset_experiment(self):
         """Resets the exp object for each component"""
@@ -63,7 +63,7 @@ class TestComponentCompilerPython(object):
 
     def create_component_output(self, compName):
         """Create the Python script"""
-        psyexpCompile.compileScript(infile=self.exp, outfile='new{}.py'.format(compName))
+        psyexpCompile.compileScript(infile=self.exp, outfile='{}/new{}.py'.format(self.temp_dir, compName))
 
     def test_component_type_in_experiment(self):
         for compName in self.allComp:


### PR DESCRIPTION
This fix stops the creation of many Python and JS "new" scripts
when test_scripts tests are run.