### PR TITLE
BF: don't call _createFontInfo() if font doesn't have family name

### DIFF
--- a/psychopy/visual/textbox2/fontmanager.py
+++ b/psychopy/visual/textbox2/fontmanager.py
@@ -742,6 +742,10 @@ class FontManager(object):
                 logging.warning("Font Manager failed to load file {}"
                                 .format(fontPath))
                 return
+            if face.family_name is None:
+                logging.warning("{} doesn't have valid font family name"
+                                .format(fontPath))
+                return
             if monospaceOnly:
                 if face.is_fixed_width:
                     fi_list.add(self._createFontInfo(fontPath, face))


### PR DESCRIPTION
Fix "Can't start PsychoPy if fonts don't have family name" #3084