### PR TITLE
BF: Fix import time race condition in monitors/calibTools.py

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -25,6 +25,7 @@ try:
     haveSerial = True
 except Exception:
     haveSerial = False
+import errno
 import os
 import time
 import glob
@@ -63,8 +64,11 @@ else:
 if isinstance(monitorFolder, bytes):
     monitorFolder = monitorFolder.decode(sys.getfilesystemencoding())
 
-if not os.path.isdir(monitorFolder):
+try:
     os.makedirs(monitorFolder)
+except OSError as err:
+    if err.errno != errno.EEXIST:
+        raise
 
 
 class Monitor(object):


### PR DESCRIPTION
Currently the module tries to create the monitors directory if it's missing.
The issue with this is that there is a race condition in how it is implemented:
- The directory could be created between the `os.path.exists` and `os.makedirs` calls.

This change modifies this to use a ask-for-forgiveness approach:
- Try to create the directories, but ignore any "file/directory already exists" errors.

`errno` should work cross-platform, so this will not break multi-platform support.

