### PR TITLE
NF: Added intersectRayOBB

### DIFF
--- a/docs/source/api/tools/mathtools.rst
+++ b/docs/source/api/tools/mathtools.rst
@@ -89,6 +89,7 @@ Overview
     intersectRayPlane
     intersectRaySphere
     intersectRayAABB
+    intersectRayOBB
     ortho3Dto2D
     slerp
     quatToAxisAngle
@@ -136,6 +137,7 @@ Details
 .. autofunction:: intersectRayPlane
 .. autofunction:: intersectRaySphere
 .. autofunction:: intersectRayAABB
+.. autofunction:: intersectRayOBB
 .. autofunction:: ortho3Dto2D
 .. autofunction:: slerp
 .. autofunction:: quatToAxisAngle

--- a/docs/source/api/tools/mathtools.rst
+++ b/docs/source/api/tools/mathtools.rst
@@ -90,6 +90,7 @@ Overview
     intersectRaySphere
     intersectRayAABB
     intersectRayOBB
+    intersectRayTriangle
     ortho3Dto2D
     slerp
     quatToAxisAngle
@@ -138,6 +139,7 @@ Details
 .. autofunction:: intersectRaySphere
 .. autofunction:: intersectRayAABB
 .. autofunction:: intersectRayOBB
+.. autofunction:: intersectRayTriangle
 .. autofunction:: ortho3Dto2D
 .. autofunction:: slerp
 .. autofunction:: quatToAxisAngle

--- a/psychopy/demos/coder/misc/rigidBodyTransform.py
+++ b/psychopy/demos/coder/misc/rigidBodyTransform.py
@@ -12,7 +12,6 @@ import psychopy.visual as visual
 from psychopy.visual import SphereStim, LightSource, RigidBodyPose
 
 win = visual.Window((600, 600), allowGUI=False, monitor='testMonitor')
-win.scrWidthPIX = 1920
 
 # create a rigid body defining the pivot point of objects in the scene
 pivotPose = RigidBodyPose((0, 0, -5))

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -1389,83 +1389,34 @@ def intersectRayOBB(orig, dir, modelMatrix, boundsExtents, dtype=None):
     tmax = np.finfo(dtype).max
     d = boundsOffset - orig
 
-    xaxis = modelMatrix[:3, 0]
-    ex = np.dot(xaxis, d)
-    fx = np.dot(dir, xaxis)
+    # solve intersects for each pair of planes along each axis
+    for i in range(3):
+        axis = modelMatrix[:3, i]
+        e = np.dot(axis, d)
+        f = np.dot(dir, axis)
 
-    if np.fabs(fx) > 0.001:
-        t1 = (ex + extents[0, 0]) / fx
-        t2 = (ex + extents[1, 0]) / fx
+        if np.fabs(f) > 1e-5:
+            t1 = (e + extents[0, i]) / f
+            t2 = (e + extents[1, i]) / f
 
-        if t1 > t2:
-            temp = t1
-            t1 = t2
-            t2 = temp
+            if t1 > t2:
+                temp = t1
+                t1 = t2
+                t2 = temp
 
-        if t2 < tmax:
-            tmax = t2
+            if t2 < tmax:
+                tmax = t2
 
-        if t1 > tmin:
-            tmin = t1
+            if t1 > tmin:
+                tmin = t1
 
-        if tmin > tmax:
-            return None
+            if tmin > tmax:
+                return None
 
