### PR TITLE
WIP: Dynamic loading of plugins

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -5,6 +5,81 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2020 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
+"""Module for the PsychoPy GUI application."""
+
 from __future__ import absolute_import, print_function
 
+__all__ = ['startApp', 'getApp', 'getAppFrame']
+
+from psychopy.app._psychopyApp import PsychoPyApp
 from .frametracker import openFrames
+
+# Handle to the PsychoPy GUI application instance. We need to have this mainly
+# to allow the plugin system to access GUI to allow for changes after startup.
+_psychopyApp = None
+
+
+def startApp(safeMode=False, showSplash=True):
+    """Start the PsychoPy GUI. This can be called only once per session.
+    Additional calls after the app starts will have no effect.
+
+    After calling this function, you can get the handle to the created app's
+    `PsychoPyApp` instance by calling :func:`getApp`.
+
+    Parameters
+    ----------
+    safeMode : bool
+        Start PsychoPy in safe-mode. If `True`, the GUI application will launch
+        with without plugins and will use a default a configuration (planned
+        feature, not implemented yet).
+    showSplash : bool
+        Show the splash screen on start.
+
+    """
+    global _psychopyApp
+    if _psychopyApp is None:
+        _psychopyApp = PsychoPyApp(0, showSplash=showSplash)
+        _psychopyApp.MainLoop()
+
+
+def getApp():
+    """Get a reference to the `PsychoPyApp` object. This function will return
+    `None` if PsychoPy has been imported as a library or the app has not been
+    fully realized.
+
+    Returns
+    -------
+    PsychoPyApp or None
+        Handle to the application instance. Returns `None` if the app has not
+        been started yet or the PsychoPy is being used without a GUI.
+
+    """
+    return _psychopyApp  # use a function here to protect the reference
+
+
+def getAppFrame(frameName):
+    """Get the reference to one of PsychoPy's application frames. Returns `None`
+    if the coder frame has not been realized or PsychoPy is not in GUI mode.
+
+    Parameters
+    ----------
+    frameName : str
+        Identifier for the frame to get a reference to. Valid names are
+        'coder', 'builder' or 'runner'.
+
+    Returns
+    -------
+    object or None
+        Reference to the frame (i.e. `CoderFrame`, `BuilderFrame` or
+        `RunnerFrame`). `None` is returned if the frame has not been created or
+        the app is not running.
+
+    """
+    if _psychopyApp is None:  # PsychoPy is not in GUI mode
+        return False
+
+    if frameName not in ('builder', 'coder', 'runner'):
+        raise ValueError('Invalid identifier specified as `frameName`.')
+
+    return getattr(_psychopyApp, frameName, None)
+

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -400,7 +400,7 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         # wx-windows on some platforms (Mac 10.9.4) with wx-3.0:
         v = parse_version
         if sys.platform == 'darwin':
-            if v('3.0') <= v(wx.version()) <v('4.0'):
+            if v('3.0') <= v(wx.version()) < v('4.0'):
                 _Showgui_Hack()  # returns ~immediately, no display
                 # focus stays in never-land, so bring back to the app:
                 if prefs.app['defaultView'] in ['all', 'builder', 'coder', 'runner']:
@@ -422,6 +422,10 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         if self.runner and not self.testMode:
             sys.stdout = self.runner.stdOut
             sys.stderr = self.runner.stdOut
+
+        # load startup plugins (doesn't do anything yet)
+        # if splash:
+        #     splash.SetText(_translate("  Loading plugins..."))
 
         return True
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -172,19 +172,24 @@ class BuilderFrame(wx.Frame, ThemeMixin):
         self.updateReadme()
 
         # control the panes using aui manager
-        self._mgr = aui.AuiManager(self)
+        self._mgr = aui.AuiManager(
+            self,
+            aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT)
+
         #self._mgr.SetArtProvider(PsychopyDockArt())
         #self._art = self._mgr.GetArtProvider()
         # Create panels
         self._mgr.AddPane(self.routinePanel,
                           aui.AuiPaneInfo().
                           Name("Routines").Caption("Routines").CaptionVisible(True).
+                          Floatable(False).
                           CloseButton(False).MaximizeButton(True).PaneBorder(False).
                           Center())  # 'center panes' expand
         rtPane = self._mgr.GetPane('Routines')
         self._mgr.AddPane(self.componentButtons,
                           aui.AuiPaneInfo().
                           Name("Components").Caption("Components").CaptionVisible(True).
+                          Floatable(False).
                           RightDockable(True).LeftDockable(True).
                           CloseButton(False).PaneBorder(False))
         compPane = self._mgr.GetPane('Components')
@@ -192,6 +197,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
                           aui.AuiPaneInfo().
                           Name("Flow").Caption("Flow").CaptionVisible(True).
                           BestSize((8 * self.dpi, 2 * self.dpi)).
