### PR TITLE
EN/NF: SceneSkybox and BlinnPhong material

### DIFF
--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -48,7 +48,8 @@ Multiple stimuli:
 3D shapes, materials, and lighting:
 
     * :class:`.LightSource` to define a light source in a scene
-    * :class:`.PhongMaterial` to specify a material using the Phong lighting model
+    * :class:`.SceneSkybox` to render a background skybox for VR and 3D scenes
+    * :class:`.BlinnPhongMaterial` to specify a material using the Blinn-Phong lighting model
     * :class:`.RigidBodyPose` to define poses of objects in 3D space
     * :class:`.SphereStim` to show a 3D sphere
     * :class:`.BoxStim` to show 3D boxes and cubes

--- a/docs/source/api/visual/sceneskybox.rst
+++ b/docs/source/api/visual/sceneskybox.rst
@@ -1,5 +1,5 @@
-:class:`BlinnPhongMaterial`
-----------------------
+:class:`SceneSkybox`
+---------------------
 
 Attributes
 ==========
@@ -8,13 +8,13 @@ Attributes
 
 .. autosummary:: 
 
-    BlinnPhongMaterial
+    SceneSkybox
     
         
 Details
 =======
 
-.. autoclass:: BlinnPhongMaterial
+.. autoclass:: SceneSkybox
     :members:
     :undoc-members:
     :inherited-members:

--- a/psychopy/demos/coder/misc/rigidBodyTransform.py
+++ b/psychopy/demos/coder/misc/rigidBodyTransform.py
@@ -34,6 +34,7 @@ spherePose2 = RigidBodyPose((-0.1, 0.1, 0.1))
 spherePose3 = RigidBodyPose((0.1, -0.1, -0.1))
 
 # create some sphere stim objects
+lightSphere = SphereStim(win, radius=0.05, color='white', useShaders=False)
 sphere1 = SphereStim(win, radius=0.05, color='red', useShaders=False)
 sphere2 = SphereStim(win, radius=0.1, color='green', useShaders=False)
 sphere3 = SphereStim(win, radius=0.075, color='blue', useShaders=False)
@@ -47,6 +48,11 @@ while not event.getKeys():
     # setup drawing
     win.setPerspectiveView()
 
+    # sphere for the light source, note this does not actually emit light
+    lightSphere.thePose = pivotPose
+    lightSphere.draw()
+
+    # call after drawing `lightSphere` since we don't want it being shaded
     win.useLights = True
 
     # multiplying pose puts the first object in the reference frame of the

