### PR TITLE
NF: `Pie` shape class for pac-man shapes.

### DIFF
--- a/docs/source/api/visual/pie.rst
+++ b/docs/source/api/visual/pie.rst
@@ -1,0 +1,8 @@
+
+
+:class:`Pie`
+------------------------------------
+.. autoclass:: psychopy.visual.Pie
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/psychopy/demos/coder/stimuli/kanizsa.py
+++ b/psychopy/demos/coder/stimuli/kanizsa.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Demo for the class psychopy.visual.Pie().
+
+Use the `Pie` class to create a Kanizsa figure which produces illusory
+contours.
+
+"""
+from psychopy import core
+import psychopy.visual as visual
+from psychopy.visual.pie import Pie
+from psychopy import event
+
+# open a window to render the shape
+win = visual.Window((600, 600), allowGUI=False, monitor='testMonitor')
+
+# create the stimulus object
+pieStim = Pie(
+    win, radius=50, start=0., end=270., fillColor=(-1., -1., -1.), units='pix')
+
+message = visual.TextStim(
+    win, text='Any key to quit', pos=(0, -0.8), units='norm')
+
+# positions of the corners of the shapes
+pos = [(-100, 100), (100, 100), (-100, -100), (100, -100)]
+
+# orientations of the shapes
+ori = [180., 270., 90., 0.]
+
+while not event.getKeys():
+
+    for i in range(4):
+        pieStim.pos = pos[i]
+        pieStim.ori = ori[i]
+        pieStim.draw()
+
+    message.draw()
+    win.flip()
+
+win.close()
+core.quit()

--- a/psychopy/demos/coder/stimuli/kanizsa.py
+++ b/psychopy/demos/coder/stimuli/kanizsa.py
@@ -8,7 +8,7 @@ contours.
 """
 from psychopy import core
 import psychopy.visual as visual
-from psychopy.visual.pie import Pie
+from psychopy.visual import Pie
 from psychopy import event
 
 # open a window to render the shape

--- a/psychopy/visual/__init__.py
+++ b/psychopy/visual/__init__.py
@@ -75,6 +75,7 @@ from psychopy.visual.shape import ShapeStim
 from psychopy.visual.line import Line
 from psychopy.visual.polygon import Polygon
 from psychopy.visual.rect import Rect
