### PR TITLE
ENH: Link monospace font setting to universal validator

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -30,6 +30,17 @@ class _ValidatorMixin():
                 1, 0, 0
             ))
 
+    def updateCodeFont(self, valType):
+        """Style input box according to code wanted"""
+        if not hasattr(self, "SetFont") or self.GetName() == "name":
+            # Skip if font not applicable to object type
+            return
+        if valType == "code":
+            # Set font
+            self.SetFont(self.GetTopLevelParent().app._codeFont)
+        else:
+            self.SetFont(self.GetTopLevelParent().app._mainFont)
+
 class _FileMixin:
     @property
     def rootDir(self):
@@ -93,22 +104,7 @@ class SingleLineCtrl(wx.TextCtrl, _ValidatorMixin):
         # Add self to sizer
         self._szr.Add(self, proportion=1, border=5, flag=wx.EXPAND)
         # Bind to validation
-        self.Bind(wx.EVT_TEXT, self.codeWanted)
-        self.codeWanted(None)
-
-    def codeWanted(self, evt):
-        if self.GetValue().startswith("$") or not self.valType == "str" and not self.GetName() == "name":
-            spec = ThemeMixin.codeColors.copy()
-            base = spec['base']
-            # Override base font with user spec if present
-            if prefs.coder['codeFont'].lower() != "From Theme...".lower():
-                base['font'] = prefs.coder['codeFont']
-            self.SetFont(self.GetTopLevelParent().app._codeFont)
-            validate(self, "code")
-        else:
-            validate(self, self.valType)
-            self.SetFont(self.GetTopLevelParent().app._mainFont)
-
+        self.Bind(wx.EVT_TEXT, self.validate)
 
 class MultiLineCtrl(SingleLineCtrl, _ValidatorMixin):
     def __init__(self, parent, valType,
@@ -417,6 +413,9 @@ def validate(obj, valType):
     obj.valid = valid
     if hasattr(obj, "showValid"):
         obj.showValid(valid)
+
+    # Update code font
+    obj.updateCodeFont(valType)
 
 class DictCtrl(ListWidget, _ValidatorMixin):
     def __init__(self, parent,

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -277,7 +277,7 @@ class TableCtrl(wx.TextCtrl, _ValidatorMixin, _FileMixin):
                          ".cub",".atom",".atomsvc",
                          ".prn",".slk",".dif"]
 
-    def validate(self, evt):
+    def validate(self, evt=None):
         """Redirect validate calls to global validate method, assigning appropriate valType"""
         validate(self, "file")
         # Enable Excel button if valid

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from ..localizedStrings import _localizedDialogs as _localized
 
 class _ValidatorMixin():
-    def validate(self, evt):
+    def validate(self, evt=None):
         """Redirect validate calls to global validate method, assigning appropriate valType"""
         validate(self, self.valType)
 
@@ -105,6 +105,7 @@ class SingleLineCtrl(wx.TextCtrl, _ValidatorMixin):
         self._szr.Add(self, proportion=1, border=5, flag=wx.EXPAND)
         # Bind to validation
         self.Bind(wx.EVT_TEXT, self.validate)
+        self.validate()
 
 class MultiLineCtrl(SingleLineCtrl, _ValidatorMixin):
     def __init__(self, parent, valType,
@@ -176,6 +177,7 @@ class FileCtrl(wx.TextCtrl, _ValidatorMixin, _FileMixin):
         self._szr.Add(self.findBtn)
         # Configure validation
         self.Bind(wx.EVT_TEXT, self.validate)
+        self.validate()
 
     def findFile(self, evt):
         file = self.getFile()
@@ -264,6 +266,7 @@ class TableCtrl(wx.TextCtrl, _ValidatorMixin, _FileMixin):
         }
         # Configure validation
         self.Bind(wx.EVT_TEXT, self.validate)
+        self.validate()
         self.validExt = [".csv",".tsv",".txt",
                          ".xl",".xlsx",".xlsm",".xlsb",".xlam",".xltx",".xltm",".xls",".xlt",
                          ".htm",".html",".mht",".mhtml",
@@ -273,6 +276,7 @@ class TableCtrl(wx.TextCtrl, _ValidatorMixin, _FileMixin):
                          ".iqy",".dqy",".rqy",".oqy",
                          ".cub",".atom",".atomsvc",
                          ".prn",".slk",".dif"]
+
     def validate(self, evt):
         """Redirect validate calls to global validate method, assigning appropriate valType"""
         validate(self, "file")
@@ -333,6 +337,7 @@ class ColorCtrl(wx.TextCtrl, _ValidatorMixin):
         self._szr.Add(self.pickerBtn)
         # Bind to validation
         self.Bind(wx.EVT_TEXT, self.validate)
+        self.validate()
 
     def colorPicker(self, evt):
         PsychoColorPicker(self.GetTopLevelParent().frame)


### PR DESCRIPTION
This means that e.g. color and table params will undergo the same monospace font setting as str params, rather than doing the same "if startswith($)" type thing several times in different places