+                          Floatable(False).
                           RightDockable(True).LeftDockable(True).
                           CloseButton(False).PaneBorder(False))
         flowPane = self._mgr.GetPane('Flow')

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2019,50 +2019,8 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
                                              style=wx.BORDER_NONE)
         self._maxBtnWidth = 0  # will store width of widest button
         self.sizer = wx.BoxSizer(wx.VERTICAL)
-        self.componentButtons = []
-        self.components = experiment.getAllComponents(
-            self.app.prefs.builder['componentsFolders'])
-        categories = ['Favorites']
-        categories.extend(components.getAllCategories(
-            self.app.prefs.builder['componentsFolders']))
-        # get rid of hidden components
-        for hiddenComp in self.frame.prefs['hiddenComponents']:
-            if hiddenComp in self.components:
-                del self.components[hiddenComp]
-        # also remove settings - that's in toolbar not components panel
-        del self.components['SettingsComponent']
-        # get favorites
-        self.favorites = FavoriteComponents(componentsPanel=self)
-        # create labels and sizers for each category
-        self.componentFromID = {}
-        self.panels = {}
-        # to keep track of the objects (sections and section labels)
-        # within the main sizer
-        self.sizerList = []
 
-        for categ in categories:
-            if categ in _localized:
-                label = _localized[categ]
-            else:
-                label = categ
-            _style = platebtn.PB_STYLE_DROPARROW | platebtn.PB_STYLE_SQUARE
-            sectionBtn = PsychopyPlateBtn(self, -1, label, style=_style, name=categ)
-            # Link to onclick functions
-            sectionBtn.Bind(wx.EVT_LEFT_DOWN, self.onSectionBtn)
-            sectionBtn.Bind(wx.EVT_RIGHT_DOWN, self.onSectionBtn)
-            # Set button background and link to onhover functions
-            #sectionBtn.Bind(wx.EVT_ENTER_WINDOW, self.onHover)
-            #sectionBtn.Bind(wx.EVT_LEAVE_WINDOW, self.offHover)
-            self.panels[categ] = wx.FlexGridSizer(cols=1)
-            self.sizer.Add(sectionBtn, flag=wx.EXPAND)
-            self.sizerList.append(sectionBtn)
-            self.sizer.Add(self.panels[categ], flag=wx.ALIGN_CENTER)
-            self.sizerList.append(self.panels[categ])
-        maxWidth = self.makeComponentButtons()
-        self._rightClicked = None
-        # start all except for Favorites collapsed
-        for section in categories[1:]:
-            self.toggleSection(self.panels[section])
+        self.buildComponentsList()  # build the icon tray
 
         self.Bind(wx.EVT_SIZE, self.on_resize)
         self.SetSizer(self.sizer)
@@ -2310,6 +2268,84 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         btn = evt.GetEventObject()
         btn.SetBackgroundColour(cs['panel_bg'])
         btn.SetForegroundColour(cs['text'])
