### PR TITLE
BF: alignment broken on component params on windows

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -761,7 +761,7 @@ class _BaseParamsDlg(wx.Dialog):
             ctrls.valueCtrl.Bind(wx.EVT_KEY_UP, self.doValidate)
 
         # add the controls to the sizer
-        _flag = wx.ALIGN_RIGHT | wx.LEFT | wx.RIGHT
+        _flag = wx.ALIGN_RIGHT | wx.LEFT | wx.RIGHT | wx.ALIGN_CENTER_VERTICAL
         sizer.Add(ctrls.nameCtrl, (currRow, 0), border=5, flag=_flag)
         if ctrls.updateCtrl:
             sizer.Add(ctrls.updateCtrl, (currRow, 2), flag=_flag)


### PR DESCRIPTION
The params in the Component Dialog boxes were not well-aligned
vertically on windows (fine on Mac). It seems the controls have
different defaults on this platform so we need explicit alignment flags