### PR TITLE
FF: incorrect test of monitor duration

### DIFF
--- a/psychopy/alerts/_alerts.py
+++ b/psychopy/alerts/_alerts.py
@@ -46,14 +46,16 @@ class AlertCatalogue(object):
         """
         alertDict = {}
 
-        for alerts in self.alertFiles:
-            with open('{}'.format(alerts), 'r') as ymlFile:
+        for filePath in self.alertFiles:
+            with open(filePath, 'r') as ymlFile:
                 entry = yaml.load(ymlFile, Loader=yaml.SafeLoader)
-                if entry is not None:
-                    entry = {key: entry[key] for key in entry if type(key) == int}  # Get alert codes only
-                    key = list(entry.keys())[0]
-                    value = entry[key]
-                    alertDict[key] = value
+                if entry is None:
+                    continue  # this might be a stub for future entry
+                ID = entry['code']
+                alertDict[ID] = entry
+                if 'url' not in entry:  # give a default URL
+                    entry['url'] = ('https://psychopy.org/alerts/{}.html'
+                                    .format(ID))
 
         return alertDict
 

--- a/psychopy/alerts/alertsCatalogue/2115.yaml
+++ b/psychopy/alerts/alertsCatalogue/2115.yaml
@@ -1,12 +1,10 @@
 # The first key-value pair is used for the alerts package
 
-2115:
-  code: 2115
-  cat: Sizing
-  msg: Your stimuli size exceeds the {dimension} dimension of your window.
-  url: https://psychopy.org
+code: 2115
+cat: Sizing
+msg: Your stimuli size exceeds the {dimension} dimension of your window.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Your stimulus size exceeds the X or Y window dimensions. Stimuli sized greater than the window size will

--- a/psychopy/alerts/alertsCatalogue/2120.yaml
+++ b/psychopy/alerts/alertsCatalogue/2120.yaml
@@ -1,12 +1,10 @@
 # The first key-value pair is used for the alerts package
 
-2120:
-  code: 2120
-  cat: Sizing
-  msg: Your stimuli size is smaller than 1 pixel ({dimension} dimension).
-  url: https://psychopy.org
+code: 2120
+cat: Sizing
+msg: Your stimuli size is smaller than 1 pixel ({dimension} dimension).
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Stimuli size requested is smaller than 1 pixel on X and/oy Y dimensions. Stimuli sized smaller than

--- a/psychopy/alerts/alertsCatalogue/2155.yaml
+++ b/psychopy/alerts/alertsCatalogue/2155.yaml
@@ -1,10 +1,8 @@
 # The first key-value pair is used for the alerts package
 
-2155:
-  code: 2155
-  cat: Positioning
-  msg: Your stimuli position exceeds the {dimension} dimension of your window.
-  url: https://psychopy.org
+code: 2155
+cat: Positioning
+msg: Your stimuli position exceeds the {dimension} dimension of your window.
 
 # Each of the following key values are used for formatting online help pages, and support reStructured Text.
 

--- a/psychopy/alerts/alertsCatalogue/3110.yaml
+++ b/psychopy/alerts/alertsCatalogue/3110.yaml
@@ -1,12 +1,10 @@
 # The first key-value pair is used for the alerts package
 
-3110:
-  code: 3110
-  cat: Timing
-  msg: Your stimuli {type}-time of {time} is less than a screen refresh for a {Hz}Hz monitor.
-  url: https://psychopy.org
+code: 3110
+cat: Timing
+msg: Your stimuli {type}-time of {time} is less than a screen refresh for a {Hz}Hz monitor.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Requested start or stop times of visual components cannot be presented for times requested.

--- a/psychopy/alerts/alertsCatalogue/3115.yaml
+++ b/psychopy/alerts/alertsCatalogue/3115.yaml
@@ -1,13 +1,11 @@
 # The first key-value pair is used for the alerts package
 
-3115:
-  code: 3115
-  cat: Timing
-  msg: >-
-      Your stimuli {type}-time of {time} seconds cannot be accurately presented for {time} on a {Hz}Hz monitor.
-  url: https://psychopy.org
+code: 3115
+cat: Timing
+msg: >-
+    Your stimuli {type}-time of {time} seconds cannot be accurately presented for {time} on a {Hz}Hz monitor.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   If using a 60Hz or 100Hz monitor, then for accurate presentation of visual stimuli,

--- a/psychopy/alerts/alertsCatalogue/4105.yaml
+++ b/psychopy/alerts/alertsCatalogue/4105.yaml
@@ -1,12 +1,10 @@
 # The first key-value pair is used for the alerts package
 
-4105:
-  code: 4105
-  cat: Timing
-  msg: Your stimuli start {type} exceeds the stop {type}. Consider using a {type} duration.
-  url: https://psychopy.org
+code: 4105
+cat: Timing
+msg: Your stimuli start {type} exceeds the stop {type}. Consider using a {type} duration.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   A component start time/frame exceeds the stop time/frame.

--- a/psychopy/alerts/alertsCatalogue/4115.yaml
+++ b/psychopy/alerts/alertsCatalogue/4115.yaml
@@ -1,12 +1,11 @@
 # The first key-value pair is used for the alerts package
 
-4115:
-  code: 4115
-  cat: Timing
-  msg: Your stimuli {type}-type {frameType} must be expressed as a whole number.
-  url: https://psychopy.org
+code: 4115
+cat: Timing
+msg: Your stimuli {type}-type {frameType} must be expressed as a whole number.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Component start and stop times/durations in frames must be given as whole numbers.

--- a/psychopy/alerts/alertsCatalogue/4205.yaml
+++ b/psychopy/alerts/alertsCatalogue/4205.yaml
@@ -1,12 +1,9 @@
-# The first key-value pair is used for the alerts package
 
-4205:
-  code: 4205
-  cat: Coding
-  msg: Python Syntax Error in '{codeTab}' tab. See '{code}' on line number {lineNumber} of the '{codeTab}' tab.
-  url: https://psychopy.org
+code: 4205
+cat: Coding
+msg: Python Syntax Error in '{codeTab}' tab. See '{code}' on line number {lineNumber} of the '{codeTab}' tab.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Python syntax error found in your code component.

--- a/psychopy/alerts/alertsCatalogue/4210.yaml
+++ b/psychopy/alerts/alertsCatalogue/4210.yaml
@@ -1,12 +1,9 @@
-# The first key-value pair is used for the alerts package
 
-4210:
-  code: 4210
-  cat: Coding
-  msg: JavaScript Syntax Error in '{codeTab}' tab. See '{lineNumber}' in the '{codeTab}' tab.
-  url: https://psychopy.org
+code: 4210
+cat: Coding
+msg: JavaScript Syntax Error in '{codeTab}' tab. See '{lineNumber}' in the '{codeTab}' tab.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   JavaScript syntax error found in your code component.

--- a/psychopy/alerts/alertsCatalogue/4305.yaml
+++ b/psychopy/alerts/alertsCatalogue/4305.yaml
@@ -1,12 +1,9 @@
-# The first key-value pair is used for the alerts package
 
-4305:
-  code: 4305
-  cat: Components
-  msg: Your component is currently disabled and will not be written to your experiment script.
-  url: https://psychopy.org
+code: 4305
+cat: Components
+msg: Your component is currently disabled and will not be written to your experiment script.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   You have a disabled component in your experiment. This alert is created to inform users that

--- a/psychopy/alerts/alertsCatalogue/4310.yaml
+++ b/psychopy/alerts/alertsCatalogue/4310.yaml
@@ -1,12 +1,9 @@
-# The first key-value pair is used for the alerts package
 
-4310:
-  code: 4310
-  cat: Components
-  msg: Cannot calculate parameter.
-  url: https://psychopy.org
+code: 4310
+cat: Components
+msg: Cannot calculate parameter.
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   This alert is received when an integrity check has failed to calculate a parameter.

--- a/psychopy/alerts/alertsCatalogue/9998.yaml
+++ b/psychopy/alerts/alertsCatalogue/9998.yaml
@@ -1,8 +1,7 @@
-9998:
-  code: Code
-  cat: Category
-  msg: Message
-  url: URL
+code: Code
+cat: Category
+msg: Message
+url: URLonlyIfNotStandard
 
 # Each of the following key values supports reStructured Text.
 

--- a/psychopy/alerts/alertsCatalogue/9999.yaml
+++ b/psychopy/alerts/alertsCatalogue/9999.yaml
@@ -1,8 +1,7 @@
-9999:
-  code: 9999
-  cat: TEST_ISSUE
-  msg: TEST_MSG {testString}
-  url: https://psychopy.org
+
+code: 9999
+cat: TEST_ISSUE
+msg: TEST_MSG {testString}
 
 # Each of the following key values supports reStructured Text.
 

--- a/psychopy/alerts/alertsCatalogue/alertTemplate.yaml
+++ b/psychopy/alerts/alertsCatalogue/alertTemplate.yaml
@@ -1,12 +1,9 @@
-# The first key-value pair is used for the alerts package
 
-9999:
-  code: 9999
-  cat: AlertCategory
-  msg: Alert description (brief) - can use Python style string formatting e.g., The alert affects {component}
-  url: https://psychopy.org
+code: 9999
+cat: AlertCategory
+msg: Alert description (brief) - can use Python style string formatting e.g., The alert affects {component}
 
-# Each of the following key values are used for formatting online help pages, and support reStructured Text.
+# The following are typically used for online help pages, and support reStructured Text.
 
 synopsis: |
   Provide a few sentences (at most) about the alert.

--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -6,7 +6,15 @@ from psychopy.monitors import Monitor
 from psychopy.tools import monitorunittools
 from psychopy.alerts._alerts import alert
 
-validDuration = monitorunittools.validDuration
+
+def validDuration(t, hz, toleranceFrames=0.01):
+    """Test whether this is a possible time duration given the frame rate"""
+    # best not to use mod operator for floats. e.g. 0.5%0.01 gives 0.00999
+    # (due to a float round error?)
+    # nFrames = t*hz so test if round(nFrames)==nFrames but with a tolerance
+    nFrames = t*hz
+    return abs(nFrames - round(nFrames)) < toleranceFrames
+
 
 class TestWin(object):
     """

