### PR TITLE
BF: Fix PermissionError on windows in Preferences.getPaths

### DIFF
--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -138,11 +138,12 @@ class Preferences(object):
                 tmp = os.path.join(self.paths['userPrefsDir'], '.tmp')
                 with open(tmp, 'w') as fileh:
                     fileh.write('')
-                open(tmp).read()
+                with open(tmp) as fileh:
+                    fileh.read()
                 os.remove(tmp)
-            except Exception:  # OSError, WindowsError, ...?
-                msg = 'PsychoPy3 error: need read-write permissions for `%s`'
-                sys.exit(msg % self.paths['userPrefsDir'])
+            except Exception as err:  # OSError, WindowsError, ...?
+                msg = 'PsychoPy3 error: need read-write permissions for `%s` - `%s`'
+                sys.exit(msg % (self.paths['userPrefsDir'], err))
 
     def loadAll(self):
         """Load the user prefs and the application data


### PR DESCRIPTION
Currently the user prefs directory is tested for permissions, however they way this is done causes a `PermissionError` on windows:
```
>>> import os
>>> open("test", "r")
<_io.TextIOWrapper name='test' mode='r' encoding='cp1252'>
>>> os.remove("test")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'test'
>>>
```

This change fixes this by opening the file within a context, so the file handle is closed appropriately.
```
>>> import os
>>> with open("test2", "r") as fh:
...     fh.read()
...
''
>>> os.remove("test2")
>>>
```

Debugging this within a build system that uses prebuilt wheels is cumbersome because the code hides the underlying error.
This change updates the code to append the underlying error message to the exit message.