### PR TITLE
DOCS: Added stub for colors module documentation. 

### DIFF
--- a/docs/source/api/color.rst
+++ b/docs/source/api/color.rst
@@ -1,0 +1,26 @@
+:mod:`psychopy.colors` - For working with colors.
+------------------------------------------------
+
+Classes and functions for working with colors.
+
+Overview
+========
+
+.. currentmodule:: psychopy.colors
+
+.. autosummary::
+    Color
+    isValidColor
+    hex2rgb255
+
+Details
+=======
+
+.. autoclass:: Color
+    :members:
+    :inherited-members:
+    :undoc-members:
+
+.. autofunction:: isValidColor
+.. autofunction:: hex2rgb255
+

--- a/psychopy/visual/circle.py
+++ b/psychopy/visual/circle.py
@@ -38,7 +38,7 @@ class Circle(Polygon):
         attributes `pos`, `size` and `radius` are interpreted.
     lineWidth : float
         Width of the circle's outline.
-    lineColor, fillColor : array_like, str, :class:`~psychopy.visual.Color` or None
+    lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the circle's outline and fill. If `None`, a fully
         transparent color is used which makes the fill or outline invisible.
     lineColorSpace, fillColorSpace : str
@@ -80,7 +80,7 @@ class Circle(Polygon):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     name : str
@@ -93,7 +93,7 @@ class Circle(Polygon):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.shape.ShapeStim.draw()` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or `None`
+    color : array_like, str, :class:`~psychopy.colors.Color` or `None`
         Sets both the initial `lineColor` and `fillColor` of the shape.
     colorSpace : str
         Sets the colorspace, changing how values passed to `lineColor` and

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -44,7 +44,7 @@ class Line(ShapeStim):
         attributes `pos`, `size` and `radius` are interpreted.
     lineWidth : float
         Width of the line.
-    lineColor : array_like, str, :class:`~psychopy.visual.Color` or None
+    lineColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the line. If `None`, a fully transparent color is used which
         makes the line invisible. *Deprecated* use `color` instead.
     lineColorSpace : str or None
@@ -86,7 +86,7 @@ class Line(ShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing lines. This produces a
         smoother (less-pixelated) line.
-    lineRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `color` instead. This argument may be removed
         in a future version.
     name : str
@@ -99,7 +99,7 @@ class Line(ShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.shape.ShapeStim.draw()` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or None
+    color : array_like, str, :class:`~psychopy.colors.Color` or None
         Sets both the initial `lineColor` and `fillColor` of the shape.
     colorSpace : str
         Sets the colorspace, changing how values passed to `lineColor` and

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -44,7 +44,7 @@ class Pie(BaseShapeStim):
         attributes `pos`, `size` and `radius` are interpreted.
     lineWidth : float
         Width of the shape's outline.
-    lineColor, fillColor : array_like, str, :class:`~psychopy.visual.Color` or None
+    lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the shape outline and fill. If `None`, a fully transparent
         color is used which makes the fill or outline invisible.
     lineColorSpace, fillColorSpace : str
@@ -84,7 +84,7 @@ class Pie(BaseShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     name : str
@@ -97,7 +97,7 @@ class Pie(BaseShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.shape.ShapeStim.draw()` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or None
+    color : array_like, str, :class:`~psychopy.colors.Color` or None
         Sets both the initial `lineColor` and `fillColor` of the shape.
     colorSpace : str
         Sets the colorspace, changing how values passed to `lineColor` and

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -43,7 +43,7 @@ class Polygon(BaseShapeStim):
         attributes `pos`, `size` and `radius` are interpreted.
     lineWidth : float
         Width of the polygon's outline.
-    lineColor, fillColor : array_like, str, :class:`~psychopy.visual.Color` or `None`
+    lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or `None`
         Color of the shape's outline and fill. If `None`, a fully
         transparent color is used which makes the fill or outline invisible.
     lineColorSpace, fillColorSpace : str
@@ -85,7 +85,7 @@ class Polygon(BaseShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     name : str
@@ -98,7 +98,7 @@ class Polygon(BaseShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.shape.ShapeStim.draw()` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or `None`
+    color : array_like, str, :class:`~psychopy.colors.Color` or `None`
         Sets both the initial `lineColor` and `fillColor` of the shape.
     colorSpace : str
         Sets the colorspace, changing how values passed to `lineColor` and

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -39,7 +39,7 @@ class Rect(BaseShapeStim):
         attributes `pos`, `size` and `radius` are interpreted.
     lineWidth : float
         Width of the shape's outline.
-    lineColor, fillColor : array_like, str, :class:`~psychopy.visual.Color` or None
+    lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the shape outline and fill. If `None`, a fully transparent
         color is used which makes the fill or outline invisible.
     lineColorSpace, fillColorSpace : str
@@ -79,7 +79,7 @@ class Rect(BaseShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     name : str
@@ -92,7 +92,7 @@ class Rect(BaseShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.shape.ShapeStim.draw()` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or None
+    color : array_like, str, :class:`~psychopy.colors.Color` or None
         Sets both the initial `lineColor` and `fillColor` of the shape.
     colorSpace : str
         Sets the colorspace, changing how values passed to `lineColor` and

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -453,7 +453,7 @@ class ShapeStim(BaseShapeStim):
         `fillColor` are interpreted.
     lineWidth : float
         Width of the shape outline.
-    lineColor, fillColor : array_like, str, :class:`~psychopy.visual.Color` or None
+    lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the shape outline and fill. If `None`, a fully
         transparent color is used which makes the fill or outline invisible.
     vertices : array_like
@@ -507,9 +507,9 @@ class ShapeStim(BaseShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.ShapeStim.draw` method.
-    color : array_like, str, :class:`~psychopy.visual.Color` or None
+    color : array_like, str, :class:`~psychopy.colors.Color` or None
         Sets both the initial `lineColor` and `fillColor` of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.visual.Color` or None
+    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     lineColorSpace, fillColorSpace : str


### PR DESCRIPTION
@TEParsons Added a file for the `colors` module. Should automatically pickup all the docstrings once they are added. Also fixed the references to the color class in the visual stimuli docs.
