### PR TITLE
BF/NF: Fixed argument `rayDir` and JIT computation of normal, inverse and model matrices.

### DIFF
--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -1168,7 +1168,7 @@ def intersectRayPlane(rayOrig, rayDir, planeOrig, planeNormal, dtype=None):
     planeOrig = np.asarray(planeOrig, dtype=dtype)
     planeNormal = np.asarray(planeNormal, dtype=dtype)
 
-    denom = dot(dir, planeNormal, dtype=dtype)
+    denom = dot(rayDir, planeNormal, dtype=dtype)
     if denom == 0.0:
         return None
 


### PR DESCRIPTION
Fixes small issues and adds `normalMatrix` computation for rigid bodies needed for incoming PBR material shaders.

* Fixes incorrect argument name after refactor of mathtools.
* Adds the ability to compute a normal matrix from a rigidbody, this is needed by shaders and could be computed JIT only if a rigid body is transformed between frames.

This also should test out if Travis is enabled.