### PR TITLE
BF: Prevent builder's center pane from being moved.

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -191,6 +191,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
                           aui.AuiPaneInfo().
                           Name("Routines").Caption("Routines").CaptionVisible(True).
                           Floatable(False).
+                          Movable(False).
                           CloseButton(False).MaximizeButton(True).PaneBorder(False).
                           Center())  # 'center panes' expand
         rtPane = self._mgr.GetPane('Routines')


### PR DESCRIPTION
Prevent Builder's centre pane (Routine) from being moved which breaks the interface.