### PR TITLE
BF: handle pre-2021.1 Slider styles in 2021.1.3+

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -376,7 +376,10 @@ class Experiment(object):
 
         # custom settings (to be used when
         if valType == 'fixedList':  # convert the string to a list
-            params[name].val = eval('list({})'.format(val))
+            try:
+                params[name].val = eval('list({})'.format(val))
+            except NameError:  # if val is a single string it will look like variable
+                params[name].val = [val]
         elif name == 'storeResponseTime':
             return  # deprecated in v1.70.00 because it was redundant
         elif name == 'nVertices':  # up to 1.85 there was no shape param

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -251,7 +251,10 @@ class SliderComponent(BaseVisualComponent):
         # reformat styles for JS
         # concatenate styles and tweaks
         tweaksList = utils.listFromString(self.params['styleTweaks'].val)
-        stylesList = [inits['styles'].val] + tweaksList
+        if type(inits['styles'].val) == list:  # from an experiment <2021.1
+            stylesList = inits['styles'].val + tweaksList
+        else:
+            stylesList = [inits['styles'].val] + tweaksList
         stylesListJS = [sliderStyles[this] for this in stylesList]
         # if not isinstance(inits['styleTweaks'].val, (tuple, list)):
         #     inits['styleTweaks'].val = [inits['styleTweaks'].val]


### PR DESCRIPTION
Slider styles still not handling the old style specification correctly.

Fixes:
1. to allow the experiment to load at all we need to check if we have
a 'fixedList' valType with only a string rather than list, and convert
to string if needed in `Experiment._getParamFromXML()`
2. to allow the JS script to compile we need to handle either a list
or a string at the compile step in `SliderComponent.writeInitCodeJS()`

Another approach would have been to make a conversion *away* from the
list (into the new format) in (1.) so that (2.) wasn't needed but that
would have broken compatibility more for experiments being shared back
to older studies