### PR TITLE
NF: `coordToRay` method for window class

### DIFF
--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1076,6 +1076,32 @@ class RigidBodyPose(object):
         """
         return mt.transform(self._pos, self._ori, points=v, out=out)
 
+    def transformNormal(self, n):
+        """Rotate a normal vector with respect to this pose.
+
+        Rotates a normal vector `n` using the orientation quaternion at `ori`.
+
+        Parameters
+        ----------
+        n : array_like
+            Normal to rotate (1-D with length 3).
+
+        Returns
+        -------
+        ndarray
+            Rotated normal `n`.
+
+        """
+        pout = np.zeros((3,), dtype=np.float32)
+        pout[:] = n
+        t = np.cross(self._ori[:3], n[:3]) * 2.0
+        u = np.cross(self._ori[:3], t)
+        t *= self._ori[3]
+        pout[:3] += t
+        pout[:3] += u
+
+        return pout
+
     def __invert__(self):
         """Operator `~` to invert the pose. Returns a `RigidBodyPose` object."""
         return RigidBodyPose(


### PR DESCRIPTION
Built-in method for the window class to convert screen coordinates to a direction vector which projects from the line of sight of the viewer through the cursor or some other screen coordinate. This allows you to position 3D objects in a scene at the cursor and implement ray picking. Also, you can use the screen coordinate given by eye trackers to calculate the direction someone is looking in the scene, and possibly what they are looking at. Also opens up possibilities for gaze contingent 3D graphics displays.

Right now the only raypicking algorithm in PsychoPy is for planes (included an example), however I someday port over the one from PsychXR for bounding spheres and possibly boxes too. 