### PR TITLE
NF/EN: Better support for VAO/VBOs, GPU timer/sampling queries, more robust OBJ loading, and much more ...

### DIFF
--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1556,6 +1556,9 @@ class VertexArrayInfo(object):
         else:
             raise TypeError('Invalid type for `userData`.')
 
+    def __hash__(self):
+        return hash((self.name, self.isLegacy))
+
     def __eq__(self, other):
         """Equality test between VAO object names."""
         return self.name == other.name
@@ -1824,6 +1827,14 @@ class VertexBufferInfo(object):
             self.userData = userData
         else:
             raise TypeError('Invalid type for `userData`.')
+
+    def __hash__(self):
+        return hash((self.name,
+                     self.target,
+                     self.dataType,
+                     self.usage,
+                     self.size,
+                     self.shape))
 
     def __eq__(self, other):
         """Equality test between VBO object names."""


### PR DESCRIPTION
Major change to `gltools` which greatly improves performance and flexibility of existing features. Also adds some new features.

- Interleaved VBOs are possible now, can be used when creating VAOs too. Fully backwards compatible with the fixed-function pipeline.
- VBOs can be mapped to client memory now and be updated via a returned `ndarray` view. This allows you to update massive amounts of data within a span of a frame.
- OBJ loader is far more robust now, can handle cases where certain vertex attributes are missing. You can now process vertex attribute data (for instance, compute bitangents) before uploading data to the GPU.
- GPU timer queries for measuring how long the GPU spent on a sequence of GL commands. Also you can also get absolute GPU time in nanoseconds.
