### PR TITLE
NF: Some changes to RigidBodyPose and SceneSkybox

### DIFF
--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -2896,14 +2896,3 @@ def lensCorrection(xys, coefK=(1.0,), distCenter=(0., 0.), out=None, dtype=None)
     toReturn[:, :] = xys + (d_minus_c / denom[:, np.newaxis])
 
     return toReturn
-
-if __name__ == "__main__":
-    vec = [[1, 0, 0], [0, 0, -1]]
-    vec2 = [[1, 0, 0], [0, 0, 1]]
-
-    print(alignTo(vec, vec2))
-
-    vec3 = [0, 0, -1]
-    vec4 = [1, 0, 0]
-
-    print(applyQuat(alignTo(vec3, vec4), vec3))

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -826,6 +826,16 @@ class RigidBodyPose(object):
         self._matrixNeedsUpdate = self._invMatrixNeedsUpdate = True
 
     @property
+    def posOri(self):
+        """The position (x, y, z) and orientation (x, y, z, w)."""
+        return self._pos, self._ori
+
+    @posOri.setter
+    def posOri(self, value):
+        self._pos = np.ascontiguousarray(value[0], dtype=np.float32)
+        self._ori = np.ascontiguousarray(value[1], dtype=np.float32)
+
+    @property
     def at(self):
         """Vector defining the forward direction (-Z) of this pose."""
         if self._matrixNeedsUpdate:  # matrix needs update, this need to be too

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -236,7 +236,6 @@ class SceneSkybox(object):
     drawn after all other 3D stimuli, but before any successive call that clears
     the depth buffer (eg. `setPerspectiveView`, `resetEyeTransform`, etc.)
 
-
     """
     def __init__(self, win, tex=(), ori=0.0, axis=(0, 1, 0)):
         """
@@ -249,8 +248,8 @@ class SceneSkybox(object):
             assigned to faces depending on their index within the list ([+X,
             -X, +Y, -Y, +Z, -Z] or [right, left, top, bottom, back, front]). If
             `None` is specified, the cube map may be specified later by setting
-            the `cubemap` attribute. Alternativley, you can specify a
-            `TexCubeMap` object to set the cubemap directly.
+            the `cubemap` attribute. Alternatively, you can specify a
+            `TexCubeMap` object to set the cube map directly.
         ori : float
             Rotation of the skybox about `axis` in degrees.
         axis : array_like

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -290,7 +290,8 @@ class SceneSkybox(object):
                             GL.GL_TEXTURE_WRAP_T: GL.GL_CLAMP_TO_EDGE,
                             GL.GL_TEXTURE_WRAP_R: GL.GL_CLAMP_TO_EDGE})
                 else:
-                    ValueError("Not enough textures specified, must be 6.")
+                    raise ValueError(
+                        "Not enough textures specified, must be 6.")
             elif isinstance(tex, gt.TexCubeMap):
                 self._skyCubemap = tex
             else:

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -834,6 +834,7 @@ class RigidBodyPose(object):
     def posOri(self, value):
         self._pos = np.ascontiguousarray(value[0], dtype=np.float32)
         self._ori = np.ascontiguousarray(value[1], dtype=np.float32)
+        self._matrixNeedsUpdate = self._invMatrixNeedsUpdate = True
 
     @property
     def at(self):


### PR DESCRIPTION
* Added `posOri` attribute which sets the position and orientation at the same time. This is for compatibility with PsychXR objects and libraries like PyBullet.
* Skybox textures can now be specified as a list of image paths or as a single cubemap object. You can swap out cubemaps during runtime. 

