### PR TITLE
BF/ENH: Form styling

### DIFF
--- a/psychopy/demos/builder/Experiments/BigFiveInventory/BFI.psyexp
+++ b/psychopy/demos/builder/Experiments/BigFiveInventory/BFI.psyexp
@@ -77,11 +77,13 @@
         <Param name="Randomize" val="False" valType="bool" updates="constant"/>
         <Param name="Style" val="dark" valType="str" updates="constant"/>
         <Param name="Text Height" val="0.025" valType="num" updates="constant"/>
-        <Param name="borderColor" val="None" valType="color" updates="constant"/>
+        <Param name="borderColor" val="white" valType="color" updates="constant"/>
+        <Param name="color" val="white" valType="color" updates="constant"/>
+        <Param name="colorSpace" val="rgb" valType="str" updates="constant"/>
         <Param name="contrast" val="1" valType="code" updates="constant"/>
         <Param name="disabled" val="False" valType="bool" updates="None"/>
         <Param name="durationEstim" val="" valType="num" updates="None"/>
-        <Param name="fillColor" val="None" valType="color" updates="constant"/>
+        <Param name="fillColor" val="red" valType="color" updates="constant"/>
         <Param name="name" val="demog" valType="code" updates="None"/>
         <Param name="opacity" val="1" valType="num" updates="constant"/>
         <Param name="pos" val="(0, 0)" valType="list" updates="constant"/>
@@ -174,11 +176,13 @@
         <Param name="Randomize" val="False" valType="bool" updates="constant"/>
         <Param name="Style" val="dark" valType="str" updates="constant"/>
         <Param name="Text Height" val="0.025" valType="num" updates="constant"/>
-        <Param name="borderColor" val="None" valType="color" updates="constant"/>
+        <Param name="borderColor" val="white" valType="color" updates="constant"/>
+        <Param name="color" val="white" valType="color" updates="constant"/>
+        <Param name="colorSpace" val="rgb" valType="str" updates="constant"/>
         <Param name="contrast" val="1" valType="code" updates="constant"/>
         <Param name="disabled" val="False" valType="bool" updates="None"/>
         <Param name="durationEstim" val="" valType="num" updates="None"/>
-        <Param name="fillColor" val="None" valType="color" updates="constant"/>
+        <Param name="fillColor" val="red" valType="color" updates="constant"/>
         <Param name="name" val="TIPIForm" valType="code" updates="None"/>
         <Param name="opacity" val="1" valType="num" updates="constant"/>
         <Param name="pos" val="(0, 0)" valType="list" updates="constant"/>

--- a/psychopy/demos/builder/Experiments/BigFiveInventory/BFI.psyexp
+++ b/psychopy/demos/builder/Experiments/BigFiveInventory/BFI.psyexp
@@ -9,7 +9,7 @@
     <Param name="Enable Escape" val="True" valType="bool" updates="None"/>
     <Param name="Experiment info" val="{'participant': '', 'session': '001'}" valType="code" updates="None"/>
     <Param name="Force stereo" val="True" valType="bool" updates="None"/>
-    <Param name="Full-screen window" val="True" valType="bool" updates="None"/>
+    <Param name="Full-screen window" val="False" valType="bool" updates="None"/>
     <Param name="HTML path" val="" valType="str" updates="None"/>
     <Param name="Incomplete URL" val="" valType="str" updates="None"/>
     <Param name="Monitor" val="testMonitor" valType="str" updates="None"/>
@@ -75,17 +75,17 @@
         <Param name="Item Padding" val="0.06" valType="num" updates="constant"/>
         <Param name="Items" val="demographics.xlsx" valType="file" updates="constant"/>
         <Param name="Randomize" val="False" valType="bool" updates="constant"/>
-        <Param name="Style" val="dark" valType="str" updates="constant"/>
+        <Param name="Style" val="legalPad" valType="str" updates="constant"/>
         <Param name="Text Height" val="0.025" valType="num" updates="constant"/>
