### PR TITLE
BF: logging of app traceback in last load.log

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -241,7 +241,6 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
           testMode: bool
         """
         self.SetAppName('PsychoPy3')
-        fuck
         if showSplash: #showSplash:
             # show splash screen
             splashFile = os.path.join(

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -220,16 +220,18 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         self.locale = localization.setLocaleWX()
         self.locale.AddCatalog(self.GetAppName())
 
-        # set the exception hook to present unhandled errors in a dialog
-        if not travisCI:
-            from psychopy.app.errorDlg import exceptionCallback
-            sys.excepthook = exceptionCallback
-
+        logging.flush()
         self.onInit(testMode=testMode, **kwargs)
         if profiling:
             profile.disable()
             print("time to load app = {:.2f}".format(time.time()-t0))
             profile.dump_stats('profileLaunchApp.profile')
+        logging.flush()
+
+        # set the exception hook to present unhandled errors in a dialog
+        if not travisCI:
+            from psychopy.app.errorDlg import exceptionCallback
+            sys.excepthook = exceptionCallback
 
 
     def onInit(self, showSplash=True, testMode=False):
@@ -239,7 +241,7 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
           testMode: bool
         """
         self.SetAppName('PsychoPy3')
-
+        fuck
         if showSplash: #showSplash:
             # show splash screen
             splashFile = os.path.join(


### PR DESCRIPTION
Setting the sys.excepthook really needs to happen at the end of the
loading of the app (after onInit() ) or it could prevent the log file
reporting any crash tracebacks

I've added 2 logging.flush() calls but these are *probably* nto needed