### PR TITLE
DOCS: Fix typo in keyboard.py

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -46,7 +46,7 @@ Example usage
 
     # during your trial
     kb.clock.reset()  # when you want to start the timer from
-    keys = kb.getKeys(['right', 'left', 'quit'], waitDuration=True)
+    keys = kb.getKeys(['right', 'left', 'quit'], waitRelease=True)
     if 'quit' in keys:
         core.quit()
     for key in keys:


### PR DESCRIPTION
Fixing an argument name error in the example code, noted by Rebecca Hirst on the Discourse forum https://discourse.psychopy.org/t/equivalent-of-event-waitkeys-using-keyboard-keyboard/11076