### PR TITLE
FF: Fix validDuration calculation for frames

### DIFF
--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -23,7 +23,7 @@ def validDuration(t, hz, toleranceFrames=0.01):
     # best not to use mod operator for floats. e.g. 0.5%0.01 gives 0.00999
     # (due to a float round error?)
     # nFrames = t*hz so test if round(nFrames)==nFrames but with a tolerance
-    nFrames = t*hz
+    nFrames = float(t) * hz  # t might not be float if given as "0.5"?
     return abs(nFrames - round(nFrames)) < toleranceFrames
 
 def runTest(component):

--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -18,6 +18,13 @@ class TestWin(object):
         self.monitor = Monitor(monitor)
         self.size = self.monitor.getSizePix()
 
+def validDuration(t, hz, toleranceFrames=0.01):
+    """Test whether this is a possible time duration given the frame rate"""
+    # best not to use mod operator for floats. e.g. 0.5%0.01 gives 0.00999
+    # (due to a float round error?)
+    # nFrames = t*hz so test if round(nFrames)==nFrames but with a tolerance
+    nFrames = t*hz
+    return abs(nFrames - round(nFrames)) < toleranceFrames
 
 def runTest(component):
     """
@@ -214,19 +221,14 @@ def testValidVisualStimTiming(component):
     if testFloat(startVal):
         if component.params['startType'] == "time (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
-            if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 60), 3) != 0.0:
-                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 60})
-            if not float.is_integer(float(startVal)) and round(float(startVal) % (1.0 / 100), 3) != 0.0:
-                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 100})
+            if not validDuration(startVal, 60):
+                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 60}))
 
     if testFloat(stopVal):
         if component.params['stopType'] == "duration (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
-            if not float.is_integer(float(stopVal)) and round(float(stopVal) % (1.0 / 60), 3) != 0.0:
+            if not  validDuration(stopVal, 60):
                 alert(3115, component, {'type': 'stop', 'time': stopVal, 'Hz': 60})
-            if not float.is_integer(float(stopVal)) and round(float(stopVal) % (1.0 / 100), 3) != 0.0:
-                alert(3115, component, {'type': 'stop', 'time': stopVal, 'Hz': 100})
-
 
 def testFramesAsInt(component):
     """

--- a/psychopy/alerts/alerttools.py
+++ b/psychopy/alerts/alerttools.py
@@ -222,7 +222,7 @@ def testValidVisualStimTiming(component):
         if component.params['startType'] == "time (s)":
             # Test times are valid multiples of screen refresh for 60Hz and 100Hz monitors
             if not validDuration(startVal, 60):
-                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 60}))
+                alert(3115, component, {'type': 'start', 'time': startVal, 'Hz': 60})
 
     if testFloat(stopVal):
         if component.params['stopType'] == "duration (s)":

--- a/psychopy/tests/test_alerts/test_alerttools.py
+++ b/psychopy/tests/test_alerts/test_alerttools.py
@@ -125,3 +125,16 @@ class TestAlertTools(object):
         sys.stderr.flush()
         assert ("JavaScript Syntax Error in 'Begin JS Experiment'" in alertLog[0].msg)
 
+def test_validDuration():
+    testVals = [
+        {'t': 0.5, 'hz' : 60, 'ans': True},
+        {'t': 0.1, 'hz': 60, 'ans': True},
+        {'t': 0.01667, 'hz': 60, 'ans': True},  # 1 frame-ish
+        {'t': 0.016, 'hz': 60, 'ans': False},  # too sloppy
+        {'t': 0.01, 'hz': 60, 'ans': False},
+        {'t': 0.01, 'hz': 100, 'ans': True},
+        {'t': 0.009, 'hz': 100, 'ans': False},  # 0.9 frames
+        {'t': 0.012, 'hz': 100, 'ans': False},  # 1.2 frames
+    ]
+    for this in testVals:
+        assert alerttools.validDuration(this['t'], this['hz']) == this['ans']


### PR DESCRIPTION
Using % operator for floats gives some odd answers!
e.g. 0.5%0.01 gives 0.00999 but should be 0 (0.01*0.5 is exactly 50!)
so use our own function instead

Also removed the 100Hz tests although we should, at some point, allow
users to specify the rate of their monitor for these tests