### PR TITLE
NF/EN: Error dialog for unhandled exceptions in the GUI thread

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -191,6 +191,9 @@ class PsychoPyApp(wx.App):
             sys.stderr = sys.stdout = lastLoadErrs = self._lastRunLog
             logging.console.setLevel(logging.DEBUG)
 
+        from psychopy.app.errorDlg import exceptionCallback
+        sys.excepthook = exceptionCallback
+
         # indicates whether we're running for testing purposes
         self.osfSession = None
         self.pavloviaSession = None

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -191,9 +191,6 @@ class PsychoPyApp(wx.App):
             sys.stderr = sys.stdout = lastLoadErrs = self._lastRunLog
             logging.console.setLevel(logging.DEBUG)
 
-        from psychopy.app.errorDlg import exceptionCallback
-        sys.excepthook = exceptionCallback
-
         # indicates whether we're running for testing purposes
         self.osfSession = None
         self.pavloviaSession = None
@@ -209,6 +206,10 @@ class PsychoPyApp(wx.App):
         self.localization = localization
         self.locale = localization.setLocaleWX()
         self.locale.AddCatalog(self.GetAppName())
+
+        # set the exception hook to present unhandled errors in a dialog
+        from psychopy.app.errorDlg import exceptionCallback
+        sys.excepthook = exceptionCallback
 
         self.onInit(testMode=testMode, **kwargs)
         if profiling:

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -581,7 +581,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
             self.SetTechnology(3)
 
         # prevent flickering on update
-        self.SetBufferedDraw(True)
+        self.SetDoubleBuffered(True)
 
     def setFonts(self):
         """Make some styles,  The lexer defines what each style is used for,
@@ -696,7 +696,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
             if charPos == 0:
                 # if caret is at start of line, move to start of text instead
                 self.VCHome()
-        if keyCode == ord(']') and wx.MOD_CONTROL == _mods:
+        elif keyCode == ord(']') and wx.MOD_CONTROL == _mods:
             self.indentSelection(4)
             # if there are no characters on the line then also move caret to
             # end of indentation
@@ -705,26 +705,26 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
                 # if caret is at start of line, move to start of text instead
                 self.VCHome()
 
-        if keyCode == ord('/') and wx.MOD_CONTROL == _mods:
+        elif keyCode == ord('/') and wx.MOD_CONTROL == _mods:
             self.commentLines()
-        if keyCode == ord('/') and wx.MOD_CONTROL | wx.MOD_SHIFT == _mods:
+        elif keyCode == ord('/') and wx.MOD_CONTROL | wx.MOD_SHIFT == _mods:
             self.uncommentLines()
 
         # show completions, very simple at this point
-        if keyCode == wx.WXK_SPACE and wx.MOD_CONTROL == _mods:
+        elif keyCode == wx.WXK_SPACE and wx.MOD_CONTROL == _mods:
             self.ShowAutoCompleteList()
 
         # show a calltip with signiture
-        if keyCode == wx.WXK_SPACE and wx.MOD_CONTROL | wx.MOD_SHIFT == _mods:
+        elif keyCode == wx.WXK_SPACE and wx.MOD_CONTROL | wx.MOD_SHIFT == _mods:
             self.ShowCalltip()
 
-        if keyCode == wx.WXK_ESCAPE:  # close overlays
+        elif keyCode == wx.WXK_ESCAPE:  # close overlays
             if self.AutoCompActive():
                 self.AutoCompCancel()  # close the auto completion list
             if self.CallTipActive():
                 self.CallTipCancel()
 
-        if keyCode == wx.WXK_RETURN: # and not self.AutoCompActive():
+        elif keyCode == wx.WXK_RETURN: # and not self.AutoCompActive():
             if not self.AutoCompActive():
                 # process end of line and then do smart indentation
                 event.Skip(False)
@@ -734,7 +734,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
                 return  # so that we don't reach the skip line at end
 
         # quote line
-        if keyCode == ord("'"):
+        elif keyCode == ord("'"):
             start, end = self.GetSelection()
             if end - start > 0:
                 txt = self.GetSelectedText()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -687,7 +687,6 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
         # enable in the _-init__
         keyCode = event.GetKeyCode()
         _mods = event.GetModifiers()
-
         # handle some special keys
         if keyCode == ord('[') and wx.MOD_CONTROL == _mods:
             self.indentSelection(-4)
@@ -839,9 +838,9 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
         self.caretLineIndentLevel = self.caretLineIndentCol / self.indentSize
         self.caretAtIndentLevel = \
             (self.caretLineIndentCol % self.indentSize) == 0
-        self.shouldBackspaceUntab = \
-            self.caretAtIndentLevel and \
-            0 < self.caretColumn <= self.caretLineIndentCol
+        # self.shouldBackspaceUntab = \
+        #     self.caretAtIndentLevel and \
+        #     0 < self.caretColumn <= self.caretLineIndentCol
 
     def commentLines(self):
         # used for the comment/uncomment machinery from ActiveGrid

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -583,6 +583,13 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
         # prevent flickering on update
         self.SetDoubleBuffered(True)
 
+    def updateSettings(self):
+        """Update editor settings after preference change."""
+        # show the long line edge guide, enabled if >0
+        self.edgeGuideColumn = self.coder.prefs['edgeGuideColumn']
+        self.edgeGuideVisible = self.edgeGuideColumn > 0
+        self.setFonts()
+
     def setFonts(self):
         """Make some styles,  The lexer defines what each style is used for,
         we just have to define what each style looks like.  This set is