-        <Param name="borderColor" val="white" valType="color" updates="constant"/>
-        <Param name="color" val="white" valType="color" updates="constant"/>
+        <Param name="borderColor" val="black" valType="color" updates="constant"/>
+        <Param name="color" val="black" valType="color" updates="constant"/>
         <Param name="colorSpace" val="rgb" valType="str" updates="constant"/>
         <Param name="contrast" val="1" valType="code" updates="constant"/>
         <Param name="disabled" val="False" valType="bool" updates="None"/>
         <Param name="durationEstim" val="" valType="num" updates="None"/>
         <Param name="fillColor" val="red" valType="color" updates="constant"/>
         <Param name="name" val="demog" valType="code" updates="None"/>
-        <Param name="opacity" val="1" valType="num" updates="constant"/>
+        <Param name="opacity" val="" valType="num" updates="constant"/>
         <Param name="pos" val="(0, 0)" valType="list" updates="constant"/>
         <Param name="saveStartStop" val="True" valType="bool" updates="None"/>
         <Param name="size" val="(1, 0.7)" valType="list" updates="constant"/>
@@ -174,10 +174,10 @@
         <Param name="Item Padding" val="0.05" valType="num" updates="constant"/>
         <Param name="Items" val="TIPI.xlsx" valType="file" updates="constant"/>
         <Param name="Randomize" val="False" valType="bool" updates="constant"/>
-        <Param name="Style" val="dark" valType="str" updates="constant"/>
+        <Param name="Style" val="legalPad" valType="str" updates="constant"/>
         <Param name="Text Height" val="0.025" valType="num" updates="constant"/>
-        <Param name="borderColor" val="white" valType="color" updates="constant"/>
-        <Param name="color" val="white" valType="color" updates="constant"/>
+        <Param name="borderColor" val="black" valType="color" updates="constant"/>
+        <Param name="color" val="black" valType="color" updates="constant"/>
         <Param name="colorSpace" val="rgb" valType="str" updates="constant"/>
         <Param name="contrast" val="1" valType="code" updates="constant"/>
         <Param name="disabled" val="False" valType="bool" updates="None"/>

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -108,6 +108,13 @@ class FormComponent(BaseVisualComponent):
             hint=_translate("Store item data by columns, or rows"),
             label=_localized['Data Format'])
 
+        self.params['Style'] = Param(
+            style, valType='str', inputType="choice", categ="Appearance",
+            updates='constant', allowedVals=knownStyles,
+            hint=_translate(
+                    "Styles determine the appearance of the form"),
+            label=_localized['Style'])
+
         self.params['color'].label = _translate("Text Color")
         self.params['fillColor'].label = _translate("Marker Colors")
         self.params['borderColor'].label =_translate("Lines Color")

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -41,6 +41,9 @@ class FormComponent(BaseVisualComponent):
                  items='.csv',
                  textHeight=.03,
                  randomize=False,
+                 color='white',
+                 fillColor='red',
+                 borderColor='white',
                  size=(1, .7),
                  pos=(0, 0),
                  style='dark',
@@ -52,13 +55,12 @@ class FormComponent(BaseVisualComponent):
         super(FormComponent, self).__init__(
             exp, parentName, name=name,
             pos=pos, size=size,
+            color=color, fillColor=fillColor, borderColor=borderColor,
             startType=startType, startVal=startVal,
             stopType=stopType, stopVal=stopVal,
             startEstim=startEstim, durationEstim=durationEstim)
 
         # these are defined by the BaseVisual but we don't want them
-        del self.params['color']
-        del self.params['colorSpace']
         del self.params['ori']
         del self.params['units']  # we only support height units right now
 
@@ -70,7 +72,6 @@ class FormComponent(BaseVisualComponent):
         self.order += ['Items', 'Randomize',  # Basic tab
                        'Data Format',  # Data tab
                       ]
-        self.order.insert(self.order.index("colorSpace"), "Style")
         self.order.insert(self.order.index("units"), "Item Padding")
 
         # normal params:
