### PR TITLE
BF: Textbox startText should always be a string

### DIFF
--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -207,7 +207,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
                 lineWidth=1, lineColor=None, fillColor=fillColor, opacity=0.1,
                 autoLog=False)
         # then layout the text (setting text triggers _layout())
-        self.startText = text
+        self.startText = str(text)
         self._text = ''
         self.text = text if text is not None else ""
 

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -207,9 +207,8 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
                 lineWidth=1, lineColor=None, fillColor=fillColor, opacity=0.1,
                 autoLog=False)
         # then layout the text (setting text triggers _layout())
-        self.startText = str(text)
         self._text = ''
-        self.text = text if text is not None else ""
+        self.text = self.startText = text if text is not None else ""
 
         # caret
         self._editable = editable


### PR DESCRIPTION
Was affecting TextBox when Set Each Repeat in Builder, as it was treating startText as None and throwing an error when trying to do string operations on it