-    else:
-        if -ex + extents[0, 0] > 0.0 or -ex + extents[1, 0] < 0.0:
-            return None
-
-    yaxis = modelMatrix[:3, 1]
-    ey = np.dot(yaxis, d)
-    fy = np.dot(dir, yaxis)
-
-    if np.fabs(fy) > 0.001:
-        t1 = (ey + extents[0, 1]) / fy
-        t2 = (ey + extents[1, 1]) / fy
-
-        if t1 > t2:
-            temp = t1
-            t1 = t2
-            t2 = temp
-
-        if t2 < tmax:
-            tmax = t2
-
-        if t1 > tmin:
-            tmin = t1
-
-        if tmin > tmax:
-            return None
-
-    else:
-        if -ey + extents[0, 1] > 0.0 or -ey + extents[1, 1] < 0.0:
-            return None
-
-    zaxis = modelMatrix[:3, 2]
-    ez = np.dot(zaxis, d)
-    fz = np.dot(dir, zaxis)
-
-    if np.fabs(fy) > 0.001:
-        t1 = (ez + extents[0, 2]) / fz
-        t2 = (ez + extents[1, 2]) / fz
-
-        if t1 > t2:
-            temp = t1
-            t1 = t2
-            t2 = temp
-
-        if t2 < tmax:
-            tmax = t2
-
-        if t1 > tmin:
-            tmin = t1
-
-        if tmin > tmax:
-            return None
-
-    else:
-        if -ez + extents[0, 2] > 0.0 or -ez + extents[1, 2] < 0.0:
-            return None
+        else:
+            # very close to parallel with the face
+            if -e + extents[0, i] > 0.0 or -e + extents[1, i] < 0.0:
+                return None
 
     return (dir * tmin) + orig, tmin
 

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -2128,7 +2128,7 @@ class Rift(window.Window):
 
             GL.glBindFramebuffer(GL.GL_FRAMEBUFFER, self._mirrorFbo)
 
-            GL.glEnable(GL.GL_FRAMEBUFFER_SRGB)
+            # GL.glEnable(GL.GL_FRAMEBUFFER_SRGB)
             # bind the rift's texture to the framebuffer
             GL.glFramebufferTexture2D(
                 GL.GL_READ_FRAMEBUFFER,

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -44,7 +44,6 @@ import pyglet.gl as GL
 from psychopy.visual import window
 from psychopy import platform_specific, logging, core
 from psychopy.tools.attributetools import setAttribute
-from psychopy.tools import viewtools
 
 try:
     from PIL import Image

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -44,6 +44,7 @@ import pyglet.gl as GL
 from psychopy.visual import window
 from psychopy import platform_specific, logging, core
 from psychopy.tools.attributetools import setAttribute
+from psychopy.tools import viewtools
 
 try:
     from PIL import Image

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1450,8 +1450,10 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
             target=GL.GL_ELEMENT_ARRAY_BUFFER,
             dataType=GL.GL_UNSIGNED_INT)
 
-        return gt.createVAO({0: vertexVBO, 8: texCoordVBO, 2: normalsVBO},
-            indexBuffer=indexBuffer)
+        return gt.createVAO({GL.GL_VERTEX_ARRAY: vertexVBO,
+                             GL.GL_TEXTURE_COORD_ARRAY: texCoordVBO,
+                             GL.GL_NORMAL_ARRAY: normalsVBO},
+                            indexBuffer=indexBuffer, legacy=True)
 
     def draw(self, win=None):
         """Draw the stimulus.

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1640,6 +1640,14 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
 
         return True
 
+    def getRayIntersect(self, rayOrig, rayDir):
+        """Get the point which a ray intersects the bounding box of this
+        shape."""
+        if self.thePose.bounds is None:
+            return None  # nop
+
+
+
 
 class SphereStim(BaseRigidBodyStim):
     """Class for drawing a UV sphere.

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1641,12 +1641,30 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
         return True
 
     def getRayIntersect(self, rayOrig, rayDir):
-        """Get the point which a ray intersects the bounding box of this
-        shape."""
+        """Get the point which a ray intersects the bounding box of this mesh.
+
+        Parameters
+        ----------
+        rayOrig : array_like
+            Origin of the ray in space [x, y, z].
+        rayDir : array_like
+            Direction vector of the ray [x, y, z], should be normalized.
+
+        Returns
+        -------
+        tuple
+            Coordinate in world space of the intersection and distance in scene
+            units from `rayOrig`. Returns `None` if there is no intersection.
+
+        """
         if self.thePose.bounds is None:
             return None  # nop
 
-
+        return mt.intersectRayOBB(rayOrig,
+                                  rayDir,
+                                  self.thePose.modelMatrix,
+                                  self.thePose.bounds.extents,
+                                  dtype=np.float32)
 
 
 class SphereStim(BaseRigidBodyStim):

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1642,7 +1642,7 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
 
         return True
 