--- a/psychopy/demos/coder/stimuli/stim3d.py
+++ b/psychopy/demos/coder/stimuli/stim3d.py
@@ -7,7 +7,7 @@ This demonstrates how to render 3D stimuli, set lighting and adjust materials.
 """
 from psychopy import core
 import psychopy.visual as visual
-from psychopy.visual import LightSource, PhongMaterial, BoxStim
+from psychopy.visual import LightSource, BlinnPhongMaterial, BoxStim
 from psychopy.tools.gltools import createTexImage2dFromFile
 from psychopy import event
 
@@ -32,8 +32,8 @@ boxStim = BoxStim(win, size=(.2, .2, .2), useShaders=True)
 boxStim.thePose.pos = (0, 0, -3)
 
 # create a white material and assign it
-boxStim.material = PhongMaterial(win, diffuseColor=(1, 1, 1),
-                                 specularColor=(0, 0, 0), shininess=125.0)
+boxStim.material = BlinnPhongMaterial(win, diffuseColor=(1, 1, 1),
+                                      specularColor=(0, 0, 0), shininess=125.0)
 
 # load a diffuse texture
 boxStim.material.diffuseTexture = createTexImage2dFromFile('face.jpg')

--- a/psychopy/visual/__init__.py
+++ b/psychopy/visual/__init__.py
@@ -87,7 +87,8 @@ from psychopy.visual.rift import Rift
 
 # 3D stimuli support
 from psychopy.visual.stim3d import LightSource
-from psychopy.visual.stim3d import PhongMaterial
+from psychopy.visual.stim3d import SceneSkybox
+from psychopy.visual.stim3d import BlinnPhongMaterial
 from psychopy.visual.stim3d import RigidBodyPose
 from psychopy.visual.stim3d import SphereStim
 from psychopy.visual.stim3d import BoxStim

--- a/psychopy/visual/shaders.py
+++ b/psychopy/visual/shaders.py
@@ -294,8 +294,9 @@ void main (void)
         diffuse *= diffTexColor;
         ambient *= diffTexColor;  // ambient should be modulated by diffuse color
 #endif
+        vec3 halfwayVec = normalize(L + E);
         vec4 specular = gl_FrontLightProduct[i].specular *
-            pow(max(dot(R, E), 0.0), gl_FrontMaterial.shininess);
+            pow(max(dot(N, halfwayVec), 0.0), gl_FrontMaterial.shininess);
 
         // clamp color values for specular and diffuse
         ambient = clamp(ambient, 0.0, 1.0); 
@@ -319,5 +320,23 @@ void main (void)
     gl_FragColor = ambient;
 #endif
 #endif
+}
+"""
+
+vertSkyBox = """
+varying vec3 texCoord;
+void main(void)  
+{   
+    texCoord = gl_Vertex;
+    gl_Position = ftransform().xyww;
+}      
+"""
+
+fragSkyBox = """
+varying vec3 texCoord;
+uniform samplerCube SkyTexture;
+void main (void)  
+{  
+    gl_FragColor = texture(SkyTexture, texCoord);
 }
 """

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -223,22 +223,44 @@ class SceneSkybox(object):
     associated with them.
 
     Background images are specified as a set of image paths passed to
-    `faceTextures`, or a `TexCubeMap` object.
+    `faceTextures`::
+
+        sky = SceneSkybox(
+            win, ('rt.jpg', 'lf.jpg', 'up.jpg', 'dn.jpg', 'bk.jpg', 'ft.jpg'))
+
+    The skybox is rendered by calling `draw()` after drawing all other 3D
+    stimuli.
 
     Skyboxes are not affected by lighting, however, their colors can be
     modulated by setting the window's `sceneAmbient` value. Skyboxes should be
     drawn after all other 3D stimuli, but before any successive call that clears
     the depth buffer (eg. `setPerspectiveView`, `resetEyeTransform`, etc.)
 
+
     """
-    def __init__(self, win, faceImage=(), ori=0.0, axis=(0, 1, 0)):
+    def __init__(self, win, faceTextures=(), ori=0.0, axis=(0, 1, 0)):
+        """
+        Parameters
+        ----------
+        win : `~psychopy.visual.Window`
+            Window this skybox is associated with.
+        faceTextures : list or tuple
+            List of files paths to images to use for each face. Images are
+            assigned to faces depending on their index within the list ([+X,
+            -X, +Y, -Y, +Z, -Z] or [right, left, top, bottom, back, front]).
+        ori : float
+            Rotation of the skybox about `axis` in degrees.
+        axis : array_like
+            Axis [ax, ay, az] to rotate about, default is (0, 1, 0).
+
+        """
         self.win = win
 
         self._ori = ori
         self._axis = np.ascontiguousarray(axis, dtype=np.float32)
 
         imgFace = []
-        for img in faceImage:
+        for img in faceTextures:
             im = Image.open(img)
             im = im.convert("RGBA")
             pixelData = np.array(im).ctypes

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1181,15 +1181,33 @@ class Window(object):
             self.clearBuffer()
 
     def clearBuffer(self, color=True, depth=True, stencil=True):
-        """Clear the back buffer (to which you are currently drawing) without
-        flipping the window. Useful if you want to generate movie sequences
-        from the back buffer without actually taking the time to flip the
-        window.
+        """Clear the present buffer (to which you are currently drawing) without
+        flipping the window.
+
+        Useful if you want to generate movie sequences from the back buffer
+        without actually taking the time to flip the window.
+
+        Set `color` prior to clearing to set the color to clear the color buffer
+        to. By default, the depth buffer is cleared to a value of 1.0.
 
         Parameters
         ----------
         color, depth, stencil : bool
             Buffers to clear.
+
+        Examples
+        --------
+        Clear the color buffer to a specified color::
+
+            win.color = (1, 0, 0)
+            win.clearBuffer(color=True)
+
+        Clear only the depth buffer, `depthMask` must be `True` or else this
+        will have no effect. Depth mask is usually `True` by default, but
+        may change::
+
+            win.depthMask = True
+            win.clearBuffer(color=False, depth=True, stencil=False)
 
         """
         clearBufferBits = GL.GL_NONE
