### PR TITLE
Import ABC from collections.abc for Python 3.9 compatibility.

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -16,7 +16,6 @@ import os
 import pickle
 import copy
 import warnings
-import collections
 import numpy as np
 from pkg_resources import parse_version
 
@@ -28,6 +27,11 @@ from psychopy.contrib.quest import QuestObject
 from psychopy.contrib.psi import PsiObject
 from .base import _BaseTrialHandler, _ComparisonMixin
 from .utils import _getExcelCellName
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 try:
     # import openpyxl
@@ -1836,7 +1840,7 @@ class MultiStairHandler(_BaseTrialHandler):
 
     def _checkArguments(self):
         # Did we get a `conditions` parameter, correctly formatted?
-        if not isinstance(self.conditions, collections.Iterable):
+        if not isinstance(self.conditions, Iterable):
             raise TypeError(
                 '`conditions` parameter passed to MultiStairHandler '
                 'should be a list, not a %s.' % type(self.conditions))

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -20,7 +20,7 @@ import sys
 import string
 import copy
 import numpy
-from collections import namedtuple, OrderedDict, MutableMapping
+from collections import namedtuple, OrderedDict
 from psychopy.preferences import prefs
 
 # try to import pyglet & pygame and hope the user has at least one of them!
@@ -41,6 +41,11 @@ try:
     haveGLFW = True
 except ImportError:
     haveGLFW = False
+
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 if havePygame:
     usePygame = True  # will become false later if win not initialised

--- a/psychopy/hardware/__init__.py
+++ b/psychopy/hardware/__init__.py
@@ -8,9 +8,14 @@ from builtins import range
 from past.builtins import basestring
 import sys
 import glob
-import collections
 from itertools import chain
 from psychopy import logging
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 __all__ = ['forp', 'cedrus', 'minolta', 'pr', 'crs', 'iolab']
 
 
@@ -137,7 +142,7 @@ def findPhotometer(ports=None, device=None):
     """
     if isinstance(device, basestring):
         photometers = [getPhotometerByName(device)]
-    elif isinstance(device, collections.Iterable):
+    elif isinstance(device, Iterable):
         # if we find a string assume it is a name, otherwise treat it like a
         # photometer
         photometers = [getPhotometerByName(d)

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -9,7 +9,6 @@ import os
 import inspect
 import warnings
 import numpy
-import collections
 import numbers  # numbers.Integral is like (int, long) but supports Py3
 import datetime
 
@@ -25,6 +24,11 @@ try:
     from yaml import CLoader as yLoader, CDumper as yDumper
 except ImportError:
     from yaml import Loader as yLoader, Dumper as yDumper
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 # Only turn on converting all strings to unicode by the YAML loader
 # if running Python 2.7 or higher. 2.6 does not seem to like unicode dict keys.
@@ -107,7 +111,7 @@ def module_directory(local_function):
 
 
 def isIterable(o):
-    return isinstance(o, collections.Iterable)
+    return isinstance(o, Iterable)
 
 if sys.platform == 'win32':
     import pythoncom

--- a/psychopy/tests/test_hardware/test_ports.py
+++ b/psychopy/tests/test_hardware/test_ports.py
@@ -1,4 +1,3 @@
-import collections
 import psychopy.hardware as hw
 import pytest
 try:
@@ -12,6 +11,11 @@ except Exception:
 else:
     def require_mock(fn):
         return fn
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 try:
     from contextlib import nested  # Python 2
@@ -77,7 +81,7 @@ def test_getCRSPhotometers():
             for p in photoms:
                 assert p.longName != "CRS ColorCAL"
 
-            assert isinstance(photoms,collections.Iterable)
+            assert isinstance(photoms, Iterable)
             # missing crs shouldn't break it
             assert len(photoms) > 0
     except (AssertionError, ImportError):
@@ -109,7 +113,7 @@ def test_getPhotometers():
     photoms = hw.getAllPhotometers()
 
     # Always iterable
-    assert isinstance(photoms,collections.Iterable)
+    assert isinstance(photoms, Iterable)
 
     photoms = list(photoms)
 


### PR DESCRIPTION
Fixes #3341 