### PR TITLE
BF/TESTS: Fixed broadcasting issue with `distance` function, added better tests.

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -172,19 +172,24 @@ class BuilderFrame(wx.Frame, ThemeMixin):
         self.updateReadme()
 
         # control the panes using aui manager
-        self._mgr = aui.AuiManager(self)
+        self._mgr = aui.AuiManager(
+            self,
+            aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT)
+
         #self._mgr.SetArtProvider(PsychopyDockArt())
         #self._art = self._mgr.GetArtProvider()
         # Create panels
         self._mgr.AddPane(self.routinePanel,
                           aui.AuiPaneInfo().
                           Name("Routines").Caption("Routines").CaptionVisible(True).
+                          Floatable(False).
                           CloseButton(False).MaximizeButton(True).PaneBorder(False).
                           Center())  # 'center panes' expand
         rtPane = self._mgr.GetPane('Routines')
         self._mgr.AddPane(self.componentButtons,
                           aui.AuiPaneInfo().
                           Name("Components").Caption("Components").CaptionVisible(True).
+                          Floatable(False).
                           RightDockable(True).LeftDockable(True).
                           CloseButton(False).PaneBorder(False))
         compPane = self._mgr.GetPane('Components')
@@ -192,6 +197,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
                           aui.AuiPaneInfo().
                           Name("Flow").Caption("Flow").CaptionVisible(True).
                           BestSize((8 * self.dpi, 2 * self.dpi)).
+                          Floatable(False).
                           RightDockable(True).LeftDockable(True).
                           CloseButton(False).PaneBorder(False))
         flowPane = self._mgr.GetPane('Flow')

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1069,9 +1069,6 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
                 start = 0
                 loc = textstring.find(findstring, start)
 
-        # Adjust for offset
-        loc += 2
-
         # was it still not found?
         if loc == -1:
             dlg = dialogs.MessageDialog(self, message=_translate(

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -3044,6 +3044,11 @@ def concatenate(matrices, out=None, dtype=None):
     --------
     * multMatrix : Chain multiplication of matrices.
 
+    Notes
+    -----
+    * This function should only be used for combining transformation matrices.
+      Use `multMatrix` for general matrix chain multiplication.
+
     Examples
     --------
     Create an SRT (scale, rotate, and translate) matrix to convert model-space


### PR DESCRIPTION
A bug-fix and touch-ups ...

* This PR fixes an array broadcasting issue with the `distance` function in `mathtools`, were the 1-to-many calculation was incorrectly setting up an output array with the wrong size, causing a hard crash if you tried using it that way. This is a show-stopper bug so it wouldn't have silently screwed up anything people were doing.
* Added some better tests for the `distance` function which covers some other functions too. I've also improved the tests for matrix and quaternion rotation functions to ensure they give similar results when applied to the same set of random points. 
* Removed the `matrixAngle` function since it's pretty useless, it's simpler to just convert the matrix to a quaternion and get both the axis *and* angle from that.
* Calculations for bounding box corners with `computeBBoxCorners` now accepts `extents` as non-ndarray types. This function is used for visibility culling in VR for 3D stimuli.
* Some touch-ups to the docs here and there.
* Added a caveat to `concatenate`'s docs, specifying that it should only be used for transformation matrices, use `multMatrix` for all your chain multiplication needs (eg. colorspace transform matrices).