@@ -1847,6 +1865,118 @@ class Window(object):
                 -1, 1, -1, 1, -1, 1, dtype=numpy.float32)
 
         self.applyEyeTransform(clearDepth)
+
+    def setReadBuffer(self, buffer):
+        """Set the buffer to read values from.
+
+        Parameters
+        ----------
+        buffer : str
+            Name of the buffer to read from. Values can be 'back', 'front',
+            'left', 'right' or `None`.
+
+        """
+        if buffer == 'back' and self.useFBO:
+            GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+        elif buffer == 'back':
+            GL.glReadBuffer(GL.GL_BACK)
+        elif buffer == 'front':
+            if self.useFBO:
+                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT, 0)
+            GL.glReadBuffer(GL.GL_FRONT)
+        elif buffer is None:
+            GL.glReadBuffer(GL.GL_NONE)
+        else:
+            raise ValueError("Requested read from buffer '{}' but should be "
+                             "'front', 'back' or `None`.".format(buffer))
+
+    def setDrawBuffer(self, buffer):
+        """Set the buffer to draw to.
+
+        Parameters
+        ----------
+        buffer : str
+            Name of the buffer to draw to. Values can be 'back', 'front',
+            'left', 'right' or `None`. If `None`, values drawn to the buffer
+            are discarded.
+
+        """
+        if buffer == 'back' and self.useFBO:
+            GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
+        elif buffer == 'back':
+            GL.glDrawBuffer(GL.GL_BACK)
+        elif buffer == 'front':
+            if self.useFBO:
+                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT, 0)
+            GL.glDrawBuffer(GL.GL_FRONT)
+        elif buffer is None:
+            GL.glDrawBuffer(GL.GL_NONE)
+        else:
+            raise ValueError("Requested draw to buffer '{}' but should be "
+                             "'front' or 'back'".format(buffer))
+
+    def blitBuffer(self, srcRect=None, dstRect=None, filter='nearest',
+                   color=True, depth=False, stencil=False):
+        """Blit pixel data from one framebuffer to another.
+
+        This copies pixels between from the buffer defined by `setReadBuffer`
+        to the one specified by `setDrawBuffer`. You can specify rectangles
+        on the buffer defining sub-regions to copy. If not specified, the
+        current `viewport` is used to define the rectangle.
+
+        Blitting can be used to resolve multisample framebuffers. This is
+        needed to use multisample anti-aliasing (MSAA) on FBOs.
+
+        Parameters
+        ----------
+        srcRect : array_like
+            Source rectangle [x, y, w, h] on the buffer.
+        dstRect : array_like
+            Destination rectangle [x, y, w, h] on the buffer.
+        filter : str
+            Filtering to use, values can be 'nearest' or 'linear'.
+        color, depth, stencil : bool
+            Which buffers associated with the framebuffer to blit. By default,
+            only color values are copied.
+
+        Examples
+        --------
+        Copy the contents of the front buffer to the back buffer::
+
+            win.setReadBuffer('front')
+            win.setDrawBuffer('back')
+            win.blitBuffer()
+
+        """
+        # filtering to use
+        if filter == 'nearest':
+            glFilter = GL.GL_NEAREST
+        elif filter == 'linear':
+            glFilter = GL.GL_LINEAR
+        else:
+            raise ValueError(
+                "Value for `filter` must be 'linear' or 'nearest'.")
+
+        # buffers to copy over
+        blitBufferBits = GL.GL_NONE
+        if color:
+            blitBufferBits |= GL.GL_COLOR_BUFFER_BIT
+        if depth:
+            blitBufferBits |= GL.GL_DEPTH_BUFFER_BIT
+        if stencil:
+            blitBufferBits |= GL.GL_STENCIL_BUFFER_BIT
+
+        # source and destination rectangles
+        if srcRect is None:
+            srcRect = self.viewport
+
+        if dstRect is None:
+            dstRect = self.viewport
+
+        GL.glBlitFramebuffer(
+            int(srcRect[0]), int(srcRect[1]), int(srcRect[2]), int(srcRect[3]),
+            int(dstRect[0]), int(dstRect[1]), int(dstRect[2]), int(dstRect[3]),
+            blitBufferBits, glFilter)
 
     def getMovieFrame(self, buffer='front'):
         """Capture the current Window as an image.

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1744,15 +1744,17 @@ class Window(object):
         # apply the projection and view transformations
         if hasattr(self, '_projectionMatrix'):
             GL.glMatrixMode(GL.GL_PROJECTION)
+            GL.glLoadIdentity()
             projMat = self._projectionMatrix.ctypes.data_as(
                 ctypes.POINTER(ctypes.c_float))
-            GL.glLoadTransposeMatrixf(projMat)
+            GL.glMultTransposeMatrixf(projMat)
 
         if hasattr(self, '_viewMatrix'):
             GL.glMatrixMode(GL.GL_MODELVIEW)
+            GL.glLoadIdentity()
             viewMat = self._viewMatrix.ctypes.data_as(
                 ctypes.POINTER(ctypes.c_float))
-            GL.glLoadTransposeMatrixf(viewMat)
+            GL.glMultTransposeMatrixf(viewMat)
 
         oldDepthMask = self.depthMask
         if clearDepth:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -458,7 +458,7 @@ class Window(object):
 
         # 3D rendering related attributes
         self.frontFace = 'ccw'
-        self.depthFunc = 'lequal'
+        self.depthFunc = 'less'
         self.depthMask = False
         self.cullFace = False
         self.cullFaceMode = 'back'
@@ -1180,7 +1180,7 @@ class Window(object):
         if clear:
             self.clearBuffer()
 
-    def clearBuffer(self, color=True, depth=True, stencil=True):
+    def clearBuffer(self, color=True, depth=False, stencil=False):
         """Clear the present buffer (to which you are currently drawing) without
         flipping the window.
 
