### PR TITLE
BF: set multiline:true for TextBox in JS

### DIFF
--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -229,6 +229,7 @@ class TextboxComponent(BaseVisualComponent):
                 "  opacity: %(opacity)s,\n"
                 "  padding: %(padding)s,\n"
                 "  editable: %(editable)s,\n"
+                "  multiline: true,\n"
                 "  anchor: %(anchor)s,\n")
         buff.writeIndentedLines(code % inits)
 


### PR DESCRIPTION
To allow the TextBox on JS to be height-adjustable we need to specify
the multiline=true

fixes GH-3352

See discourse.psychopy.org/t/16870