### PR TITLE
Fix fontmanager.addFontDirectory and update to setup.cfg

### DIFF
--- a/psychopy/visual/textbox2/fontmanager.py
+++ b/psychopy/visual/textbox2/fontmanager.py
@@ -582,13 +582,15 @@ def findFontFiles(folders=(), recursive=True):
     -------
     list of pathlib.Path objects
     """
-    if sys.platform == 'win32':
-        searchPaths = []  # just leave it to matplotlib as below
-    elif sys.platform == 'darwin':
-        # on mac matplotlib doesn't include 'ttc' files (which are fine)
-        searchPaths = _OSXFontDirectories
-    elif sys.platform.startswith('linux'):
-        searchPaths = _X11FontDirectories
+    searchPaths = folders
+    if searchPaths is None or len(searchPaths)==0:
+        if sys.platform == 'win32':
+            searchPaths = []  # just leave it to matplotlib as below
+        elif sys.platform == 'darwin':
+            # on mac matplotlib doesn't include 'ttc' files (which are fine)
+            searchPaths = _OSXFontDirectories
+        elif sys.platform.startswith('linux'):
+            searchPaths = _X11FontDirectories
     # search those folders
     fontPaths = []
     for thisFolder in searchPaths:

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ install_requires =
     astunparse
     esprima
     freetype-py
+    python-vlc
     jedi >= 0.15.2
     # Platform-specific dependencies.
     javascripthon; python_version >= "3.5"


### PR DESCRIPTION
BF: Both textbox and textbox2 fontmanager.addFontDirectory() was not working.
BF: textbox MonospaceFontAtlas.saveGlyphBitmap() was broken (was using now non existant scipy function)
ADD: Added python-vlc to setup.cfg package dependency list, fixes #3486