### PR TITLE
Better mac keyboard handling

### DIFF
--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -36,7 +36,8 @@ class MessageDialog(wx.Dialog):
         if not title:
             title = type
         labels = {'Warning': _translate('Warning'),
-                  'Info': _translate('Info')}
+                  'Info': _translate('Info'),
+                  'Query': _translate('Query')}
         try:
             label = labels[title]
         except Exception:
@@ -60,6 +61,15 @@ class MessageDialog(wx.Dialog):
             btnSizer.Add((60, 20), 0, wx.EXPAND)
             btnSizer.Add(self.cancelBtn, wx.ALIGN_RIGHT)
             btnSizer.Add((5, 20), 0)
+            btnSizer.Add(self.yesBtn, wx.ALIGN_RIGHT)
+        if type == 'Query':  # we need Yes,No
+            self.yesBtn = wx.Button(self, wx.ID_YES, _translate('Yes'))
+            self.yesBtn.SetDefault()
+            self.noBtn = wx.Button(self, wx.ID_NO, _translate('No'))
+            self.Bind(wx.EVT_BUTTON, self.onButton, id=wx.ID_YES)
+            self.Bind(wx.EVT_BUTTON, self.onButton, id=wx.ID_NO)
+#            self.Bind(wx.EVT_CLOSE, self.onEscape)
+            btnSizer.Add(self.noBtn, wx.ALIGN_RIGHT)
             btnSizer.Add(self.yesBtn, wx.ALIGN_RIGHT)
         elif type == 'Info':  # just an OK button
             self.okBtn = wx.Button(self, wx.ID_OK, _translate('OK'))

--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -62,7 +62,7 @@ class MessageDialog(wx.Dialog):
             btnSizer.Add(self.cancelBtn, wx.ALIGN_RIGHT)
             btnSizer.Add((5, 20), 0)
             btnSizer.Add(self.yesBtn, wx.ALIGN_RIGHT)
-        if type == 'Query':  # we need Yes,No
+        elif type == 'Query':  # we need Yes,No
             self.yesBtn = wx.Button(self, wx.ID_YES, _translate('Yes'))
             self.yesBtn.SetDefault()
             self.noBtn = wx.Button(self, wx.ID_NO, _translate('No'))

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -312,9 +312,9 @@ class _KeyBuffers(dict):
                                   "You need to add PsychoPy App bundle (or the "
                                   "terminal if you run from terminal) to the "
                                   "System Preferences/Privacy/Accessibility "
-                                  "(MacOS <= 10.14) or "
+                                  "(macOS <= 10.14) or "
                                   "System Preferences/Privacy/InputMonitoring "
-                                  "(MacOS >= 10.15).")
+                                  "(macOS >= 10.15).")
                 else:
                     raise(e)
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -302,8 +302,21 @@ class _KeyBuffers(dict):
 
     def getBuffer(self, kb_id, bufferSize=defaultBufferSize):
         if kb_id not in self:
-            self[kb_id] = _KeyBuffer(bufferSize=bufferSize,
-                                     kb_id=kb_id)
+            try:
+                self[kb_id] = _KeyBuffer(bufferSize=bufferSize,
+                                         kb_id=kb_id)
+            except FileNotFoundError as e:
+                if sys.platform == 'darwin':
+                    # this is caused by a problem with SysPrefs
+                    raise OSError("Failed to connect to Keyboard globally. "
+                                  "Need to adjust the "
+                                  "System Preferences/Privacy/Accessibility "
+                                  "(up to OS X <= 10.14) or "
+                                  "System Preferences/Privacy/InputMonitoring "
+                                  "(up to OS X >= 10.15).")
+                else:
+                    raise(e)
+
         return self[kb_id]
 
 
@@ -494,10 +507,18 @@ keyNamesLinux={
     }
 
 
-
 if sys.platform == 'darwin':
     keyNames = keyNamesMac
 elif sys.platform == 'win32':
     keyNames = keyNamesWin
 else:
     keyNames = keyNamesLinux
+
+# check if mac prefs are working
+macPrefsBad = False
+if sys.platform == 'darwin' and havePTB:
+    try:
+        Keyboard()
+    except OSError:
+        macPrefsBad = True
+        havePTB = False

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -309,11 +309,12 @@ class _KeyBuffers(dict):
                 if sys.platform == 'darwin':
                     # this is caused by a problem with SysPrefs
                     raise OSError("Failed to connect to Keyboard globally. "
-                                  "Need to adjust the "
+                                  "You need to add PsychoPy App bundle (or the "
+                                  "terminal if you run from terminal) to the "
                                   "System Preferences/Privacy/Accessibility "
-                                  "(up to OS X <= 10.14) or "
+                                  "(MacOS <= 10.14) or "
                                   "System Preferences/Privacy/InputMonitoring "
-                                  "(up to OS X >= 10.15).")
+                                  "(MacOS >= 10.15).")
                 else:
                     raise(e)
 


### PR DESCRIPTION
Better info to user for how to turn on the necessary privacy settings to use PTB keyboard class:

- in keyboard.py we now detect that PTB keyboard didn't work. Falls back to using the event.getKeys Keyboard class if PTB can't be used
- the app detects that the PTB keyboard not working (from the above mechanism) and provides a dialog taking the user to the appropriate setting in System Preferences (the Assistance panel for<=Mojave and the InputMonitoring panel for >=Catalina
