### PR TITLE
FF: Too many arguments being passed to `setVertexAttribPointer`

### DIFF
--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -1661,7 +1661,7 @@ def createVAO(attribBuffers, indexBuffer=None, legacy=False):
                 raise ValueError('Invalid attribute values.')
 
         enableVertexAttribArray(i, legacy)
-        setVertexAttribPointer(i, buffer, size, offset, normalize, True, legacy)
+        setVertexAttribPointer(i, buffer, size, offset, normalize, legacy)
 
         activeAttribs[i] = buffer
         bufferIndices.append(buffer.shape[0])

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -2305,11 +2305,11 @@ def setVertexAttribPointer(index,
         # ... before rendering, set the attribute pointers
         GL.glBindBuffer(vboInterleaved.target, vboInterleaved.name)
         gltools.setVertexAttribPointer(
-            0, vboInterleaved, size=3, offset=0, bind=False)  # vertex pointer
+            0, vboInterleaved, size=3, offset=0)  # vertex pointer
         gltools.setVertexAttribPointer(
-            8, vboInterleaved, size=2, offset=3, bind=False)  # texture pointer
+            8, vboInterleaved, size=2, offset=3)  # texture pointer
         gltools.setVertexAttribPointer(
-            3, vboInterleaved, size=3, offset=5, bind=False)  # normals pointer
+            3, vboInterleaved, size=3, offset=5)  # normals pointer
 
         # Note, we specified `bind=False` since we are managing the binding
         # state. It is recommended that you do this when setting up interleaved


### PR DESCRIPTION
Fixes an issue where too many arguments are being passed to `setVertexAttribPointer` when creating a VAO.