### PR TITLE
BF: Disable the Form aperture on creation, enable only on draw

### DIFF
--- a/docs/source/builder/components/form.rst
+++ b/docs/source/builder/components/form.rst
@@ -41,7 +41,7 @@ Items : List of dicts or csv / xlsx file
         *responseColor*
             The response object color
 
-    Missing column headers will be replaced by default entries. The default entries are::
+    Missing column headers will be replaced by default entries. The default entries are:
         *index*
             0 (increments for each item)
         *questionText*

--- a/docs/source/builder/components/form.rst
+++ b/docs/source/builder/components/form.rst
@@ -22,22 +22,44 @@ Stop : int, float
 
 Items : List of dicts or csv / xlsx file
     A list of dicts or csv file should have the following key, value pairs / column headers:
-    :*index*: The item index as a number
-    :*questionText*: item question string
-    :*questionWidth*: question width between 0:1
-    :*type*: type of rating e.g., 'radio', 'rating', 'slider'
-    :*responseWidth*: question width between 0:1
-    :*options*: A sequence of tick labels for options e.g., yes, no
-    :*layout*: Response object layout e.g., 'horiz' or 'vert'
+        *index*
+            The item index as a number
+        *questionText*
+            The item question string
+        *questionWidth*
+            The question width between 0 : 1
+        *type*
+            The type of rating e.g., 'radio', 'rating', 'slider'
+        *responseWidth*
+            The question width between 0 : 1
+        *options*
+            A sequence of tick labels for options e.g., yes, no
+        *layout*
+            Response object layout e.g., 'horiz' or 'vert'
+        *questionColor*
+            The question text font color
+        *responseColor*
+            The response object color
 
-    Missing column headers will be replaced by default entries. The default entries are:
-    :*index*: 0 (increments for each item)
-    :*questionText*: Default question
-    :*questionWidth*: 0.7
-    :*type*: rating
-    :*responseWidth*: 0.3
-    :*options*: Yes, No
-    :*layout*: horiz
+    Missing column headers will be replaced by default entries. The default entries are::
+        *index*
+            0 (increments for each item)
+        *questionText*
+            Default question
+        *questionWidth*
+            0.7
+        *type*
+            rating
+        *responseWidth*
+            0.3
+        *options*
+            Yes, No
+        *layout*
+            horiz
+        *questionColor*
+            white
+        *responseColor*
+            white
 
 Text height : float
     Text height of the Form elements (i.e., question and response text).

