### PR TITLE
DOC Update preferences.rst

### DIFF
--- a/docs/source/api/preferences.rst
+++ b/docs/source/api/preferences.rst
@@ -6,7 +6,7 @@
 You can set preferences on a per-experiment basis. For example, if you would like to use a specific :doc:`audio library</api/sound>`, but don't want to touch your user settings in general, you can import preferences and set the option :ref:`audioLib<generalSettings>` accordingly::
 
     from psychopy import prefs
-    prefs.general['audioLib'] = ['pyo']
+    prefs.hardware['audioLib'] = ['pyo']
     from psychopy import sound
 
 **!!IMPORTANT!!** You must import the sound module **AFTER** setting the preferences. To check that you are getting what you want (don't do this in your actual experiment)::


### PR DESCRIPTION
#fixes  #2651
You can set the preferred audio backend. However, it is not in prefs.general, but in prefs.hardware.