--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -6,6 +6,7 @@ from psychopy.monitors import Monitor
 from psychopy.tools import monitorunittools
 from psychopy.alerts._alerts import alert
 
+validDuration = monitorunittools.validDuration
 
 class TestWin(object):
     """
@@ -214,18 +215,14 @@ def testValidVisualStimTiming(component):
     if testFloat(startVal):
         if component.params['startType'] == "time (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
-            if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 60), 3) != 0.0:
+            if not validDuration(startVal, 60):
                 alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 60})
-            if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 100), 3) != 0.0:
-                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 100})
 
     if testFloat(stopVal):
         if component.params['stopType'] == "duration (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
-            if not float.is_integer(float(stopVal)) and round(float(stopVal) % (1.0 / 60), 3) != 0.0:
+            if not validDuration(stopVal, 60):
                 alert(3115, component, {'type': 'stop', 'time': stopVal, 'Hz': 60})
-            if not float.is_integer(float(stopVal)) and round(float(stopVal) % (1.0 / 100), 3) != 0.0:
-                alert(3115, component, {'type': 'stop', 'time': stopVal, 'Hz': 100})
 
 
 def testFramesAsInt(component):

--- a/psychopy/tests/test_tools/test_monitortools.py
+++ b/psychopy/tests/test_tools/test_monitortools.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Tests for psychopy.tools.viewtools
+"""
+
+from psychopy.tools.monitorunittools import *
+
+
+def test_validDuration():
+    testVals = [
+        {'t': 0.5, 'hz' : 60, 'ans': True},
+        {'t': 0.1, 'hz': 60, 'ans': True},
+        {'t': 0.01667, 'hz': 60, 'ans': True},  # 1 frame-ish
+        {'t': 0.016, 'hz': 60, 'ans': False},  # too sloppy
+        {'t': 0.01, 'hz': 60, 'ans': False},
+        {'t': 0.01, 'hz': 100, 'ans': True},
+        {'t': 0.009, 'hz': 100, 'ans': False},  # 0.9 frames
+        {'t': 0.012, 'hz': 100, 'ans': False},  # 1.2 frames
+    ]
+    for this in testVals:
+        assert validDuration(this['t'], this['hz']) == this['ans']
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main()

