### PR TITLE
Create conda environment with default python

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -133,9 +133,9 @@ as needed:
 Anaconda and Miniconda
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-With Python 3.6::
+With the default system python::
 
-  conda create -n psypy3 python=3.6
+  conda create -n psypy3
   conda activate psypy3
   conda install numpy scipy matplotlib pandas pyopengl pillow lxml openpyxl xlrd configobj pyyaml gevent greenlet msgpack-python psutil pytables requests[security] cffi seaborn wxpython cython pyzmq pyserial
   conda install -c conda-forge pyglet pysoundfile python-bidi moviepy pyosf


### PR DESCRIPTION
Installation does not work when I try to install as specified with python 3.6. When I install with python 3.7 (default) everything works correctly.