+from psychopy.visual.pie import Pie
 
 # stimuli derived from Polygon
 from psychopy.visual.circle import Circle

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Creates a pie shape."""
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+from __future__ import absolute_import, print_function
+from psychopy.visual.shape import BaseShapeStim
+from psychopy.tools.attributetools import attributeSetter, setAttribute
+import numpy as np
+
+
+class Pie(BaseShapeStim):
+    """Creates a pie shape which is a circle with a wedge cut-out. This
+    shape is frequently used for creating Kanizsa figures. However, it
+    can be adapted for other uses.
+
+    Attributes
+    ----------
+    start, end : float or int
+        Start and end angles of the filled region of the shape in
+        degrees. Shapes are filled counter clockwise between the
+        specified angles.
+    radius : float or int
+        Radius of the shape.
+
+    """
+    def __init__(self, win, radius=.5, edges=64, start=0.0, end=90.0, **kwargs):
+        self.radius = radius
+        self.edges = edges
+        self.__dict__['start'] = start
+        self.__dict__['end'] = end
+
+        self._initParams = dir()
+        self._initParams.remove('self')
+        # kwargs isn't a parameter, but a list of params
+        self._initParams.remove('kwargs')
+        self._initParams.extend(kwargs)
+
+        self.vertices = self._calcVertices()
+        kwargs['closeShape'] = True
+        kwargs['vertices'] = self.vertices
+
+        super(Pie, self).__init__(win, **kwargs)
+
+    def _calcVertices(self):
+        """Calculate the required vertices for the figure.
+        """
+        startRadians = np.radians(self.start)
+        endRadians = np.radians(self.end)
+
+        # get number of steps for vertices
+        steps = np.linspace(startRadians, endRadians, num=self.edges)
+
+        # offset by 1 since the first vertex needs to be at centre
+        verts = np.zeros((self.edges + 1, 2), float)
+        verts[1:, 0] = np.sin(steps)
+        verts[1:, 1] = np.cos(steps)
+
+        verts *= self.radius
+
+        return verts
+
+    @attributeSetter
+    def start(self, value):
+        """int or float.
+        Height of the Rectangle (in its respective units, if specified).
+
+        :ref:`Operations <attrib-operations>` supported.
+        """
+        self.__dict__['start'] = value
+        self._calcVertices()
+        self.setVertices(self.vertices, log=False)
+
+    def setStart(self, start, operation='', log=None):
+        """Usually you can use 'stim.attribute = value' syntax instead,
+        but use this method if you need to suppress the log message
+        """
+        setAttribute(self, 'start', start, log, operation)
+
+    @attributeSetter
+    def end(self, value):
+        """int or float.
+        Height of the Rectangle (in its respective units, if specified).
+
+        :ref:`Operations <attrib-operations>` supported.
+        """
+        self.__dict__['end'] = value
+        self._calcVertices()
+        self.setVertices(self.vertices, log=False)
+
+    def setEnd(self, end, operation='', log=None):
+        """Usually you can use 'stim.attribute = value' syntax instead,
+        but use this method if you need to suppress the log message
+        """
+        setAttribute(self, 'end', end, log, operation)
+
+    @attributeSetter
+    def radius(self, value):
+        """int or float.
+        Height of the Rectangle (in its respective units, if specified).
+
+        :ref:`Operations <attrib-operations>` supported.
+        """
+        self.__dict__['radius'] = value
+        self._calcVertices()
+        self.setVertices(self.vertices, log=False)
+
+    def setRadius(self, end, operation='', log=None):
+        """Usually you can use 'stim.attribute = value' syntax instead,
+        but use this method if you need to suppress the log message
+        """
+        setAttribute(self, 'radius', end, log, operation)

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -22,29 +22,69 @@ class Pie(BaseShapeStim):
     ----------
     start, end : float or int
         Start and end angles of the filled region of the shape in
-        degrees. Shapes are filled counter clockwise between the
-        specified angles.
+        degrees. Shapes are filled counter clockwise between the specified
+        angles.
     radius : float or int
         Radius of the shape.
 
     """
-    def __init__(self, win, radius=.5, edges=64, start=0.0, end=90.0, **kwargs):
-        self.radius = radius
-        self.edges = edges
+    def __init__(self,
+                 win,
+                 radius=.5,
+                 start=0.0,
+                 end=90.0,
+                 edges=32,
+                 units='',
+                 lineWidth=1.5,
+                 lineColor=(1.0, 1.0, 1.0),
+                 lineColorSpace='rgb',
+                 fillColor=None,
+                 fillColorSpace='rgb',
+                 pos=(0, 0),
+                 ori=0.0,
+                 opacity=1.0,
+                 contrast=1.0,
+                 depth=0,
+                 interpolate=True,
+                 lineRGB=None,
+                 fillRGB=None,
+                 name=None,
+                 autoLog=None,
+                 autoDraw=False,
+                 color=None,
+                 colorSpace=None):
+
+        self.__dict__['radius'] = radius
+        self.__dict__['edges'] = edges
         self.__dict__['start'] = start
         self.__dict__['end'] = end
 
-        self._initParams = dir()
-        self._initParams.remove('self')
-        # kwargs isn't a parameter, but a list of params
-        self._initParams.remove('kwargs')
-        self._initParams.extend(kwargs)
-
         self.vertices = self._calcVertices()
-        kwargs['closeShape'] = True
-        kwargs['vertices'] = self.vertices
 
