### PR TITLE
BF: Remove json from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,6 @@ install_requires =
     astunparse
     esprima
     freetype-py
-    json
     jedi
     # Platform-specific dependencies.
     javascripthon; python_version >= "3.5"


### PR DESCRIPTION
`json` is a built-in Python library, so it causes this error on attempting installation:
    ERROR: Could not find a version that satisfies the requirement json (from PsychoPy==2020.1.3) (from versions: none)
    ERROR: No matching distribution found for json (from PsychoPy==2020.1.3)