### PR TITLE
BF:  ERROR path is on mount ‘0:’, start on mount ‘C:’

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -744,16 +744,16 @@ class Experiment(object):
             :return: dict of 'asb' and 'rel' paths or None
             """
             thisFile = {}
-            if len(filePath) > 2 and (filePath[0] == "/" or filePath[1] == ":"):
+            if len(filePath) > 2 and (filePath[0] == "/" or filePath[1] == ":")\
+                    and os.path.isfile(filePath):
                 thisFile['abs'] = filePath
                 thisFile['rel'] = os.path.relpath(filePath, srcRoot)
+                return thisFile
             else:
                 thisFile['rel'] = filePath
                 thisFile['abs'] = os.path.normpath(join(srcRoot, filePath))
-            if os.path.isfile(thisFile['abs']):
-                return thisFile
-            else:
-                return None
+                if os.path.isfile(thisFile['abs']):
+                    return thisFile
 
         def findPathsInFile(filePath):
             """Recursively search a conditions file (xlsx or csv)


### PR DESCRIPTION
This was being raised when using a conditions file contained rows to control
subsets of a conditions file. The entry (e.g. 0:5 ) would look to the
code like it might be a file location (e.g. c: ) because we only used the :
to indicate a file path