### PR TITLE
EN/RF: Faster DotStim

### DIFF
--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -508,15 +508,16 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             outofbounds = np.hypot(normXY[:, 0], normXY[:, 1]) > 1.
 
         # update any dead dots
-        if np.sum(dead):
-            self._verticesBase[dead, :] = self._newDotsXY(dead.sum())
+        nDead = dead.sum()
+        if nDead:
+            self._verticesBase[dead, :] = self._newDotsXY(nDead)
 
         # Reposition any dots that have gone out of bounds. Net effect is to
         # place dot one step inside the boundary on the other side of the
         # aperture.
-        if np.any(outofbounds):
-            self._verticesBase[outofbounds, :] = self._newDotsXY(
-                outofbounds.sum())
+        nOutOfBounds = outofbounds.sum()
+        if nOutOfBounds:
+            self._verticesBase[outofbounds, :] = self._newDotsXY(nOutOfBounds)
 
         # update the pixel XY coordinates in pixels (using _BaseVisual class)
         self._updateVertices()

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -44,7 +44,11 @@ from psychopy.visual.basevisual import (BaseVisualStim, ColorMixin,
                                         ContainerMixin)
 
 import numpy as np
-from numpy import pi
+
+# some constants
+_piOver2 = np.pi / 2.
+_piOver180 = np.pi / 180.
+_2pi = 2 * np.pi
 
 
 class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
@@ -238,7 +242,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # fieldPos = pos, fieldSize=size and then dotSize as additional param
         self.fieldPos = fieldPos  # self.pos is also set here
         self.fieldSize = val2array(fieldSize, False)  # self.size is also set
-        if type(dotSize) in [tuple, list]:
+        if type(dotSize) in (tuple, list):
             self.dotSize = np.array(dotSize)
         else:
             self.dotSize = dotSize
@@ -278,8 +282,8 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # pre-allocate array for flagging dead dots
         self._deadDots = np.zeros(self.nDots, dtype=bool)
         # set directions (only used when self.noiseDots='direction')
-        self._dotsDir = np.random.rand(self.nDots) * 2. * pi
-        self._dotsDir[self._signalDots] = self.dir * pi / 180.
+        self._dotsDir = np.random.rand(self.nDots) * _2pi
+        self._dotsDir[self._signalDots] = self.dir * _piOver180
 
         self._update_dotsXY()
 
@@ -425,8 +429,8 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # otherwise would be signal dots adopt random directions when the become
         # sinal dots in later trails
         if self.noiseDots in ('direction', 'position', 'walk'):
