### PR TITLE
BF: Use primary display for Dlg if screen is unavailable

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -125,7 +125,9 @@ class Dlg(QtWidgets.QDialog):
             raise RuntimeWarning("Dlg does not currently support the "
                                  "style kwarg.")
         self.size = size
-        self.screen = screen
+
+        nScreens = len(qtapp.screens())
+        self.screen = -1 if screen >= nScreens else screen
         # self.labelButtonOK = labelButtonOK
         # self.labelButtonCancel = labelButtonCancel
 

--- a/travis/environment-2.7.yml
+++ b/travis/environment-2.7.yml
@@ -32,6 +32,7 @@ dependencies:
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyglet>=1.3,<1.4
+- glfw<3.3.1
 - pyglfw
 - pyopengl
 - pyosf

--- a/travis/environment-3.6.yml
+++ b/travis/environment-3.6.yml
@@ -32,6 +32,7 @@ dependencies:
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyglet>=1.3
+- glfw<3.3.1
 - pyglfw
 - pyopengl
 - pyosf

--- a/travis/environment-3.7.yml
+++ b/travis/environment-3.7.yml
@@ -32,6 +32,7 @@ dependencies:
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyglet>=1.3
+- glfw<3.3.1
 - pyglfw
 - pyopengl
 - pyosf

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -32,6 +32,7 @@ dependencies:
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
 - pyglet>=1.3.3
+- glfw<3.3.1
 - pyglfw
 - pyopengl
 - pyosf


### PR DESCRIPTION
Addresses #2741, but only in PyQt.

This change makes Dlg use the primary display if the screen that was asked for does not exist. As I use standalone and therefore PyQt, this fixed the issue for me.