### PR TITLE
BF: harmless but annoying error on shutdown caused by garbage collect…

### DIFF
--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -730,5 +730,8 @@ class ElementArrayStim(MinimalStim, TextureMixin):
         self.mask = value
 
     def __del__(self):
-        # remove textures from graphics card to prevent crash
-        self.clearTextures()
+        # remove textures from graphics card to prevent OpenGl memory leak
+        try:
+            self.clearTextures()
+        except ModuleNotFoundError:
+            pass  # has probably been garbage-collected already

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -234,9 +234,12 @@ class ImageStim(BaseVisualStim, ContainerMixin, ColorMixin, TextureMixin):
     def __del__(self):
         """Remove textures from graphics card to prevent crash
         """
-        if hasattr(self, '_listID'):
-            GL.glDeleteLists(self._listID, 1)
-        self.clearTextures()
+        try:
+            if hasattr(self, '_listID'):
+                GL.glDeleteLists(self._listID, 1)
+            self.clearTextures()
+        except ModuleNotFoundError:
+            pass  # has probably been garbage-collected already
 
     def draw(self, win=None):
         """Draw.

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -495,7 +495,10 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
                                level=logging.EXP, obj=self)
 
     def __del__(self):
-        self._unload()
+        try:
+            self._unload()
+        except ModuleNotFoundError:
+            pass  # has probably been garbage-collected already
 
     def setAutoDraw(self, val, log=None):
         """Add or remove a stimulus from the list of stimuli that will be

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -620,6 +620,9 @@ class RadialStim(GratingStim):
     def __del__(self):
         """Remove textures from graphics card to prevent crash
         """
-        if not self.useShaders:
-            GL.glDeleteLists(self._listID, 1)
-        self.clearTextures()
+        try:
+            if not self.useShaders:
+                GL.glDeleteLists(self._listID, 1)
+            self.clearTextures()
+        except ModuleNotFoundError:
+            pass  # has probably been garbage-collected already

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -236,7 +236,10 @@ class TextStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
     def __del__(self):
         if GL:  # because of pytest fail otherwise
-            GL.glDeleteLists(self._listID, 1)
+            try:
+                GL.glDeleteLists(self._listID, 1)
+            except ModuleNotFoundError:
+                pass  # if pyglet no longer exists
 
     @attributeSetter
     def height(self, height):

--- a/psychopy/visual/vlcmoviestim.py
+++ b/psychopy/visual/vlcmoviestim.py
@@ -615,7 +615,10 @@ class VlcMovieStim(BaseVisualStim, ContainerMixin):
                                level=logging.EXP, obj=self)
 
     def __del__(self):
-        self._unload()
+        try:
+            self._unload()
+        except ModuleNotFoundError:
+            pass  # has probably been garbage-collected already
 
     def setAutoDraw(self, val, log=None):
         """Add or remove a stimulus from the list of stimuli that will be


### PR DESCRIPTION
… order

This appears to be something to do with pyglet event module and the order
of garbage collection.

Creating any of the stimuli in this pull request and then ending the script
will yield:
```
ModuleNotFoundError: import of pyglet halted; None in sys.modules
```

It's harmless because the script is closing anyway but annoying to see.

Fixes #1816 improves on #2085