### PR TITLE
BF: Remove "" from OSX search paths, should mean fontmanager doesn't look in the experiment folder for fonts

### DIFF
--- a/psychopy/visual/textbox2/fontmanager.py
+++ b/psychopy/visual/textbox2/fontmanager.py
@@ -52,7 +52,6 @@ _OSXFontDirectories = [
     "/System/Library/Fonts",
     # fonts installed via MacPorts
     "/opt/local/share/fonts",
-    ""
 ]
 
 _weightMap = {


### PR DESCRIPTION
… (removing the possibility that it could search a huge amount of files if the experiment file is somewhere silly)