### PR TITLE
Replace platform.dist with distro.linux_distribution

### DIFF
--- a/createInitFile.py
+++ b/createInitFile.py
@@ -6,8 +6,11 @@
 
 from __future__ import absolute_import, print_function
 from setuptools.config import read_configuration
-import os, copy, platform, subprocess
+import os
+import platform
+import subprocess
 from psychopy.constants import PY3
+
 
 thisLoc = os.path.split(__file__)[0]
 # import versioneer
@@ -30,7 +33,7 @@ def createInitFile(dist=None, version=None, sha=None):
     """
     # get default values if None
     if version is None:
-        with open(os.path.join(thisLoc,'version')) as f:
+        with open(os.path.join(thisLoc, 'version')) as f:
             version = f.read().strip()
     if sha is None:
         sha = _getGitShaString(dist)
@@ -48,12 +51,13 @@ def createInitFile(dist=None, version=None, sha=None):
                 'platform': platformStr}
 
     # write it
-    with open(os.path.join(thisLoc, 'psychopy','__init__.py'), 'w') as f:
+    with open(os.path.join(thisLoc, 'psychopy', '__init__.py'), 'w') as f:
         outStr = template.format(**infoDict)
         f.write(outStr)
     print('wrote init for ', version, sha)
     # and return it
     return outStr
+
 
 template = """#!/usr/bin/env python
 # -*- coding: utf-8 -*-
@@ -85,12 +89,12 @@ __all__ = ["gui", "misc", "visual", "core",
 # for developers the following allows access to the current git sha from
 # their repository
 if __git_sha__ == 'n/a':
-    import subprocess
+    from subprocess import check_output, PIPE
     # see if we're in a git repo and fetch from there
     try:
         thisFileLoc = os.path.split(__file__)[0]
-        output = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
-                                         cwd=thisFileLoc, stderr=subprocess.PIPE)
+        output = check_output(['git', 'rev-parse', '--short', 'HEAD'],
+                              cwd=thisFileLoc, stderr=PIPE)
     except Exception:
         output = False
     if output:
@@ -124,17 +128,13 @@ def _getGitShaString(dist=None, sha=None):
             shaStr = "{}".format(repo_commit.strip())
         else:
             shaStr = 'n/a'
-        #this looks neater but raises errors on win32
-        #        output = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).split()[0]
-        #        if output:
-        #            shaStr = output
     return shaStr
 
 
 def _getPlatformString(dist=None):
     """If generic==True then returns empty __build_platform__ string
     """
-    if dist=='bdist':
+    if dist == 'bdist':
         # get platform-specific info
         if os.sys.platform == 'darwin':
             OSXver, _, architecture = platform.mac_ver()
@@ -148,9 +148,10 @@ def _getPlatformString(dist=None):
                 platform.release())
             del distro_
         elif os.sys.platform == 'win32':
-            ver=os.sys.getwindowsversion()
-            if len(ver[4])>0:
-                systemInfo = "win32_v%i.%i.%i (%s)" %(ver[0], ver[1], ver[2], ver[4])
+            ver = os.sys.getwindowsversion()
+            if len(ver[4]) > 0:
+                systemInfo = "win32_v%i.%i.%i (%s)" % (ver[0], ver[1], ver[2],
+                                                       ver[4])
             else:
                 systemInfo = "win32_v%i.%i.%i" % (ver[0], ver[1], ver[2])
         else:

--- a/createInitFile.py
+++ b/createInitFile.py
@@ -145,7 +145,6 @@ def _getPlatformString(dist=None):
                 'Linux',
                 ':'.join([x for x in distro.linux_distribution() if x != '']),
                 platform.release())
-            del distro_
         elif os.sys.platform == 'win32':
             ver = os.sys.getwindowsversion()
             if len(ver[4]) > 0:

--- a/createInitFile.py
+++ b/createInitFile.py
@@ -141,10 +141,9 @@ def _getPlatformString(dist=None):
             systemInfo = "OSX_%s_%s" % (OSXver, architecture)
         elif os.sys.platform == 'linux':
             import distro
