### PR TITLE
BF: Fixes alerttool error from refactor.

### DIFF
--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -62,6 +62,16 @@ def convertParamToPix(value, win, units):
         value = array(value)
     return monitorunittools.convertToPix(value, array([0, 0]), units=units, win=win) * 2
 
+def testFloat(val):
+    """
+    Test value for float.
+    Used to detect use of variables, strings and none types, which cannot be checked.
+    """
+    try:
+        return type(float(val)) == float
+    except Exception:
+        return False
+
 def testSize(component, win, units):
     """
     Runs size testing for component
@@ -145,10 +155,8 @@ def testStartEndTiming(component):
     start = {'type': component.params['startType'].val, 'val' : component.params['startVal'].val}
     stop = {'type': component.params['stopType'].val, 'val' : component.params['stopVal'].val}
 
-    try:
-        float(start['val'])
-        float(stop['val'])
-    except Exception:  # Conversion to float fails - probably a variable
+    # Check for string / variable
+    if not all([testFloat(start['val']), testFloat(stop['val'])]):
         return
 
     if [start['type'], stop['type']] == ["time (s)", "time (s)"]:
@@ -172,7 +180,7 @@ def testAchievableVisualOnsetOffset(component):
     startVal = component.params['startVal'].val
     stopVal = component.params['stopVal'].val
 
-    if startVal not in ['', None, "None", "none"]:
+    if testFloat(startVal):
         if component.params['startType'] == "time (s)":
             # Test times are greater than 1 screen refresh for 60Hz and 100Hz monitors
             if not float.is_integer(float(startVal)) and float(startVal) < 1.0 / 60:
@@ -180,7 +188,7 @@ def testAchievableVisualOnsetOffset(component):
             if not float.is_integer(float(startVal)) and float(startVal) < 1.0 / 100:
                 alert(3110, component, {'type': 'start', 'time': startVal, 'Hz': 100})
 
-    if stopVal not in ['', None, "None", "none"]:
+    if testFloat(stopVal):
         if component.params['stopType'] == "duration (s)":
             # Test times are greater than 1 screen refresh for 60Hz and 100Hz monitors
             if not float.is_integer(float(stopVal)) and float(stopVal) < 1.0 / 60:
@@ -199,10 +207,11 @@ def testValidVisualStimTiming(component):
     if "startType" not in component.params or "stopType" not in component.params:
         return
 
+    # Check for string / variable
     startVal = component.params['startVal'].val
     stopVal = component.params['stopVal'].val
 
-    if startVal not in ['', None, "None", "none"]:
+    if testFloat(startVal):
         if component.params['startType'] == "time (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
             if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 60), 3) != 0.0:
@@ -210,7 +219,7 @@ def testValidVisualStimTiming(component):
             if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 100), 3) != 0.0:
                 alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 100})
 
-    if stopVal not in ['', None, "None", "none"]:
+    if testFloat(stopVal):
         if component.params['stopType'] == "duration (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
             if not float.is_integer(float(stopVal)) and round(float(stopVal) % (1.0 / 60), 3) != 0.0:
@@ -230,13 +239,13 @@ def testFramesAsInt(component):
     startVal = component.params['startVal'].val
     stopVal = component.params['stopVal'].val
 
-    if startVal not in ['', None, "None", "none"]:
+    if testFloat(startVal):
         if component.params['startType'] in ["frame N", "duration (frames)"]:
             # Test frames are whole numbers
             if not float.is_integer(float(startVal)):
                 alert(4115, component, {'type': 'start', 'frameType': component.params['startType']})
 
-    if stopVal not in ['', None, "None", "none"]:
+    if testFloat(stopVal):
         if component.params['stopType'] in ["frame N", "duration (frames)"]:
             # Test frames are whole numbers
             if not float.is_integer(float(stopVal)):

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -81,9 +81,13 @@ def expression2js(expr):
     # into a list for the number of tuples in the expression.
     try:
         syntaxTree = ast.parse(expr)
-    except Exception as err:
-        logging.error(err)
-        syntaxTree = ast.parse(unicode(expr))
+    except Exception:
+        try:
+            syntaxTree = ast.parse(unicode(expr))
+        except Exception as err:
+            logging.error(err)
+            return
+
 
     for node in ast.walk(syntaxTree):
         TupleTransformer().visit(node)  # Transform tuples to list


### PR DESCRIPTION
The refactor did not catch use of variables in all cases. Variables cause
errors when converting to float, since variable names are strings.
This fix checks each value can be converted to a float
(meaning it is a number), but is now more specific so start and end
times are checked independently. Also handles syntax errors in dialog
boxes, so real time syntax errors are not raised and printed to console,
but caught and thus allowing the dialog to perform its syntax warnings.