### PR TITLE
BF: QuestPlusHandler now accepts "unknown" kwargs

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1313,7 +1313,7 @@ class QuestPlusHandler(StairHandler):
                  psychometricFunc='weibull', stimScale='log10',
                  stimSelectionMethod='minEntropy',
                  stimSelectionOptions=None, paramEstimationMethod='mean',
-                 extraInfo=None, name='', label=''):
+                 extraInfo=None, name='', label='', **kwargs):
         """
         QUEST+ implementation. Currently only supports parameter estimation of
         a Weibull-shaped psychometric function.
@@ -1417,6 +1417,17 @@ class QuestPlusHandler(StairHandler):
         label : str
             Only used by :class:`MultiStairHandler`, and otherwise ignored.
 
+        kwargs : dict
+            Additional keyword arguments. These might be passed, for example,
+            through a :class:`MultiStairHandler`, and will be ignored. A
+            warning will be printed whenever additional keyword arguments
+            have been passed.
+
+        Warns
+        -----
+        RuntimeWarning
+            Emits a warning if an unknown keyword argument was passed.
+
         Notes
         -----
         The QUEST+ algorithm was first described by [1]_.
@@ -1435,6 +1446,21 @@ class QuestPlusHandler(StairHandler):
         msg = ('The QUEST+ staircase implementation is currently being '
                'tested and may be subject to change.')
         logging.critical(msg)
+
+        if kwargs:
+            msg = ('The  following keyword arguments are unknown to QuestPlus '
+                   'and will be ignored by QuestPlusHandler: \n')
+            for k in kwargs.keys():
+                msg += '\n  - %s' % k
+            msg += ('\n\nIf you are using QuestPlusHandler through a '
+                    'MultiStairHandler, it may be safe to ignore this '
+                    'warning.')
+            logging.warn(msg)
+
+            # Ensure we get a proper unit-testable warning too (not just a
+            # logfile entry)
+            msg = 'Unknown keyword argument(s) passed to QuestPlusHandler'
+            warnings.warn(msg, RuntimeWarning)
 
         super().__init__(startVal=startIntensity, nTrials=nTrials,
                          extraInfo=extraInfo, name=name)

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1420,13 +1420,13 @@ class QuestPlusHandler(StairHandler):
         kwargs : dict
             Additional keyword arguments. These might be passed, for example,
             through a :class:`MultiStairHandler`, and will be ignored. A
-            warning will be printed whenever additional keyword arguments
+            warning will be emitted whenever additional keyword arguments
             have been passed.
 
         Warns
         -----
         RuntimeWarning
-            Emits a warning if an unknown keyword argument was passed.
+            If an unknown keyword argument was passed.
 
         Notes
         -----
@@ -1448,8 +1448,8 @@ class QuestPlusHandler(StairHandler):
         logging.critical(msg)
 
         if kwargs:
-            msg = ('The  following keyword arguments are unknown to QuestPlus '
-                   'and will be ignored by QuestPlusHandler: \n')
+            msg = ('The  following keyword arguments are unknown to '
+                   'QuestPlusHandler and will be ignored: \n')
             for k in kwargs.keys():
                 msg += '\n  - %s' % k
             msg += ('\n\nIf you are using QuestPlusHandler through a '

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -1018,6 +1018,32 @@ def test_QuestPlusHandler_posterior_weibull():
     assert 'lapseRate' in q.posterior.keys()
 
 
+def test_QuesPlusHandler_unknown_kwargs():
+    import sys
+    if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        pytest.skip('QUEST+ only works on Python 3.6+')
+
+    from psychopy.data.staircase import QuestPlusHandler
+
+    thresholds = np.arange(-40, 0 + 1)
+    slope, guess, lapse = 3.5, 0.5, 0.02
+    contrasts = thresholds.copy()
+    response_vals = ['Correct', 'Incorrect']
+    func = 'weibull'
+    unknown_kwargs = dict(foo=1, bar='baz')
+
+    with pytest.warns(RuntimeWarning):
+        QuestPlusHandler(nTrials=20,
+                         intensityVals=contrasts,
+                         thresholdVals=thresholds,
+                         slopeVals=slope,
+                         lowerAsymptoteVals=guess,
+                         lapseRateVals=lapse,
+                         responseVals=response_vals,
+                         psychometricFunc=func,
+                         **unknown_kwargs)
+
+
 if __name__ == '__main__':
     # test_QuestPlusHandler()
     # test_QuestPlusHandler_startIntensity()


### PR DESCRIPTION
This is necessary e.g. when `QuestPlusHandlers` are created via a `MultiStairHandler`, and all "MultiStair conditions" are passed down to `QuestPlusHandler`. These are now all swallowed through a `**kwarg` in the signature. To warn users of potential typos in their code, a warning will be emitted if one or more unknown kwargs are encountered.