@@ -94,13 +95,6 @@ class FormComponent(BaseVisualComponent):
             hint=_translate("Do you want to randomize the order of your questions?"),
             label=_localized['Randomize'])
 
-        self.params['Style'] = Param(
-            style, valType='str', inputType="choice", categ="Appearance",
-            updates='constant', allowedVals=knownStyles,
-            hint=_translate(
-                    "Styles determine the appearance of the form"),
-            label=_localized['Style'])
-
         self.params['Item Padding'] = Param(
             itemPadding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant',
@@ -114,6 +108,10 @@ class FormComponent(BaseVisualComponent):
             hint=_translate("Store item data by columns, or rows"),
             label=_localized['Data Format'])
 
+        self.params['color'].label = _translate("Text Color")
+        self.params['fillColor'].label = _translate("Marker Colors")
+        self.params['borderColor'].label =_translate("Lines Color")
+
         self.params['pos'].allowedUpdates = []
         self.params['size'].allowedUpdates = []
 
@@ -125,6 +123,7 @@ class FormComponent(BaseVisualComponent):
                    "    items={Items},\n"
                    "    textHeight={Text Height},\n"
                    "    randomize={Randomize},\n"
+                   "    color={color}, fillColor={fillColor}, borderColor={borderColor}, colorSpace={colorSpace}, \n"
                    "    size={size},\n"
                    "    pos={pos},\n"
                    "    style={Style},\n"

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -122,6 +122,11 @@ class FormComponent(BaseVisualComponent):
         self.params['borderColor'].label =_translate("Lines Color")
         self.params['borderColor'].allowedUpdates = []
 
+        # TEMPORARY: Hide color params until we have something that works
+        del self.params['color']
+        del self.params['fillColor']
+        del self.params['borderColor']
+
         self.params['pos'].allowedUpdates = []
         self.params['size'].allowedUpdates = []
 
@@ -133,7 +138,7 @@ class FormComponent(BaseVisualComponent):
                    "    items={Items},\n"
                    "    textHeight={Text Height},\n"
                    "    randomize={Randomize},\n"
-                   "    color={color}, fillColor={fillColor}, borderColor={borderColor}, colorSpace={colorSpace}, \n"
+                   # "    color={color}, fillColor={fillColor}, borderColor={borderColor}, colorSpace={colorSpace}, \n"
                    "    size={size},\n"
                    "    pos={pos},\n"
                    "    style={Style},\n"

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -116,11 +116,11 @@ class FormComponent(BaseVisualComponent):
             label=_localized['Style'])
 
         self.params['color'].label = _translate("Text Color")
-        self.params['color'].updates = 'constant'
+        self.params['color'].allowedUpdates = []
         self.params['fillColor'].label = _translate("Marker Colors")
-        self.params['fillColor'].updates = 'constant'
+        self.params['fillColor'].allowedUpdates = []
         self.params['borderColor'].label =_translate("Lines Color")
-        self.params['borderColor'].updates = 'constant'
+        self.params['borderColor'].allowedUpdates = []
 
     def writeInitCode(self, buff):
         inits = getInitVals(self.params)

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -116,11 +116,11 @@ class FormComponent(BaseVisualComponent):
             label=_localized['Style'])
 
         self.params['color'].label = _translate("Text Color")
-        self.params['color'].updates = 'constant'
+        self.params['color'].allowedUpdates = []
         self.params['fillColor'].label = _translate("Marker Colors")
-        self.params['fillColor'].updates = 'constant'
+        self.params['fillColor'].allowedUpdates = []
         self.params['borderColor'].label =_translate("Lines Color")
-        self.params['borderColor'].updates = 'constant'
+        self.params['borderColor'].allowedUpdates = []
 
         self.params['pos'].allowedUpdates = []
         self.params['size'].allowedUpdates = []

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -46,7 +46,7 @@ class FormComponent(BaseVisualComponent):
                  borderColor='white',
                  size=(1, .7),
                  pos=(0, 0),