+
+    def buildComponentsList(self, evt=None):
+        """Build the component buttons.
+
+        This function handles creating the icon tray at when the applications
+        starts. This function can be called to refresh the list if plugins
+        registering Builder components have been loaded after `loadPlugin` was
+        called.
+
+        Parameters
+        ----------
+        evt : wxEvent
+            Optional event object. This is needed if this method is bound to a
+            GUI event.
+
+        """
+        # clear the windows in the sizer
+        if self.sizer.Children:
+            self.sizer.Clear(True)
+
+        # get the components currently installed
+        self.componentButtons = []
+        self.components = experiment.getAllComponents(
+            self.app.prefs.builder['componentsFolders'])
+        categories = ['Favorites']
+        categories.extend(components.getAllCategories(
+            self.app.prefs.builder['componentsFolders']))
+
+        # get rid of hidden components
+        for hiddenComp in self.frame.prefs['hiddenComponents']:
+            if hiddenComp in self.components:
+                del self.components[hiddenComp]
+
+        # also remove settings - that's in toolbar not components panel
+        del self.components['SettingsComponent']
+
+        # get favorites
+        self.favorites = FavoriteComponents(componentsPanel=self)
+
+        # create labels and sizers for each category
+        self.componentFromID = {}
+        self.panels = {}
+
+        # to keep track of the objects (sections and section labels)
+        # within the main sizer
+        self.sizerList = []
+
+        for categ in categories:
+            if categ in _localized:
+                label = _localized[categ]
+            else:
+                label = categ
+            _style = platebtn.PB_STYLE_DROPARROW | platebtn.PB_STYLE_SQUARE
+            sectionBtn = PsychopyPlateBtn(
+                self, -1, label, style=_style, name=categ)
+
+            # Link to onclick functions
+            sectionBtn.Bind(wx.EVT_LEFT_DOWN, self.onSectionBtn)
+            sectionBtn.Bind(wx.EVT_RIGHT_DOWN, self.onSectionBtn)
+
+            # Set button background and link to onhover functions
+            #sectionBtn.Bind(wx.EVT_ENTER_WINDOW, self.onHover)
+            #sectionBtn.Bind(wx.EVT_LEAVE_WINDOW, self.offHover)
+            self.panels[categ] = wx.FlexGridSizer(cols=1)
+            self.sizer.Add(sectionBtn, flag=wx.EXPAND)
+            self.sizerList.append(sectionBtn)
+            self.sizer.Add(self.panels[categ], flag=wx.ALIGN_CENTER)
+            self.sizerList.append(self.panels[categ])
+
+        maxWidth = self.makeComponentButtons()
+        self._rightClicked = None
+
+        # start all except for Favorites collapsed
+        for section in categories[1:]:
+            self.toggleSection(self.panels[section])
+
+        if evt is not None:
+            evt.Skip()
 
 
 class FavoriteComponents(object):

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2272,10 +2272,10 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
     def buildComponentsList(self, evt=None):
         """Build the component buttons.
 
-        This function handles creating the icon tray at when the applications
+        This function handles creating the icon tray when the applications
         starts. This function can be called to refresh the list if plugins
-        registering Builder components have been loaded after `loadPlugin` was
-        called.
+        registering Builder components have been registered if `loadPlugin`
+        was called while the app is running.
 
         Parameters
         ----------
@@ -2315,6 +2315,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         # within the main sizer
         self.sizerList = []
 
+        # add sub-windows to sizer
         for categ in categories:
             if categ in _localized:
                 label = _localized[categ]
@@ -2328,7 +2329,7 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
             sectionBtn.Bind(wx.EVT_LEFT_DOWN, self.onSectionBtn)
             sectionBtn.Bind(wx.EVT_RIGHT_DOWN, self.onSectionBtn)
 
-            # Set button background and link to onhover functions
+            # Set button background and link to onHover functions
             #sectionBtn.Bind(wx.EVT_ENTER_WINDOW, self.onHover)
             #sectionBtn.Bind(wx.EVT_LEAVE_WINDOW, self.offHover)
             self.panels[categ] = wx.FlexGridSizer(cols=1)

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1069,9 +1069,6 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
                 start = 0
                 loc = textstring.find(findstring, start)
 
-        # Adjust for offset
-        loc += 2
-
         # was it still not found?
         if loc == -1:
             dlg = dialogs.MessageDialog(self, message=_translate(

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, print_function
 
 import sys
+import psychopy.app
 
 # fix macOS locale-bug on startup: sets locale to LC_ALL (must be defined!)
 import psychopy.locale_setup  # noqa
@@ -25,8 +26,9 @@ def start_app():
     if '--no-splash' in sys.argv:
         showSplash = False
         del sys.argv[sys.argv.index('--no-splash')]
-    app = PsychoPyApp(0, showSplash=showSplash)
-    app.MainLoop()
+
+    # register the handle within the PsychoPy app module
+    psychopy.app.startApp(False, showSplash)
 
 
 def main():

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -21,6 +21,7 @@ import pkg_resources
 from psychopy import logging
 from psychopy.preferences import prefs
 import psychopy.experiment.components as components
+import psychopy.app as app
 
 # Keep track of plugins that have been loaded. Keys are plugin names and values
 # are their entry point mappings.
@@ -925,7 +926,7 @@ def _registerWindowBackend(attr, ep):
     backend.winTypes.update(foundBackends)  # update installed backends
 
 
-def _registerBuilderComponent(ep):
+def _registerBuilderComponent(ep, updatePanel=True):
     """Register a PsychoPy builder component module.
 
     This function is called by :func:`loadPlugin` when encountering an entry
@@ -944,8 +945,13 @@ def _registerBuilderComponent(ep):
 
     Parameters
     ----------
-    module : ModuleType
+    ep : ModuleType
         Module containing the builder component to register.
+    updatePanel : bool
+        Update Builder's component icon tray after registering the component.
+        This can be disabled to prevent the tray from updating when loading a
+        series of plugins to avoid unneeded updates to the GUI. The panel can be
+        updated after the last plugin is loaded.
 
     """
     if not inspect.ismodule(ep):  # not a module
@@ -982,3 +988,12 @@ def _registerBuilderComponent(ep):
         # assign the module categories to the Component
         if not hasattr(components.pluginComponents[attrib], 'categories'):
             components.pluginComponents[attrib].categories = ['Custom']
+
+    # update the components panel after loading
+    if updatePanel:
+        # Only bother doing this when Builder has been loaded, since it will be
+        # done automatically when next time its created.
+        builder = app.getAppFrame('builder')
+        if builder is not None:
+            builder.componentButtons.buildComponentsList()
+


### PR DESCRIPTION
This PR allows for plugins containing components to be loaded after startup. This removes the need for builder only plugins to be loaded when running scripts or sub-processes. Also no longer having start up plugins being loaded when using PsychoPy as a library.

Changes also adds the ability for plugins to gain access to the PsychoPy GUI, allowing for them to add menu items and such after the GUI has been realized, but also access objects in the workspace. This is handy for "helper" plugins to that do some sort of automation. For instance, a plugin can add a tool to the menu which generates a complex routine when clicked. It can even show a custom dialog defined in the plugin itself.

Still working through the issues around the plugin dialog, it hasn't been updated to deal with runtime loading yet. 