### PR TITLE
BF: make data.importConditions() able to import csv with ',' and ';' separator

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -273,16 +273,27 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
     if fileName.endswith('.csv') or (fileName.endswith(('.xlsx','.xls','.xlsm'))
                                      and haveXlrd):
         if fileName.endswith('.csv'):
-            trialsArr = pd.read_csv(fileName, encoding='utf-8-sig')
-            logging.debug(u"Read csv file with pandas: {}".format(fileName))
+            try:
+                trialsArr = pd.read_csv(fileName, encoding='utf-8-sig',sep = ',')
+                logging.debug(u"Read csv file with pandas: {}".format(fileName))
+                unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
+                trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
+                logging.debug(u"Clearing unnamed columns from {}".format(fileName))
+                trialList, fieldNames = pandasToDictList(trialsArr)
+            except ValueError:
+                trialsArr = pd.read_csv(fileName, encoding='utf-8-sig',sep = ';')
+                logging.debug(u"Read csv file with pandas: {}".format(fileName))
+                unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
+                trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
+                logging.debug(u"Clearing unnamed columns from {}".format(fileName))
+                trialList, fieldNames = pandasToDictList(trialsArr)
         else:
             trialsArr = pd.read_excel(fileName)
             logging.debug(u"Read Excel file with pandas: {}".format(fileName))
-
-        unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
-        trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
-        logging.debug(u"Clearing unnamed columns from {}".format(fileName))
-        trialList, fieldNames = pandasToDictList(trialsArr)
+            unnamed = trialsArr.columns.to_series().str.contains('^Unnamed: ')
+            trialsArr = trialsArr.loc[:, ~unnamed]  # clear unnamed cols
+            logging.debug(u"Clearing unnamed columns from {}".format(fileName))
+            trialList, fieldNames = pandasToDictList(trialsArr)
 
     elif fileName.endswith(('.xlsx','.xlsm')):
         if not haveOpenpyxl:


### PR DESCRIPTION
In the data.importConditions() (lines 276-289) I added a try/except block to allow an automatic loading of csv with either ',' or ';' as separator. 
Now, pandas loads the file without raising errors even if only one column is detected (for example when loading a file separated with semicolon with the argument sep = ',') and the presence of weird punctuation in the dataset is only tested later when the _assertValidVarNames() function is called from within the pandasToDictList() function. Therefore the except function only works if pandasToDictList(trialsArr) is run before it. 
Right now to avoid changing the code too much I have repeated the same block of code twice (and it is used one more time later on for the excel format). It works but it seems to me a bit redundant.
What do you think? 