-                 style=['dark'],
+                 style='basic',
                  itemPadding=0.05,
                  startType='time (s)', startVal='0.0',
                  stopType='duration (s)', stopVal='',

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -116,8 +116,11 @@ class FormComponent(BaseVisualComponent):
             label=_localized['Style'])
 
         self.params['color'].label = _translate("Text Color")
+        self.params['color'].updates = 'constant'
         self.params['fillColor'].label = _translate("Marker Colors")
+        self.params['fillColor'].updates = 'constant'
         self.params['borderColor'].label =_translate("Lines Color")
+        self.params['borderColor'].updates = 'constant'
 
         self.params['pos'].allowedUpdates = []
         self.params['size'].allowedUpdates = []

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -116,8 +116,11 @@ class FormComponent(BaseVisualComponent):
             label=_localized['Style'])
 
         self.params['color'].label = _translate("Text Color")
+        self.params['color'].updates = 'constant'
         self.params['fillColor'].label = _translate("Marker Colors")
+        self.params['fillColor'].updates = 'constant'
         self.params['borderColor'].label =_translate("Lines Color")
+        self.params['borderColor'].updates = 'constant'
 
     def writeInitCode(self, buff):
         inits = getInitVals(self.params)

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -41,6 +41,9 @@ class FormComponent(BaseVisualComponent):
                  items='.csv',
                  textHeight=.03,
                  randomize=False,
+                 color='white',
+                 fillColor='red',
+                 borderColor='white',
                  size=(1, .7),
                  pos=(0, 0),
                  style=['dark'],
@@ -52,13 +55,12 @@ class FormComponent(BaseVisualComponent):
         super(FormComponent, self).__init__(
             exp, parentName, name=name,
             pos=pos, size=size,
+            color=color, fillColor=fillColor, borderColor=borderColor,
             startType=startType, startVal=startVal,
             stopType=stopType, stopVal=stopVal,
             startEstim=startEstim, durationEstim=durationEstim)
 
         # these are defined by the BaseVisual but we don't want them
-        del self.params['color']
-        del self.params['colorSpace']
         del self.params['ori']
         del self.params['units']  # we only support height units right now
 
@@ -70,7 +72,6 @@ class FormComponent(BaseVisualComponent):
         self.order += ['Items', 'Randomize',  # Basic tab
                        'Data Format',  # Data tab
                       ]
-        self.order.insert(self.order.index("colorSpace"), "Style")
         self.order.insert(self.order.index("units"), "Item Padding")
 
         # normal params:
@@ -94,13 +95,6 @@ class FormComponent(BaseVisualComponent):
             hint=_translate("Do you want to randomize the order of your questions?"),
             label=_localized['Randomize'])
 
-        self.params['Style'] = Param(
-            style, valType='str', inputType="choice", categ="Appearance",
-            updates='constant', allowedVals=knownStyles,
-            hint=_translate(
-                    "Styles determine the appearance of the form"),
-            label=_localized['Style'])
-
         self.params['Item Padding'] = Param(
             itemPadding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant',
@@ -114,6 +108,10 @@ class FormComponent(BaseVisualComponent):
             hint=_translate("Store item data by columns, or rows"),
             label=_localized['Data Format'])
 
+        self.params['color'].label = _translate("Text Color")
+        self.params['fillColor'].label = _translate("Marker Colors")
+        self.params['borderColor'].label =_translate("Lines Color")
+
     def writeInitCode(self, buff):
         inits = getInitVals(self.params)
         # build up an initialization string for Form():
@@ -122,6 +120,7 @@ class FormComponent(BaseVisualComponent):
                    "    items={Items},\n"
                    "    textHeight={Text Height},\n"
                    "    randomize={Randomize},\n"
+                   "    color={color}, fillColor={fillColor}, borderColor={borderColor}, colorSpace={colorSpace}, \n"
                    "    size={size},\n"
                    "    pos={pos},\n"
                    "    style={Style},\n"

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -101,14 +101,15 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                  win,
                  name='default',
                  colorSpace='rgb',
