### PR TITLE
BF: iohub eyelink device sendings messages as byte arrays

### DIFF
--- a/docs/source/api/iohub/device/eyetracker_interface/SR_Research_Implementation_Notes.rst
+++ b/docs/source/api/iohub/device/eyetracker_interface/SR_Research_Implementation_Notes.rst
@@ -5,8 +5,8 @@ SR Research
 **Platforms:** 
 
 * Windows 7 / 10
-* Linux (not tested)
-* macOS (not tested)
+* Linux
+* macOS
 
 **Required Python Version:** 
 
@@ -15,8 +15,7 @@ SR Research
 **Supported Models:**
 
 * EyeLink 1000
-* EyeLink 1000 Remote (not tested)
-* EyeLink 1000 Plus (not tested)
+* EyeLink 1000 Plus
 
 Additional Software Requirements
 #################################

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -371,18 +371,22 @@ class EyeTracker(EyeTrackerDevice):
 
         """
         try:
+            if isinstance(message_contents, bytes):
+                message_contents = message_contents.decode('utf-8')
+
             if time_offset:
                 r = self._eyelink.sendMessage(
                     '\t%d\t%s' %
                     (time_offset, message_contents))
             else:
-                r = self._eyelink.sendMessage(message_contents)
+                r = self._eyelink.sendMessage('%s'%message_contents)
 
             if r == 0:
                 return EyeTrackerConstants.EYETRACKER_OK
             return EyeTrackerConstants.EYETRACKER_ERROR
         except Exception as e:
             printExceptionDetailsToStdErr()
+        return EyeTrackerConstants.EYETRACKER_ERROR
 
     def runSetupProcedure(self):
         """Start the EyeLink Camera Setup and Calibration procedure.


### PR DESCRIPTION
byte arrays are now converted to strings before being passed to pylink.sendMessage()