### PR TITLE
FF: Corrected issue with `normalMatrix`

### DIFF
--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -809,6 +809,9 @@ class RigidBodyPose(object):
 
         self._bounds = None
 
+    def __repr__(self):
+        return 'RigidBodyPose({}, {}), %s)'.format(self.pos, self.ori)
+
     @property
     def bounds(self):
         """Bounding box associated with this pose."""
@@ -1009,15 +1012,14 @@ class RigidBodyPose(object):
         if not self._normalMatrixNeedsUpdate:
             return self._normalMatrix
 
-        modelMatrix = self.getModelMatrix()
-        self._normalMatrix[:, :] = np.linalg.inv(modelMatrix).T
+        self._normalMatrix[:, :] = np.linalg.inv(self.modelMatrix).T
 
         if out is not None:
             out[:, :] = self._normalMatrix[:, :]
 
         self._normalMatrixNeedsUpdate = False
 
-        return self.normalMatrix
+        return self._normalMatrix
 
     def getModelMatrix(self, inverse=False, out=None):
         """Get the present rigid body transformation as a 4x4 matrix.

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -919,7 +919,8 @@ class RigidBodyPose(object):
         self._pos.fill(0.0)
         self._ori[:3] = 0.0
         self._ori[3] = 1.0
-        self._matrixNeedsUpdate = self._invMatrixNeedsUpdate = True
+        self._matrixNeedsUpdate = self._normalMatrixNeedsUpdate = \
+            self._invMatrixNeedsUpdate = True
 
     def getOriAxisAngle(self, degrees=True):
         """Get the axis and angle of rotation for the rigid body. Converts the

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -989,7 +989,7 @@ class RigidBodyPose(object):
         if not self._normalMatrixNeedsUpdate:
             return self._normalMatrix
         else:
-            return self.getModelMatrix(inverse=True)
+            return self.getNormalMatrix()
 
     def getNormalMatrix(self, out=None):
         """Get the present normal matrix.
@@ -1010,7 +1010,10 @@ class RigidBodyPose(object):
             return self._normalMatrix
 
         modelMatrix = self.getModelMatrix()
-        self.normalMatrix[:, :] = np.linalg.inv(modelMatrix).T
+        self._normalMatrix[:, :] = np.linalg.inv(modelMatrix).T
+
+        if out is not None:
+            out[:, :] = self._normalMatrix[:, :]
 
         self._normalMatrixNeedsUpdate = False
 


### PR DESCRIPTION
Fixes an issue with the `normalMatrix` attribute. I've run the new code in a 3D rendering application and it seems to be working fine. 

This functionality was also ported to PsychXR's `LibOVRPose` class for compatibility.