### PR TITLE
BF: Fix version sorting

### DIFF
--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -17,6 +17,7 @@ import psychopy  # for currently loaded version
 from psychopy import prefs
 from psychopy import logging, tools, web, constants
 from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 if constants.PY3:
     from importlib import reload
 
@@ -184,8 +185,9 @@ def versionOptions(local=True):
     majorMinor = sorted(
         list({'.'.join(v.split('.')[:2])
               for v in availableVersions(local=local)}),
+        key=parse_version, 
         reverse=True)
-    major = sorted(list({v.split('.')[0] for v in majorMinor}), reverse=True)
+    major = sorted(list({v.split('.')[0] for v in majorMinor}), key=parse_version, reverse=True)
     special = ['latest']
     return special + major + majorMinor
 
@@ -200,7 +202,7 @@ def _localVersions(forceCheck=False):
             tagInfo = subprocess.check_output(cmd.split(), cwd=VERSIONSDIR,
                                               env=constants.ENVIRON).decode('UTF-8')
             allTags = tagInfo.splitlines()
-            _localVersionsCache = sorted(allTags, reverse=True)
+            _localVersionsCache = sorted(allTags, key=parse_version, reverse=True)
     return _localVersionsCache
 
 
@@ -224,7 +226,7 @@ def _remoteVersions(forceCheck=False):
                            for line in tagInfo.splitlines()
                            if '^{}' not in line]
             # ensure most recent (i.e., highest) first
-            _remoteVersionsCache = sorted(allTags, reverse=True)
+            _remoteVersionsCache = sorted(allTags, key=parse_version, reverse=True)
     return _remoteVersionsCache
 
 
@@ -279,6 +281,7 @@ def availableVersions(local=True, forceCheck=False):
             return sorted(
                 list(set([psychopy.__version__] + _localVersions(forceCheck) + _remoteVersions(
                     forceCheck))),
+                key=parse_version,
                 reverse=True)
     except subprocess.CalledProcessError:
         return []


### PR DESCRIPTION
Correctly sort versions from high to low. Below is some test script that demonstrates the fix and the new behaviors of psychopy.tools.versionchooser 

```python
# Testing sorting versions high to low
from packaging.version import parse as parse_version
versions = ['3.2.4', '3.2.3', '3.2.2', '3.2.1', '3.2.0', '3.1.5', '3.1.4', '3.1.3', '3.1.2', '3.1.1', '3.1.0', '3.0.7', '3.0.6', '3.0.5', '3.0.4', '3.0.3', '3.0.2', '3.0.1', '3.0.0', '2020.2.6', '2020.2.5', '2020.2.4', '2020.2.3', '2020.2.2', '2020.2.1', '2020.2.0', '2020.1.3', '2020.1.2', '2020.1.1', '1.90.2', '1.90.1', '1.90.0', '1.85.6', '1.85.4', '1.85.3', '1.85.2', '1.85.1', '1.85.0', '1.84.2', '1.84.1', '1.84.0', '1.83.04', '1.83.03', '1.83.01', '1.83.00', '1.82.01', '1.82.00', '1.81.03', '1.81.02', '1.81.01', '1.81.00', '1.80.06', '1.80.05', '1.80.03', '1.80.02', '1.80.01', '1.80.00', '1.79.00', '1.78.01', '1.78.00', '1.77.02', '1.77.01', '1.77.00', '1.76.00']
print(sorted(versions, key=parse_version, reverse = True))


# Getting output from each function in psychopy.tools.versionchooser that uses sorted and returns a list of versions
from  psychopy.tools.versionchooser import availableVersions, versionOptions,_localVersions, _remoteVersions, availableVersions
print('availableVersions(local = False)')
print(availableVersions(local = False))
print('versionOptions')
print(versionOptions())
print('_localVersions')
print(_localVersions())
print('_remoteVersions')
print(_remoteVersions())
print('availableVersions')
print(availableVersions())

# Getting output of useVersion
from psychopy.tools.versionchooser import useVersion
print('useVersion(\'latest\')')
print(useVersion('latest'))
```
