### PR TITLE
Use MovieStim3 in demo

### DIFF
--- a/psychopy/demos/coder/stimuli/variousVisualStims.py
+++ b/psychopy/demos/coder/stimuli/variousVisualStims.py
@@ -13,7 +13,7 @@ import numpy
 win = visual.Window([600, 600], color='black')
 
 gabor = visual.GratingStim(win, mask='gauss', pos=[-0.5, -0.5], color=[0, 0, 1], sf=5, ori=30)
-movie = visual.MovieStim(win, 'jwpIntro.mov', units='pix', pos=[100, 100], size=[160, 120])
+movie = visual.MovieStim3(win, 'jwpIntro.mov', units='pix', pos=[100, 100], size=[160, 120])
 txt = u"unicode (eg \u03A8 \u040A \u03A3)"
 text = visual.TextStim(win, pos=[0.5, -0.5], text=txt, font=['Times New Roman'])
 faceRGB = visual.ImageStim(win, image='face.jpg', pos=[-0.5, 0.5])


### PR DESCRIPTION
Since `MovieStim` seems to be deprecated in favor of `MovieStim3` (#1532), I thought it would be a good idea to use `MovieStim3` in `variousVisualStims.py`. The demo threw an error on my fresh Windows installation, but it works with `MovieStim3`.