--- a/psychopy/demos/builder/BigFiveInventory/bigFiveItems.csv
+++ b/psychopy/demos/builder/BigFiveInventory/bigFiveItems.csv
@@ -1,45 +1,45 @@
-index,questionText,options,layout,type,questionWidth,responseWidth
-1,Is talkative,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-2,Tends to find fault in others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-3,Does a thorough job,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-4,"Is depressed, blue","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-5,"Is original, comes up with new ideas","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-6,Is reserved,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-7,Is helpful and unselfish with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-8,Can be somewhat careless,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-9,"Is relaxed, handles stress well","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-10,Is curious about many different things,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-11,Is full of energy,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-12,Starts quarrels with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-13,Is a reliable worker,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-14,Can be tense,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-15,"Is ingenious, a deep thinker","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-16,Generates a lot of enthusiasm,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-17,Has a forgiving nature,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-18,Tends to be organised,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-19,Worries a lot,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-20,Has an active imagination,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-21,Tends to be quiet,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-22,Is generally trusting,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-23,Tends to be lazy,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-24,"Is emotionally stable, not easily upset","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-25,Is inventive,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-26,Has an assertive personality,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-27,Can be cold and aloof,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-28,Perserveres until the task is finished,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-29,Can be moody,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-30,"Values artistic, aesthetic experiences","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-31,"Is sometimes shy, inhibited","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-32,Is considerate and kind to almost everyone,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-33,Does things efficiently,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-34,Remains calm in tense situations,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-35,Prefers work that is routine,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-36,"Is outgoing, sociable","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-37,Is sometimes rude to others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-38,Makes plans and follows through with them,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-39,Gets nervous easily,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-40,"Likes to reflect, play with ideas","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-41,Has few artistic interests,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-42,Likes to cooperate with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-43,Is easily distracted,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
-44,"Is sophisticated in art, music, or literature","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4
+index,questionText,options,layout,type,questionWidth,responseWidth,questionColor,responseColor
+1,Is talkative,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+2,Tends to find fault in others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+3,Does a thorough job,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+4,"Is depressed, blue","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+5,"Is original, comes up with new ideas","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+6,Is reserved,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+7,Is helpful and unselfish with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+8,Can be somewhat careless,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+9,"Is relaxed, handles stress well","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+10,Is curious about many different things,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+11,Is full of energy,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+12,Starts quarrels with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+13,Is a reliable worker,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+14,Can be tense,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+15,"Is ingenious, a deep thinker","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+16,Generates a lot of enthusiasm,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+17,Has a forgiving nature,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+18,Tends to be organised,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+19,Worries a lot,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+20,Has an active imagination,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+21,Tends to be quiet,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+22,Is generally trusting,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+23,Tends to be lazy,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+24,"Is emotionally stable, not easily upset","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+25,Is inventive,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+26,Has an assertive personality,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+27,Can be cold and aloof,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+28,Perserveres until the task is finished,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+29,Can be moody,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+30,"Values artistic, aesthetic experiences","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+31,"Is sometimes shy, inhibited","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+32,Is considerate and kind to almost everyone,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+33,Does things efficiently,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+34,Remains calm in tense situations,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+35,Prefers work that is routine,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+36,"Is outgoing, sociable","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+37,Is sometimes rude to others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+38,Makes plans and follows through with them,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+39,Gets nervous easily,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+40,"Likes to reflect, play with ideas","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+41,Has few artistic interests,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+42,Likes to cooperate with others,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+43,Is easily distracted,"Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white
+44,"Is sophisticated in art, music, or literature","Disagree strongly, Disagree a little, Neither agree nor disagree, Agree a little, Agree strongly",horiz,radio,0.6,0.4,white,white

--- a/psychopy/demos/builder/BigFiveInventory/demographics.csv
+++ b/psychopy/demos/builder/BigFiveInventory/demographics.csv
@@ -1,5 +1,5 @@
-index,questionText,options,layout,type,questionWidth,responseWidth
-1,Please select your gender,"Male, Female, Other",horiz,rating,0.6,0.4
-2,Please select your age,"18 - 26, 26 - 34, 34 - 42, 42 - 50, 50+",vert,radio,0.6,0.4
-3,Please select your highest qualification,"None, GCSE, A-Levels or similar, Under- graduate degree, Post- graduate degree",horiz,radio,0.6,0.4
-4,Please select your mood,"Happy, Sad",horiz,slider,0.6,0.4
+index,questionText,options,layout,type,questionWidth,responseWidth,questionColor,responseColor
+1,Please select your gender,"Male, Female, Other",horiz,rating,0.6,0.4,lightblue,pink
+2,Please select your age,"18 - 26, 26 - 34, 34 - 42, 42 - 50, 50+",vert,radio,0.6,0.4,lightblue,pink
+3,Please select your highest qualification,"None, GCSE, A-Levels or similar, Under- graduate degree, Post- graduate degree",horiz,radio,0.6,0.4,lightblue,pink
+4,Please select your mood,"Happy, Sad",horiz,slider,0.6,0.4,lightblue,pink

--- a/psychopy/tests/test_all_visual/test_form.py
+++ b/psychopy/tests/test_all_visual/test_form.py
@@ -30,7 +30,10 @@ class Test_Form(object):
                            "responseWidth": 0.3,
                            "options": "Male, Female, Other",
                            "layout": 'vert',
-                           "index": 0}
+                           "index": 0,
+                           "questionColor": "white",
+                           "responseColor": "white"
+                           }
         self.questions.append(self.genderItem)
         # then a set of ratings
         items = ["running", "cake", "programming"]
