### PR TITLE
NF: Add fullRandom method to MultiStairHandler

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1646,8 +1646,8 @@ class QuestPlusHandler(StairHandler):
 class MultiStairHandler(_BaseTrialHandler):
 
     def __init__(self, stairType='simple', method='random',
-                 conditions=None, nTrials=50, originPath=None,
-                 name='', autoLog=True):
+                 conditions=None, nTrials=50, randomSeed=None,
+                 originPath=None, name='', autoLog=True):
         """A Handler to allow easy interleaved staircase procedures
         (simple or QUEST).
 
@@ -1671,10 +1671,14 @@ class MultiStairHandler(_BaseTrialHandler):
                 Use a :class:`StairHandler`, a :class:`QuestHandler`, or a
                  :class:`QuestPlusHandler`.
 
-            method: 'random' or 'sequential'
-                The stairs are shuffled in each repeat but not randomised
-                more than that (so you can't have 3 repeats of the same
-                staircase in a row unless it's the only one still running)
+            method: 'random', 'fullRandom', or 'sequential'
+                If `random`, stairs are shuffled in each repeat but not
+                randomized more than that (so you can't have 3 repeats of the
+                same staircase in a row unless it's the only one still
+                running). If `fullRandom`, the staircase order is "fully"
+                randomized, meaning that, theoretically, a large number of
+                subsequent trials could invoke the same staircase repeatedly.
+                If `sequential`, don't perform any randomization.
 
             conditions: a list of dictionaries specifying conditions
                 Can be used to control parameters for the different staicases.
@@ -1690,6 +1694,11 @@ class MultiStairHandler(_BaseTrialHandler):
                 Minimum trials to run (but may take more if the staircase
                 hasn't also met its minimal reversals.
                 See :class:`~psychopy.data.StairHandler`
+
+            randomSeed : int or None
+                The seed with which to initialize the random number generator
+                (RNG). If `None` (default), do not initialize the RNG with
+                a specific value.
 
         Example usage::
 
@@ -1712,11 +1721,19 @@ class MultiStairHandler(_BaseTrialHandler):
             stairs.saveDataAsExcel(fileName)  # easy to browse
             stairs.saveAsPickle(fileName)  # contains more info
 
+        Raises
+        ------
+            ValueError
+                If an unknown randomiation option was passed via the `method`
+                keyword argument.
+
         """
         self.name = name
         self.autoLog = autoLog
         self.type = stairType
-        self.method = method  # 'random' or 'sequential'
+        self.method = method
+        self.randomSeed = randomSeed
+        self._rng = np.random.RandomState(seed=randomSeed)
         self.conditions = conditions
         self.nTrials = nTrials
         self.finished = False
@@ -1872,9 +1889,21 @@ class MultiStairHandler(_BaseTrialHandler):
         This is not normally needed by the user - it gets called at __init__
         and every time that next() runs out of trials for this pass.
         """
-        self.thisPassRemaining = copy.copy(self.runningStaircases)
-        if self.method == 'random':
-            np.random.shuffle(self.thisPassRemaining)
+        if self.method == 'sequential':
+            self.thisPassRemaining = copy.copy(self.runningStaircases)
+        elif self.method == 'random':
+            # np.random.shuffle() works in-place!
+            self.thisPassRemaining = copy.copy(self.runningStaircases)
+            self._rng.shuffle(self.thisPassRemaining)
+        elif self.method == 'fullRandom':
+            n = len(self.runningStaircases)
+            self.thisPassRemaining = self._rng.choice(self.runningStaircases,
+                                                      size=n, replace=True)
+            # np.random.choice() returns an ndarray, so convert back to a list
+            # again.
+            self.thisPassRemaining = list(self.thisPassRemaining)
+        else:
+            raise ValueError('Unknown randomization method requested.')
 
     def addResponse(self, result, intensity=None):
         """Add a 1 or 0 to signify a correct / detected or

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -543,6 +543,7 @@ class MultiStairHandler(object):
                 "name='%(name)s',\n"
                 "    nTrials=%(nReps)s,\n"
                 "    conditions=conditions,\n"
