### PR TITLE
BF: Enable/disable OK button in Loop properties when text is edited...

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1341,6 +1341,7 @@ class DlgLoopProperties(_BaseParamsDlg):
                 self.Bind(wx.EVT_BUTTON, self.onBrowseTrialsFile,
                           ctrls.browseCtrl)
                 ctrls.valueCtrl.Bind(wx.EVT_RIGHT_DOWN, self.viewConditions)
+                ctrls.valueCtrl.Bind(wx.EVT_TEXT, self.doValidate)
                 panelSizer.Add(ctrls.nameCtrl, [row, 0])
                 panelSizer.Add(ctrls.valueCtrl, [row, 1])
                 panelSizer.Add(ctrls.browseCtrl, [row, 2])


### PR DESCRIPTION
…rather than when button is pressed, meaning it can be re-enabled when a mistake is fixed. @RebeccaHirst this fixes the problem you were having!