### PR TITLE
TESTS, ENH: Enable Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,12 @@ before_script:
 #    fi;
 
 script:
-  - pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
+  - |
+    if [ "${PYTHON_VERSION}" == "3.8" ]; then
+      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" -m "not needs_pygame" psychopy
+    else
+      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
+    fi
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
     - os: linux
       env: CONDA=true PYTHON_VERSION=3.7 DISPLAY=:99.0 AUDIODEV=null
 
+    - os: linux
+      env: CONDA=true PYTHON_VERSION=3.8 DISPLAY=:99.0 AUDIODEV=null
+
 #  allow_failures:
 #    - python: "2.7_with_system_site_packages"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ before_script:
 script:
   - |
     if [ "${PYTHON_VERSION}" == "3.8" ]; then
-      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" -m "not needs_pygame" psychopy
+      pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound and not needs_pygame" psychopy
     else
       pytest --cov-config .travis_coveragerc --cov=psychopy -v -s -m "not needs_sound" psychopy
     fi

--- a/createInitFile.py
+++ b/createInitFile.py
@@ -7,6 +7,7 @@
 from __future__ import absolute_import, print_function
 from setuptools.config import read_configuration
 import os, copy, platform, subprocess
+import distro
 from psychopy.constants import PY3
 
 thisLoc = os.path.split(__file__)[0]
@@ -140,10 +141,12 @@ def _getPlatformString(dist=None):
             OSXver, _, architecture = platform.mac_ver()
             systemInfo = "OSX_%s_%s" % (OSXver, architecture)
         elif os.sys.platform == 'linux':
+            distro_ = distro.linux_distribution(full_distribution_name=False)
             systemInfo = '%s_%s_%s' % (
                 'Linux',
-                ':'.join([x for x in platform.dist() if x != '']),
+                ':'.join([x for x in distro_ if x != '']),
                 platform.release())
+            del distro_
         elif os.sys.platform == 'win32':
             ver=os.sys.getwindowsversion()
             if len(ver[4])>0:

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -26,7 +26,14 @@ import weakref
 import serial
 import numpy as np
 from copy import copy, deepcopy
-from time import sleep, clock
+from time import sleep
+import time
+
+# Python 3.8 removed time.clock()
+if sys.version_info < (3, 8):
+    clock = time.clock
+else:
+    clock = time.perf_counter
 
 from . import shaders
 from psychopy import logging, core

--- a/psychopy/tests/test_all_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_all_visual/test_all_stimuli.py
@@ -887,7 +887,7 @@ class TestPygletDegFlatPos(_baseVisualTest):
         self.contextName='degFlatPos'
         self.scaleFactor=4#applied to size/pos values
 
-
+@pytest.mark.needs_pygame
 class TestPygameNorm(_baseVisualTest):
    @classmethod
    def setup_class(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
 
 [options]
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
+setup_requires = distro
 install_requires =
     requests[security]
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,3 +89,5 @@ tag_prefix = ''
 [tool:pytest]
 markers =
     needs_sound: requires sound hw, thus should not be excercised e.g. on travis-ci
+    needs_pygame: requires pygame
+

--- a/travis/environment-2.7.yml
+++ b/travis/environment-2.7.yml
@@ -8,6 +8,7 @@ dependencies:
 - backports
 - codecov
 - coveralls
+- distro
 - esprima-python
 - gitpython
 - ffmpeg

--- a/travis/environment-3.6.yml
+++ b/travis/environment-3.6.yml
@@ -8,6 +8,7 @@ dependencies:
 - backports
 - codecov
 - coveralls
+- distro
 - esprima-python
 - gitpython
 - ffmpeg

--- a/travis/environment-3.7.yml
+++ b/travis/environment-3.7.yml
@@ -8,6 +8,7 @@ dependencies:
 - backports
 - codecov
 - coveralls
+- distro
 - esprima-python
 - gitpython
 - ffmpeg

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -8,6 +8,7 @@ dependencies:
 - backports
 - codecov
 - coveralls
+- distro
 - esprima-python
 - gitpython
 - ffmpeg

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -53,6 +53,7 @@ dependencies:
 - wheel
 - wxpython
 - xlrd
+- pip
 - pip:
   - pygame
   - pyparallel

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -1,0 +1,57 @@
+name: conda-py3.8
+channels:
+- conda-forge
+dependencies:
+- python=3.8
+- arabic_reshaper
+- astunparse
+- backports
+- codecov
+- coveralls
+- esprima-python
+- gitpython
+- ffmpeg
+- freetype-py
+- future
+- gevent
+- greenlet
+- imageio
+- imageio-ffmpeg
+- json_tricks
+- lxml
+- matplotlib
+- moviepy
+- msgpack-numpy
+- msgpack-python
+- numpy
+- opencv
+- openpyxl
+- pandas
+- pillow
+- pip!=19.0,!=19.0.1,!=19.0.2
+- psutil
+- pyglet>=1.3,<1.4
+- pyglfw
+- pyopengl
+- pyosf
+- pyqt
+- pyserial
+- pysoundfile
+- pytables
+- attrs<18.0
+- pytest<4.1
+- pytest-cov
+- python-bidi
+- python-gitlab
+- python-sounddevice
+- pyyaml
+- pyzmq
+- questplus
+- requests
+- scipy
+- wheel
+- wxpython
+- xlrd
+- pip:
+  - pygame
+  - pyparallel


### PR DESCRIPTION
- Make `hardware/crs/bits.py` and `createInitFilt.py` work on Python 3.8
- Add `pytest` marker for PyGame visual tests
- Skip PyGame tests on Python 3.8 for now due to unavailability of Linux wheels