-                 fillColor=None,
-                 borderColor=None,
+                 color='white',
+                 fillColor='red',
+                 borderColor='white',
                  foreColor='white',
                  items=None,
                  textHeight=.02,
                  size=(.5, .5),
                  pos=(0, 0),
-                 style='dark',
+                 style=None,
                  itemPadding=0.05,
                  units='height',
                  randomize=False,
@@ -119,7 +120,6 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self.win = win
         self.autoLog = autoLog
         self.name = name
-        self.style = style
         self.randomize = randomize
         self.items = self.importItems(items)
         self.size = size
@@ -153,6 +153,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         # Create layout of form
         self._createItemCtrls()
+        self.style = style
 
         if self.autoLog:
             logging.exp("Created {} = {}".format(self.name, repr(self)))
@@ -261,7 +262,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                             continue
                         # Default to colour scheme if specified
                         if defaultValues[header] in ['fg', 'bg', 'em']:
-                            item[header] = self.colorScheme[defaultValues[header]]
+                            item[header] = self.color
                         else:
                             item[header] = defaultValues[header]
                         missingHeaders.append(header)
@@ -378,8 +379,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 size=[w, None],  # expand height with text
                 autoLog=False,
                 colorSpace=self.colorSpace,
-                color=item['itemColor'] if item['itemColor'] else self.colorScheme['fg'],
-                fillColor=self.colorScheme['bg'],
+                color=item['itemColor'] or self.color,
+                fillColor=None,
                 padding=0,  # handle this by padding between items
                 borderWidth=1,
                 borderColor=None,  # add borderColor to help debug
@@ -513,12 +514,10 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 flip=True,
                 style=style,
                 autoLog=False,
-                colorSpace=self.colorSpace,
-                color=item['responseColor'])
-        resp.line.lineColor = self.colorScheme['fg']
-        resp.line.fillColor = self.colorScheme['fg']
-        resp.marker.lineColor = self.colorScheme['em']
-        resp.marker.fillColor = self.colorScheme['em']
+                color=item['responseColor'] or self.color,
+                fillColor=self.fillColor,
+                borderColor=self.borderColor,
+                colorSpace=self.colorSpace)
 
         if item['layout'] == 'horiz':
             h += self.textHeight*2
@@ -569,13 +568,13 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 letterHeight=self.textHeight,
                 units=self.units,
                 anchor='top-right',
-                color=self.colorScheme['fg'],
+                color=item['responseColor'] or self.color,
                 colorSpace=self.colorSpace,
-                font='Arial',
+                font='Open Sans',
                 editable=True,
-                borderColor=self.colorScheme['fg'],
+                borderColor=self.borderColor,
                 borderWidth=2,
-                fillColor=self.colorScheme['bg'],
+                fillColor=None,
                 onTextCallback=self._layoutY,
         )
 
@@ -596,14 +595,11 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         scroll = psychopy.visual.Slider(win=self.win,
                                       size=self._scrollBarSize,
                                       ticks=[0, 1],
-                                      style='slider',
+                                      style='scrollbar',
+                                      borderColor= self.borderColor,
+                                      fillColor= self.fillColor,
                                       pos=(self.rightEdge - .008, self.pos[1]),
                                       autoLog=False)
-        scroll.line.lineColor = self.colorScheme['bg']
-        scroll.line.fillColor = self.colorScheme['bg']
-        scroll.marker.lineColor = self.colorScheme['em']
-        scroll.marker.fillColor = self.colorScheme['em']
-
         return scroll
 
     def _setBorder(self):
@@ -620,8 +616,9 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                                     width=self.size[0],
                                     height=self.size[1],
                                     colorSpace=self.colorSpace,
-                                    fillColor=self.fillColor if self.fillColor is not None else self.colorScheme['bg'],
-                                    lineColor=self.borderColor if self.borderColor is not None else self.colorScheme['bg'],
+                                    fillColor=None,
+                                    lineColor=None,
+                                    opacity=None,
                                     autoLog=False)
 
     def _setAperture(self):
