### PR TITLE
setup.cfg dependency cleanup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
 setup_requires = 
     distro; platform_system == "Linux"
 install_requires =
+    packaging
     requests[security]
     numpy
     scipy
@@ -53,6 +54,7 @@ install_requires =
     psutil
     tables
     pyzmq
+    ujson
     moviepy
     opencv-python
     python-gitlab
@@ -63,8 +65,8 @@ install_requires =
     jedi >= 0.15.2
     # Platform-specific dependencies.
     javascripthon; python_version >= "3.5"
-    pyglet < 1.5; python_version < "3.8"
-    pyglet < 1.5; python_version >= "3.8"
+    pyglet >= 1.5; platform_system == "Darwin"
+    pyglet < 1.5; platform_system != "Darwin"
     pathlib; python_version < "3.4"
     questplus >= 2019.3; python_version >= "3.6"
     imageio < 2.5; python_version < "3"
@@ -78,8 +80,12 @@ install_requires =
     pypiwin32; platform_system == "Windows"
     pyobjc-core; platform_system == "Darwin"
     pyobjc-framework-Quartz; platform_system == "Darwin"
+    pyobjc; platform_system == "Darwin"
+    python-xlib; platform_system == "Linux"
     distro; platform_system == "Linux"
     websocket_client
+    # Hardware specific dependencies
+    tobii-research; python_version <= "3.6"
 
 [options.entry_points]
 gui_scripts =


### PR DESCRIPTION
- Related to / closes #3429, pyglet 1.4.x is used on win and linux, pyglet 1.5.x is used on macos as it is needed for big sur.
- added packaging dependency, does not seem to get included sometimes (some systems?)
- added pyobj dependency for macos - atleast when using anaconda this must be installed or a objc lib version error occurs.
- added python-xlib for linux install, needed by iohub
- added tobii-research package if python <= 3.6
- added ujson package (used by iohub if present)