### PR TITLE
Correct range for X and Y coordinates of new DotStim dots

### DIFF
--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -559,8 +559,7 @@ class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
             newDots *= self.fieldSize * .5
         else:
-            newDots = np.random.uniform(
-                -.5 * self.fieldSize[0], .5 * self.fieldSize[1], (nDots, 2))
+            newDots = np.random.uniform(-0.5, 0.5, size = (nDots, 2)) * self.fieldSize
 
         return newDots
 


### PR DESCRIPTION
Up to now, the coordinates of new dots were sampled from the same
uniform probability distribution with a range of [-width/2, height/2) in
DotStim._newDotsXY().  This is presumably a bug; X coordinates should be
sampled from [-width/2, width/2), and Y coordinates from [-height/2,
height/2).

Under the previous behaviour, some of the stimulus field would go
unused, whereas some new dots would be randomly placed in an
out-of-field position before being removed one frame later by
DotStim._update_dotsXY().  This patch fixes these problems.