@@ -926,25 +923,18 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         """
         self._style = style
-        # Default colours
-        self.colorScheme = {
-            'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-            'bg': Color([0,0,0], 'rgb'),  # background
-            'fg': Color([1,1,1], 'rgb'),  # foreground
-        }
-        if 'light' in style:
-            self.colorScheme = {
-                'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-                'bg': Color([0.89,0.89,0.89], 'rgb'),  # background
-                'fg': Color([-1,-1,-1], 'rgb'),  # foreground
-            }
 
-        if 'dark' in style:
-            self.colorScheme = {
-                'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-                'bg': Color([-0.19,-0.19,-0.14], 'rgb'),  # background
-                'fg': Color([0.89,0.89,0.89], 'rgb'),  # foreground
-            }
+        # Legacy
+        if style == 'light':
+            self.color = 'black'
+            self.borderColor = 'black'
+            self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')
+            self.border.fillColor = Color([0.89,0.89,0.89], 'rgb')
+        if style == 'dark':
+            self.color = 'white'
+            self.borderColor = 'white'
+            self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')
+            self.border.fillColor = Color([-0.19,-0.19,-0.14], 'rgb')
 
     @property
     def values(self):

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -109,7 +109,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                  textHeight=.02,
                  size=(.5, .5),
                  pos=(0, 0),
-                 style=None,
+                 style='dark',
                  itemPadding=0.05,
                  units='height',
                  randomize=False,

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -101,14 +101,15 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                  win,
                  name='default',
                  colorSpace='rgb',
-                 fillColor=None,
-                 borderColor=None,
+                 color='white',
+                 fillColor='red',
+                 borderColor='white',
                  foreColor='white',
                  items=None,
                  textHeight=.02,
                  size=(.5, .5),
                  pos=(0, 0),
-                 style='dark',
+                 style=None,
                  itemPadding=0.05,
                  units='height',
                  randomize=False,
@@ -119,7 +120,6 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self.win = win
         self.autoLog = autoLog
         self.name = name
-        self.style = style
         self.randomize = randomize
         self.items = self.importItems(items)
         self.size = size
@@ -153,6 +153,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         # Create layout of form
         self._createItemCtrls()
+        self.style = style
 
         if self.autoLog:
             logging.exp("Created {} = {}".format(self.name, repr(self)))
@@ -261,7 +262,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                             continue
                         # Default to colour scheme if specified
                         if defaultValues[header] in ['fg', 'bg', 'em']:
-                            item[header] = self.colorScheme[defaultValues[header]]
+                            item[header] = self.color
                         else:
                             item[header] = defaultValues[header]
                         missingHeaders.append(header)
@@ -378,8 +379,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 size=[w, None],  # expand height with text
                 autoLog=False,
                 colorSpace=self.colorSpace,
-                color=item['itemColor'] if item['itemColor'] else self.colorScheme['fg'],
-                fillColor=self.colorScheme['bg'],
+                color=item['itemColor'] or self.color,
+                fillColor=None,
                 padding=0,  # handle this by padding between items
                 borderWidth=1,
                 borderColor=None,  # add borderColor to help debug
@@ -513,12 +514,10 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 flip=True,
                 style=style,
                 autoLog=False,
-                colorSpace=self.colorSpace,
-                color=item['responseColor'])
-        resp.line.lineColor = self.colorScheme['fg']
-        resp.line.fillColor = self.colorScheme['fg']
-        resp.marker.lineColor = self.colorScheme['em']
-        resp.marker.fillColor = self.colorScheme['em']
+                color=item['responseColor'] or self.color,
+                fillColor=self.fillColor,
+                borderColor=self.borderColor,
+                colorSpace=self.colorSpace)
 
         if item['layout'] == 'horiz':
             h += self.textHeight*2
@@ -569,13 +568,13 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                 letterHeight=self.textHeight,
                 units=self.units,
                 anchor='top-right',
-                color=self.colorScheme['fg'],
+                color=item['responseColor'] or self.color,
                 colorSpace=self.colorSpace,
-                font='Arial',
+                font='Open Sans',
                 editable=True,
-                borderColor=self.colorScheme['fg'],
+                borderColor=self.borderColor,
                 borderWidth=2,
-                fillColor=self.colorScheme['bg'],
+                fillColor=None,
                 onTextCallback=self._layoutY,
         )
 
@@ -596,14 +595,11 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         scroll = psychopy.visual.Slider(win=self.win,
                                       size=self._scrollBarSize,
                                       ticks=[0, 1],
-                                      style='slider',
+                                      style='scrollbar',
+                                      borderColor= self.borderColor,
+                                      fillColor= self.fillColor,
                                       pos=(self.rightEdge - .008, self.pos[1]),
                                       autoLog=False)
-        scroll.line.lineColor = self.colorScheme['bg']
-        scroll.line.fillColor = self.colorScheme['bg']
-        scroll.marker.lineColor = self.colorScheme['em']
-        scroll.marker.fillColor = self.colorScheme['em']
-
         return scroll
 
     def _setBorder(self):
@@ -620,8 +616,9 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                                     width=self.size[0],
                                     height=self.size[1],
                                     colorSpace=self.colorSpace,
-                                    fillColor=self.fillColor if self.fillColor is not None else self.colorScheme['bg'],
-                                    lineColor=self.borderColor if self.borderColor is not None else self.colorScheme['bg'],
+                                    fillColor=None,
+                                    lineColor=None,
+                                    opacity=None,
                                     autoLog=False)
 
     def _setAperture(self):
@@ -892,25 +889,18 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         """
         self._style = style
