### PR TITLE
TESTS: Require pyglet 1.4.9+

### DIFF
--- a/travis/environment-3.6.yml
+++ b/travis/environment-3.6.yml
@@ -31,7 +31,7 @@ dependencies:
 - pillow
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
-- pyglet>=1.3
+- pyglet>=1.4.9
 - glfw<3.3.1
 - pyglfw
 - pyopengl

--- a/travis/environment-3.7.yml
+++ b/travis/environment-3.7.yml
@@ -31,7 +31,7 @@ dependencies:
 - pillow
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
-- pyglet>=1.3
+- pyglet>=1.4.9
 - glfw<3.3.1
 - pyglfw
 - pyopengl

--- a/travis/environment-3.8.yml
+++ b/travis/environment-3.8.yml
@@ -31,7 +31,7 @@ dependencies:
 - pillow
 - pip!=19.0,!=19.0.1,!=19.0.2
 - psutil
-- pyglet>=1.3.3
+- pyglet>=1.4.9
 - glfw<3.3.1
 - pyglfw
 - pyopengl


### PR DESCRIPTION
Prepares for changes in Python 3.7.6, and future 3.6 and 3.8 releases to come:
https://github.com/pyglet/pyglet/issues/112

Note that we still run tests with pyglet 1.3 too.