### PR TITLE
NF: High-DPI awareness on Windows.

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -16,7 +16,6 @@ import sys
 import psychopy
 from pkg_resources import parse_version
 from psychopy.constants import PY3
-from psychopy.preferences import prefs
 import io
 from . import urls
 from . import frametracker
@@ -61,10 +60,20 @@ else:
 
 # Enable high-dpi support if on Windows. This fixes blurry text rendering.
 if sys.platform == 'win32':
-    try:
-        ctypes.windll.shcore.SetProcessDpiAwareness(prefs.app['highDPI'])
-    except:
-        pass
+    # get the preference for high DPI
+    if 'highDPI' in preferences.prefs.app.keys():  # check if we have the option
+        enableHighDPI = preferences.prefs.app['highDPI']
+
+        # check if we have OS support for it
+        if hasattr(ctypes.windll.shcore, "SetProcessDpiAwareness"):
+            ctypes.windll.shcore.SetProcessDpiAwareness(enableHighDPI)
+        else:
+            logging.warn(
+                "High DPI support is not appear to be supported by this version"
+                " of Windows. Disabling in preferences.")
+
+            preferences.prefs.app['highDPI'] = False
+            preferences.prefs.saveUserPrefs()
 
 
 class MenuFrame(wx.Frame):

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -16,6 +16,7 @@ import sys
 import psychopy
 from pkg_resources import parse_version
 from psychopy.constants import PY3
+from psychopy.preferences import prefs
 import io
 from . import urls
 from . import frametracker
@@ -61,7 +62,7 @@ else:
 # Enable high-dpi support if on Windows. This fixes blurry text rendering.
 if sys.platform == 'win32':
     try:
-        ctypes.windll.shcore.SetProcessDpiAwareness(True)
+        ctypes.windll.shcore.SetProcessDpiAwareness(prefs.app['highDPI'])
     except:
         pass
 

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -40,6 +40,7 @@ from psychopy.localization import _translate
 # take a while
 
 # needed by splash screen for the path to resources/psychopySplash.png
+import ctypes
 from psychopy import preferences, logging, __version__
 from psychopy import projects
 from . import connections
@@ -55,6 +56,14 @@ if not PY3 and sys.platform == 'darwin':
     blockTips = True
 else:
     blockTips = False
+
+
+# Enable high-dpi support if on Windows. This fixes blurry text rendering.
+if sys.platform == 'win32':
+    try:
+        ctypes.windll.shcore.SetProcessDpiAwareness(True)
+    except:
+        pass
 
 
 class MenuFrame(wx.Frame):

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -63,6 +63,8 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
+    # Enable High-DPI awareness on Windows, requires restart. (EXPERIMENTAL)
+    highDPI = boolean(default='False')
 
 # Settings for the Coder window
 [coder]


### PR DESCRIPTION
I noticed Builder and Coder are pretty blurry on Windows on my high-dpi display, it makes some text completely illegible for me. I added a preference that enables High-DPI awareness which makes text rendering and graphics appear much sharper. Scaling is messed up in some places, so the feature is disabled by default and flagged as experimental.