-        # Default colours
-        self.colorScheme = {
-            'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-            'bg': Color([0,0,0], 'rgb'),  # background
-            'fg': Color([1,1,1], 'rgb'),  # foreground
-        }
-        if 'light' in style:
-            self.colorScheme = {
-                'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-                'bg': Color([0.89,0.89,0.89], 'rgb'),  # background
-                'fg': Color([-1,-1,-1], 'rgb'),  # foreground
-            }
 
-        if 'dark' in style:
-            self.colorScheme = {
-                'em': Color([0.89, -0.35, -0.28], 'rgb'),  # emphasis
-                'bg': Color([-0.19,-0.19,-0.14], 'rgb'),  # background
-                'fg': Color([0.89,0.89,0.89], 'rgb'),  # foreground
-            }
+        # Legacy
+        if style == 'light':
+            self.color = 'black'
+            self.borderColor = 'black'
+            self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')
+            self.border.fillColor = Color([0.89,0.89,0.89], 'rgb')
+        if style == 'dark':
+            self.color = 'white'
+            self.borderColor = 'white'
+            self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')
+            self.border.fillColor = Color([-0.19,-0.19,-0.14], 'rgb')
 
     @property
     def values(self):

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -909,6 +909,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
     knownStyles = ["basic", "legalPad"]
     legacyStyles = ["light", "dark"]
+    knownStyles = legacyStyles # Overwrite new styles until implemented
 
     @property
     def style(self):
@@ -975,12 +976,20 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
             self._externalDecorations.insert(0, shadow)
 
         # Legacy
-        if style == 'light':
+        if style == 'light' or str(style) == "['light']":
+            # Set fill/border color the old fashioned way
+            self.border.fillColor = self._fillColor.copy()
+            self.border.borderColor = self._borderColor.copy()
+            # ...then replace set colors with colors from style
             self.color = 'black'
             self.borderColor = 'black'
             self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')
             self.border.fillColor = Color([0.89,0.89,0.89], 'rgb')
-        if style == 'dark':
+        if style == 'dark' or str(style) == "['dark']":
+            # Set fill/border color the old fashioned way
+            self.border.fillColor = self._fillColor.copy()
+            self.border.borderColor = self._borderColor.copy()
+            # ...then replace set colors with colors from style
             self.color = 'white'
             self.borderColor = 'white'
             self.fillColor = Color([0.89, -0.35, -0.28], 'rgb')

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -132,7 +132,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         # Appearance
         self.colorSpace = colorSpace
         self.fillColor = fillColor
