### PR TITLE
BF: Editable form items need to respect the Form's aperture while retaining autoDraw status to be editable

### DIFF
--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -785,7 +785,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         """
         for i in self.items:
             if i['responseCtrl']:
-                i['responseCtrl'].setAutoDraw(value)        
+                i['responseCtrl'].__dict__['autoDraw'] = value
+                self.win.addEditable(i['responseCtrl'])
         BaseVisualStim.setAutoDraw(self, value, log)
         
     def draw(self):


### PR DESCRIPTION
tagging Sol as this touches your fixes to autoDraw and I want to be sure it doesn't break them