### PR TITLE
BF: PsychoJS script should also not log params that "set every frame"

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -459,6 +459,8 @@ class BaseComponent(object):
         # then write the line
         if updateType == 'set every frame' and target == 'PsychoPy':
             loggingStr = ', log=False'
+        if updateType == 'set every frame' and target == 'PsychoJS':
+            loggingStr = ', log=false'
         else:
             loggingStr = ''
 


### PR DESCRIPTION
This was omitted from writing the PsychoJS script in the days where
log=False was not supported but it is now so make sure it's used.

This is likely to have contributed to dynamic stimuli memory leak
and to the massive log files being uploaded to Pavlovia