### PR TITLE
RF: changed/fixes to component param defaults

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -448,8 +448,8 @@ class _BaseParamsDlg(wx.Dialog):
                                proportion=1, flag=wx.EXPAND | wx.ALL, border=5)
         # Sort category names
         allCategNames = sorted(categs)
-        firstCategs = ['Basic', 'Appearance', 'Layout', 'Formatting', 'Texture', 'Data']
-        lastCategs = ['Custom', 'Hardware', 'Testing']
+        firstCategs = ['Basic', 'Layout', 'Appearance', 'Formatting', 'Texture']
+        lastCategs = ['Data', 'Custom', 'Hardware', 'Testing']
         bonusCategs = [nm for nm in allCategNames if nm not in firstCategs+lastCategs]
         categNames = [nm for nm in firstCategs if nm in allCategNames] \
                      + bonusCategs \

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -578,7 +578,7 @@ class BaseVisualComponent(BaseComponent):
     categories = ['Stimuli']
 
     def __init__(self, exp, parentName, name='',
-                 units='from exp settings', color='white', fillColor="None", borderColor="None",
+                 units='from exp settings', color='white', fillColor="", borderColor="",
                  pos=(0, 0), size=(0, 0), ori=0, colorSpace='rgb', opacity=1, contrast=1,
                  startType='time (s)', startVal='',
                  stopType='duration (s)', stopVal='',

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -33,7 +33,7 @@ class GratingComponent(BaseVisualComponent):
     """A class for presenting grating stimuli"""
 
     def __init__(self, exp, parentName, name='grating', image='sin',
-                 mask='None', sf='None', interpolate='linear',
+                 mask='', sf='', interpolate='linear',
                  units='from exp settings', color='$[1,1,1]', colorSpace='rgb',
                  contrast=1.0, pos=(0, 0), size=(0.5, 0.5), ori=0, phase=0.0, texRes='128',
                  startType='time (s)', startVal=0.0,
@@ -66,7 +66,7 @@ class GratingComponent(BaseVisualComponent):
         msg = _translate("An image to define the alpha mask (ie shape)- "
                          "gauss, circle... or a filename (including path)")
         self.params['mask'] = Param(
-            mask, valType='file', inputType="file", allowedVals=["gauss, circle"], allowedTypes=[], categ='Texture',
+            mask, valType='file', inputType="file", allowedVals=["gauss", "circle"], allowedTypes=[], categ='Texture',
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,

--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -29,7 +29,7 @@ _localized.update({'image': _translate('Image'),
 class ImageComponent(BaseVisualComponent):
     """An event class for presenting image-based stimuli"""
 
-    def __init__(self, exp, parentName, name='image', image='None', mask='None',
+    def __init__(self, exp, parentName, name='image', image='', mask='',
                  interpolate='linear', units='from exp settings',
                  color='$[1,1,1]', colorSpace='rgb', pos=(0, 0),
                  size=(0.5, 0.5), ori=0, texRes='128', flipVert=False,

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -74,7 +74,8 @@ class KeyboardComponent(BaseComponent):
             "A comma-separated list of keys (with quotes), such as "
             "'q','right','space','left'")
         self.params['allowedKeys'] = Param(
-            allowedKeys, valType='list', inputType="single", allowedTypes=[], categ='Data',
+            allowedKeys, valType='list', inputType="single", allowedTypes=[],
+            categ='Basic',
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=(msg),

--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -37,8 +37,8 @@ class PolygonComponent(BaseVisualComponent):
 
     def __init__(self, exp, parentName, name='polygon', interpolate='linear',
                  units='from exp settings',
-                 lineColor='$[1,1,1]', lineColorSpace='rgb', lineWidth=1,
-                 fillColor='$[1,1,1]', fillColorSpace='rgb',
+                 lineColor='white', lineColorSpace='rgb', lineWidth=1,
+                 fillColor='white', fillColorSpace='rgb',
                  shape='triangle', nVertices=4,
                  pos=(0, 0), size=(0.5, 0.5), ori=0,
                  startType='time (s)', startVal=0.0,
@@ -46,6 +46,7 @@ class PolygonComponent(BaseVisualComponent):
                  startEstim='', durationEstim=''):
         super(PolygonComponent, self).__init__(
             exp, parentName, name=name, units=units,
+            fillColor=fillColor, borderColor=lineColor,
             pos=pos, size=size, ori=ori,
             startType=startType, startVal=startVal,
             stopType=stopType, stopVal=stopVal,

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -66,7 +66,7 @@ class SliderComponent(BaseVisualComponent):
                  style=['rating'],
                  granularity=0,
                  color="LightGray",
-                 font="Open Sans",
+                 font="Arial",
                  startType='time (s)', startVal='0.0',
                  stopType='condition', stopVal='',
                  startEstim='', durationEstim='',
@@ -74,6 +74,7 @@ class SliderComponent(BaseVisualComponent):
                  storeRating=True, storeRatingTime=True, storeHistory=False, readOnly=False):
         super(SliderComponent, self).__init__(
                 exp, parentName, name,
+                pos=pos, size=size,
                 startType=startType, startVal=startVal,
                 stopType=stopType, stopVal=stopVal,
                 startEstim=startEstim, durationEstim=durationEstim)
@@ -94,21 +95,21 @@ class SliderComponent(BaseVisualComponent):
         # normal params:
         # = the usual as inherited from BaseVisual plus:
         self.params['ticks'] = Param(
-                ticks, valType='list', inputType="single", allowedTypes=[], categ='Data',
+                ticks, valType='list', inputType="single", allowedTypes=[], categ='Basic',
                 updates='constant',
                 allowedUpdates=['constant', 'set every repeat'],
                 hint=_translate("Tick positions (numerical) on the scale, "
                                 "separated by commas"),
                 label=_localized['ticks'])
         self.params['labels'] = Param(
-                labels, valType='list', inputType="single", allowedTypes=[], categ='Data',
+                labels, valType='list', inputType="single", allowedTypes=[], categ='Basic',
                 updates='constant',
                 allowedUpdates=['constant', 'set every repeat'],
                 hint=_translate("Labels for the tick marks on the scale, "
                                 "separated by commas"),
                 label=_localized['labels'])
         self.params['granularity'] = Param(
-                granularity, valType='num', inputType="single", allowedTypes=[], categ='Data',
+                granularity, valType='num', inputType="single", allowedTypes=[], categ='Basic',
                 updates='constant',
                 allowedUpdates=['constant', 'set every repeat'],
                 hint=_translate("Specifies the minimum step size "

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -36,7 +36,7 @@ class TextComponent(BaseVisualComponent):
     def __init__(self, exp, parentName, name='text',
                  # effectively just a display-value
                  text=_translate('Any text\n\nincluding line breaks'),
-                 font='Open Sans', units='from exp settings',
+                 font='Arial', units='from exp settings',
                  color='white', colorSpace='rgb',
                  pos=(0, 0), letterHeight=0.1, ori=0,
                  startType='time (s)', startVal=0.0,

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -47,7 +47,7 @@ class TextboxComponent(BaseVisualComponent):
     def __init__(self, exp, parentName, name='textbox',
                  # effectively just a display-value
                  text=_translate('Any text\n\nincluding line breaks'),
-                 font='Open Sans', units='from exp settings', bold=False, italic=False,
+                 font='Arial', units='from exp settings', bold=False, italic=False,
                  color='white', colorSpace='rgb', opacity=1.0,
                  pos=(0, 0), size='', letterHeight=0.05, ori=0,
                  lineSpacing=1.0, padding="",  # gap between box and text


### PR DESCRIPTION
Range of changes:

- ordering: Data tab now comes later (after Component-specific tabs)
- fonts: set default font to be Arial not Open Sans so users don't start
with a warning
- Slider:
    - size was default of 0,0 so didn't appear by default
    - Ticks, Labels and Granularity are Basic params
- Moved several components into the Basic tab for their type
  (e.g. allowedKeys is a basic property of keyboard)