-            distro_ = distro.linux_distribution(full_distribution_name=False)
             systemInfo = '%s_%s_%s' % (
                 'Linux',
-                ':'.join([x for x in distro_ if x != '']),
+                ':'.join([x for x in distro.linux_distribution() if x != '']),
                 platform.release())
             del distro_
         elif os.sys.platform == 'win32':

--- a/createInitFile.py
+++ b/createInitFile.py
@@ -7,7 +7,6 @@
 from __future__ import absolute_import, print_function
 from setuptools.config import read_configuration
 import os, copy, platform, subprocess
-import distro
 from psychopy.constants import PY3
 
 thisLoc = os.path.split(__file__)[0]
@@ -102,7 +101,7 @@ if 'installing' not in locals():
     from psychopy.preferences import prefs
     for pathName in prefs.general['paths']:
         sys.path.append(pathName)
-    
+
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
 
 """
@@ -141,6 +140,7 @@ def _getPlatformString(dist=None):
             OSXver, _, architecture = platform.mac_ver()
             systemInfo = "OSX_%s_%s" % (OSXver, architecture)
         elif os.sys.platform == 'linux':
+            import distro
             distro_ = distro.linux_distribution(full_distribution_name=False)
             systemInfo = '%s_%s_%s' % (
                 'Linux',

--- a/psychopy/app/connections/sendusage.py
+++ b/psychopy/app/connections/sendusage.py
@@ -37,9 +37,10 @@ def sendUsageStats(app=None):
         OSXver, junk, architecture = platform.mac_ver()
         systemInfo = "OSX_%s" % (OSXver)
     elif sys.platform.startswith('linux'):
+        from distro import linux_distribution
         systemInfo = '%s_%s_%s' % (
             'Linux',
-            ':'.join([x for x in platform.dist() if x != '']),
+            ':'.join([x for x in linux_distribution() if x != '']),
             platform.release())
         if len(systemInfo) > 30:  # if it's too long PHP/SQL fails to store!?
             systemInfo = systemInfo[0:30]

--- a/psychopy/app/connections/updates.py
+++ b/psychopy/app/connections/updates.py
@@ -618,9 +618,10 @@ def sendUsageStats():
         OSXver, junk, architecture = platform.mac_ver()
         systemInfo = "OSX_%s_%s" % (OSXver, architecture)
     elif sys.platform.startswith('linux'):
+        from distro import linux_distribution
         systemInfo = '%s_%s_%s' % (
             'Linux',
-            ':'.join([x for x in platform.dist() if x != '']),
+            ':'.join([x for x in linux_distribution() if x != '']),
             platform.release())
         if len(systemInfo) > 30:  # if it's too long PHP/SQL fails to store!?
             systemInfo = systemInfo[0:30]

--- a/psychopy/demos/coder/hardware/testSoundLatency.py
+++ b/psychopy/demos/coder/hardware/testSoundLatency.py
@@ -96,7 +96,8 @@ elif sys.platform == 'win32':
     sysName = 'win'
     sysVer = platform.win32_ver()[0]
 elif sys.platform.startswith('linux'):
-    sysName = 'linux_' + platform.dist()
+    from distro import linux_distribution
+    sysName = 'linux_' + linux_distribution()
     sysVer = platform.release()
 else:
     sysName = sysVer = 'n/a'

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ classifiers =
 
 [options]
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
-setup_requires = distro; platform_system == "Linux"
+setup_requires = 
+    distro; platform_system == "Linux"
 install_requires =
     requests[security]
     numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ install_requires =
     pypiwin32; platform_system == "Windows"
     pyobjc-core; platform_system == "Darwin"
     pyobjc-framework-Quartz; platform_system == "Darwin"
+    distro; platform_system == "Linux"
 
 [options.entry_points]
 gui_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 
 [options]
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
-setup_requires = distro
+setup_requires = distro; platform_system == "Linux"
 install_requires =
     requests[security]
     numpy


### PR DESCRIPTION
Fixes #2733.

I've only replaced the `platform.dist` calls, but I noticed problems that should be fixed in another PR:

- https://github.com/psychopy/psychopy/blob/master/psychopy/demos/coder/hardware/testSoundLatency.py#L99 concatenates a `str` and a `tuple`
- https://github.com/psychopy/psychopy/blob/master/psychopy/app/connections/updates.py contains undefined names `unicode`, `time`, and `platform`