### PR TITLE
BF: Code Type is now set correctly on opening the dialog

### DIFF
--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -95,9 +95,14 @@ class DlgCodeComponentProperties(wx.Dialog):
                 self.nameOKlabel.SetForegroundColour(wx.RED)
             elif paramName == 'Code Type':
                 _codeTypes = self.params['Code Type'].allowedVals
+                _selectedCodeType = self.params['Code Type'].val
+                _selectedCodeTypeIndex = _codeTypes.index(_selectedCodeType)
                 self.codeTypeMenu = wx.Choice(self, choices=_codeTypes)
-                self.codeTypeMenu.SetSelection(
-                    _codeTypes.index(_codeTypes[hasMetapensiero - 2]))
+
+                if not hasMetapensiero and _selectedCodeType.lower() == 'auto->js':
+                    _selectedCodeTypeIndex -= 1
+
+                self.codeTypeMenu.SetSelection(_selectedCodeTypeIndex)
                 self.codeTypeMenu.Bind(wx.EVT_CHOICE, self.onCodeChoice)
                 self.codeTypeName = wx.StaticText(self, wx.ID_ANY,
                                                   _translate(param.label))


### PR DESCRIPTION
Previously, the code type was forced to either Auto->JS, or Both, because
code type selection was conditional based on whether metapensiero was
installed. This fix now unselects Auto->JS if metapensiero is not
installed, but otherwise loads previously selected code type.