### PR TITLE
Use platform markers in conda env

### DIFF
--- a/conda/psychopy-env.yml
+++ b/conda/psychopy-env.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
 - python=3.6
 - psychopy
+- pip
 - pip:
   - psychtoolbox
   - pygame

--- a/conda/psychopy-env.yml
+++ b/conda/psychopy-env.yml
@@ -4,9 +4,8 @@ channels:
 dependencies:
 - python=3.6
 - psychopy
-- pip
 - pip:
   - psychtoolbox
   - pygame
-  - pyparallel
-  - SoundFile
+  - pyparallel; platform_system == "Darwin" or platform_system == "Linux"
+  - SoundFile; platform_system == "Windows"

--- a/conda/psychopy-env.yml
+++ b/conda/psychopy-env.yml
@@ -8,5 +8,5 @@ dependencies:
 - pip:
   - psychtoolbox
   - pygame
-  - pyparallel; platform_system == "Darwin" or platform_system == "Linux"
+  - pyparallel; platform_system != "Windows"
   - SoundFile; platform_system == "Windows"


### PR DESCRIPTION
Follow up for #2730.

It is not necessary to specify `pip` because this package is installed by default in any conda env. Furthermore, what do you think about removing `pygame`? This is the oldest backend and PsychoPy ships with better options.