-        self.foreColor = foreColor
+        self.foreColor = color
         self.borderColor = borderColor
 
         self.textHeight = textHeight

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -143,6 +143,7 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self.topEdge = None
         self._currentVirtualY = 0  # Y position in the virtual sheet
         self._decorations = []
+        self._externalDecorations = []
         # Check units - only works with height units for now
         if self.win.units != 'height':
             logging.warning(
@@ -160,8 +161,6 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
     def __repr__(self, complete=False):
         return self.__str__(complete=complete)  # from MinimalStim
-
-    knownStyles = ['light', 'dark']
 
     def importItems(self, items):
         """Import items from csv or excel sheet and convert to list of dicts.
@@ -759,6 +758,10 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         """Draw decorations on form."""
         [decoration.draw() for decoration in self._decorations]
 
+    def _drawExternalDecorations(self):
+        """Draw decorations outside the aperture"""
+        [decoration.draw() for decoration in self._externalDecorations]
+
     def _drawCtrls(self):
         """Draw elements on form within border range.
 
@@ -782,6 +785,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         # Check mouse wheel
         self.scrollbar.markerPos += self.scrollbar.mouse.getWheelRel()[
                                         1] / self.scrollSpeed
+        # draw the box and scrollbar
+        self._drawExternalDecorations()
         # enable aperture
         self.aperture.enable()
         # draw the box and scrollbar
@@ -868,10 +873,12 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self.getData()
         return self._complete
 
+    knownStyles = ["basic", "legalPad"]
+    legacyStyles = ["light", "dark"]
+
     @property
     def style(self):
         return self._style
-
     @style.setter
     def style(self, style):
         """Sets some predefined styles or use these to create your own.
@@ -889,6 +896,49 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         """
         self._style = style
+
+        if style == "basic":
+            # Basic is the default, do nothing
+            return
+
+        if style == 'legalPad':
+            # Set page fill color
+            self.border.fillColor = '#F2F6A7' # Legal pad yellow
+
+            # Add left line
+            margin = psychopy.visual.Line(self.win,
+                                 start=[self.pos[0]-self.size[0]/2+self.itemPadding*0.8, self.pos[1]+self.size[1]/2],
+                                 end=[self.pos[0]-self.size[0]/2+self.itemPadding*0.8, self.pos[1]-self.size[1]/2],
+                                 units=self.units,
+                                 lineColor='red'
+                                 )
+            self._decorations.append(margin)
+
+            # Create a drop shadow
+            unitAdjs = {
+                'height': 0.02,
+                'norm': 0.02,
+                'pix': 10,
+                'cm': 1,
+                'deg': 0.5,
+                'degFlatPos': 0.5,
+                'degFlat': 0.5
+            }
+            if self.units in unitAdjs:
+                shadowAdj = unitAdjs[self.units]
+            else:
+                shadowAdj = 0
+            shadow = psychopy.visual.Rect(self.win,
+                units=self.units,
+                pos=[self.pos[0] + shadowAdj, self.pos[1] - shadowAdj],
+                width=self.size[0],
+                height=self.size[1],
+                colorSpace=self.colorSpace,
+                fillColor=Color((-1, -1, -1, 0.2), 'rgb'),
+                lineColor=None,
+                opacity=None,
+                autoLog=False)
+            self._externalDecorations.insert(0, shadow)
 
         # Legacy
         if style == 'light':


### PR DESCRIPTION
Originally was going to rework how form styling works, but to keep things consistent with 2020.2 I've kept the rework in the backend (which makes Form a bit more stable and easy to work with, but doesn't affect anything on the user end) and kept the front end unchanged. This means that Forms will have and be able to respond to fillColor, borderColor, foreColor, etc. but these aren't exposed in Builder and are overridden if the user chooses a legacy `style` (which are currently the only styles exposed in Builder)