### PR TITLE
BF: Double buffer panels/fix high DPI error on Windows <8.1

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -66,15 +66,16 @@ if sys.platform == 'win32':
         enableHighDPI = preferences.prefs.app['highDPI']
 
         # check if we have OS support for it
-        if hasattr(ctypes.windll.shcore, "SetProcessDpiAwareness"):
-            ctypes.windll.shcore.SetProcessDpiAwareness(enableHighDPI)
-        else:
-            logging.warn(
-                "High DPI support is not appear to be supported by this version"
-                " of Windows. Disabling in preferences.")
+        if enableHighDPI:
+            try:
+                ctypes.windll.shcore.SetProcessDpiAwareness(enableHighDPI)
+            except OSError:
+                logging.warn(
+                    "High DPI support is not appear to be supported by this version"
+                    " of Windows. Disabling in preferences.")
 
-            preferences.prefs.app['highDPI'] = False
-            preferences.prefs.saveUserPrefs()
+                preferences.prefs.app['highDPI'] = False
+                preferences.prefs.saveUserPrefs()
 
 
 class MenuFrame(wx.Frame):

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -745,6 +745,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         self.SetSizer(self.sizer)
         self.SetAutoLayout(True)
         self.SetupScrolling()
+        self.SetDoubleBuffered(True)
 
     def on_resize(self, event):
         if self.app.prefs.app['largeIcons']:

--- a/psychopy/app/builder/flow.py
+++ b/psychopy/app/builder/flow.py
@@ -141,6 +141,9 @@ class FlowPanel(wx.ScrolledWindow):
         ])
         self.SetAcceleratorTable(aTable)
 
+        # set double buffering to reduce flicker
+        self.SetDoubleBuffered(True)
+
     def clearMode(self, event=None):
         """If we were in middle of doing something (like inserting routine)
         then end it, allowing user to cancel


### PR DESCRIPTION
When creating a new loop or collapsing component panes, either the control flickers when moving the mouse around or only partially redraws. This PR double buffers the controls providing a smoother visual experience (on Windows at least). 

Also includes a bugfix for #2818.

 