### PR TITLE
Add SoundFile to conda env

### DIFF
--- a/conda/psychopy-env.yml
+++ b/conda/psychopy-env.yml
@@ -9,3 +9,4 @@ dependencies:
   - psychtoolbox
   - pygame
   - pyparallel
+  - SoundFile


### PR DESCRIPTION
Playing sounds with `psychtoolbox` requires `SoundFile`, which I've added to the conda env so that this gets installed automatically.