+                "    method=%(switchMethod)s,\n"
                 "    originPath=-1)\n"
                 "thisExp.addLoop(%(name)s)  # add the loop to the experiment\n"
                 "# initialise values for first condition\n"

--- a/psychopy/tests/test_data/test_MultiStairHandler.py
+++ b/psychopy/tests/test_data/test_MultiStairHandler.py
@@ -96,7 +96,6 @@ class TestMultiStairHandler(object):
                                      dataFileName=os.path.join(self.temp_dir,
                                                                'multiQuestPlusExperiment'),
                                      autoLog=False)
-        rng = np.random.RandomState(seed=self.random_seed)
         exp.addLoop(stairs)
 
         for intensity, condition in stairs:
@@ -108,6 +107,67 @@ class TestMultiStairHandler(object):
         # contains more info
         stairs.saveAsPickle(os.path.join(self.temp_dir, 'multiQuestPlusOut'))
         exp.close()
+
+
+def test_random():
+    conditions = data.importConditions(os.path.join(fixturesPath,
+                                                    'multiStairConds.xlsx'))
+
+    seed = 11
+    first_pass = ['low', 'high', 'medium']
+
+    kwargs = dict(method='random', randomSeed=seed, stairType='simple',
+                  conditions=conditions, nTrials=5)
+
+    multistairs = data.MultiStairHandler(**kwargs)
+
+    for staircase_idx, staircase in enumerate(multistairs.thisPassRemaining):
+        assert staircase.condition['label'] == first_pass[staircase_idx]
+
+
+def test_different_seeds():
+    conditions = data.importConditions(os.path.join(fixturesPath,
+                                                    'multiStairConds.xlsx'))
+
+    seeds = [7, 11]
+    first_pass = [['high', 'medium', 'low'],
+                  ['low', 'high', 'medium']]
+
+    kwargs = dict(method='random', stairType='simple',
+                  conditions=conditions, nTrials=5)
+
+    for seed_idx, seed in enumerate(seeds):
+        multistairs = data.MultiStairHandler(randomSeed=seed, **kwargs)
+
+        for staircase_idx, staircase in enumerate(multistairs.thisPassRemaining):
+            assert staircase.condition['label'] == first_pass[seed_idx][staircase_idx]
+
+
+def test_fullRandom():
+    conditions = data.importConditions(os.path.join(fixturesPath,
+                                                    'multiStairConds.xlsx'))
+
+    seed = 11
+    first_pass = ['medium', 'low', 'medium']
+
+    kwargs = dict(method='fullRandom', randomSeed=seed, stairType='simple',
+                  conditions=conditions, nTrials=5)
+
+    multistairs = data.MultiStairHandler(**kwargs)
+
+    for staircase_idx, staircase in enumerate(multistairs.thisPassRemaining):
+        assert staircase.condition['label'] == first_pass[staircase_idx]
+
+
+def test_invalid_method():
+    conditions = data.importConditions(os.path.join(fixturesPath,
+                                                    'multiStairConds.xlsx'))
+
+    kwargs = dict(method='foobar', stairType='simple',
+                  conditions=conditions, nTrials=5)
+
+    with pytest.raises(ValueError):
+        data.MultiStairHandler(**kwargs)
 
 
 if __name__ == '__main__':

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -764,10 +764,8 @@ class TestMultiStairHandler(_BaseTestMultiStairHandler):
             dict(list({'label': 'staircase_1'}.items()) + list(conditions.items())),
         ]
 
-        self.stairs = data.MultiStairHandler(
-                stairType='quest', method='linear',
-                conditions=self.conditions
-        )
+        self.stairs = data.MultiStairHandler(stairType='quest',
+                                             conditions=self.conditions)
 
         # Responses for only one staircase. We will duplicate this below.
         responses = makeBasicResponseCycles(


### PR DESCRIPTION
`MultiStairHandler` now supports a `fullRandom` randomization method. We do this by sampling with replacement from the list of all running staircases on each "pass".

To make this testable, I also added a `randomSeed` kwarg to `MultiStairHandler`, which is used to seed a `np.random.RandomState` RNG. All randomization operations are then being done through that object.

Closes GH-2635.