### PR TITLE
Add high DPI support for visual stimuli.

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -141,6 +141,7 @@ _localized = {
     'audioDevice': _translate("audio device"),
     'parallelPorts': _translate("parallel ports"),
     'qmixConfiguration': _translate("Qmix configuration"),
+    'highDPI': _translate('Try to support display high DPI'),
     # pref labels in Connections section
     'proxy': _translate('proxy'),
     'autoProxy': _translate('auto-proxy'),

--- a/psychopy/visual/__init__.py
+++ b/psychopy/visual/__init__.py
@@ -14,7 +14,17 @@ import sys
 if sys.platform == 'win32':
     from pyglet.libs import win32  # pyglet patch for ANACONDA install
     from ctypes import *
+    from psychopy import prefs
     win32.PUINT = POINTER(wintypes.UINT)
+    # get the preference for high DPI
+    if 'highDPI' in prefs.hardware.keys():  # check if we have the option
+        enableHighDPI = prefs.hardware['highDPI']
+        # check if we have OS support for it
+        if enableHighDPI:
+            try:
+                windll.shcore.SetProcessDpiAwareness(enableHighDPI)
+            except OSError:
+                pass
 
 from psychopy.visual import filters
 from psychopy.visual.backends import gamma


### PR DESCRIPTION
I haven't contributed to psychopy before, so if something more is needed, please let me know and I'll happily put in the extra work! :)
I found that on my laptop display, the stimulus images looked blurry and scaled. This PR adds an option to set high DPI support on windows for visual stimuli. This also fixes a problem where the reported size of the screen/display/windows differs from the actual size in pixels.

With high DPI support disabled:
`3.3480  WARNING         User requested fullscreen with size [3200 1800], but screen is actually [1829, 1029]. Using actual size`


```python
from psychopy import prefs
prefs.hardware['highDPI'] = False
# ...
visual.ImageStim(win, image)
````
![image](https://user-images.githubusercontent.com/75656/94899198-260caa80-0493-11eb-9274-99af21c5fac4.png)

With high DPI support enabled:
```python
from psychopy import prefs
prefs.hardware['highDPI'] = True
# ...
visual.ImageStim(win, image)
````

![screenshot_f](https://user-images.githubusercontent.com/75656/94900079-ad0e5280-0494-11eb-93e1-f1c9f791f5a4.png)