-            self._dotsDir = np.random.rand(self.nDots) * 2. * pi
-            self._dotsDir[self._signalDots] = self.dir * pi / 180.
+            self._dotsDir = np.random.rand(self.nDots) * _2pi
+            self._dotsDir[self._signalDots] = self.dir * _piOver180
 
     def setFieldCoherence(self, val, op='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead, but use 
@@ -440,12 +444,12 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         <attrib-operations>` are supported.
         """
         # check which dots are signal before setting new dir
-        signalDots = self._dotsDir == (self.dir * pi / 180.)
+        signalDots = self._dotsDir == (self.dir * _piOver180)
         self.__dict__['dir'] = dir
 
         # dots currently moving in the signal direction also need to update
         # their direction
-        self._dotsDir[signalDots] = self.dir * pi / 180.
+        self._dotsDir[signalDots] = self.dir * _piOver180
 
     def setDir(self, val, op='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead, but use 
@@ -547,7 +551,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         """
         if self.fieldShape == 'circle':
             length = np.sqrt(np.random.uniform(0, 1, (nDots,)))
-            angle = np.random.uniform(0., 2. * np.pi, (nDots,))
+            angle = np.random.uniform(0., _2pi, (nDots,))
 
             newDots = np.zeros((nDots, 2))
             newDots[:, 0] = length * np.cos(angle)
@@ -592,14 +596,14 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             # noise and signal dots change identity constantly
             np.random.shuffle(self._dotsDir)
             # and then update _signalDots from that
-            self._signalDots = (self._dotsDir == (self.dir * pi / 180.))
+            self._signalDots = (self._dotsDir == (self.dir * _piOver180))
 
         # update the locations of signal and noise; 0 radians=East!
         reshape = np.reshape
         if self.noiseDots == 'walk':
             # noise dots are ~self._signalDots
             sig = np.random.rand(np.sum(~self._signalDots))
-            self._dotsDir[~self._signalDots] = sig * pi * 2.
+            self._dotsDir[~self._signalDots] = sig * _2pi
             # then update all positions from dir*speed
             cosDots = reshape(np.cos(self._dotsDir), (self.nDots,))
             sinDots = reshape(np.sin(self._dotsDir), (self.nDots,))

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -99,6 +99,8 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         ----------
         win : window.Window
             Window this stimulus is associated with.
+        units : str
+            Units to use.
         nDots : int
             Number of dots to present.
         coherence : float
@@ -157,6 +159,10 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             random, but constant direction. For 'walk' noise dots vary their
             direction every frame, but keep a constant speed. This value can be
             set using the `noiseDots` property after initialization.
+        name : str, optional
+            Optional name to use for logging.
+        autoLog : bool
+            Enable automatic logging.
 
         """
         # what local vars are defined (these are the init params) for use by

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -97,10 +97,67 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         """
         Parameters
         ----------
-        fieldSize : array_like
+        win : window.Window
+            Window this stimulus is associated with.
+        nDots : int
+            Number of dots to present.
+        coherence : float
+            Proportion of dots which are coherent. This value can be set using
+            the `coherence` property after initialization.
+        fieldPos : array_like
+            (x,y) or [x,y] position of the field. This value can be set using
+            the `fieldPos` property after initialization.
+        fieldSize : array_like, int or float
             (x,y) or [x,y] or single value (applied to both dimensions). Sizes
-            can be negative and can extend beyond the window.
-            
+            can be negative and can extend beyond the window. This value can be
+            set using the `fieldSize` property after initialization.
+        fieldShape : str
+            Defines the envelope used to present the dots. If changed while
+            drawing by setting the `fieldShape` property, dots outside new
+            envelope will be respawned., valid values are 'square', 'sqr' or
+            'circle'.
+        dotSize : array_like or float
+            Size of the dots. If given an array, the sizes of individual dots
+            will be set. The array must have length `nDots`. If a single value
+            is given, all dots will be set to the same size.
+        dotLife : float
+            Lifetime of a dot in frames. Dot lives are initiated randomly from a
+            uniform distribution from 0 to dotLife. If changed while drawing,
+            the lives of all dots will be randomly initiated again.
+        dir : float
+            Direction of the coherent dots in degrees.
+        speed : float
+            Speed of the dots (in *units* per frame).
+        rgb : array_like, optional
+            Color of the dots in form (r, g, b) or [r, g, b].
+        color : array_like or str
+            Color of the dots.
+        colorSpace : str
+            Colorspace to use.
+        opacity : float
+            Opacity of the dots from 0.0 to 1.0.
+        contrast : float
+            Contrast of the dots.
+        depth : float
+        element : object
+            This can be any object that has a ``.draw()`` method and a
+            ``.setPos([x,y])`` method (e.g. a GratingStim, TextStim...)!!
+            DotStim assumes that the element uses pixels as units.
+            ``None`` defaults to dots.
+        signalDots : str
+            If 'same' then the signal and noise dots are constant. If different
+            then the choice of which is signal and which is noise gets
+            randomised on each frame. This corresponds to Scase et al's (1996)
+            categories of RDK. This value can be set using the `signalDots`
+            property after initialization.
+        noiseDots : str
+            Determines the behaviour of the noise dots, taken directly from
+            Scase et al's (1996) categories. For 'position', noise dots take a
+            random position every frame. For 'direction' noise dots follow a
+            random, but constant direction. For 'walk' noise dots vary their
+            direction every frame, but keep a constant speed. This value can be
+            set using the `noiseDots` property after initialization.
+
         """
         # what local vars are defined (these are the init params) for use by
         # __repr__

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -52,27 +52,27 @@ _2pi = 2 * np.pi
 
 
 class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
-    """This stimulus class defines a field of dots with an update rule
-    that determines how they change on every call to the .draw() method.
+    """This stimulus class defines a field of dots with an update rule that
+    determines how they change on every call to the .draw() method.
 
-    This single class can be used to generate a wide variety of
-    dot motion types. For a review of possible types and their pros and
-    cons see Scase, Braddick & Raymond (1996). All six possible motions
-    they describe can be generated with appropriate choices of the
-    signalDots (which determines whether signal dots are the 'same' or
-    'different' on each frame), noiseDots (which determines the locations
-    of the noise dots on each frame) and the dotLife (which determines
-    for how many frames the dot will continue before being regenerated).
+    This single class can be used to generate a wide variety of dot motion
+    types. For a review of possible types and their pros and cons see Scase,
+    Braddick & Raymond (1996). All six possible motions they describe can be
+    generated with appropriate choices of the `signalDots` (which determines
+    whether signal dots are the 'same' or 'different' on each frame),
+    `noiseDots` (which determines the locations of the noise dots on each frame)
+    and the `dotLife` (which determines for how many frames the dot will
+    continue before being regenerated).
 
     The default settings (as of v1.70.00) is for the noise dots to have
-    identical velocity but random direction and signal dots remain the
-    'same' (once a signal dot, always a signal dot).
+    identical velocity but random direction and signal dots remain the 'same'
+    (once a signal dot, always a signal dot).
 
-    For further detail about the different configurations see :ref:`dots`
-    in the Builder Components section of the documentation.
+    For further detail about the different configurations see :ref:`dots` in the
+    Builder Components section of the documentation.
 
-    If further customisation is required, then the DotStim should be
-    subclassed and its _update_dotsXY and _newDotsXY methods overridden.
+    If further customisation is required, then the DotStim should be subclassed
+    and its _update_dotsXY and _newDotsXY methods overridden.
 
     The maximum number of dots that can be drawn is limited by system
     performance.
@@ -624,7 +624,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             self._verticesBase[sd, 0] += self.speed * cosDots
             self._verticesBase[sd, 1] += self.speed * sinDots
             # update noise dots
-            self._deadDots = self._deadDots + (~self._signalDots)  # just create new ones
+            self._deadDots[:] = self._deadDots + (~self._signalDots)
 
         # handle boundaries of the field
         if self.fieldShape in (None, 'square', 'sqr'):

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -10,9 +10,14 @@ determines how they change on every call to the .draw() method.
 # Distributed under the terms of the GNU General Public License (GPL).
 
 # Bugfix by Andrew Schofield.
-# Replaces out of bounds but still live dots at opposite edge of aperture instead of randomly within the field. This stops the concentration of dots at one side of field when lifetime is long.
-# Update the dot direction immediately for 'walk' as otherwise when the coherence varies some signal dots will inherit the random directions of previous walking dots.
-# Provide a visible wrapper function to refresh all the dot locations so that the whole field can be more easily refreshed between trials.
+# Replaces out of bounds but still live dots at opposite edge of aperture 
+# instead of randomly within the field. This stops the concentration of dots at 
+# one side of field when lifetime is long.
+# Update the dot direction immediately for 'walk' as otherwise when the 
+# coherence varies some signal dots will inherit the random directions of 
+# previous walking dots.
+# Provide a visible wrapper function to refresh all the dot locations so that 
+# the whole field can be more easily refreshed between trials.
 
 from __future__ import absolute_import, division, print_function
 
@@ -35,11 +40,10 @@ from psychopy import logging
 # (JWP has no idea why!)
 from psychopy.tools.attributetools import attributeSetter, setAttribute
 from psychopy.tools.arraytools import val2array
-from psychopy.tools.monitorunittools import cm2pix, deg2pix
 from psychopy.visual.basevisual import (BaseVisualStim, ColorMixin,
                                         ContainerMixin)
 
-import numpy
+import numpy as np
 from numpy import pi
 
 
@@ -65,8 +69,8 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
     If further customisation is required, then the DotStim should be
     subclassed and its _update_dotsXY and _newDotsXY methods overridden.
-    """
 
+    """
     def __init__(self,
                  win,
                  units='',
@@ -93,9 +97,10 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         """
         Parameters
         ----------
-        fieldSize : (x,y) or [x,y] or single value (applied to both
-            dimensions). Sizes can be negative and can extend beyond
-            the window.
+        fieldSize : array_like
+            (x,y) or [x,y] or single value (applied to both dimensions). Sizes
+            can be negative and can extend beyond the window.
+            
         """
         # what local vars are defined (these are the init params) for use by
         # __repr__
@@ -111,7 +116,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.fieldPos = fieldPos  # self.pos is also set here
         self.fieldSize = val2array(fieldSize, False)  # self.size is also set
         if type(dotSize) in [tuple, list]:
-            self.dotSize = numpy.array(dotSize)
+            self.dotSize = np.array(dotSize)
         else:
             self.dotSize = dotSize
         if self.win.useRetina:
@@ -143,15 +148,15 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.noiseDots = noiseDots
 
         # initialise a random array of X,Y
-        self. _verticesBase = self._dotsXY = self._newDotsXY(self.nDots)
+        self._verticesBase = self._dotsXY = self._newDotsXY(self.nDots)
         # all dots have the same speed
-        self._dotsSpeed = numpy.ones(self.nDots, 'f') * self.speed
+        self._dotsSpeed = np.ones(self.nDots, dtype=float) * self.speed
         # abs() means we can ignore the -1 case (no life)
-        self._dotsLife = abs(dotLife) * numpy.random.rand(self.nDots)
-        # numpy.random.shuffle(self._signalDots)  # not really necessary
+        self._dotsLife = np.abs(dotLife) * np.random.rand(self.nDots)
+        # np.random.shuffle(self._signalDots)  # not really necessary
         # set directions (only used when self.noiseDots='direction')
-        self._dotsDir = numpy.random.rand(self.nDots) * 2 * pi
-        self._dotsDir[self._signalDots] = self.dir * pi / 180
+        self._dotsDir = np.random.rand(self.nDots) * 2. * pi
+        self._dotsDir[self._signalDots] = self.dir * pi / 180.
 
         self._update_dotsXY()
 
@@ -191,7 +196,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         :ref:`operations <attrib-operations>` are supported.
         """
         self.__dict__['dotLife'] = dotLife
-        self._dotsLife = abs(self.dotLife) * numpy.random.rand(self.nDots)
+        self._dotsLife = abs(self.dotLife) * np.random.rand(self.nDots)
 
     @attributeSetter
     def signalDots(self, signalDots):
@@ -205,7 +210,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
     @attributeSetter
     def noiseDots(self, noiseDots):
-        """Str. *'direction'*, 'position' or 'walk'
+        """str - *'direction'*, 'position' or 'walk'
         Determines the behaviour of the noise dots, taken directly from
         Scase et al's (1996) categories. For 'position', noise dots take a
         random position every frame. For 'direction' noise dots follow a
@@ -242,8 +247,8 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.__dict__['fieldPos'] = self.pos
 
     def setFieldPos(self, val, op='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
+        """Usually you can use 'stim.attribute = value' syntax instead, but use 
+        this method if you need to suppress the log message.
         """
         setAttribute(self, 'fieldPos', val, log, op)  # calls attributeSetter
 
@@ -254,17 +259,16 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
                       "Use DotStim.SetFieldPos(pos) instead.")
 
     def setFieldSize(self, val, op='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
+        """Usually you can use 'stim.attribute = value' syntax instead, but use 
+        this method if you need to suppress the log message.
         """
         setAttribute(self, 'fieldSize', val, log, op)  # calls attributeSetter
 
     @attributeSetter
     def fieldSize(self, size):
         """Specifying the size of the field of dots using a
-        :ref:`x,y-pair <attrib-xy>`.
-        See e.g. :class:`.ShapeStim` for more documentation /
-        examples on how to set position.
+        :ref:`x,y-pair <attrib-xy>`. See e.g. :class:`.ShapeStim` for more 
+        documentation/examples on how to set position.
 
         :ref:`operations <attrib-operations>` are supported.
         """
@@ -277,62 +281,66 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
     def coherence(self, coherence):
         """Scalar between 0 and 1.
 
-        Change the coherence (%) of the DotStim. This will be rounded
-        according to the number of dots in the stimulus.
+        Change the coherence (%) of the DotStim. This will be rounded according 
+        to the number of dots in the stimulus.
 
         :ref:`operations <attrib-operations>` are supported.
         """
         if not 0 <= coherence <= 1:
             raise ValueError('DotStim.coherence must be between 0 and 1')
+
         _cohDots = coherence * self.nDots
-        self.__dict__['coherence'] = round(_cohDots)/self.nDots
-        self._signalDots = numpy.zeros(self.nDots, dtype=bool)
+
+        self.__dict__['coherence'] = round(_cohDots) /self.nDots
+        self._signalDots = np.zeros(self.nDots, dtype=bool)
         self._signalDots[0:int(self.coherence * self.nDots)] = True
         # for 'direction' method we need to update the direction of the number
         # of signal dots immediately, but for other methods it will be done
         # during updateXY
-        #:::::::::::::::::::: AJS Actually you need to do this for 'walk' also
+
+        # NB - AJS Actually you need to do this for 'walk' also
         # otherwise would be signal dots adopt random directions when the become
         # sinal dots in later trails
         if self.noiseDots in ['direction', 'position','walk']:
-            self._dotsDir = numpy.random.rand(self.nDots) * 2 * pi
-            self._dotsDir[self._signalDots] = self.dir * pi / 180
+            self._dotsDir = np.random.rand(self.nDots) * 2. * pi
+            self._dotsDir[self._signalDots] = self.dir * pi / 180.
 
     def setFieldCoherence(self, val, op='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
+        """Usually you can use 'stim.attribute = value' syntax instead, but use 
+        this method if you need to suppress the log message.
         """
         setAttribute(self, 'coherence', val, log, op)  # calls attributeSetter
 
     @attributeSetter
     def dir(self, dir):
-        """float (degrees). direction of the coherent dots.
-        :ref:`operations <attrib-operations>` are supported.
+        """float (degrees). direction of the coherent dots. :ref:`operations 
+        <attrib-operations>` are supported.
         """
         # check which dots are signal before setting new dir
-        signalDots = self._dotsDir == (self.dir * pi / 180)
+        signalDots = self._dotsDir == (self.dir * pi / 180.)
         self.__dict__['dir'] = dir
 
         # dots currently moving in the signal direction also need to update
         # their direction
-        self._dotsDir[signalDots] = self.dir * pi / 180
+        self._dotsDir[signalDots] = self.dir * pi / 180.
 
     def setDir(self, val, op='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
+        """Usually you can use 'stim.attribute = value' syntax instead, but use 
+        this method if you need to suppress the log message.
         """
         setAttribute(self, 'dir', val, log, op)
 
     @attributeSetter
     def speed(self, speed):
-        """float. speed of the dots (in *units*/frame).
-        :ref:`operations <attrib-operations>` are supported.
+        """float. speed of the dots (in *units*/frame). :ref:`operations 
+        <attrib-operations>` are supported.
         """
         self.__dict__['speed'] = speed
 
     def setSpeed(self, val, op='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
+        """Usually you can use 'stim.attribute = value' syntax instead, but use 
+        this method if you need to suppress the log message.
+        
         """
         setAttribute(self, 'speed', val, log, op)
 
@@ -415,38 +423,37 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         """
         if self.fieldShape == 'circle':
-            length = numpy.sqrt(numpy.random.uniform(0, 1, (nDots,)))
-            angle = numpy.random.uniform(0., 2. * numpy.pi, (nDots,))
+            length = np.sqrt(np.random.uniform(0, 1, (nDots,)))
+            angle = np.random.uniform(0., 2. * np.pi, (nDots,))
 
-            newDots = numpy.zeros((nDots, 2))
-            newDots[:, 0] = length * numpy.cos(angle)
-            newDots[:, 1] = length * numpy.sin(angle)
+            newDots = np.zeros((nDots, 2))
+            newDots[:, 0] = length * np.cos(angle)
+            newDots[:, 1] = length * np.sin(angle)
 
             newDots *= self.fieldSize * .5
         else:
-            newDots = numpy.random.uniform(
+            newDots = np.random.uniform(
                 -.5 * self.fieldSize[0], .5 * self.fieldSize[1], (nDots, 2))
 
         return newDots
 
     def refreshDots(self):
-        """Callable user function to choose a new set of dots"""
+        """Callable user function to choose a new set of dots."""
         self._verticesBase = self._dotsXY = self._newDotsXY(self.nDots)
 
     def _update_dotsXY(self):
         """The user shouldn't call this - its gets done within draw().
         """
-
         # Find dead dots, update positions, get new positions for
         # dead and out-of-bounds
         # renew dead dots
-        if self.dotLife > 0:  # if less than zero ignore it
+        if self.dotLife > 0.:  # if less than zero ignore it
             # decrement. Then dots to be reborn will be negative
-            self._dotsLife -= 1
+            self._dotsLife -= 1.
             dead = (self._dotsLife <= 0.0)
             self._dotsLife[dead] = self.dotLife
         else:
-            dead = numpy.zeros(self.nDots, dtype=bool)
+            dead = np.zeros(self.nDots, dtype=bool)
 
         # update XY based on speed and dir
         # NB self._dotsDir is in radians, but self.dir is in degs
@@ -455,33 +462,33 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             #  **up to version 1.70.00 this was the other way around,
             # not in keeping with Scase et al**
             # noise and signal dots change identity constantly
-            numpy.random.shuffle(self._dotsDir)
+            np.random.shuffle(self._dotsDir)
             # and then update _signalDots from that
-            self._signalDots = (self._dotsDir == (self.dir * pi / 180))
+            self._signalDots = (self._dotsDir == (self.dir * pi / 180.))
 
         # update the locations of signal and noise; 0 radians=East!
-        reshape = numpy.reshape
+        reshape = np.reshape
         if self.noiseDots == 'walk':
             # noise dots are ~self._signalDots
-            sig = numpy.random.rand((~self._signalDots).sum())
-            self._dotsDir[~self._signalDots] = sig * pi * 2
+            sig = np.random.rand(np.sum(~self._signalDots))
+            self._dotsDir[~self._signalDots] = sig * pi * 2.
             # then update all positions from dir*speed
-            cosDots = reshape(numpy.cos(self._dotsDir), (self.nDots,))
-            sinDots = reshape(numpy.sin(self._dotsDir), (self.nDots,))
+            cosDots = reshape(np.cos(self._dotsDir), (self.nDots,))
+            sinDots = reshape(np.sin(self._dotsDir), (self.nDots,))
             self._verticesBase[:, 0] += self.speed * cosDots
             self._verticesBase[:, 1] += self.speed * sinDots
         elif self.noiseDots == 'direction':
             # simply use the stored directions to update position
-            cosDots = reshape(numpy.cos(self._dotsDir), (self.nDots,))
-            sinDots = reshape(numpy.sin(self._dotsDir), (self.nDots,))
+            cosDots = reshape(np.cos(self._dotsDir), (self.nDots,))
+            sinDots = reshape(np.sin(self._dotsDir), (self.nDots,))
             self._verticesBase[:, 0] += self.speed * cosDots
             self._verticesBase[:, 1] += self.speed * sinDots
         elif self.noiseDots == 'position':
             # update signal dots
             sd = self._signalDots
             sdSum = self._signalDots.sum()
-            cosDots = reshape(numpy.cos(self._dotsDir[sd]), (sdSum,))
-            sinDots = reshape(numpy.sin(self._dotsDir[sd]), (sdSum,))
+            cosDots = reshape(np.cos(self._dotsDir[sd]), (sdSum,))
+            sinDots = reshape(np.sin(self._dotsDir[sd]), (sdSum,))
             self._verticesBase[sd, 0] += self.speed * cosDots
             self._verticesBase[sd, 1] += self.speed * sinDots
             # update noise dots
@@ -489,43 +496,27 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # handle boundaries of the field
         if self.fieldShape in (None, 'square', 'sqr'):
-            #dead0 = (numpy.abs(self._verticesBase[:, 0]) > 0.5)
-            #dead1 = (numpy.abs(self._verticesBase[:, 1]) > 0.5)
-            #dead = dead + dead0 + dead1
-            out0 = (numpy.abs(self._verticesBase[:, 0]) > 0.5*self.fieldSize[0])
-            out1 = (numpy.abs(self._verticesBase[:, 1]) > 0.5*self.fieldSize[1])
+            out0 = (np.abs(self._verticesBase[:, 0]) > 0.5 * self.fieldSize[0])
+            out1 = (np.abs(self._verticesBase[:, 1]) > 0.5 * self.fieldSize[1])
             outofbounds = out0 + out1
-
-        elif self.fieldShape == 'circle':
-            #outofbounds=None
+        else:
             # transform to a normalised circle (radius = 1 all around)
             # then to polar coords to check
             # the normalised XY position (where radius should be < 1)
             normXY = self._verticesBase / 0.5 / self.fieldSize
             # add out-of-bounds to those that need replacing
-            #dead+= (numpy.hypot(normXY[:, 0], normXY[:, 1]) > 1)
-            outofbounds = (numpy.hypot(normXY[:, 0], normXY[:, 1]) > 1)
+            outofbounds = np.hypot(normXY[:, 0], normXY[:, 1]) > 1.
 
         # update any dead dots
-        if sum(dead):
-            self._verticesBase[dead, :] = self._newDotsXY(sum(dead))
-            #self._verticesBase[dead, :] = -self._verticesBase[dead,:]
+        if np.sum(dead):
+            self._verticesBase[dead, :] = self._newDotsXY(dead.sum())
 
         # Reposition any dots that have gone out of bounds. Net effect is to
         # place dot one step inside the boundary on the other side of the
         # aperture.
-        if sum(outofbounds):
-            self._verticesBase[outofbounds, :] = self._newDotsXY(sum(outofbounds))
-            #wind the dots back one step and store as tempary values
-            # if self.noiseDots == 'position':
-            #     tempvert0=self._verticesBase[sd,0]-self.speed * cosDots
-            #     tempvert1=self._verticesBase[sd,1]-self.speed * sinDots
-            # else:
-            #     tempvert0=self._verticesBase[:,0]-self.speed * cosDots
-            #     tempvert1=self._verticesBase[:,1]-self.speed * sinDots
-            # #reflect the position of the dots about the origine of the dot field
-            # self._verticesBase[outofbounds, 0] = -tempvert0[outofbounds]
-            # self._verticesBase[outofbounds, 1] = -tempvert1[outofbounds]
+        if np.any(outofbounds):
+            self._verticesBase[outofbounds, :] = self._newDotsXY(
+                outofbounds.sum())
 
         # update the pixel XY coordinates in pixels (using _BaseVisual class)
         self._updateVertices()

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -70,6 +70,57 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
     If further customisation is required, then the DotStim should be
     subclassed and its _update_dotsXY and _newDotsXY methods overridden.
 
+    The maximum number of dots that can be drawn is limited by system
+    performance.
+
+    Attributes
+    ----------
+    fieldShape : str
+        *'sqr'* or 'circle'. Defines the envelope used to present the dots. If
+        changed while drawing, dots outside new envelope will be respawned.
+    dotSize : float
+        Dot size specified in pixels (overridden if `element` is specified).
+        :ref:`operations <attrib-operations>` are supported.
+    dotLife : int
+        Number of frames each dot lives for (-1=infinite). Dot lives are
+        initiated randomly from a uniform distribution from 0 to dotLife. If
+        changed while drawing, the lives of all dots will be randomly initiated
+        again.
+    signalDots : str
+        If 'same' then the signal and noise dots are constant. If 'different'
+        then the choice of which is signal and which is noise gets randomised on
+        each frame. This corresponds to Scase et al's (1996) categories of RDK.
+    noiseDots : str
+        Determines the behaviour of the noise dots, taken directly from Scase et
+        al's (1996) categories. For 'position', noise dots take a random
+        position every frame. For 'direction' noise dots follow a random, but
+        constant direction. For 'walk' noise dots vary their direction every
+        frame, but keep a constant speed.
+    element : object
+        This can be any object that has a ``.draw()`` method and a
+        ``.setPos([x,y])`` method (e.g. a GratingStim, TextStim...)!! DotStim
+        assumes that the element uses pixels as units. ``None`` defaults to
+        dots.
+    fieldPos : array_like
+        Specifying the location of the centre of the stimulus using a
+        :ref:`x,y-pair <attrib-xy>`. See e.g. :class:`.ShapeStim` for more
+        documentation/examples on how to set position.
+        :ref:`operations <attrib-operations>` are supported.
+    fieldSize : array_like
+        Specifying the size of the field of dots using a
+        :ref:`x,y-pair <attrib-xy>`. See e.g. :class:`.ShapeStim` for more
+        documentation/examples on how to set position.
+        :ref:`operations <attrib-operations>` are supported.
+    coherence : float
+        Change the coherence (%) of the DotStim. This will be rounded according
+        to the number of dots in the stimulus.
+    dir : float
+        Direction of the coherent dots in degrees. :ref:`operations
+        <attrib-operations>` are supported.
+    speed : float
+        Speed of the dots (in *units*/frame). :ref:`operations
+        <attrib-operations>` are supported.
+
     """
     def __init__(self,
                  win,
@@ -102,7 +153,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
         units : str
             Units to use.
         nDots : int
-            Number of dots to present.
+            Number of dots to present in the field.
         coherence : float
             Proportion of dots which are coherent. This value can be set using
             the `coherence` property after initialization.
@@ -122,25 +173,34 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
             Size of the dots. If given an array, the sizes of individual dots
             will be set. The array must have length `nDots`. If a single value
             is given, all dots will be set to the same size.
-        dotLife : float
+        dotLife : int
             Lifetime of a dot in frames. Dot lives are initiated randomly from a
             uniform distribution from 0 to dotLife. If changed while drawing,
-            the lives of all dots will be randomly initiated again.
+            the lives of all dots will be randomly initiated again. A value of
+            -1 results in dots having an infinite lifetime. This value can be
+            set using the `dotLife` property after initialization.
         dir : float
-            Direction of the coherent dots in degrees.
+            Direction of the coherent dots in degrees. At 0 degrees, coherent
+            dots will move from left to right. Increasing the angle will rotate
+            the direction counter-clockwise. This value can be set using the
+            `dir` property after initialization.
         speed : float
-            Speed of the dots (in *units* per frame).
+            Speed of the dots (in *units* per frame). This value can be set
+            using the `speed` property after initialization.
         rgb : array_like, optional
-            Color of the dots in form (r, g, b) or [r, g, b].
+            Color of the dots in form (r, g, b) or [r, g, b]. **Deprecated**,
+            use `color` instead.
         color : array_like or str
-            Color of the dots.
+            Color of the dots in form (r, g, b) or [r, g, b].
         colorSpace : str
             Colorspace to use.
         opacity : float
             Opacity of the dots from 0.0 to 1.0.
         contrast : float
-            Contrast of the dots.
+            Contrast of the dots 0.0 to 1.0. This value is simply multiplied by
+            the `color` value.
         depth : float
+            **Deprecated**, depth is now controlled simply by drawing order.
         element : object
             This can be any object that has a ``.draw()`` method and a
             ``.setPos([x,y])`` method (e.g. a GratingStim, TextStim...)!!


### PR DESCRIPTION
Went through the code and optimized some areas of `DotStim` to handle substantially more dots than before. Looks like most of the slowdown was caused by the Python `sum` function being used on `ndarrays` instead of the `Numpy` one which is several orders of magnitude faster. I also cleaned up some docstrings and comments. The documentation needs some love, really inconsistent style in there. 