### PR TITLE
ENH: Allow Brush to draw without holding down the mouse button

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -276,6 +276,9 @@ def getInitVals(params, target="PsychoPy"):
         elif name == 'marker_value':
             inits[name].val = 'Value'
             inits[name].valType = 'str'
+        elif name == 'buttonRequired':
+            inits[name].val = "True"
+            inits[name].valType = 'code'
         else:
             print("I don't know the appropriate default value for a '%s' "
                   "parameter. Please email the mailing list about this error" %

--- a/psychopy/experiment/components/brush/__init__.py
+++ b/psychopy/experiment/components/brush/__init__.py
@@ -22,6 +22,7 @@ _localized = {'lineColorSpace': _translate('Line color-space'),
               'lineColor': _translate('Line color'),
               'lineWidth': _translate('Line width'),
               'opacity': _translate('Opacity'),
+              'buttonRequired':_translate('Press button')
               }
 
 class BrushComponent(BaseVisualComponent):
@@ -32,6 +33,7 @@ class BrushComponent(BaseVisualComponent):
     def __init__(self, exp, parentName, name='brush',
                  lineColor='$[1,1,1]', lineColorSpace='rgb',
                  lineWidth=1.5, opacity=1,
+                 buttonRequired=True,
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim=''):
@@ -45,7 +47,7 @@ class BrushComponent(BaseVisualComponent):
         self.url = "http://www.psychopy.org/builder/components/brush.html"
         self.exp.requirePsychopyLibs(['visual'])
         self.targets = ['PsychoPy', 'PsychoJS']
-        self.order = ['lineWidth', 'opacity']
+        self.order = ['lineWidth', 'opacity', 'buttonRequired']
 
         del self.params['color']  # because color is defined by lineColor
         del self.params['colorSpace']
@@ -83,12 +85,19 @@ class BrushComponent(BaseVisualComponent):
 
         msg = _translate("The line opacity")
         self.params['opacity'] = Param(
-            opacity, valType='str',
-            allowedVals=[],
+            opacity, valType='code', allowedTypes=[],
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
             label=_localized['opacity'])
+
+        msg = _translate("Whether a button needs to be pressed to draw (True/False)")
+        self.params['buttonRequired'] = Param(
+            buttonRequired, valType='code', allowedTypes=[],
+            updates='constant',
+            allowedUpdates=['constant', 'set every repeat'],
+            hint=msg,
+            label=_localized['buttonRequired'], categ='Advanced')
 
     def writeInitCode(self, buff):
         params = getInitVals(self.params)
@@ -96,11 +105,13 @@ class BrushComponent(BaseVisualComponent):
                 "   lineWidth={lineWidth},\n"
                 "   lineColor={lineColor},\n"
                 "   lineColorSpace={lineColorSpace},\n"
-                "   opacity={opacity})").format(name=params['name'],
+                "   opacity={opacity},\n"
+                "   buttonRequired={buttonRequired})").format(name=params['name'],
                                                 lineWidth=params['lineWidth'],
                                                 lineColor=params['lineColor'],
                                                 lineColorSpace=params['lineColorSpace'],
-                                                opacity=params['opacity'])
+                                                opacity=params['opacity'],
+                                                buttonRequired=params['buttonRequired'])
         buff.writeIndentedLines(code)
 
     def writeInitCodeJS(self, buff):

--- a/psychopy/visual/brush.py
+++ b/psychopy/visual/brush.py
@@ -28,6 +28,7 @@ class Brush(MinimalStim):
                  lineColorSpace='rgb',
                  opacity=1.0,
                  closeShape=False,
+                 buttonRequired=True,
                  name=None,
                  depth=0,
                  autoLog=True,
@@ -45,6 +46,7 @@ class Brush(MinimalStim):
         self.lineWidth = lineWidth
         self.opacity = opacity
         self.closeShape = closeShape
+        self.buttonRequired = buttonRequired
         self.pointer = event.Mouse(win=self.win)
         self.shapes = []
         self.brushPos = []
@@ -102,9 +104,12 @@ class Brush(MinimalStim):
         Returns
         -------
         Bool
-            True if left mouse button is pressed, False otherwise.
+            True if left mouse button is pressed or if no button press is required, otherwise False.
         """
-        return self.pointer.getPressed()[0] == 1
+        if self.buttonRequired:
+            return self.pointer.getPressed()[0] == 1
+        else:
+            return True
 
     def onBrushDown(self):
         """
@@ -177,3 +182,14 @@ class Brush(MinimalStim):
             Opacity range(0, 1)
         """
         self.opacity = value
+
+    def setButtonRequired(self, value):
+        """
+        Sets whether or not a button press is needed to draw the line..
+
+        Parameters
+        ----------
+        value
+            Button press required (True or False).
+        """
+        self.buttonRequired = value


### PR DESCRIPTION
Currently to draw with the Brush stimulus requires holding down the mouse button. Allowing drawing without a button press can be useful, and may be easier with trackpads, touch interfaces, and so on.
Also exposed this functionality via the Builder component UI.
***NB this has been implemented only for PsychoPy.*** Equivalent changes would need to be made for PsychoJS. Any volunteers?

Made in response to this forum topic:
https://discourse.psychopy.org/t/creating-a-mouse-trail-for-trail-tracing/15138