### PR TITLE
ENH: Better handling of QuestPlus stimSelectionOptions

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1422,7 +1422,9 @@ class QuestPlusHandler(StairHandler):
             For exmaple, to randomly pick a stimulus from those which will
             produce the 4 smallest expected entropies, and to allow the same
             stimulus to be presented on two consecutive trials max, use
-            `stimSelectionDuration=dict(N=4, maxConsecutiveReps=2)`.
+            `stimSelectionOptions=dict(N=4, maxConsecutiveReps=2)`.
+            To achieve reproducible results, you may pass a seed to the
+            random number generator via the `randomSeed` key.
 
         paramEstimationMethod : {'mean', 'mode'}
             How to calculate the final parameter estimate. `mean` returns the
@@ -1516,6 +1518,18 @@ class QuestPlusHandler(StairHandler):
         else:
             raise ValueError('Unknown stimSelectionMethod requested.')
 
+        if self.stimSelectionOptions is not None:
+            stimSelectionOptions_ = dict()
+
+            if 'N' in self.stimSelectionOptions:
+                stimSelectionOptions_['n'] = self.stimSelectionOptions['N']
+            if 'maxConsecutiveReps' in self.stimSelectionOptions:
+                stimSelectionOptions_['max_consecutive_reps'] = self.stimSelectionOptions['maxConsecutiveReps']
+            if 'randomSeed' in self.stimSelectionOptions:
+                stimSelectionOptions_['random_seed'] = self.stimSelectionOptions['randomSeed']
+        else:
+            stimSelectionOptions_ = self.stimSelectionOptions
+
         if self.psychometricFunc == 'weibull':
             self._qp = qp.QuestPlusWeibull(
                 intensities=self.intensityVals,
@@ -1526,7 +1540,7 @@ class QuestPlusHandler(StairHandler):
                 responses=self.responseVals,
                 stim_scale=self.stimScale,
                 stim_selection_method=stimSelectionMethod_,
-                stim_selection_options=self.stimSelectionOptions,
+                stim_selection_options=stimSelectionOptions_,
                 param_estimation_method=self.paramEstimationMethod)
         else:
             msg = ('Currently only the Weibull psychometric function is '

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -1116,7 +1116,45 @@ def test_QuesPlusHandler_unused_StairHandler_attribs():
     assert q.stepType == q.stimScale
 
 
+def test_QuesPlusHandler_stimSelectionOptions():
+    import sys
+    if not (sys.version_info.major == 3 and sys.version_info.minor >= 6):
+        pytest.skip('QUEST+ only works on Python 3.6+')
+
+    from psychopy.data.staircase import QuestPlusHandler
+
+    thresholds = np.arange(-40, 0 + 1)
+    slope, guess, lapse = 3.5, 0.5, 0.02
+    contrasts = thresholds.copy()
+    response_vals = ['Correct', 'Incorrect']
+    func = 'weibull'
+    stim_scale = 'linear'
+    stim_selection_method = 'minNEntropy'
+    stim_selection_options = dict(N=10, maxConsecutiveReps=4, randomSeed=0)
+    stim_selection_options_qp = dict(n=10, max_consecutive_reps=4,
+                                     random_seed=0)
+
+    q = QuestPlusHandler(nTrials=20,
+                         intensityVals=contrasts,
+                         thresholdVals=thresholds,
+                         slopeVals=slope,
+                         lowerAsymptoteVals=guess,
+                         lapseRateVals=lapse,
+                         responseVals=response_vals,
+                         psychometricFunc=func,
+                         stimScale=stim_scale,
+                         stimSelectionMethod=stim_selection_method,
+                         stimSelectionOptions=stim_selection_options)
+
+    assert q.stimSelectionOptions == stim_selection_options
+    assert q._qp.stim_selection_options == stim_selection_options_qp
+
+
 if __name__ == '__main__':
-    # test_QuestPlusHandler()
-    # test_QuestPlusHandler_startIntensity()
+    test_QuestPlusHandler()
+    test_QuestPlusHandler_startIntensity()
     test_QuestPlusHandler_saveAsJson()
+    test_QuestPlusHandler_paramEstimate_weibull()
+    test_QuestPlusHandler_posterior_weibull()
+    test_QuesPlusHandler_unknown_kwargs()
+    test_QuesPlusHandler_unused_StairHandler_attribs()

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     pyglet >= 1.3; python_version < "3.8"
     pyglet >= 1.3.3; python_version >= "3.8"
     pathlib; python_version < "3.4"
-    questplus; python_version >= "3.6"
+    questplus >= 2019.2; python_version >= "3.6"
     imageio < 2.5; python_version < "3"
     imageio >= 2.5; python_version >= "3"
     imageio-ffmpeg; python_version >= "3"

--- a/travis/environment-3.6.yml
+++ b/travis/environment-3.6.yml
@@ -47,7 +47,7 @@ dependencies:
 - python-sounddevice
 - pyyaml
 - pyzmq
-- questplus
+- questplus >=2019.2
 - requests
 - scipy
 - wheel

--- a/travis/environment-3.7.yml
+++ b/travis/environment-3.7.yml
@@ -47,7 +47,7 @@ dependencies:
 - python-sounddevice
 - pyyaml
 - pyzmq
-- questplus
+- questplus >=2019.2
 - requests
 - scipy
 - wheel

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -47,7 +47,7 @@ dependencies:
 - python-sounddevice
 - pyyaml
 - pyzmq
-- questplus
+- questplus >=2019.2
 - requests
 - scipy
 - wheel


### PR DESCRIPTION
Users may now pass a dict that contains only a subset of the supported options (needed to contain _all_ options before, otherwise it would throw an error). Requires `questplus` 2019.2.