-        super(Pie, self).__init__(win, **kwargs)
+        super(Pie, self).__init__(
+             win,
+             units=units,
+             lineWidth=lineWidth,
+             lineColor=lineColor,
+             lineColorSpace=lineColorSpace,
+             fillColor=fillColor,
+             fillColorSpace=fillColorSpace,
+             vertices=self.vertices,
+             closeShape=True,
+             pos=pos,
+             size=1,
+             ori=ori,
+             opacity=opacity,
+             contrast=contrast,
+             depth=depth,
+             interpolate=interpolate,
+             lineRGB=lineRGB,
+             fillRGB=fillRGB,
+             name=name,
+             autoLog=autoLog,
+             autoDraw=autoDraw,
+             color=color,
+             colorSpace=colorSpace)
 
     def _calcVertices(self):
         """Calculate the required vertices for the figure.
@@ -53,10 +93,11 @@ class Pie(BaseShapeStim):
         endRadians = np.radians(self.end)
 
         # get number of steps for vertices
-        steps = np.linspace(startRadians, endRadians, num=self.edges)
+        edges = self.__dict__['edges']
+        steps = np.linspace(startRadians, endRadians, num=edges)
 
         # offset by 1 since the first vertex needs to be at centre
-        verts = np.zeros((self.edges + 1, 2), float)
+        verts = np.zeros((edges + 1, 2), float)
         verts[1:, 0] = np.sin(steps)
         verts[1:, 1] = np.cos(steps)
 
@@ -106,8 +147,7 @@ class Pie(BaseShapeStim):
         :ref:`Operations <attrib-operations>` supported.
         """
         self.__dict__['radius'] = value
