### PR TITLE
BF: Fixed case where _currentEditableRef=None

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -921,7 +921,8 @@ class Window(object):
     @property
     def currentEditable(self):
         """The editable (Text?) object that currently has key focus"""
-        return self._currentEditableRef()
+        if self._currentEditableRef:
+            return self._currentEditableRef()
 
     @currentEditable.setter
     def currentEditable(self, editable):


### PR DESCRIPTION
In commit d347908333 window creates _currentEditableRef=None
but then returns it as if already a weakref resulting in
NoneType not callable error