@@ -41,7 +44,10 @@ class Test_Form(object):
                      "responseWidth": 0.3,
                      "options":"Lots, some, Not a lot, Longest Option",
                      "layout": 'horiz',
-                     "index": idx+1}
+                     "index": idx+1,
+                     "questionColor": "white",
+                     "responseColor": "white"
+                     }
             self.questions.append(entry)
         self.survey = Form(self.win, items=self.questions, size=(1.0, 0.3), pos=(0.0, 0.0), autoLog=False)
 
@@ -51,7 +57,10 @@ class Test_Form(object):
                       "c": "radio",
                       "d": 0.3,
                       "e": "Male, Female, Other",
-                      "f": 'vert'}]
+                      "f": 'vert',
+                      "g": "white",
+                      "h": "white"
+                        }]
 
         wrongOptions = [{"questionText": "What is your gender?",
                       "questionWidth": 0.7,
@@ -59,7 +68,9 @@ class Test_Form(object):
                       "responseWidth": 0.3,
                       "options": "Other",
                       "layout": 'vert',
-                      "index": 0}]
+                      "index": 0,
+                      "questionColor": "white",
+                      "responseColor": "white"}]
 
         reducedHeaders = [{"questionText": "What is your gender?"}]
 

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -159,7 +159,9 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
             -------
                 missingHeaders : Set of missing headers, or None if no missing headers
             """
-            surveyFields = {'index', 'responseWidth', 'layout', 'questionText', 'type', 'questionWidth', 'options'}
+            surveyFields = {'index', 'responseWidth', 'layout', 'questionText',
+                            'type', 'questionWidth', 'options',
+                            'questionColor', 'responseColor'}
             fields = set(fields)
 
             if not surveyFields == fields:
@@ -189,7 +191,9 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                              'layout': 'horiz',
                              'questionText': 'Default question',
                              'type': 'rating',
-                             'options': 'Yes, No'}
+                             'options': 'Yes, No',
+                             'questionColor': 'white',
+                             'responseColor': 'white'}
 
             msg = "Using default values for the following headers: {}".format(missingHeaders)
             if self.autoLog:
@@ -324,7 +328,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                                             height=self.textHeight,
                                             alignHoriz='left',
                                             wrapWidth=self._questionTextWrap(item['questionWidth']),
-                                            autoLog=False)
+                                            autoLog=False,
+                                            color=item['questionColor'])
 
         questionHeight = self._getQuestionHeight(question)
         questionWidth = self._getQuestionWidth(question)
@@ -463,7 +468,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                                       granularity=sliderType[item['type'].lower()]['granularity'],
                                       flip=True,
                                       style=sliderType[item['type'].lower()]['style'],
-                                      autoLog=False, )
+                                      autoLog=False,
+                                      color=item['responseColor'])
 
         return resp, respHeight
 

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -408,7 +408,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
             The position of the response object
         """
         pos = (self.rightEdge
-               - (item['responseWidth'] / 2)
+               - ((item['responseWidth'] * self.size[0]) / 2)
                - self._scrollBarSize[0]
                - self.itemPadding
                * self.size[0],

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -596,13 +596,15 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         psychopy.visual.Aperture
             The aperture setting viewable area for forms
         """
-        return psychopy.visual.Aperture(win=self.win,
-                                        name='aperture',
-                                        units=self.units,
-                                        shape='square',
-                                        size=self.size,
-                                        pos=(0, 0),
-                                        autoLog=False)
+        aperture = psychopy.visual.Aperture(win=self.win,
+                                            name='aperture',
+                                            units=self.units,
+                                            shape='square',
+                                            size=self.size,
+                                            pos=(0, 0),
+                                            autoLog=False)
+        aperture.disable()  # Disable on creation. Only enable on draw.
+        return aperture
 
     def _getScrollOffset(self):
         """Calculate offset position of items in relation to markerPos


### PR DESCRIPTION
This fix stops the aperture from being drawn when the Form is created.
This was causing the aperture to persist over all routines, until the
Form was actually drawn, where the aperture could be disabled.