-        self._calcVertices()
-        self.setVertices(self.vertices, log=False)
+        self.size = value
 
     def setRadius(self, end, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Creates a pie shape."""
+"""Create a pie shape."""
 
 # Part of the PsychoPy library
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019 Open Science Tools Ltd.
@@ -16,7 +16,7 @@ import numpy as np
 class Pie(BaseShapeStim):
     """Creates a pie shape which is a circle with a wedge cut-out.
 
-    This shape is sometimes refered to as a Pac-Man shape which is frequently
+    This shape is sometimes referred to as a Pac-Man shape which is often
     used for creating Kanizsa figures. However, the shape can be adapted for
     other uses.
 

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -14,9 +14,11 @@ import numpy as np
 
 
 class Pie(BaseShapeStim):
-    """Creates a pie shape which is a circle with a wedge cut-out. This
-    shape is frequently used for creating Kanizsa figures. However, it
-    can be adapted for other uses.
+    """Creates a pie shape which is a circle with a wedge cut-out.
+
+    This shape is sometimes refered to as a Pac-Man shape which is frequently
+    used for creating Kanizsa figures. However, the shape can be adapted for
+    other uses.
 
     Attributes
     ----------
@@ -25,7 +27,8 @@ class Pie(BaseShapeStim):
         degrees. Shapes are filled counter clockwise between the specified
         angles.
     radius : float or int
-        Radius of the shape.
+        Radius of the shape. Avoid using `size` for adjusting figure dimensions
+        if radius != 0.5 which will result in undefined behavior.
 
     """
     def __init__(self,
@@ -36,11 +39,12 @@ class Pie(BaseShapeStim):
                  edges=32,
                  units='',
                  lineWidth=1.5,
-                 lineColor=(1.0, 1.0, 1.0),
+                 lineColor=None,
                  lineColorSpace='rgb',
                  fillColor=None,
                  fillColorSpace='rgb',
                  pos=(0, 0),
+                 size=1,
                  ori=0.0,
                  opacity=1.0,
                  contrast=1.0,
@@ -54,6 +58,23 @@ class Pie(BaseShapeStim):
                  color=None,
                  colorSpace=None):
 
+        """
+        Parameters
+        ----------
+        win : `~psychopy.visual.Window`
+            Window this shape is associated with.
+        radius : float or int
+            Radius of the shape. Avoid using `size` for adjusting figure
+            dimensions if radius != 0.5 which will result in undefined behavior.
+        start, end : float or int
+            Start and end angles of the filled region of the shape in
+            degrees. Shapes are filled counter clockwise between the specified
+            angles.
+        edges : int
+            Number of edges to use when drawing the figure. A greater number of
+            edges will result in smoother curves, but will require more time
+            to compute.
+        """
         self.__dict__['radius'] = radius
         self.__dict__['edges'] = edges
         self.__dict__['start'] = start
@@ -72,7 +93,7 @@ class Pie(BaseShapeStim):
              vertices=self.vertices,
              closeShape=True,
              pos=pos,
-             size=1,
+             size=size,
              ori=ori,
              opacity=opacity,
              contrast=contrast,
@@ -97,9 +118,9 @@ class Pie(BaseShapeStim):
         steps = np.linspace(startRadians, endRadians, num=edges)
 
         # offset by 1 since the first vertex needs to be at centre
-        verts = np.zeros((edges + 1, 2), float)
-        verts[1:, 0] = np.sin(steps)
-        verts[1:, 1] = np.cos(steps)
+        verts = np.zeros((edges + 2, 2), float)
+        verts[1:-1, 0] = np.sin(steps)
+        verts[1:-1, 1] = np.cos(steps)
 
         verts *= self.radius
 
@@ -107,8 +128,7 @@ class Pie(BaseShapeStim):
 
     @attributeSetter
     def start(self, value):
-        """int or float.
-        Height of the Rectangle (in its respective units, if specified).
+        """Start angle of the slice/wedge in degrees (`float` or `int`).
 
         :ref:`Operations <attrib-operations>` supported.
         """
@@ -124,8 +144,7 @@ class Pie(BaseShapeStim):
 
     @attributeSetter
     def end(self, value):
-        """int or float.
-        Height of the Rectangle (in its respective units, if specified).
+        """End angle of the slice/wedge in degrees (`float` or `int`).
 
         :ref:`Operations <attrib-operations>` supported.
         """
@@ -142,7 +161,7 @@ class Pie(BaseShapeStim):
     @attributeSetter
     def radius(self, value):
         """int or float.
-        Height of the Rectangle (in its respective units, if specified).
+        Radius of the shape in `units` (`float` or `int`).
 
         :ref:`Operations <attrib-operations>` supported.
         """

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -133,7 +133,7 @@ class Pie(BaseShapeStim):
         :ref:`Operations <attrib-operations>` supported.
         """
         self.__dict__['start'] = value
-        self._calcVertices()
+        self.vertices = self._calcVertices()
         self.setVertices(self.vertices, log=False)
 
     def setStart(self, start, operation='', log=None):
@@ -149,7 +149,7 @@ class Pie(BaseShapeStim):
         :ref:`Operations <attrib-operations>` supported.
         """
         self.__dict__['end'] = value
-        self._calcVertices()
+        self.vertices = self._calcVertices()
         self.setVertices(self.vertices, log=False)
 
     def setEnd(self, end, operation='', log=None):
@@ -165,7 +165,8 @@ class Pie(BaseShapeStim):
         :ref:`Operations <attrib-operations>` supported.
         """
         self.__dict__['radius'] = value
-        self.size = value
+        self.vertices = self._calcVertices()
+        self.setVertices(self.vertices, log=False)
 
     def setRadius(self, end, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -160,8 +160,7 @@ class Pie(BaseShapeStim):
 
     @attributeSetter
     def radius(self, value):
-        """int or float.
-        Radius of the shape in `units` (`float` or `int`).
+        """Radius of the shape in `units` (`float` or `int`).
 
         :ref:`Operations <attrib-operations>` supported.
         """


### PR DESCRIPTION
Here is a stimulus class that create "pie" shapes, which is a circle with a wedge cut out. This is usually called a pac-man shape in the VS community. Typically, you would use these to generate Kanizsa figures. This is a pretty well-known illusion and it might be useful to have this class for teaching. You can also use these shapes in applications where you need to visually represent a proportion. For instance a visual countdown timer where filled proportion of the shape shrinks with time. 

The shape takes arguments `start` and `end` in degrees, which defines the filled region of the shape. Using negative values will fill in the opposite direction. The size of the shape is defined by `radius`. The code which generates the vertices is pretty fast, so you can make updates to these values in real-time.

Demos and documentation have been included. Takes nearly all arguments `BaseShapeStim` accepts. So you can also outline the shapes if you wish by setting `lineColor`. By default, there is no outline. 

