### PR TITLE
BF: macOS Standalone crashing with autocomplete turned on

### DIFF
--- a/setupApp.py
+++ b/setupApp.py
@@ -104,7 +104,7 @@ packages = ['wx', 'psychopy',
             'badapted', 'darc_toolbox',  # adaptive methods from Ben Vincent
             'questplus',
             'metapensiero.pj', 'dukpy', 'macropy',
-            'jedi',
+            'jedi','parso',
             'psychtoolbox',
             'freetype', 'h5py',
             ]


### PR DESCRIPTION
setupAppp needs to package parso outside the site-packages.zip

fixes #3170