### PR TITLE
experiment/settings/JS_htmlHeader: link to pixi latest (5.3.3)

### DIFF
--- a/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
+++ b/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
@@ -18,7 +18,7 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/seedrandom/3.0.1/seedrandom.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/4.8.7/pixi.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/5.3.3/pixi.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/PreloadJS/1.0.1/preloadjs.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.14.2/xlsx.full.min.js"></script>


### PR DESCRIPTION
@peircej @apitiot Tweak script tag for linking to the latest version of PixiJS as required to address psychopy/psychojs#168. Closes #3144, but would need to be pulled in together with psychopy/psychojs#181 if at all possible to avoid any accidents  :blush: