### PR TITLE
BF: fixed detection of component orphan files from Py3 installs

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -150,9 +150,14 @@ def getComponents(folder=None, fetchIcons=True):
         except ImportError:
             continue  # not a valid module (no __init__.py?)
         # check for orphaned pyc files (__file__ is not a .py file)
-        if hasattr(module, '__file__') and module.__file__.endswith('.pyc'):
-            if not os.path.isfile(module.__file__[:-1]):
-                continue  # looks like an orphaned pyc file
+        if hasattr(module, '__file__'):
+            if not module.__file__:
+                # with Py3, orphans have a __pycharm__ folder but no file
+                continue
+            elif module.__file__.endswith('.pyc'):
+                # with Py2, orphans have a xxxxx.pyc file
+                if not os.path.isfile(module.__file__[:-1]):
+                    continue  # looks like an orphaned pyc file
         # give a default category
         if not hasattr(module, 'categories'):
             module.categories = ['Custom']


### PR DESCRIPTION
This only really affects developers when going back to older versions of
PsychoPy (that don't have all the builder components of newer versions)

The Components folder can be left with orphaned .pyc files but the old
way to detect those doesn't work for Py3 orphans. In Py3 these appear in
a __pycache__ folder whereas in Py2 they were in the main folder next to
the .py files