### PR TITLE
FF: fix for "Marker type" and "Size" of RatingScale component

### DIFF
--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -128,6 +128,7 @@ class RatingScaleComponent(BaseComponent):
             label=_localized['labels'])
         self.params['marker'] = Param(
             marker, valType='str', inputType="choice", allowedTypes=[], categ='Interface',
+            allowedVals=['last key', 'first key', 'all keys', 'nothing'],
             updates='constant', allowedUpdates=[],  # categ="Advanced",
             hint=_translate("Style for the marker: triangle, circle, glow, "
                             "slider, hover"),

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -128,7 +128,7 @@ class RatingScaleComponent(BaseComponent):
             label=_localized['labels'])
         self.params['marker'] = Param(
             marker, valType='str', inputType="choice", allowedTypes=[], categ='Interface',
-            allowedVals=['last key', 'first key', 'all keys', 'nothing'],
+            allowedVals=['triangle', 'circle', 'glow', 'slider', 'hover'],
             updates='constant', allowedUpdates=[],  # categ="Advanced",
             hint=_translate("Style for the marker: triangle, circle, glow, "
                             "slider, hover"),

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -225,7 +225,15 @@ class RatingScaleComponent(BaseComponent):
                 init_str += ', marker=%s' % repr(self.params['marker'].val)
                 if self.params['marker'].val == 'glow':
                     init_str += ', markerExpansion=5'
-            init_str += ", size=%s" % self.params['size']
+
+            s = str(self.params['size'].val)
+            s = s.lstrip('([ ').strip(')] ')
+            try:
+                size = list(map(float, s.split(','))) * 2
+                init_str += ", size=%s" % size[0]
+            except Exception:
+                pass  # size = None
+
             s = str(self.params['pos'].val)
             s = s.lstrip('([ ').strip(')] ')
             try:


### PR DESCRIPTION
Fix these issues:

1. list of "Marker type" parameter is empty.
2. While "Size" parameter of the RatingScale must be a single number, Builder outputs the value as a list.  For example, setting "1.0" to "Size" results in "size=[1.0]" in the complied code.

I'm not sure my fix for issue 2 is the best way.