### PR TITLE
Warn user when reusing global symbols as variables

### DIFF
--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -238,6 +238,16 @@ class CodeSnippetValidator(BaseValidator):
                             msg = msg.format(name, self.displayName)
                             OK = True
 
+                    for newName in names:
+                        namespace = parent.frame.exp.namespace
+                        if newName in namespace.user or newName in namespace.builder:
+                            continue
+                        used = namespace.exists(newName)
+                        sameAsOldName = bool(newName == parent.params['name'].val)
+                        if used and not sameAsOldName:
+                            msg = _translate("Variable name $%s is in use (by %s). Try another name.") % (newName, _translate(used))
+                            # let the user continue if this is what they intended
+                            OK = True
 
         parent.warningsDict[field] = msg
         return msg, OK


### PR DESCRIPTION
Hi,

I've been debugging a PsychoPy experiment which failed running on PsychoJS (on Pavlovia), here's what went wrong:

1. The experiment contained a Sound item whose sound value was set to `$sound`, which corresponded to a variable set in an xlsx column "sound". However, the sound value was left as 'constant' instead of 'set every repeat'.
2. This results in an initialization statement being generated at the beginning of the experiment, which looks like that:

```
sound_1 = sound.Sound(sound, secs=1.0, stereo=True, hamming=True,
    name='sound_1')
```

Later during the actual trial, the correct sound file is loaded like so:
```
sound_1.setSound(sound, hamming=False)
```

3. In the first snippet above, `sound` is a reference to the PsychoPy sound module, while in the second snippet it is a local variable. PsychoPy doesn't really mind during initialization, and the experiment works as expected (the sound is used only once, so it doesn't matter that it's set to constant)

4. When exporting to PsychoJS, we get the following initialization statement:

```
  sound_1 = new sound.Sound({
    win: psychoJS.window,
    value: sound,
    secs: 1.0,
    });
```

When `Sound` is constructed, it calls `TonePlayer.accept()` which in turn calls `$.isNumeric(sound.value)`, where an exception is thrown becaue `sound.value` is a module and doesn't have a `toString()` function.

5. The end result is that the experiment fails to start due to an "Unspecified JavaScript error" with no relevant information in the browser console.


In the pull request I copied a relevant snippet from the `NameValidator` class. I'm not sure if that's the right way to warn against this kind of name collision. I'd be happy to rework this with some feedback from the PsychoPy team.