--- a/psychopy/tests/test_tools/test_monitortools.py
+++ b/psychopy/tests/test_tools/test_monitortools.py
@@ -2,7 +2,7 @@
 """Tests for psychopy.tools.viewtools
 """
 
-from psychopy.tools.monitorunittools import *
+from psychopy.alerts.alerttools import validDuration
 
 
 def test_validDuration():

--- a/psychopy/tools/monitorunittools.py
+++ b/psychopy/tools/monitorunittools.py
@@ -17,14 +17,6 @@ import numpy as np
 from numpy import array, sin, cos, tan, pi, radians, degrees, hypot
 
 
-def validDuration(t, hz, toleranceFrames=0.01):
-    """Test whether this is a possible time duration given the frame rate"""
-    # best not to use mod operator for floats. e.g. 0.5%0.01 gives 0.00999
-    # (due to a float round error?)
-    # nFrames = t*hz so test if round(nFrames)==nFrames but with a tolerance
-    nFrames = t*hz
-    return abs(nFrames - round(nFrames)) < toleranceFrames
-
 # Maps supported coordinate unit type names to the function that converts
 # the given unit type to PsychoPy OpenGL pix unit space.
 _unit2PixMappings = dict()

--- a/psychopy/tools/monitorunittools.py
+++ b/psychopy/tools/monitorunittools.py
@@ -16,6 +16,15 @@ from psychopy import monitors
 import numpy as np
 from numpy import array, sin, cos, tan, pi, radians, degrees, hypot
 
+
+def validDuration(t, hz, toleranceFrames=0.01):
+    """Test whether this is a possible time duration given the frame rate"""
+    # best not to use mod operator for floats. e.g. 0.5%0.01 gives 0.00999
+    # (due to a float round error?)
+    # nFrames = t*hz so test if round(nFrames)==nFrames but with a tolerance
+    nFrames = t*hz
+    return abs(nFrames - round(nFrames)) < toleranceFrames
+
 # Maps supported coordinate unit type names to the function that converts
 # the given unit type to PsychoPy OpenGL pix unit space.
 _unit2PixMappings = dict()


### PR DESCRIPTION
Using % operator for floats gives some odd answers!
e.g. 0.5%0.01 gives 0.00999 but should be 0 (0.01*0.5 is exactly 50!)
so use our own function instead

Also removed the 100Hz tests althouhg we should at some point allow
users to specify the rate of their monitor for these tests