### PR TITLE
BF: Fixed exception in textbox stim caused by change to colors.isValidColor behaviour

### DIFF
--- a/psychopy/visual/textbox/__init__.py
+++ b/psychopy/visual/textbox/__init__.py
@@ -1137,9 +1137,9 @@ class TextBox(object):
 
         if color is None:
             raise ValueError("TextBox: None is not a valid color input")
-        if not colors.isValidColor(color):
-            raise ValueError(
-                "TextBox: %s is not a valid color." % (str(color)))
+        #if not colors.isValidColor(color):
+        #    raise ValueError(
+        #        "TextBox: %s is not a valid color." % (str(color)))
 
         valid_opacity = opacity >= 0.0 and opacity <= 1.0
         if isinstance(color, basestring):


### PR DESCRIPTION
BF: Textbox started to fail because colors.isValidColor no longer returns True for 'valid' rgb255 or rgb tuples.