### PR TITLE
RF: Have attributes `width` and `height` aliased with size in `RectStim`.

### DIFF
--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -10,11 +10,9 @@
 
 from __future__ import absolute_import, print_function
 
-import numpy
+import numpy as np
 
 import psychopy  # so we can get the __path__
-from psychopy import logging
-
 from psychopy.visual.shape import BaseShapeStim
 from psychopy.tools.attributetools import attributeSetter, setAttribute
 
@@ -24,11 +22,29 @@ class Rect(BaseShapeStim):
     :class:`~psychopy.visual.ShapeStim`
 
     (New in version 1.72.00)
-    """
 
+    Attributes
+    ----------
+    width, height : float or int
+        The width and height of the rectangle. Values are aliased with fields
+        in the `size` attribute. Use these values to adjust the size of the
+        rectangle in a single dimension after initialization.
+
+    """
     def __init__(self, win, width=.5, height=.5, autoLog=None, **kwargs):
         """Rect accepts all input parameters, that
         `~psychopy.visual.ShapeStim` accept, except vertices and closeShape.
+
+        Parameters
+        ----------
+        win : psychopy.visual.Window
+            Window object to be associated with this stimuli.
+        width, height : float or int
+            The width and height of the rectangle. *DEPRECATED* use `size`
+            to define the dimensions of the rectangle on initialization. If
+            `size` is specified the values of `width` and `height` are
+            ignored.
+
         """
         # what local vars are defined (these are the init params) for use by
         # __repr__
@@ -41,17 +57,52 @@ class Rect(BaseShapeStim):
         self.__dict__['width'] = width
         self.__dict__['height'] = height
         self.__dict__['autoLog'] = autoLog
-        self._calcVertices()
+
+        # vertices for rectangle, CCW winding order
+        self.vertices = np.array([[-1.,  1.],
+                                  [ 1.,  1.],
+                                  [ 1., -1.],
+                                  [-1., -1.]])
+
+        self.setVertices(self.vertices, log=False)
+
         kwargs['closeShape'] = True  # Make sure nobody messes around here
         kwargs['vertices'] = self.vertices
 
         super(Rect, self).__init__(win, **kwargs)
 
-    def _calcVertices(self):
-        self.vertices = numpy.array([(-self.width * .5, self.height * .5),
-                                     (self.width * .5, self.height * .5),
-                                     (self.width * .5, -self.height * .5),
-                                     (-self.width * .5, -self.height * .5)])
+        # Get the value of `size` if specified and use it instead of `width`
+        # and `height`.
+        argSize = kwargs.get('size', None)
+
+        # If the size argument was specified, override values of width and
+        # height, this is too maintain legacy compatibility. Args width and
+        # height should be deprecated in later releases.
+        if argSize is None:
+            self.size = (width, height)
+        else:
+            self.size = argSize
+
+    @attributeSetter
+    def size(self, value):
+        """array-like.
+        Size of the rectangle (`width` and `height`).
+        """
+        # Needed to override `size` to ensure `width` and `height` attrs
+        # are updated when it changes.
+        self.__dict__['size'] = np.array(value, float)
+
+        width, height = self.__dict__['size']
+        self.__dict__['width'] = width
+        self.__dict__['height'] = height
+
+    def setSize(self, size, operation='', log=None):
+        """Usually you can use 'stim.attribute = value' syntax instead,
+        but use this method if you need to suppress the log message
+
+        :ref:`Operations <attrib-operations>` supported.
+        """
+        setAttribute(self, 'size', size, log, operation)
 
     @attributeSetter
     def width(self, value):
@@ -60,9 +111,8 @@ class Rect(BaseShapeStim):
 
         :ref:`Operations <attrib-operations>` supported.
         """
-        self.__dict__['width'] = value
-        self._calcVertices()
-        self.setVertices(self.vertices, log=False)
+        self.__dict__['width'] = float(value)
+        self.size = (self.__dict__['width'], self.size[1])
 
     def setWidth(self, width, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,
@@ -77,9 +127,8 @@ class Rect(BaseShapeStim):
 
         :ref:`Operations <attrib-operations>` supported.
         """
