### PR TITLE
BF: handle multiple mouse objects in one Routine in JS

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -417,32 +417,32 @@ class MouseComponent(BaseComponent):
         # write param checking code
         if (self.params['saveMouseState'].val == 'on click'
                 or forceEnd in ['any click', 'valid click']):
-            code = ("let buttons = %(name)s.getPressed();\n")
+            code = ("_mouseButtons = %(name)s.getPressed();\n")
             buff.writeIndentedLines(code % self.params)
             # buff.setIndentLevel(1, relative=True)
             # dedentAtEnd += 1
-            code = "if (!buttons.every( (e,i,) => (e == prevButtonState[i]) )) { // button state changed?\n"
+            code = "if (!_mouseButtons.every( (e,i,) => (e == prevButtonState[i]) )) { // button state changed?\n"
             buff.writeIndented(code)
             buff.setIndentLevel(1, relative=True)
             dedentAtEnd += 1
             buff.writeIndented("prevButtonState = buttons;\n")
-            code = ("if (buttons.reduce( (e, acc) => (e+acc) ) > 0) { // state changed to a new click\n")
+            code = ("if (_mouseButtons.reduce( (e, acc) => (e+acc) ) > 0) { // state changed to a new click\n")
             buff.writeIndentedLines(code % self.params)
             buff.setIndentLevel(1, relative=True)
             dedentAtEnd += 1
 
         elif self.params['saveMouseState'].val == 'every frame':
-            code = "let buttons = %(name)s.getPressed();\n" % self.params
+            code = "_mouseButtons = %(name)s.getPressed();\n" % self.params
             buff.writeIndented(code)
 
         # only do this if buttons were pressed
         if self.params['saveMouseState'].val in ['on click', 'every frame']:
-            code = ("const xys = %(name)s.getPos();\n"
-                    "%(name)s.x.push(xys[0]);\n"
-                    "%(name)s.y.push(xys[1]);\n"
-                    "%(name)s.leftButton.push(buttons[0]);\n"
-                    "%(name)s.midButton.push(buttons[1]);\n"
-                    "%(name)s.rightButton.push(buttons[2]);\n" %
+            code = ("_mouseXYs = %(name)s.getPos();\n"
+                    "%(name)s.x.push(_mouseXYs[0]);\n"
+                    "%(name)s.y.push(_mouseXYs[1]);\n"
+                    "%(name)s.leftButton.push(_mouseButtons[0]);\n"
+                    "%(name)s.midButton.push(_mouseButtons[1]);\n"
+                    "%(name)s.rightButton.push(_mouseButtons[2]);\n" %
                     self.params)
             code += ("%s.time.push(%s.getTime());\n" % (self.params['name'], self.clockStr))
             buff.writeIndentedLines(code)


### PR DESCRIPTION
Previously we were defining the `xys` and `buttons` with local scope.

Instead remove that local definition (const/let) and the script compiler
will then automatically give it global scope (var at the top of the script)

To avoid likely clashes we've given more obscure names:
- `_buttonXYs`
- `_mouseButtons`

fixes psychopy/psychojs-88