### PR TITLE
BF: Builder was raising error when right clicking on components

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1568,7 +1568,7 @@ class RoutineCanvas(wx.ScrolledWindow):
             x, y = self.ConvertEventCoords(event)
             icons = self.pdc.FindObjectsByBBox(x, y)
             menuPos = event.GetPosition()
-            if self.app.prefs.builder['topFlow']:
+            if 'flowTop' in self.app.prefs.builder['builderLayout']:
                 # width of components panel
                 menuPos[0] += self.frame.componentButtons.GetSize()[0]
                 # height of flow panel


### PR DESCRIPTION
this is due to deprecated "topFlow" pref