### PR TITLE
BF: None being passed to pygletbackend onKey

### DIFF
--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -367,23 +367,24 @@ class PygletBackend(BaseBackend):
         :return:
         """
         wins = _default_display_.get_windows()
-
         for win in wins:
             win.dispatch_events()
 
     def onKey(self, evt, modifiers):
         "Check for tab key then pass all events to event package"
-        thisKey = pyglet.window.key.symbol_string(evt).lower()
-        if thisKey == 'tab':
-            self.onText('\t')
-        event._onPygletKey(evt, modifiers)
+        if evt is not None:
+            thisKey = pyglet.window.key.symbol_string(evt).lower()
+            if thisKey == 'tab':
+                self.onText('\t')
+            event._onPygletKey(evt, modifiers)
 
     def onText(self, evt):
         """Retrieve the character event(s?) for this window"""
-        currentEditable = self.win.currentEditable
-        if currentEditable:
-            currentEditable._onText(evt)
-        event._onPygletText(evt)  # duplicate the event to the psychopy.events lib
+        if evt is not None:
+            currentEditable = self.win.currentEditable
+            if currentEditable:
+                currentEditable._onText(evt)
+            event._onPygletText(evt)  # duplicate the event to the psychopy.events lib
 
     def onCursorKey(self, evt):
         """Processes the events from pyglet.window.on_text_motion


### PR DESCRIPTION
BF: None being passed to pygletbackend onKey was causing an exception. 
Now check before passing onto other code. 
Issue was reported: https://discourse.psychopy.org/t/importerror-sys-meta-path-is-none-python-is-likely-shutting-down/20641/4
fixes #3615