-        self.__dict__['height'] = value
-        self._calcVertices()
-        self.setVertices(self.vertices, log=False)
+        self.__dict__['height'] = float(value)
+        self.size = (self.size[0], self.__dict__['height'])
 
     def setHeight(self, height, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -59,10 +59,10 @@ class Rect(BaseShapeStim):
         self.__dict__['autoLog'] = autoLog
 
         # vertices for rectangle, CCW winding order
-        self.vertices = np.array([[-1.,  1.],
-                                  [ 1.,  1.],
-                                  [ 1., -1.],
-                                  [-1., -1.]])
+        self.vertices = np.array([[-.5,  .5],
+                                  [ .5,  .5],
+                                  [ .5, -.5],
+                                  [-.5, -.5]])
 
         self.setVertices(self.vertices, log=False)
 

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -31,57 +31,81 @@ class Rect(BaseShapeStim):
         rectangle in a single dimension after initialization.
 
     """
-    def __init__(self, win, width=.5, height=.5, autoLog=None, **kwargs):
-        """Rect accepts all input parameters, that
-        `~psychopy.visual.ShapeStim` accept, except vertices and closeShape.
-
+    def __init__(self,
+                 win,
+                 width=.5,
+                 height=.5,
+                 autoLog=None,
+                 units='',
+                 lineWidth=1.5,
+                 lineColor='white',
+                 lineColorSpace='rgb',
+                 fillColor=None,
+                 fillColorSpace='rgb',
+                 pos=(0, 0),
+                 size=None,
+                 ori=0.0,
+                 opacity=1.0,
+                 contrast=1.0,
+                 depth=0,
+                 interpolate=True,
+                 name=None,
+                 autoDraw=False):
+        """
         Parameters
         ----------
-        win : psychopy.visual.Window
+        win : `~psychopy.visual.Window`
             Window object to be associated with this stimuli.
         width, height : float or int
             The width and height of the rectangle. *DEPRECATED* use `size`
             to define the dimensions of the rectangle on initialization. If
             `size` is specified the values of `width` and `height` are
-            ignored.
+            ignored. This is to provide legacy compatibility for existing
+            applications.
+        size : array_like, float or int
+            Width and height of the rectangle as (w, h) or [w, h]. If a single
+            value is provided, the width and height will be set to the same
+            specified value. If `None` is specified, the `size` will be set
+            with values passed to `width` and `height`.
 
         """
-        # what local vars are defined (these are the init params) for use by
-        # __repr__
-        self._initParams = dir()
-        self._initParams.remove('self')
-        # kwargs isn't a parameter, but a list of params
-        self._initParams.remove('kwargs')
-        self._initParams.extend(kwargs)
-
-        self.__dict__['width'] = width
-        self.__dict__['height'] = height
-        self.__dict__['autoLog'] = autoLog
-
-        # vertices for rectangle, CCW winding order
-        self.vertices = np.array([[-.5,  .5],
-                                  [ .5,  .5],
-                                  [ .5, -.5],
-                                  [-.5, -.5]])
-
-        self.setVertices(self.vertices, log=False)
-
-        kwargs['closeShape'] = True  # Make sure nobody messes around here
-        kwargs['vertices'] = self.vertices
-
-        super(Rect, self).__init__(win, **kwargs)
-
-        # Get the value of `size` if specified and use it instead of `width`
-        # and `height`.
-        argSize = kwargs.get('size', None)
+        # width and height attributes, these are later aliased with `size`
+        self.__dict__['width'] = float(width)
+        self.__dict__['height'] = float(height)
 
         # If the size argument was specified, override values of width and
-        # height, this is too maintain legacy compatibility. Args width and
+        # height, this is to maintain legacy compatibility. Args width and
         # height should be deprecated in later releases.
-        if argSize is None:
-            self.size = (width, height)
-        else:
-            self.size = argSize
+        if size is None:
+            size = (self.__dict__['width'],
+                    self.__dict__['height'])
+
+        # vertices for rectangle, CCW winding order
+        vertices = np.array([[-.5,  .5],
+                             [ .5,  .5],
+                             [ .5, -.5],
+                             [-.5, -.5]])
+
+        super(Rect, self).__init__(
+            win,
+            units=units,
+            lineWidth=lineWidth,
+            lineColor=lineColor,
+            lineColorSpace=lineColorSpace,
+            fillColor=fillColor,
+            fillColorSpace=fillColorSpace,
+            vertices=vertices,
+            closeShape=True,
+            pos=pos,
+            size=size,
+            ori=ori,
+            opacity=opacity,
+            contrast=contrast,
+            depth=depth,
+            interpolate=interpolate,
+            name=name,
+            autoLog=autoLog,
+            autoDraw=autoDraw)
 
     @attributeSetter
     def size(self, value):


### PR DESCRIPTION
Fixes issue #2644 by aliasing `width` and `height` with `size`.

Behavior of `__init__` has been changed to use `size` only to set the dimensions of the rectangle. Keyword arguments `width` and `height` set `size`. If `size` is specified, the values of `width` and `height` are ignored. Documentation has been updated to reveal this new behavior. Attributes `width` and `height` can be set after initialization so operations may be used to manipulate the shape of the rectangle in one dimension. Changing the size attribute will also update the values of `width` and `height`.