### PR TITLE
ENH: anchors version for blank/latest, and filters single val versions

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -11,7 +11,7 @@ import wx.__version__
 import psychopy
 from psychopy import logging
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.tools.versionchooser import versionOptions, availableVersions, _versionFilter
+from psychopy.tools.versionchooser import versionOptions, availableVersions, _versionFilter, latestVersion
 from psychopy.constants import PY3
 
 # for creating html output folders:
@@ -531,16 +531,18 @@ class SettingsComponent(object):
 
         # decide if we need anchored useVersion or leave plain
         useVer = self.params['Use version'].val
-        if useVer in ['', 'latest']:
-            versionStr = ''  # nothing to do - use unversioned version
+        if useVer == '':
+            useVer = '.'.join(version.split('.')[:2])
+        elif useVer == 'latest':
+            useVer = '.'.join(latestVersion().split('.')[:2])
         else:
             # do we shorten minor versions ('3.4.2' to '3.4')?
             # only from 3.2 onwards
             if (parse_version(useVer) > (parse_version('3.2'))
                     and len(useVer.split('.'))>2):
                 useVer = '.'.join(useVer.split('.')[:2])
-            # prepend the hyphen
-            versionStr = '-{}'.format(useVer)
+        # prepend the hyphen
+        versionStr = '-{}'.format(useVer)
 
         # html header
         template = readTextFile("JS_htmlHeader.tmpl")

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -246,7 +246,10 @@ def _versionFilter(versions, wxVersion):
     if constants.PY3:
         msg = _translate("Filtering versions of PsychoPy only compatible with Python 3.")
         logging.info(msg)
-        versions = [ver for ver in versions if ver == 'latest' or parse_version(ver) >= parse_version('1.90')]
+        versions = [ver for ver in versions
+                    if ver == 'latest'
+                    or parse_version(ver) >= parse_version('1.90')
+                    and len(ver) > 1]
 
     # Get WX Compatibility
     compatibleWX = '4.0'
@@ -255,7 +258,10 @@ def _versionFilter(versions, wxVersion):
                          "PsychoPy only compatible with wx >= version {}".format(wxVersion,
                                                                               compatibleWX))
         logging.info(msg)
-        return [ver for ver in versions if ver == 'latest' or parse_version(ver) > parse_version('1.85.04')]
+        return [ver for ver in versions
+                if ver == 'latest'
+                or parse_version(ver) > parse_version('1.85.04')
+                and len(ver) > 1]
     return versions
 
 


### PR DESCRIPTION
The filtering removes the option to select a Major release version from
the drop down menu, whilst preserving the ability to retrieve these values
from version retrieving methods.