### PR TITLE
Remove encoding parameter from json.load for Python 3.9 compatibility.

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -442,8 +442,14 @@ class Monitor(object):
         else:
             if ext==".json":
                 with open(thisFileName, 'r') as thisFile:
-                    self.calibs = json_tricks.load(thisFile, ignore_comments=False,
-                                                   encoding='utf-8', preserve_order=False)
+                    if six.PY2:
+                        self.calibs = json_tricks.load(thisFile, ignore_comments=False,
+                                                       encoding='utf-8', preserve_order=False)
+                    else:
+                        # Passing encoding parameter to json.loads has been deprecated and
+                        # removed in Python 3.9
+                        self.calibs = json_tricks.load(thisFile, ignore_comments=False,
+                                                       preserve_order=False)
             else:
                 with open(thisFileName, 'rb') as thisFile:
                     self.calibs = pickle.load(thisFile)


### PR DESCRIPTION
Fixes #3340 