### PR TITLE
FF: Make pyo parsing of devices more robust

### DIFF
--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -12,6 +12,7 @@ import sys
 import os
 import atexit
 import threading
+from itertools import chain
 from numpy import float64
 from psychopy import prefs, exceptions
 from psychopy import core, logging
@@ -74,57 +75,29 @@ def _bestDriver(devNames, devIDs):
         return None, None
 
 
-def _query_devices():
-    f = StringIO()
-    with redirect_stdout(f):
-        pyo.pa_list_devices()
-    s = f.getvalue().strip().split("\n")[1:]
-    devices = []
-    for device in s:
-        info = {}
-        for v in device.split(",")[1:]:
-            info[v.strip().split(": ")[0]] = v.strip().split(": ")[1]
-        info["id"], info["type"] = device.split(",")[0].split(": ")
-        devices.append(info)
-    return devices
-
-
 def get_devices_infos():
-    devices = _query_devices()
-    in_devices = {}
-    out_devices = {}
-    for device in devices:
-        param = {'host api index': device['host api index'],
-                 'latency': device['latency'],
-                 'default sr': device['default sr'],
-                 'name': device['name']}
-        if device['type'] == 'IN':
-            in_devices[int(device["id"])] = param
-        if device['type'] == 'OUT':
-            out_devices[int(device["id"])] = param
+    in_devices, out_devices = pyo.pa_get_devices_infos()
+    for index, device in chain(in_devices.items(), out_devices.items()):
+        device.update({
+            'default sr': '{} Hz'.format(device['default sr']),
+            'host api index': str(device['host api index']),
+            'latency': '{} s'.format(round(device['latency'], 6)),
+        })
     return (in_devices, out_devices)
 
 
 def get_output_devices():
-    devices = _query_devices()
-    names = []
-    ids = []
-    for device in devices:
-        if device['type'] == 'OUT':
-            names.append(device['name'])
-            ids.append(int(device["id"]))
-    return (names, ids)
+    _, out_devices = get_devices_infos()
+    return tuple(zip(*[
+        (device['name'], dev_id) for dev_id, device in out_devices.items()
+    ]))
 
 
 def get_input_devices():
-    devices = _query_devices()
-    names = []
-    ids = []
-    for device in devices:
-        if device['type'] == 'IN':
-            names.append(device['name'])
-            ids.append(int(device["id"]))
-    return (names, ids)
+    in_devices, _ = get_devices_infos()
+    return tuple(zip(*[
+        (device['name'], dev_id) for dev_id, device in in_devices.items()
+    ]))
 
 
 def getDevices(kind=None):


### PR DESCRIPTION
The methods to get input/output sound devices info in the pyo backend
rely on a parsing of the output of `pyo.pa_list_devices()`. It splits
the fields (name, host api index, latency, default sr) by splitting
on commas. This is fragile as the name can contain commas (e.g.
"Logitech USB Headset: Audio (hw:1,0)"), which leads to `IndexError:
list index out of range` error.

`pyo` provides a method [`pa_get_devices_infos()`](https://github.com/belangeo/pyo/blob/274ed61d6664d44d23416957e781b8afbb559589/src/engine/pyomodule.c#L139) that returns 2
dictionaries for input and output devices, almost exactly in the
expected format as returned by the current implementation of
`_query_devices()`. The only differences are in the fields values: no
units ("Hz", "s"), do not split the name to exclude the content after a
colon and the delay has many digits (vs 6 in the initial
implementation).

This commit switches to using `pa_get_devices_infos()` with a small
adaptation of the format to keep the same output (but the name) as the
previous implementation was doing.

:warning:  Behavior change:

The name of a sound device is now more precise, e.g.

Before: "Logitech USB Headset"
After: "Logitech USB Headset: Audio (hw:1,0)"

It makes the identifier more unique, as it contains the hardware position,
for example if we have several identical headsets connected.

Fixes #3365