### PR TITLE
DOC: Clarify differences between reset() for CountdownTimer vs. Clock

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -207,6 +207,10 @@ class CountdownTimer(Clock):
         return self._timeAtLastReset - getTime()
 
     def reset(self, t=None):
+        """Reset the time on the clock. With no args, time will be set to the
+        time used for last reset (or start time if no previous resets). If a 
+        float is received, this will be the new time on the clock.
+        """
         if t is None:
             Clock.reset(self, self._countdown_duration)
         else:


### PR DESCRIPTION
Proposing a docstring for `CountdownTimer.reset()`. Previously, at least on the API docs on the web, it was inheriting the description of the reset method for Clock, which works differently. (In particular, it's not the case that "With no args time will be set to zero.")