### PR TITLE
BF: Treat `None` as a special case, whose opacity should always be 0

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -375,10 +375,7 @@ class Color(object):
         if isinstance(target, Color):
             return np.all(np.round(target.rgba, 2) == np.round(self.rgba, 2))
         elif target == None:
-            if len(self) > 1:
-                return all(self.alpha == 0)
-            else:
-                return self.alpha == 0
+            return self._requested is None
         else:
             return False
 

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1385,11 +1385,14 @@ class BaseVisualStim(MinimalStim, WindowMixin, LegacyVisualMixin):
             # If opacity is set to be None, this indicates that each color should handle its own opacity
             return
         if hasattr(self, '_foreColor'):
-            self._foreColor.alpha = value
+            if self._foreColor != None:
+                self._foreColor.alpha = value
         if hasattr(self, '_fillColor'):
-            self._fillColor.alpha = value
+            if self._fillColor != None:
+                self._fillColor.alpha = value
         if hasattr(self, '_borderColor'):
-            self._borderColor.alpha = value
+            if self._borderColor != None:
+                self._borderColor.alpha = value
 
     def updateOpacity(self):
         """Placeholder method to update colours when set externally, for example


### PR DESCRIPTION
… rather than just a named color whose value is (0, 0, 0, 0). Setting the alpha of the Color will still have an affect, but any colors which are statedly None won't be affected by changes to the opacity of the object. So, for example, a Textbox with `fillColor=None` can vary its opacity without a box appearing around it