### PR TITLE
BF: iohub keyboard / mouse event timing on macos

### DIFF
--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -765,13 +765,13 @@ class ioServer(object):
                 if dev_cls_name not in self._hookDevice:
                     if dev_cls_name == 'Mouse':
                         dmouse = deviceDict['Mouse']
-                        mouseHookMonitor = DeviceMonitor(dmouse, 0.004)
+                        mouseHookMonitor = DeviceMonitor(dmouse, 0.001)
                         self.deviceMonitors.append(mouseHookMonitor)
                         dmouse._CGEventTapEnable(dmouse._tap, True)
                         self._hookDevice.append('Mouse')
                     if dev_cls_name == 'Keyboard':
                         dkeyboard = deviceDict['Keyboard']
-                        kbHookMonitor = DeviceMonitor(dkeyboard, 0.004)
+                        kbHookMonitor = DeviceMonitor(dkeyboard, 0.001)
                         self.deviceMonitors.append(kbHookMonitor)
                         dkeyboard._CGEventTapEnable(dkeyboard._tap, True)
                         self._hookDevice.append('Keyboard')


### PR DESCRIPTION
BF: iohub had been hard coded to only check for kb or mouse events every 4 msec on macOS. Now tries to check every 1 msec.