### PR TITLE
NF: add contrast parameter to visual grating component in builder UI

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -579,7 +579,7 @@ class BaseVisualComponent(BaseComponent):
 
     def __init__(self, exp, parentName, name='',
                  units='from exp settings', color='$[1,1,1]', borderColor="", fillColor="",
-                 pos=(0, 0), size=(0, 0), ori=0, colorSpace='rgb', opacity=1,
+                 pos=(0, 0), size=(0, 0), ori=0, colorSpace='rgb', opacity=1, contrast=1,
                  startType='time (s)', startVal='',
                  stopType='duration (s)', stopVal='',
                  startEstim='', durationEstim='',
@@ -666,6 +666,16 @@ class BaseVisualComponent(BaseComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['opacity'])
+
+        msg = _translate("Contrast of the stimulus (1.0=unchanged contrast, "
+                         "0.5=decrease contrast, 0.0=uniform/no contrast, "
+                         "-0.5=slightly inverted, -1.0=totally inverted)")
+        self.params['contrast'] = Param(
+            contrast, valType='code', allowedTypes=[], categ='Appearance',
+            updates='constant',
+            allowedUpdates=['constant', 'set every repeat', 'set every frame'],
+            hint=msg,
+            label=_localized['contrast'])
 
         msg = _translate("Position of this stimulus (e.g. [1,2] )")
         self.params['pos'] = Param(

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -35,13 +35,13 @@ class GratingComponent(BaseVisualComponent):
     def __init__(self, exp, parentName, name='grating', image='sin',
                  mask='None', sf='None', interpolate='linear',
                  units='from exp settings', color='$[1,1,1]', colorSpace='rgb',
-                 pos=(0, 0), size=(0.5, 0.5), ori=0, phase=0.0, texRes='128',
+                 contrast=1.0, pos=(0, 0), size=(0.5, 0.5), ori=0, phase=0.0, texRes='128',
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0, blendmode='avg',
                  startEstim='', durationEstim=''):
         super(GratingComponent, self).__init__(
             exp, parentName, name=name, units=units,
-            color=color, colorSpace=colorSpace,
+            color=color, colorSpace=colorSpace, contrast=contrast,
             pos=pos, size=size, ori=ori,
             startType=startType, startVal=startVal,
             stopType=stopType, stopVal=stopVal,
@@ -135,7 +135,7 @@ class GratingComponent(BaseVisualComponent):
                 "    ori=%(ori)s, pos=%(pos)s, size=%(size)s, " % inits +
                 "sf=%(sf)s, phase=%(phase)s,\n" % inits +
                 "    color=%(color)s, colorSpace=%(colorSpace)s, " % inits +
-                "opacity=%(opacity)s,blendmode=%(blendmode)s,\n" % inits +
+                "opacity=%(opacity)s,contrast=%(contrast)s,blendmode=%(blendmode)s,\n" % inits +
                 # no newline - start optional parameters
                 "    texRes=%(texture resolution)s" % inits)
 

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -134,8 +134,8 @@ class GratingComponent(BaseVisualComponent):
                 "    tex=%(tex)s, mask=%(mask)s,\n" % inits +
                 "    ori=%(ori)s, pos=%(pos)s, size=%(size)s, " % inits +
                 "sf=%(sf)s, phase=%(phase)s,\n" % inits +
-                "    color=%(color)s, colorSpace=%(colorSpace)s, " % inits +
-                "opacity=%(opacity)s,contrast=%(contrast)s,blendmode=%(blendmode)s,\n" % inits +
+                "    color=%(color)s, colorSpace=%(colorSpace)s,\n" % inits +
+                "    opacity=%(opacity)s, contrast=%(contrast)s, blendmode=%(blendmode)s,\n" % inits +
                 # no newline - start optional parameters
                 "    texRes=%(texture resolution)s" % inits)
 

--- a/psychopy/localization/__init__.py
+++ b/psychopy/localization/__init__.py
@@ -170,6 +170,7 @@ _localized = {
     'fillColorSpace': _translate('Fill Color Space'),
     'borderColor': _translate('Border Color'),
     'borderColorSpace': _translate('Border Color Space'),
+    'contrast': _translate('Contrast'),
     'opacity': _translate('Opacity'),
     'pos': _translate('Position [x,y]'),
     'ori': _translate('Orientation'),


### PR DESCRIPTION
This PR exposes the [contrast parameter](https://www.psychopy.org/api/visual/gratingstim.html#psychopy.visual.GratingStim.contrast) for visual GratigStim in the Builder UI. 

I modeled it after the Opacity parameter. Ran tests and did not see any errors related to this commit. 