@@ -1865,118 +1865,6 @@ class Window(object):
                 -1, 1, -1, 1, -1, 1, dtype=numpy.float32)
 
         self.applyEyeTransform(clearDepth)
-
-    def setReadBuffer(self, buffer):
-        """Set the buffer to read values from.
-
-        Parameters
-        ----------
-        buffer : str
-            Name of the buffer to read from. Values can be 'back', 'front',
-            'left', 'right' or `None`.
-
-        """
-        if buffer == 'back' and self.useFBO:
-            GL.glReadBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-        elif buffer == 'back':
-            GL.glReadBuffer(GL.GL_BACK)
-        elif buffer == 'front':
-            if self.useFBO:
-                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT, 0)
-            GL.glReadBuffer(GL.GL_FRONT)
-        elif buffer is None:
-            GL.glReadBuffer(GL.GL_NONE)
-        else:
-            raise ValueError("Requested read from buffer '{}' but should be "
-                             "'front', 'back' or `None`.".format(buffer))
-
-    def setDrawBuffer(self, buffer):
-        """Set the buffer to draw to.
-
-        Parameters
-        ----------
-        buffer : str
-            Name of the buffer to draw to. Values can be 'back', 'front',
-            'left', 'right' or `None`. If `None`, values drawn to the buffer
-            are discarded.
-
-        """
-        if buffer == 'back' and self.useFBO:
-            GL.glDrawBuffer(GL.GL_COLOR_ATTACHMENT0_EXT)
-        elif buffer == 'back':
-            GL.glDrawBuffer(GL.GL_BACK)
-        elif buffer == 'front':
-            if self.useFBO:
-                GL.glBindFramebufferEXT(GL.GL_FRAMEBUFFER_EXT, 0)
-            GL.glDrawBuffer(GL.GL_FRONT)
-        elif buffer is None:
-            GL.glDrawBuffer(GL.GL_NONE)
-        else:
-            raise ValueError("Requested draw to buffer '{}' but should be "
-                             "'front' or 'back'".format(buffer))
-
-    def blitBuffer(self, srcRect=None, dstRect=None, filter='nearest',
-                   color=True, depth=False, stencil=False):
-        """Blit pixel data from one framebuffer to another.
-
-        This copies pixels between from the buffer defined by `setReadBuffer`
-        to the one specified by `setDrawBuffer`. You can specify rectangles
-        on the buffer defining sub-regions to copy. If not specified, the
-        current `viewport` is used to define the rectangle.
-
-        Blitting can be used to resolve multisample framebuffers. This is
-        needed to use multisample anti-aliasing (MSAA) on FBOs.
-
-        Parameters
-        ----------
-        srcRect : array_like
-            Source rectangle [x, y, w, h] on the buffer.
-        dstRect : array_like
-            Destination rectangle [x, y, w, h] on the buffer.
-        filter : str
-            Filtering to use, values can be 'nearest' or 'linear'.
-        color, depth, stencil : bool
-            Which buffers associated with the framebuffer to blit. By default,
-            only color values are copied.
-
-        Examples
-        --------
-        Copy the contents of the front buffer to the back buffer::
-
-            win.setReadBuffer('front')
-            win.setDrawBuffer('back')
-            win.blitBuffer()
-
-        """
-        # filtering to use
-        if filter == 'nearest':
-            glFilter = GL.GL_NEAREST
-        elif filter == 'linear':
-            glFilter = GL.GL_LINEAR
-        else:
-            raise ValueError(
-                "Value for `filter` must be 'linear' or 'nearest'.")
-
-        # buffers to copy over
-        blitBufferBits = GL.GL_NONE
-        if color:
-            blitBufferBits |= GL.GL_COLOR_BUFFER_BIT
-        if depth:
-            blitBufferBits |= GL.GL_DEPTH_BUFFER_BIT
-        if stencil:
-            blitBufferBits |= GL.GL_STENCIL_BUFFER_BIT
-
-        # source and destination rectangles
-        if srcRect is None:
-            srcRect = self.viewport
-
-        if dstRect is None:
-            dstRect = self.viewport
-
-        GL.glBlitFramebuffer(
-            int(srcRect[0]), int(srcRect[1]), int(srcRect[2]), int(srcRect[3]),
-            int(dstRect[0]), int(dstRect[1]), int(dstRect[2]), int(dstRect[3]),
-            blitBufferBits, glFilter)
 
     def getMovieFrame(self, buffer='front'):
         """Capture the current Window as an image.


### PR DESCRIPTION
Changes:

* Adds a Blinn-Phong material for use with 3D stimuli replacing Phong only. This material is a better approximation of real lighting.
* Adds a skybox object for rendering backgrounds with cubemaps. Useful for VR environments. This class came with the original version of PsychXR.
* `clearBuffer` can also clear depth and stencil buffers.
* Added `resetViewport` function.
* Made the default depth compare function `less`, which is the OpenGL default.