### PR TITLE
experiment/settings/JS_htmlHeader: rely on Tone.js latest (14.7.61)

### DIFF
--- a/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
+++ b/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
@@ -23,7 +23,7 @@
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.16.7/xlsx.full.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/log4javascript/1.4.9/log4javascript.min.js"></script>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tone/13.8.6/Tone.min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.7.61/Tone.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.2/howler.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/pako/1.0.10/pako.min.js"></script>
 


### PR DESCRIPTION
@apitiot @peircej To help with https://github.com/psychopy/psychojs/issues/211. Parallel post upgrade PsychoJS tweaks are required for which a separate PR is in the works, closes #3218 