### PR TITLE
FF: Copy when there is a selection for System Info

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -819,7 +819,6 @@ class PreferencesDlg(wx.Dialog):
                 doc = coder.shelf.GetPage(ii)
                 doc.theme = prefs.app['theme']
 
-
     def OnApplyClicked(self, event):
         """Apply button clicked, this makes changes to the UI without leaving
         the preference dialog. This can be used to see the effects of setting

--- a/psychopy/app/sysInfoDlg.py
+++ b/psychopy/app/sysInfoDlg.py
@@ -194,9 +194,16 @@ class SystemInfoDialog(wx.Dialog):
 
     def OnCopy(self, event):
         """Copy system information to clipboard."""
+
+        # check if we have a selection
+        start, end = self.txtSystemInfo.GetSelection()
+        if start != end:
+            txt = self.txtSystemInfo.GetStringSelection()
+        else:
+            txt = self.txtSystemInfo.GetValue()
+
         if wx.TheClipboard.Open():
-            wx.TheClipboard.SetData(
-                wx.TextDataObject(self.txtSystemInfo.GetValue()))
+            wx.TheClipboard.SetData(wx.TextDataObject(txt))
             wx.TheClipboard.Close()
 
         event.Skip()


### PR DESCRIPTION
Makes copy behavior consistent with the System Info dialog.