### PR TITLE
BF: beginRoutineJS code was broekn if continueRoutine==False

### DIFF
--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -270,7 +270,9 @@ class Routine(list):
         code = ("//------Prepare to start Routine '%(name)s'-------\n"
                 "t = 0;\n"
                 "%(name)sClock.reset(); // clock\n"
-                "frameN = -1;\n" % self.params)
+                "frameN = -1;\n"
+                "continueRoutine = true; // until we're told otherwise\n"
+                % self.params)
         buff.writeIndentedLines(code)
         # can we use non-slip timing?
         maxTime, useNonSlip = self.getMaxTime()
@@ -304,15 +306,11 @@ class Routine(list):
         buff.writeIndentedLines(code)
 
         # are we done yet?
-        code = ("// check if the Routine should terminate\n"
-                "if (!continueRoutine) {"
-                "  // a component has requested a forced-end of Routine\n"
-                "  return Scheduler.Event.NEXT;\n"
-                "}\n")
+        code = ("return Scheduler.Event.NEXT;\n")
         buff.writeIndentedLines(code)
 
         buff.setIndentLevel(-1, relative=True)
-        buff.writeIndentedLines("};\n")
+        buff.writeIndentedLines("}\n")
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("}\n")
 
@@ -329,7 +327,6 @@ class Routine(list):
         buff.setIndentLevel(1, relative=True)
 
         code = ("//------Loop for each frame of Routine '%(name)s'-------\n"
-                "let continueRoutine = true; // until we're told otherwise\n"
                 "// get current time\n"
                 "t = %(name)sClock.getTime();\n"
                 "frameN = frameN + 1;"

--- a/psychopy/tests/data/correctScript/js/correctTextComponent.js
+++ b/psychopy/tests/data/correctScript/js/correctTextComponent.js
@@ -102,6 +102,7 @@ function trialRoutineBegin() {
   trialClock.reset(); // clock
   frameN = -1;
   routineTimer.add(1.000000);
+
   // update component parameters for each repeat
   // keep track of which components have finished
   trialComponents = [];
@@ -118,7 +119,7 @@ var frameRemains;
 var continueRoutine;
 function trialRoutineEachFrame() {
   //------Loop for each frame of Routine 'trial'-------
-  let continueRoutine = true; // until we're told otherwise
+
   // get current time
   t = trialClock.getTime();
   frameN = frameN + 1;// number of completed frames (so 0 is the first frame)


### PR DESCRIPTION
The output tried to return early (as if in the eachFrame block) whereas
what it should have done was store continueRoutine as a global.

Key changes
--------------

1. Set continueRoutine as a global at *top* of beginRoutine code block
so it can be modified later in that block

2. remove this line from eachFrame (it would undo above fix)
	let continueRoutine = true; // until we're told otherwise

3. remove the erroneous code where the return Scheduler.Event.NEXT was
made dependent on continueRoutine