### PR TITLE
DOC, ENH: QUEST improvements

### DIFF
--- a/psychopy/contrib/quest.py
+++ b/psychopy/contrib/quest.py
@@ -61,10 +61,11 @@ class QuestObject(object):
 
     The Weibull psychometric function:
 
-    p2=delta*gamma+(1-delta)*(1-(1-gamma)*exp(-10**(beta*(x-xThreshold))))
+    p2=delta*gamma+(1-delta)*(1-(1-gamma)*exp(-10**(beta*(x2+xThreshold))))
 
-    where x represents log10 contrast relative to threshold. The
-    Weibull function itself appears only in recompute(), which uses
+    where x2 represents log10 contrast relative to threshold (i.e.,
+    x2 = x - T, where x is intensity or contrast, and T is threshold)
+    The Weibull function itself appears only in recompute(), which uses
     the specified parameter values in self to compute a psychometric
     function and store it in self. All the other methods simply use
     the psychometric function stored as instance

--- a/psychopy/contrib/quest.py
+++ b/psychopy/contrib/quest.py
@@ -63,8 +63,13 @@ class QuestObject(object):
 
     p2=delta*gamma+(1-delta)*(1-(1-gamma)*exp(-10**(beta*(x2+xThreshold))))
 
-    where x2 represents log10 contrast relative to threshold (i.e.,
-    x2 = x - T, where x is intensity or contrast, and T is threshold)
+    where x2 represents log10 intensity relative to threshold
+    (i.e., x2 = x - T, where x is intensity, and T is threshold intensity).
+    xThreshold shifts the psychometric function along the intensity axis
+    such that threshold performance (specified as pThreshold below) will
+    occur at intensity x = T, i.e., x2 = x - T = 0. In the 
+    Watson & Pelli (1983) paper, xThreshold is denoted as epsilon and used
+    to perform testing at the "ideal sweat factor".
     The Weibull function itself appears only in recompute(), which uses
     the specified parameter values in self to compute a psychometric
     function and store it in self. All the other methods simply use

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -692,12 +692,18 @@ class QuestHandler(StairHandler):
     Measures threshold using a Weibull psychometric function. Currently, it is
     not possible to use a different psychometric function.
 
-    Threshold 't' is measured on an abstract 'intensity' scale, which
-    usually corresponds to log10 contrast.
+    The Weibull psychometric function is given by the formula
+    
+    :math:`\Psi(x) = \delta \gamma + (1 - \delta) [1 - (1 - \gamma)\, \exp(-10^{\beta (x - T + \epsilon)})]`
 
-    The Weibull psychometric function:
-
-    Psi(x) = delta * gamma + (1-delta) * (1 - (1 - gamma) * exp(-10 ** (beta * (x - xThreshold))))
+    Here, :math:`x` is an intensity or a contrast (in log10 units), and :math:`T` is estimated threshold.
+    
+    Quest internally shifts the psychometric function such that intensity at the user-specified
+    threshold performance level ``pThreshold`` (e.g., 50% in a yes-no or 75% in a 2-AFC task) is euqal to 0.
+    The parameter :math:`\epsilon` is responsible for this shift, and is determined automatically based on the
+    specified ``pThreshold`` value. It is the parameter Watson & Pelli (1983) introduced to perform measurements
+    at the "optimal sweat factor". Assuming your ``QuestHandler`` instance is called ``q``, you can retrieve this
+    value via ``q.epsilon``.
 
     **Example**::
 
@@ -883,6 +889,9 @@ class QuestHandler(StairHandler):
     @property
     def delta(self):
         return self._quest.delta
+    @property
+    def epsilon(self):
+        return self._quest.xThreshold
 
     @property
     def grain(self):

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -595,6 +595,25 @@ class TestQuestHandler(_BaseTestStairHandler):
         q_loaded = fromFile(path)
         assert q == q_loaded
 
+    def test_epsilon(self):
+        # Values used by Harvey (1986).
+        beta = 3.5
+        gamma = 0
+        delta = 0
+        epsilon = 0.0571
+        
+        # Estimate the target proportion correct based on epsilon
+        def weibull(x, beta, gamma, delta):
+            p = delta*gamma + (1-delta) * (1 - (1-gamma) * np.exp(-10 ** (beta*x)))
+            return p
+
+        p = weibull(x=epsilon, beta=beta, gamma=gamma, delta=delta)
+        
+        q = data.QuestHandler(0.5, 0.2, pThreshold=p, beta=3.5,
+                              gamma=0, delta=0)
+        
+        assert np.isclose(q.epsilon, epsilon, atol=1e-4)
+
 
 class TestPsiHandler(_BaseTestStairHandler):
     def test_comparison_equals(self):

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -602,6 +602,11 @@ class TestQuestHandler(_BaseTestStairHandler):
         delta = 0
         epsilon = 0.0571
         
+        # QuestHandler needs this, but it doesn't influence our
+        # test. Values chosen arbitrarily.
+        startVal = 0.5
+        startValSd = 1
+        
         # Estimate the target proportion correct based on epsilon
         def weibull(x, beta, gamma, delta):
             p = delta*gamma + (1-delta) * (1 - (1-gamma) * np.exp(-10 ** (beta*x)))
@@ -609,8 +614,8 @@ class TestQuestHandler(_BaseTestStairHandler):
 
         p = weibull(x=epsilon, beta=beta, gamma=gamma, delta=delta)
         
-        q = data.QuestHandler(0.5, 0.2, pThreshold=p, beta=3.5,
-                              gamma=0, delta=0)
+        q = data.QuestHandler(startVal=startVal, startValSd=startValSd,
+                              pThreshold=p, beta=beta, gamma=gamma, delta=delta)
         
         assert np.isclose(q.epsilon, epsilon, atol=1e-4)
 

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -596,7 +596,7 @@ class TestQuestHandler(_BaseTestStairHandler):
         assert q == q_loaded
 
     def test_epsilon(self):
-        # Values used by Harvey (1986).
+        # Values used by Harvey (1986), Table 3.
         beta = 3.5
         gamma = 0
         delta = 0
@@ -607,7 +607,10 @@ class TestQuestHandler(_BaseTestStairHandler):
         startVal = 0.5
         startValSd = 1
         
-        # Estimate the target proportion correct based on epsilon
+        # Estimate the target proportion correct based on epsilon.
+        # (The values provided by Harvey (1986) are rounded to two
+        #  decimal places and, therefore, too imprecise. So we
+        #  have to we calculate it again.)
         def weibull(x, beta, gamma, delta):
             p = delta*gamma + (1-delta) * (1 - (1-gamma) * np.exp(-10 ** (beta*x)))
             return p


### PR DESCRIPTION
Update QUEST documentation to clarify meaning of parameters of the psychometric function, based on my research found [here](https://github.com/Psychtoolbox-3/Psychtoolbox-3/issues/515#issuecomment-564293107) and in the following comments. Also expose the `epsilon` parameter.

Closes #2722.