### PR TITLE
BF: some machines (with bitlocker?) were failing b/c scipy.optim failed

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -34,7 +34,6 @@ import sys
 from copy import deepcopy, copy
 
 import numpy as np
-import scipy.optimize as optim
 from scipy import interpolate
 import json_tricks  # allows json to dump/load np.arrays and dates
 
@@ -746,6 +745,7 @@ class GammaCalculator(object):
             -yVals are the measured luminances from a photometer/spectrometer
 
         """
+        import scipy.optimize as optim
         minGamma = 0.8
         maxGamma = 20.0
         gammaGuess = 2.0


### PR DESCRIPTION
Delay loading scipt.optimize unless/until it's actually needed

I don't know *why* scipy.optimize doesn't load on machines with bitlocker
and the fix here won't solve the problem for those that need gamma
correction but it mitigates the issue for all those that don't need
gamma and bitlocker at the same time

fixes #3286 #3229