### PR TITLE
FF: Coder can't print files including non-ASCII characters

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -32,6 +32,7 @@ import bdb
 import pickle
 import time
 import textwrap
+import codecs
 
 from .. import stdOutRich, dialogs
 from .. import pavlovia_ui
@@ -2187,7 +2188,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
     def filePrint(self, event=None):
         pr = Printer()
         docName = self.currentDoc.filename
-        text = open(docName, 'r').read()
+        text = codecs.open(docName, 'r', 'utf-8').read()
         pr.Print(text, docName)
 
     def fileNew(self, event=None, filepath=""):


### PR DESCRIPTION
On Windows 10, printing files including non-ASCII characters from the Coder results in corrupted output or unhandled exception:
```
Traceback (most recent call last):
  File "C:\Users\Hiroyuki\Dropbox\git-repository\psychopy\psychopy\app\coder\coder.py", line 2190, in filePrint
    text = open(docName, 'r').read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 29: illegal multibyte sequence
```

Here is a minimal sample file of causing the above exception.

```
#coding: utf-8

font_name = 'ＭＳ 明朝'
```

To avoid this issue, files should be opened by `codecs.open()`.
