### PR TITLE
BF: Fix for PY2 counting screens for Qt4 distribution #2879

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -126,7 +126,10 @@ class Dlg(QtWidgets.QDialog):
                                  "style kwarg.")
         self.size = size
 
-        nScreens = len(qtapp.screens())
+        if haveQt == 'PyQt5':
+            nScreens = len(qtapp.screens())
+        else:
+            nScreens = QtWidgets.QDesktopWidget().screenCount()
         self.screen = -1 if screen >= nScreens else screen
         # self.labelButtonOK = labelButtonOK
         # self.labelButtonCancel = labelButtonCancel


### PR DESCRIPTION
PsychoPy3_PY2 uses Qt4 which can run into errors when trying to count the number of screens (as seen in #2879) as code assumes Qt5 - this checks if using Qt5 or another version, and if not Qt5, applies the older QtWidgets.QtDesktopWidget().screenCount() method to return int for number of screens. 