### PR TITLE
Change multi choice ctrl to use listFromString not regex

### DIFF
--- a/building/apple_sign.py
+++ b/building/apple_sign.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
 from pathlib import Path
 import subprocess
 import re

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
 import os
 import wx
 
@@ -11,6 +18,7 @@ import re
 from pathlib import Path
 
 from ..localizedStrings import _localizedDialogs as _localized
+
 
 class _ValidatorMixin():
     def validate(self, evt=None):
@@ -164,6 +172,7 @@ class ChoiceCtrl(wx.Choice, _ValidatorMixin):
         # because label string is localized.
         wx.Choice.SetSelection(self, self._choices.index(string))
 
+
 class MultiChoiceCtrl(wx.CheckListBox, _ValidatorMixin):
     def __init__(self, parent, valType,
                  vals="", choices=[], fieldName="",
@@ -190,6 +199,7 @@ class MultiChoiceCtrl(wx.CheckListBox, _ValidatorMixin):
 
     def GetValue(self, evt=None):
         return self.GetCheckedStrings()
+
 
 class FileCtrl(wx.TextCtrl, _ValidatorMixin, _FileMixin):
     def __init__(self, parent, valType,

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -175,9 +175,7 @@ class MultiChoiceCtrl(wx.CheckListBox, _ValidatorMixin):
         # Make initial selection
         if isinstance(vals, str):
             # Convert to list if needed
-            vals = re.sub(r"[\[\]\(\)\"\']", "", vals).split(",")
-            # Remove empties
-            vals = [v for v in vals if v]
+            vals = data.utils.listFromString(vals, excludeEmpties=True)
         self.SetCheckedStrings(vals)
         self.validate()
 

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
 from __future__ import absolute_import, division, print_function
 
 # from future import standard_library

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -165,15 +165,17 @@ def indicesFromString(indsString):
         pass
 
 
-def listFromString(val):
+def listFromString(val, excludeEmpties=False):
     """Take a string that looks like a list (with commas and/or [] and make
     an actual python list"""
+    # was previously called strToList and str2list might have been an option!
+    # I'll leave those here for anyone doing a find-in-path for those
     if type(val) == tuple:
         return list(val)
     elif type(val) == list:
         return list(val)  # nothing to do
     elif type(val) != str:
-        raise ValueError("_strToList requires a string as its input not {}"
+        raise ValueError("listFromString requires a string as its input not {}"
                          .format(repr(val)))
     # try to evaluate with ast (works for "'yes,'no'" or "['yes', 'no']")
     try:
@@ -188,7 +190,10 @@ def listFromString(val):
     if val.startswith(('[', '(')) and val.endswith((']', ')')):
         val = val[1:-1]
     asList = val.split(",")
-    asList = [this.strip() for this in asList]
+    if excludeEmpties:
+        asList = [this.strip() for this in asList if this]
+    else:
+        asList = [this.strip() for this in asList]
     return asList
 
 


### PR DESCRIPTION
History of this is that:
- Py3.8 complained about one of the escape characters
- we moved the string to be a r' '
- then it wasn't clear what was correct anymore
- but we have a function to do this that's neater than using regex anyway