### PR TITLE
BF: update fromFile to allow files from Python2 versoins to be loaded

### DIFF
--- a/psychopy/compatibility.py
+++ b/psychopy/compatibility.py
@@ -88,9 +88,10 @@ def fromFile(filename):
             # Try to load the psydat file into the new-style class.
             contents = pickle.load(f)
         except UnicodeDecodeError:
+            f.seek(0)  # reset to start of file to try again
             contents = pickle.load(f, encoding='latin1')  # python 2 data files
         except TypeError as e:
-            f.seek(0)
+            f.seek(0)  # reset to start of file to try again
             # check er as string for one of our handlers
             errStr = "{}".format(e)
             name = ''

--- a/psychopy/compatibility.py
+++ b/psychopy/compatibility.py
@@ -87,6 +87,8 @@ def fromFile(filename):
         try:
             # Try to load the psydat file into the new-style class.
             contents = pickle.load(f)
+        except UnicodeDecodeError:
+            contents = pickle.load(f, encoding='latin1')  # python 2 data files
         except TypeError as e:
             f.seek(0)
             # check er as string for one of our handlers

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -52,6 +52,10 @@ def fromFile(filename, encoding='utf-8-sig'):
     filename = pathToString(filename)
     if filename.endswith('.psydat'):
         with open(filename, 'rb') as f:
+            try:
+                contents = pickle.load(f)
+            except UnicodeDecodeError:
+                contents = pickle.load(f, encoding='latin1')  # python 2 data files
             contents = pickle.load(f)
             # if loading an experiment file make sure we don't save further
             # copies using __del__

--- a/psychopy/tools/filetools.py
+++ b/psychopy/tools/filetools.py
@@ -55,8 +55,8 @@ def fromFile(filename, encoding='utf-8-sig'):
             try:
                 contents = pickle.load(f)
             except UnicodeDecodeError:
+                f.seek(0)  # reset to start of file to try again
                 contents = pickle.load(f, encoding='latin1')  # python 2 data files
-            contents = pickle.load(f)
             # if loading an experiment file make sure we don't save further
             # copies using __del__
             if hasattr(contents, 'abort'):


### PR DESCRIPTION
As reported on discourse:
https://discourse.psychopy.org/t/making-the-fromfile-function-compatible-with-psydat-files-obtained-with-python-2-easy-fix/13785

Thanks to @mservantufc for working out the fix