-    def getRayIntersect(self, rayOrig, rayDir):
+    def getRayIntersectBounds(self, rayOrig, rayDir):
         """Get the point which a ray intersects the bounding box of this mesh.
 
         Parameters
@@ -1779,7 +1779,32 @@ class SphereStim(BaseRigidBodyStim):
         self.material = useMaterial
         self._useShaders = useShaders
 
+        self._radius = radius  # for raypicking
+
         self.extents = (vertices.min(axis=0), vertices.max(axis=0))
+
+    def getRayIntersectSphere(self, rayOrig, rayDir):
+        """Get the point which a ray intersects the sphere.
+
+        Parameters
+        ----------
+        rayOrig : array_like
+            Origin of the ray in space [x, y, z].
+        rayDir : array_like
+            Direction vector of the ray [x, y, z], should be normalized.
+
+        Returns
+        -------
+        tuple
+            Coordinate in world space of the intersection and distance in scene
+            units from `rayOrig`. Returns `None` if there is no intersection.
+
+        """
+        return mt.intersectRaySphere(rayOrig,
+                                     rayDir,
+                                     self.thePose.pos,
+                                     self._radius,
+                                     dtype=np.float32)
 
 
 class BoxStim(BaseRigidBodyStim):

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1809,6 +1809,7 @@ class BoxStim(BaseRigidBodyStim):
                  opacity=1.0,
                  useMaterial=None,
                  useShaders=False,
+                 textureScale=None,
                  name='',
                  autoLog=True):
         """
@@ -1847,6 +1848,11 @@ class BoxStim(BaseRigidBodyStim):
             Opacity of the stimulus ranging from 0.0 to 1.0. Note that
             transparent objects look best when rendered from farthest to
             nearest.
+        textureScale : array_like or float, optional
+            Scaling factors for texture coordinates (sx, sy). By default,
+            a factor of 1 will have the entire texture cover the surface of the
+            mesh. If a single number is provided, the texture will be scaled
+            uniformly.
         name : str
             Name of this object for logging purposes.
         autoLog : bool
@@ -1867,6 +1873,14 @@ class BoxStim(BaseRigidBodyStim):
 
         # create a vertex array object for drawing
         vertices, texCoords, normals, faces = gt.createBox(size, flipFaces)
+
+        # scale the texture
+        if textureScale is not None:
+            if isinstance(textureScale, (int, float)):
+                texCoords *= textureScale
+            else:
+                texCoords *= np.asarray(textureScale, dtype=np.float32)
+
         self._vao = self._createVAO(vertices, texCoords, normals, faces)
 
         self.setColor(color, colorSpace=self.colorSpace, log=False)
@@ -1903,6 +1917,7 @@ class PlaneStim(BaseRigidBodyStim):
                  opacity=1.0,
                  useMaterial=None,
                  useShaders=False,
+                 textureScale=None,
                  name='',
                  autoLog=True):
         """
@@ -1928,6 +1943,23 @@ class PlaneStim(BaseRigidBodyStim):
             `material` attribute after initialization. If not material is
             specified, the diffuse and ambient color of the shape will track the
             current color specified by `glColor`.
+        colorSpace : str
+            Colorspace of `color` to use.
+        contrast : float
+            Contrast of the stimulus, value modulates the `color`.
+        opacity : float
+            Opacity of the stimulus ranging from 0.0 to 1.0. Note that
+            transparent objects look best when rendered from farthest to
+            nearest.
+        textureScale : array_like or float, optional
+            Scaling factors for texture coordinates (sx, sy). By default,
+            a factor of 1 will have the entire texture cover the surface of the
+            mesh. If a single number is provided, the texture will be scaled
+            uniformly.
+        name : str
+            Name of this object for logging purposes.
+        autoLog : bool
+            Enable automatic logging on attribute changes.
 
         """
         super(PlaneStim, self).__init__(
@@ -1944,6 +1976,14 @@ class PlaneStim(BaseRigidBodyStim):
 
         # create a vertex array object for drawing
         vertices, texCoords, normals, faces = gt.createPlane(size)
+
+        # scale the texture
+        if textureScale is not None:
+            if isinstance(textureScale, (int, float)):
+                texCoords *= textureScale
+            else:
+                texCoords *= np.asarray(textureScale, dtype=np.float32)
+
         self._vao = self._createVAO(vertices, texCoords, normals, faces)
 
         self.setColor(color, colorSpace=self.colorSpace, log=False)


### PR DESCRIPTION
This function computes the intersect of a ray and bounding box of arbitrary orientation. This is likely the most useful of the ray picking algorithms included with PsychoPy. Allows you to find the intersect for `RigidBodyPose` objects and 3D stimulus classes which use it. 