### PR TITLE
BF: Fix regression in continueRoutine behaviour

### DIFF
--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -117,6 +117,9 @@ class Routine(list):
         # create the frame loop for this routine
         code = ('\n# ------Prepare to start Routine "%s"-------\n')
         buff.writeIndentedLines(code % (self.name))
+        code = 'continueRoutine = True\n'
+        buff.writeIndentedLines(code)
+
         # can we use non-slip timing?
         maxTime, useNonSlip = self.getMaxTime()
         if useNonSlip:
@@ -147,7 +150,6 @@ class Routine(list):
                 '_timeToFirstFrame = win.getFutureFlipTime(clock="now")\n'
                 '{clockName}.reset(-_timeToFirstFrame)  # t0 is time of first possible flip\n'
                 'frameN = -1\n'
-                'continueRoutine = True\n'
                 '\n# -------Run Routine "{name}"-------\n')
         buff.writeIndentedLines(code.format(name=self.name,
                                             clockName=self._clockName))


### PR DESCRIPTION
This addresses a regression in version 3.2.0 in which setting `continueRoutine = False` no longer has an effect in Builder code components (because the Builder-generated code overrides the custom code by always resetting `continueRoutine = True` immediately before the routine begins). All this pull request does its shift `continueRoutine = True` to be first rather than last in the order of execution prior to a routine, so that custom code can override it.

For recent bug reports, see:
https://discourse.psychopy.org/t/continueroutine-false-in-begin-routine-tab-has-no-effect/9801

and for previous development history, see:
https://github.com/psychopy/psychopy/issues/1143