### PR TITLE
ENH: save variable "reliableFrame" to output for online experiments (…

### DIFF
--- a/psychopy/experiment/components/settings/JS_setupExp.tmpl
+++ b/psychopy/experiment/components/settings/JS_setupExp.tmpl
@@ -8,9 +8,11 @@ function updateInfo() {{
 
   // store frame rate of monitor if we can measure it successfully
   expInfo['frameRate'] = psychoJS.window.getActualFrameRate();
+  expInfo['reliableFrame'] = true;
   if (typeof expInfo['frameRate'] !== 'undefined')
     frameDur = 1.0 / Math.round(expInfo['frameRate']);
   else
+    expInfo['reliableFrame'] = false;
     frameDur = 1.0 / 60.0; // couldn't get a reliable measure so guess
 
   // add info from the URL:


### PR DESCRIPTION
…was the frame rate reliably measured or was 60Hz assumed?) adds a column to output file to save a binary variable staing if the frame rate was measured reliably or not for that experiment (i.e. was 60Hz assumed)