### PR TITLE
RF: In QuestPlusHandler, Initialize unused inherited attribs (to avoid confusion), and exclude them from being written to the MultiStairHandler log

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1484,7 +1484,13 @@ class QuestPlusHandler(StairHandler):
             warnings.warn(msg, RuntimeWarning)
 
         super().__init__(startVal=startIntensity, nTrials=nTrials,
-                         extraInfo=extraInfo, name=name)
+                         stepType=stimScale, extraInfo=extraInfo, name=name)
+
+        # We  don't use these attributes that were inherited from StairHandler.
+        self.currentDirection = None
+        self.stepSizeCurrent = None
+        # Note that self.stepType is not used either: we use self.stimScale
+        # instead (which is defined below).
 
         self.intensityVals = intensityVals
         self.thresholdVals = thresholdVals

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1858,9 +1858,12 @@ class MultiStairHandler(_BaseTrialHandler):
                             self.conditions.index(stair.condition))
                 exp.addData(self.name + '.thisRepN', stair.thisTrialN + 1)
                 exp.addData(self.name + '.thisN', self.totalTrials)
-                exp.addData(self.name + '.direction', stair.currentDirection)
-                exp.addData(self.name + '.stepSize', stair.stepSizeCurrent)
-                exp.addData(self.name + '.stepType', stair.stepType)
+
+                if self.type != 'questplus':
+                    exp.addData(self.name + '.direction', stair.currentDirection)
+                    exp.addData(self.name + '.stepSize', stair.stepSizeCurrent)
+                    exp.addData(self.name + '.stepType', stair.stepType)
+
                 exp.addData(self.name + '.intensity', self._nextIntensity)
             return self._nextIntensity, self.currentStaircase.condition
         else:

--- a/psychopy/tests/clock/test_clock.py
+++ b/psychopy/tests/clock/test_clock.py
@@ -21,6 +21,7 @@ def test_StaticPeriod_finish_on_time():
 def test_StaticPeriod_overrun():
     """Test unsuccessful completion (period "overran")
     """
+    static = StaticPeriod()
     static.start(0.1)
     wait(0.11)
     assert static.complete() == 0
@@ -39,7 +40,8 @@ def test_StaticPeriod_recordFrameIntervals():
 def test_StaticPeriod_screenHz():
     """Test if screenHz parameter is respected, i.e., if after completion of the
     StaticPeriod, 1/screenHz seconds are still remaining, so the period will
-    complete after the next flip."""
+    complete after the next flip.
+    """
     refresh_rate = 100.0
     period_duration = 0.1
     timer = CountdownTimer()

--- a/psychopy/tests/clock/test_clock.py
+++ b/psychopy/tests/clock/test_clock.py
@@ -9,15 +9,24 @@ from psychopy.visual import Window
 
 
 @pytest.mark.staticperiod
-def test_StaticPeriod():
+def test_StaticPeriod_finish_on_time():
+    """Test successful completion (finishing "on time")
+    """
     static = StaticPeriod()
     static.start(0.1)
-    wait(0.05)
-    assert static.complete()==1
+    wait(0.01)
+    assert static.complete() == 1
+
+@pytest.mark.staticperiod
+def test_StaticPeriod_overrun():
+    """Test unsuccessful completion (period "overran")
+    """
     static.start(0.1)
     wait(0.11)
-    assert static.complete()==0
+    assert static.complete() == 0
 
+@pytest.mark.staticperiod
+def test_StaticPeriod_recordFrameIntervals():
     win = Window(autoLog=False)
     static = StaticPeriod(screenHz=60, win=win)
     static.start(.002)
@@ -26,9 +35,11 @@ def test_StaticPeriod():
     assert static._winWasRecordingIntervals == win.recordFrameIntervals
     win.close()
 
-    # Test if screenHz parameter is respected, i.e., if after completion of the
-    # StaticPeriod, 1/screenHz seconds are still remaining, so the period will
-    # complete after the next flip.
+@pytest.mark.staticperiod
+def test_StaticPeriod_screenHz():
+    """Test if screenHz parameter is respected, i.e., if after completion of the
+    StaticPeriod, 1/screenHz seconds are still remaining, so the period will
+    complete after the next flip."""
     refresh_rate = 100.0
     period_duration = 0.1
     timer = CountdownTimer()
@@ -43,7 +54,3 @@ def test_StaticPeriod():
                        1.0/refresh_rate,
                        atol=0.001)
     win.close()
-
-
-if __name__ == '__main__':
-    test_StaticPeriod()

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -1062,6 +1062,35 @@ def test_QuesPlusHandler_unknown_kwargs():
                          **unknown_kwargs)
 
 
+def test_QuesPlusHandler_unused_StairHandler_attribs():
+    import sys
+    if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        pytest.skip('QUEST+ only works on Python 3.6+')
+
+    from psychopy.data.staircase import QuestPlusHandler
+
+    thresholds = np.arange(-40, 0 + 1)
+    slope, guess, lapse = 3.5, 0.5, 0.02
+    contrasts = thresholds.copy()
+    response_vals = ['Correct', 'Incorrect']
+    func = 'weibull'
+    stim_scale = 'linear'
+
+    q = QuestPlusHandler(nTrials=20,
+                         intensityVals=contrasts,
+                         thresholdVals=thresholds,
+                         slopeVals=slope,
+                         lowerAsymptoteVals=guess,
+                         lapseRateVals=lapse,
+                         responseVals=response_vals,
+                         psychometricFunc=func,
+                         stimScale=stim_scale)
+
+    assert q.currentDirection is None
+    assert q.stepSizeCurrent is None
+    assert q.stepType == q.stimScale
+
+
 if __name__ == '__main__':
     # test_QuestPlusHandler()
     # test_QuestPlusHandler_startIntensity()


### PR DESCRIPTION
`.currentDirection` and `.stepSizeCurrent` attribs don't make sense for QUEST+ and only lead to confusion when their default values appear in logs. The `.stepType` attrib is never used (we use `.stimScale` instead). This PR ensures that we don't write any of these attribs to the `MultiStairHandler` data files any longer: the columns `direction`, `stepSize`, and `stepType` will not be included anymore.