### PR TITLE
BF: Only add "editable" to Window's editables list if it is editable …

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -949,8 +949,8 @@ class Window(object):
         # Ignore if object is not editable
         if not hasattr(editable, "editable"):
             return
-        #if not editable.editable:
-        #    return
+        if not editable.editable:
+            return
         # If editable is already present do nothing
         eRef = False
         for ref in weakref.getweakrefs(editable):


### PR DESCRIPTION
…- otherwise non-editable Textboxes get set to editable