### PR TITLE
BF: Set opacity /after/ setting colors for shape stim

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -126,7 +126,6 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         super(BaseShapeStim, self).__init__(win, units=units,
                                             name=name, autoLog=False)
 
-        self.opacity = opacity
         self.pos = numpy.array(pos, float)
         self.closeShape = closeShape
         self.lineWidth = lineWidth
@@ -161,6 +160,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
                             " Please use color and colorSpace args instead")
             self.setFillColor(fillRGB, colorSpace='rgb', log=None)
         self.contrast = contrast
+        self.opacity = opacity
 
         # Other stuff
         self.depth = depth


### PR DESCRIPTION
as Color objects have their own alpha values, if you set them after setting opacity then these override the object's opacity (whereas the object's opacity should override the Color objects'), fixes #3494