### PR TITLE
Fixes to JS script Builder outputs

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -437,12 +437,13 @@ class BaseComponent(object):
         # code conversions for PsychoJS
         if target == 'PsychoJS':
             endStr = ';'
-            if isinstance(val, Param):
-                val = val.val
             try:
                 valStr = str(val).strip()
             except TypeError:
-                raise TypeError(f"Value of parameter {paramName} of component {compName} could not be coerced to a string. Value is of type {type(val)}")
+                if isinstance(val, Param):
+                    val = val.val
+                raise TypeError(f"Value of parameter {paramName} of component {compName} "
+                                f"could not be converted to JS. Value is {val}")
             # convert (0,0.5) to [0,0.5] but don't convert "rand()" to "rand[]"
             if valStr.startswith("(") and valStr.endswith(")"):
                 valStr = valStr.replace("(", "[", 1)

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, print_function
 
 from os import path
+import copy
 from psychopy import logging
 from psychopy.experiment.components import BaseVisualComponent, getInitVals, Param, _translate
 from psychopy.localization import _localized as __localized
@@ -155,7 +156,7 @@ class MovieComponent(BaseVisualComponent):
         if useInits:
             inits = getInitVals(self.params)
         else:
-            inits = self.params
+            inits = copy.deepcopy(self.params)
 
         noAudio = '{}'.format(inits['No audio'].val).lower()
         loop = '{}'.format(inits['loop'].val).lower()


### PR DESCRIPTION
While trying to fix an issue on discourse caused by user err with $ sign we
ended up removing the js-translation of all code in 275d2ab

fixes gh-3241