### PR TITLE
ENH: Presents rich text alerts

### DIFF
--- a/psychopy/alerts/_alertDialog.py
+++ b/psychopy/alerts/_alertDialog.py
@@ -1,4 +1,5 @@
 import wx
+import webbrowser
 from psychopy.alerts._alerts import AlertEntry
 from psychopy.alerts._alerts import alertLog
 
@@ -7,43 +8,83 @@ class AlertPanel(wx.Panel):
     """
     Alerts panel for presenting alerts stored in _alerts.alertLog
     """
-    def __init__(self, parent=None, id=wx.ID_ANY, size=[300,300]):
+    def __init__(self, parent=None, id=wx.ID_ANY, size=[400,150]):
         wx.Panel.__init__(self, parent, id, size=size)
 
-        self.lblDetails = wx.StaticText(self, -1, "Alerts")
-        self.listCtrl = wx.ListCtrl(self, -1, style=wx.LC_REPORT)
-        self.ConfigureListCtrl()
+        self.alertTextCtrl = AlertRichText(parent=self, style=wx.TE_MULTILINE, size=size)
+
+        header = AlertEntry(9998, {})
+        self.write(header)
 
         for alert in alertLog:
             if isinstance(alert, AlertEntry):
-                temp = [alert.code, alert.cat, alert.name, alert.msg, alert.url]
-                self.listCtrl.Append(temp)
-
-        # self.listCtrl.Bind(wx.EVT_LIST_ITEM_SELECTED, self.getListItem)
-        # self.details = wx.TextCtrl(panel, -1, value='', style=wx.TE_MULTILINE)
+                self.write(alert)
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)
-        mainSizer.Add(self.lblDetails, 0, wx.LEFT, 10)
-        mainSizer.Add(self.listCtrl, 1, wx.EXPAND | wx.ALL, 10)
-        self.SetSizerAndFit(mainSizer)
+        mainSizer.Add(self.alertTextCtrl, 1, wx.EXPAND | wx.ALL, 10)
 
         self.SetSizerAndFit(mainSizer)
         self.SetMinSize(size)
 
-    # def getListItem(self, evt):
-    #     itemSelected = evt.GetEventObject().GetFirstSelected()
-    #     helpText = self.listCtrl.GetItem(itemIdx=itemSelected, col=3).Text
-    #     self.details.SetLabel(helpText)
+    def onURL(self, evt):
+        """
+        Open link in default browser.
+        """
+        wx.BeginBusyCursor()
+        try:
+            if evt.String.startswith("http"):
+                webbrowser.open(evt.String)
+        except Exception:
+            print("Could not open URL: {}".format(evt.String))
+        wx.EndBusyCursor()
 
-    def ConfigureListCtrl(self):
-        self.listCtrl.InsertColumn(0, "Code")
-        self.listCtrl.InsertColumn(1, "Category")
-        self.listCtrl.InsertColumn(2, "Component")
-        self.listCtrl.InsertColumn(3, "Message")
-        self.listCtrl.InsertColumn(4, "URL")
+    def write(self, text):
+        self.alertTextCtrl.write(text)
 
-        self.listCtrl.SetColumnWidth(0, 50)
-        self.listCtrl.SetColumnWidth(1, 100)
-        self.listCtrl.SetColumnWidth(2, 150)
-        self.listCtrl.SetColumnWidth(3, 500)
-        self.listCtrl.SetColumnWidth(4, 250)
+
+class AlertRichText(wx.richtext.RichTextCtrl):
+    """
+    A rich text ctrl for formatting and presenting alerts.
+    """
+    def __init__(self, parent, style, size=None, font=None, fontSize=None):
+        kwargs = {'parent': parent, 'style': style}
+        if size is not None:
+            kwargs['size'] = size
+        wx.richtext.RichTextCtrl.__init__(self, **kwargs)
+
+        currFont = wx.Font(10, wx.FONTFAMILY_TELETYPE, wx.NORMAL, wx.NORMAL)
+        if fontSize:
+            currFont.SetPointSize(fontSize)
+        self.BeginFont(currFont)
+
+        self.parent = parent
+        self.Bind(wx.EVT_TEXT_URL, parent.onURL)
+
+    def write(self, alert):
+        # Write Code
+        self.BeginTextColour([255, 105, 0])
+        self.WriteText("{:<8}".format(alert.code))
+        self.EndTextColour()
+
+        # Write category
+        self.BeginTextColour([255, 0, 0])
+        self.WriteText("{:<13}".format(alert.cat))
+        self.EndTextColour()
+
+        # Write URL
+        self.BeginBold()
+        self.BeginTextColour(wx.BLUE)
+        self.BeginURL(alert.url)
+        urlLabel = [alert.url, "Learn more"][type(alert.code) == int]  # Set header as "URL"
+        self.WriteText("{:<15}".format(urlLabel))
+        self.EndURL()
+        self.EndBold()
+        self.EndTextColour()
+
+        # Write Message
+        self.BeginTextColour([0, 150, 0])
+        self.WriteText(alert.msg)
+        self.EndTextColour()
+
+        self.Newline()
+        self.ShowPosition(self.GetLastPosition())

--- a/psychopy/alerts/alertsCatalogue/9998.yaml
+++ b/psychopy/alerts/alertsCatalogue/9998.yaml
@@ -1,0 +1,19 @@
+9998:
+  code: Code
+  cat: Category
+  msg: Message
+  url: URL
+
+# Each of the following key values supports reStructured Text.
+
+synopsis: |
+  Provide a few sentences (at most) about the alert.
+
+details: |
+  Longer description with optional links to further information
+
+solutions: |
+  Describe fixes/workarounds for the user
+
+versions: |
+  Info about what versions are affected if this has been fixed

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -398,7 +398,7 @@ class ProjectFrame(wx.Dialog):
 
         self.mainSizer = wx.BoxSizer(wx.VERTICAL)
         self.mainSizer.Add(self.detailsPanel, 1, wx.EXPAND | wx.ALL, 5)
-        self.mainSizer.Add(self.alertPanel, .5, wx.EXPAND | wx.ALL, 5)
+        self.mainSizer.Add(self.alertPanel, .5, wx.EXPAND | wx.ALL, 10)
         self.SetSizerAndFit(self.mainSizer)
 
         if self.parent:


### PR DESCRIPTION
Alerts now formatted using rich text rather than list control. URLs
that point to help pages created from the alerts catalogue
are opened using python built-in webbrowser, which uses the default
browser for loading the webpage.

Next step should be to create the runner frame, and present the alerts each time a script is compiled or run.