### PR TITLE
FF: Remove offset when searching text.

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1039,9 +1039,6 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
                 start = 0
                 loc = textstring.find(findstring, start)
 
-        # Adjust for offset
-        loc += 2
-
         # was it still not found?
         if loc == -1:
             dlg = dialogs.MessageDialog(self, message=_translate(


### PR DESCRIPTION
Remove the offset applied when searching for text in a Coder editor window. Must have been needed before, but now it's not.