### PR TITLE
Fix paths by having pathto(...) point to the right Sphinx documents

### DIFF
--- a/docs/themes/psychopy_bootstrap/navbar.html
+++ b/docs/themes/psychopy_bootstrap/navbar.html
@@ -30,15 +30,14 @@
                         role="menu"
                         aria-labelledby="dLabelGlobalToc">
                         <ul>
-                            <li class="toctree-l1"><a class="reference internal" href="about/index.html">About</a>
+                            <li class="toctree-l1"><a class="reference internal" href="{{ pathto('about/index') }}">About</a>
                             </li>
-                            <li class="toctree-l1"><a class="reference internal"
-                                                      href="documentation.html">Documentation</a></li>
-                            <li class="toctree-l1"><a class="reference internal" href="api/api.html">Reference Manual
+                            <li class="toctree-l1"><a class="reference internal" href="{{ pathto('documentation') }}">Documentation</a></li>
+                            <li class="toctree-l1"><a class="reference internal" href="{{ pathto('api/index') }}">Reference Manual
                                 (API)</a></li>
-                            <li class="toctree-l1"><a class="reference internal" href="changelog.html">Changelog</a>
+                            <li class="toctree-l1"><a class="reference internal" href="{{ pathto('changelog') }}">Changelog</a>
                             </li>
-                            <li class="toctree-l1"><a class="reference internal" href="resources/index.html">Resources
+                            <li class="toctree-l1"><a class="reference internal" href="{{ pathto('resources/index') }}">Resources
                                 (e.g. for teaching)</a></li>
                         </ul>
                     </ul>


### PR DESCRIPTION
The links in the Documentation dropdown menu of the navbar used relative paths to HTML documents. This didn't work when the navbar was presented in a subdirectory (such as over [here](https://www.psychopy.org/online/index.html)). By replacing the link targets with pathto pointing to the right Sphinx documents, I resolved this issue.