@@ -2767,3 +2774,5 @@ class CoderFrame(wx.Frame):
     def setPavloviaUser(self, user):
         # TODO: update user icon on button to user avatar
         pass
+
+

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1977,6 +1977,7 @@ class CoderFrame(wx.Frame):
     def onIdle(self, event):
         # check the script outputs to see if anything has been written to
         # stdout
+        raise RuntimeError
         if self.scriptProcess is not None:
             if self.scriptProcess.IsInputAvailable():
                 stream = self.scriptProcess.GetInputStream()
@@ -2316,7 +2317,7 @@ class CoderFrame(wx.Frame):
 
             self.currentDoc.setLexerFromFileName()  # chose the best lexer
 
-            self.setFileModified(False)
+            self.setFileModified(True)
             self.currentDoc.SetFocus()
             self.statusBar.SetStatusText(self.currentDoc.getFileType(), 2)
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -45,6 +45,7 @@ from psychopy.app.coder.sourceTree import SourceTreePanel
 from psychopy.app.coder.styling import applyStyleSpec
 from psychopy.app.coder.folding import CodeEditorFoldingMixin
 from psychopy.app.icons import combineImageEmblem
+from psychopy.app.errorDlg import ErrorMsgDialog
 
 try:
     import jedi

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -742,6 +742,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin):
 
         # quote line
         elif keyCode == ord("'"):
+            raise RuntimeError
             start, end = self.GetSelection()
             if end - start > 0:
                 txt = self.GetSelectedText()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1977,7 +1977,6 @@ class CoderFrame(wx.Frame):
     def onIdle(self, event):
         # check the script outputs to see if anything has been written to
         # stdout
-        raise RuntimeError
         if self.scriptProcess is not None:
             if self.scriptProcess.IsInputAvailable():
                 stream = self.scriptProcess.GetInputStream()
@@ -2317,7 +2316,7 @@ class CoderFrame(wx.Frame):
 
             self.currentDoc.setLexerFromFileName()  # chose the best lexer
 
-            self.setFileModified(True)
+            self.setFileModified(False)
             self.currentDoc.SetFocus()
             self.statusBar.SetStatusText(self.currentDoc.getFileType(), 2)
 

