### PR TITLE
BF: Builder failing to sync new git projects

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1045,8 +1045,13 @@ def getGitRoot(p):
     if not p.is_dir():
         p = p.parent  # given a file instead of folder?
 
-    if 'not a git repository' in subprocess.check_output(["git", "branch", "--show-current"],
-                                                         cwd=str(p)).decode('utf-8'):
+    proc = subprocess.Popen('git branch --show-current',
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            cwd=str(p), shell=True,
+                            universal_newlines=True)  # newlines forces stdout to unicode
+    stdout, stderr = proc.communicate()
+    if 'not a git repository' in (stdout + stderr):
         return None
     else:
         # this should have been possible with git rev-parse --top-level


### PR DESCRIPTION
The switch to use check_output meant that when there was no
existing git repo in the folder the call `git branch --show-current`
returns non-zero but with check_output that causes an error to be
raised. We don't want that - we want to know it happened and move on.