### PR TITLE
NF: Added `cursorToRay` and `BoundingBox`

### DIFF
--- a/docs/source/api/visual.rst
+++ b/docs/source/api/visual.rst
@@ -51,6 +51,7 @@ Multiple stimuli:
     * :class:`.SceneSkybox` to render a background skybox for VR and 3D scenes
     * :class:`.BlinnPhongMaterial` to specify a material using the Blinn-Phong lighting model
     * :class:`.RigidBodyPose` to define poses of objects in 3D space
+    * :class:`.BoundingBox` to define bounding boxes around 3D objects
     * :class:`.SphereStim` to show a 3D sphere
     * :class:`.BoxStim` to show 3D boxes and cubes
     * :class:`.PlaneStim` to show 3D plane

--- a/docs/source/api/visual/boundingbox.rst
+++ b/docs/source/api/visual/boundingbox.rst
@@ -1,0 +1,20 @@
+:class:`BoundingBox`
+----------------------
+
+Attributes
+==========
+
+.. currentmodule:: psychopy.visual
+
+.. autosummary:: 
+
+    BoundingBox
+    
+        
+Details
+=======
+
+.. autoclass:: BoundingBox
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -2897,13 +2897,3 @@ def lensCorrection(xys, coefK=(1.0,), distCenter=(0., 0.), out=None, dtype=None)
 
     return toReturn
 
-if __name__ == "__main__":
-    vec = [[1, 0, 0], [0, 0, -1]]
-    vec2 = [[1, 0, 0], [0, 0, 1]]
-
-    print(alignTo(vec, vec2))
-
-    vec3 = [0, 0, -1]
-    vec4 = [1, 0, 0]
-
-    print(applyQuat(alignTo(vec3, vec4), vec3))

--- a/psychopy/tools/viewtools.py
+++ b/psychopy/tools/viewtools.py
@@ -15,7 +15,6 @@ __all__ = ['Frustum',
            'perspectiveProjectionMatrix',
            'lookAt',
            'pointToNdc',
-           'unProject',
            'cursorToRay']
 
 import numpy as np

--- a/psychopy/visual/__init__.py
+++ b/psychopy/visual/__init__.py
@@ -90,6 +90,7 @@ from psychopy.visual.stim3d import LightSource
 from psychopy.visual.stim3d import SceneSkybox
 from psychopy.visual.stim3d import BlinnPhongMaterial
 from psychopy.visual.stim3d import RigidBodyPose
+from psychopy.visual.stim3d import BoundingBox
 from psychopy.visual.stim3d import SphereStim
 from psychopy.visual.stim3d import BoxStim
 from psychopy.visual.stim3d import PlaneStim

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -826,6 +826,16 @@ class RigidBodyPose(object):
         self._matrixNeedsUpdate = self._invMatrixNeedsUpdate = True
 
     @property
+    def posOri(self):
+        """The position (x, y, z) and orientation (x, y, z, w)."""
+        return self._pos, self._ori
+
+    @posOri.setter
+    def posOri(self, value):
+        self._pos = np.ascontiguousarray(value[0], dtype=np.float32)
+        self._ori = np.ascontiguousarray(value[1], dtype=np.float32)
+
+    @property
     def at(self):
         """Vector defining the forward direction (-Z) of this pose."""
         if self._matrixNeedsUpdate:  # matrix needs update, this need to be too

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -2160,10 +2160,3 @@ class ObjMeshStim(BaseRigidBodyStim):
 
         win.draw3d = False
 
-
-if __name__ == "__main__":
-    bbox = BoundingBox(((-1, -1, -1), (1, 1, 1)))
-    print(bbox.isValid)
-    bbox.clear()
-
-    print(bbox.isValid)

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -834,6 +834,7 @@ class RigidBodyPose(object):
     def posOri(self, value):
         self._pos = np.ascontiguousarray(value[0], dtype=np.float32)
         self._ori = np.ascontiguousarray(value[1], dtype=np.float32)
+        self._matrixNeedsUpdate = self._invMatrixNeedsUpdate = True
 
     @property
     def at(self):

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -290,7 +290,7 @@ class SceneSkybox(object):
                             GL.GL_TEXTURE_WRAP_T: GL.GL_CLAMP_TO_EDGE,
                             GL.GL_TEXTURE_WRAP_R: GL.GL_CLAMP_TO_EDGE})
                 else:
-                    ValueError("Not enough textures specified, must be 6.")
+                   raise ValueError("Not enough textures specified, must be 6.")
             elif isinstance(tex, gt.TexCubeMap):
                 self._skyCubemap = tex
             else:


### PR DESCRIPTION
Two features to make the 3D support more useful.

* `BoundingBox` is a class that attaches to `RigidBodyPose` which is used for visibility culling. This is a feature ported over from PsychXR to give users a pure-python option. All 3D stimuli when created generate a bounding box automatically. They have a `isVisible` attribute to determine if they shouldn't be drawn as all the geometry falls outside of the viewing frustum. 
* `cursorToRay` computes a direction vector between the eye point and the mouse cursor location. This allows you to convert a 2D screen location to a 3D direction or position if you transform the vector using the view matrix. This allows you to implement ray picking so you can click on 3D objects in the scene. 

