### PR TITLE
ENH: Italic docstrings, remove off-scheme green from PsychopyLight

### DIFF
--- a/psychopy/app/themes/Classic.json
+++ b/psychopy/app/themes/Classic.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#4C4C4C",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#4C4C4C",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#CDCDCD",

--- a/psychopy/app/themes/ClassicDark.json
+++ b/psychopy/app/themes/ClassicDark.json
@@ -130,12 +130,12 @@
   "documentation2": {
     "fg": "#CDCDCD",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#CDCDCD",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "python": {
 

--- a/psychopy/app/themes/GitHub.json
+++ b/psychopy/app/themes/GitHub.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "",

--- a/psychopy/app/themes/HiVisDark.json
+++ b/psychopy/app/themes/HiVisDark.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#F1D302",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#F1D302",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#7C7C86",

--- a/psychopy/app/themes/HiVisLight.json
+++ b/psychopy/app/themes/HiVisLight.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#800080",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#800080",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#F2F2F2",

--- a/psychopy/app/themes/MinimalDark.json
+++ b/psychopy/app/themes/MinimalDark.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#ACACB0",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#ACACB0",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#7C7C86",

--- a/psychopy/app/themes/MinimalLight.json
+++ b/psychopy/app/themes/MinimalLight.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#66666E",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#66666E",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#F2F2F2",

--- a/psychopy/app/themes/PsychopyDark.json
+++ b/psychopy/app/themes/PsychopyDark.json
@@ -125,12 +125,12 @@
   "documentation": {
     "fg": "#B6B6B6",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
     "fg": "#B6B6B6",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#B8B8BB",

--- a/psychopy/app/themes/PsychopyLight.json
+++ b/psychopy/app/themes/PsychopyLight.json
@@ -123,14 +123,14 @@
     "font": ""
   },
   "documentation": {
-    "fg": "#205C25",
+    "fg": "#75757D",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "documentation2": {
-    "fg": "#205C25",
+    "fg": "#75757D",
     "bg": "",
-    "font": ""
+    "font": "italic"
   },
   "whitespace": {
     "fg": "#D4D4D4",


### PR DESCRIPTION
An enhancement, but could go in a bug fix release as the only files changed are theme spec and these are all very standard parameters. The dark green on PsychopyLight was just bugging me...