--- a/psychopy/app/errorDlg.py
+++ b/psychopy/app/errorDlg.py
@@ -9,7 +9,6 @@
 app."""
 
 import wx
-import sys
 import traceback
 
 _error_dlg = None  # keep error dialogs from stacking

--- a/psychopy/app/errorDlg.py
+++ b/psychopy/app/errorDlg.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""Error dialog for showing unhandled exceptions that occur within the PsychoPy
+app."""
+
+import wx
+import traceback
+
+_error_dlg_visible = False  # keep error dialogs from stacking
+
+
+class ErrorMsgDialog(wx.Dialog):
+    """Class for creating an error report dialog"""
+    def __init__(self, parent, details=None):
+        wx.Dialog.__init__(self, parent, id=wx.ID_ANY, title=u"PsychoPy3 Error",
+                           pos=wx.DefaultPosition, size=wx.Size(735, 118),
+                           style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER)
+
+        self.details = details
+        self.SetSizeHints(wx.DefaultSize, wx.DefaultSize)
+
+        szErrorMsg = wx.BoxSizer(wx.VERTICAL)
+
+        szHeader = wx.FlexGridSizer(0, 3, 0, 0)
+        szHeader.AddGrowableCol(1)
+        szHeader.SetFlexibleDirection(wx.BOTH)
+        szHeader.SetNonFlexibleGrowMode(wx.FLEX_GROWMODE_SPECIFIED)
+
+        self.imgErrorIcon = wx.StaticBitmap(self, wx.ID_ANY, wx.ArtProvider.GetBitmap(wx.ART_ERROR, wx.ART_MESSAGE_BOX),
+                                            wx.DefaultPosition, wx.DefaultSize, 0)
+        szHeader.Add(self.imgErrorIcon, 0, wx.ALL, 5)
+
+        self.lblErrorMsg = wx.StaticText(self, wx.ID_ANY,
+                                         u"PsychoPy has encountered an unhandled internal error! Click \"Details\" to view the error report and please send it to the developers to help improve PsychoPy.",
+                                         wx.DefaultPosition, wx.DefaultSize, 0)
+        self.lblErrorMsg.Wrap(560)
+
+        szHeader.Add(self.lblErrorMsg, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        self.cmdOK = wx.Button(self, wx.ID_OK, u"&OK", wx.DefaultPosition, wx.DefaultSize, 0)
+        szHeader.Add(self.cmdOK, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        szErrorMsg.Add(szHeader, 0, wx.ALL | wx.EXPAND, 5)
+
+        self.pnlDetails = wx.CollapsiblePane(self, wx.ID_ANY, u"&Details", wx.DefaultPosition, wx.DefaultSize,
+                                             wx.CP_DEFAULT_STYLE)
+        self.pnlDetails.Collapse(True)
+
+        szDetailsPane = wx.BoxSizer(wx.VERTICAL)
+
+        self.txtErrorOutput = wx.TextCtrl(self.pnlDetails.GetPane(), wx.ID_ANY, self.details, wx.DefaultPosition,
+                                          wx.Size(640, 150),
+                                          wx.TE_AUTO_URL | wx.TE_BESTWRAP | wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP)
+
+        szDetailsPane.Add(self.txtErrorOutput, 1, wx.ALL | wx.EXPAND, 5)
+
+        szTextButtons = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.cmdCopyError = wx.Button(self.pnlDetails.GetPane(), wx.ID_ANY, u"&Copy", wx.DefaultPosition,
+                                      wx.DefaultSize, 0)
+        szTextButtons.Add(self.cmdCopyError, 0, wx.RIGHT, 5)
+
+        self.cmdSaveError = wx.Button(self.pnlDetails.GetPane(), wx.ID_ANY, u"&Save", wx.DefaultPosition,
+                                      wx.DefaultSize, 0)
+        szTextButtons.Add(self.cmdSaveError, 0)
+
+        szDetailsPane.Add(szTextButtons, 0, wx.ALL | wx.ALIGN_RIGHT, 5)
+
+        self.pnlDetails.GetPane().SetSizer(szDetailsPane)
+        self.pnlDetails.GetPane().Layout()
+        szDetailsPane.Fit(self.pnlDetails.GetPane())
+        szErrorMsg.Add(self.pnlDetails, 1, wx.ALL | wx.BOTTOM | wx.EXPAND, 5)
+
+        self.SetSizer(szErrorMsg)
+        self.Layout()
+        self.Fit()
+
+        self.Centre(wx.BOTH)
+
+        # Connect Events
+        self.cmdOK.Bind(wx.EVT_BUTTON, self.onOkay)
+        self.cmdCopyError.Bind(wx.EVT_BUTTON, self.onCopyDetails)
+        self.cmdSaveError.Bind(wx.EVT_BUTTON, self.onSaveDetails)
+
+        # ding!
+        wx.Bell()
+
+    def __del__(self):
+        pass
+
+    def onOkay(self, event):
+        event.Skip()
+
+    def onCopyDetails(self, event):
+        event.Skip()
+
+    def onSaveDetails(self, event):
+        event.Skip()
+
+
+def exceptionCallback(exc_type, exc_value, exc_traceback):
+    """Hook when an unhandled exception is raised within the current application
+    thread. Gets the exception message and creates and error dialog box.
+
+    """
+    global _error_dlg_visible
+    if not _error_dlg_visible:
+        _error_dlg_visible = True
+        # format the traceback text
+        tbText = ''.join(traceback.format_exception(
+            exc_type, exc_value, exc_traceback, limit=8))
+
+        # show the dialog
+        dlg = ErrorMsgDialog(None, details=tbText)
+        dlg.ShowModal()
+        dlg.Destroy()
+        _error_dlg_visible = False

--- a/psychopy/app/errorDlg.py
+++ b/psychopy/app/errorDlg.py
@@ -10,6 +10,8 @@ app."""
 
 import wx
 import traceback
+import psychopy.preferences
+import sys
 
 _error_dlg = None  # keep error dialogs from stacking
 
@@ -195,6 +197,12 @@ def exceptionCallback(exc_type, exc_value, exc_traceback):
     exceptions will result in a dialog being displayed.
 
     """
+    if psychopy.preferences.prefs.app['errorDialog'] is False:
+        # have the error go out to stdout if dialogs are disabled
+        traceback.print_exception(
+            exc_type, exc_value, exc_traceback, file=sys.stdout)
+        return
+
     global _error_dlg
     if not isErrorDialogVisible():
         # format the traceback text

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -779,7 +779,7 @@ class PreferencesDlg(wx.Dialog):
             # apply settings over document pages
             for ii in range(coder.notebook.GetPageCount()):
                 doc = coder.notebook.GetPage(ii)
-                doc.setFonts()
+                doc.updateSettings()
 
     def OnApplyClicked(self, event):
         """Apply button clicked, this makes changes to the UI without leaving

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -63,6 +63,8 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
+    # Show an error dialog when PsychoPy encounters an unhandled internal error.
+    errorDialog = boolean(default='True')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -63,6 +63,8 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
+    # Show an error dialog when PsychoPy encounters an unhandled internal error.
+    errorDialog = boolean(default='True')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -63,6 +63,8 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
+    # Show an error dialog when PsychoPy encounters an unhandled internal error.
+    errorDialog = boolean(default='True')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -63,7 +63,9 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
-    # Enable High-DPI awareness on Windows, requires restart. (EXPERIMENTAL)
+    # Show an error dialog when PsychoPy encounters an unhandled internal error.
+    errorDialog = boolean(default='True')
+    # Enable High-DPI awareness on Windows, requires restart. Note that this feature is currently experimental and may cause graphical artifacts in some places.
     highDPI = boolean(default='False')
 
 # Settings for the Coder window

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -59,6 +59,8 @@
     debugMode = boolean(default='False')
     # language to use in menus etc; not all translations are available. Select a value, then restart the app.
     locale = string(default='')
+    # Show an error dialog when PsychoPy encounters an unhandled internal error.
+    errorDialog = boolean(default='True')
 
 # Settings for the Coder window
 [coder]


### PR DESCRIPTION
Adds an error dialog box which comes up when an unhandled exception occurs in the GUI application thread, preventing them from going unnoticed until the user checks the output box. It's also a bit more polished than simply dumping errors to the output.

![errormsg](https://user-images.githubusercontent.com/5150568/76045161-58205300-5f2a-11ea-8860-2403b6e2d270.png)

Displays a message informing the user that an internal error occurred and presents the traceback. The dialog has buttons to copy or save the traceback making it easier for the user to get the necessary information for the developers to fix/diagnose the problem. The message also keeps errors from the GUI out of the output window, so subprocess errors are presented separately. At this point, GUI still outputs errors to stdout along with being caught by the dialog (that could be changed now). The user can press OK and continue using the application if the error is not fatal. Errors raised by subprocesses will not cause this box to come up.

We could potentially make this generate full error reports (with OS and version info) and send them via email or something. 