### PR TITLE
BF: seeded random generators in TrialHandler affected other rands()

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -262,10 +262,9 @@ class TrialHandler(_BaseTrialHandler):
 
         if self.method == 'random':
             sequenceIndices = []
-            seed = self.seed
+            randGenerator = np.random.RandomState(seed=self.seed)
             for thisRep in range(self.nReps):
-                thisRepSeq = shuffleArray(indices.flat, seed=seed).tolist()
-                seed = None  # so that we only seed the first pass through!
+                thisRepSeq = randGenerator.shuffle(indices.flat).tolist()
                 sequenceIndices.append(thisRepSeq)
             sequenceIndices = np.transpose(sequenceIndices)
         elif self.method == 'sequential':
@@ -273,7 +272,8 @@ class TrialHandler(_BaseTrialHandler):
         elif self.method == 'fullRandom':
             # indices*nReps, flatten, shuffle, unflatten; only use seed once
             sequential = np.repeat(indices, self.nReps, 1)  # = sequential
-            randomFlat = shuffleArray(sequential.flat, seed=self.seed)
+            randGenerator = np.random.RandomState(seed=self.seed)
+            randomFlat = randGenerator.shuffle(sequential.flat, seed=self.seed)
             sequenceIndices = np.reshape(
                 randomFlat, (len(indices), self.nReps))
         if self.autoLog:
@@ -1413,13 +1413,13 @@ class TrialHandlerExt(TrialHandler):
         reshape = np.reshape
         if self.method == 'random':
             seqIndices = []
-            seed = self.seed
+            randomGenerator = np.random.RandomState(seed=self.seed)
             for thisRep in range(self.nReps):
                 if self.trialWeights is None:
                     idx = indices.flat
                 else:
                     idx = repeat(indices, self.trialWeights)
-                thisRepSeq = shuffleArray(idx, seed=seed).tolist()
+                thisRepSeq = randomGenerator.shuffle(idx).tolist()
                 seed = None  # so that we only seed the first pass through!
                 seqIndices.append(thisRepSeq)
             seqIndices = np.transpose(seqIndices)
@@ -1434,13 +1434,13 @@ class TrialHandlerExt(TrialHandler):
                 # indices * nReps, flatten, shuffle, unflatten;
                 # only use seed once
                 sequential = repeat(indices, self.nReps, 1)
-                randomFlat = shuffleArray(sequential.flat, seed=self.seed)
+                randomFlat = np.random.shuffle(sequential.flat, seed=self.seed)
                 seqIndices = reshape(randomFlat,
                                      (len(indices), self.nReps))
             else:
                 _base = repeat(indices, self.trialWeights, 0)
                 sequential = repeat(_base, self.nReps, 1)
-                randomFlat = shuffleArray(sequential.flat, seed=self.seed)
+                randomFlat = np.random.shuffle(sequential.flat, seed=self.seed)
                 seqIndices = reshape(randomFlat,
                                      (sum(self.trialWeights), self.nReps))
 

--- a/psychopy/tools/arraytools.py
+++ b/psychopy/tools/arraytools.py
@@ -149,7 +149,7 @@ def shuffleArray(inArray, shuffleAxis=-1, seed=None):
     """
     # arrAsList = shuffle(list(inArray))
     # return numpy.array(arrAsList)
-    rng = numpy.random.RandomState(seed=seed)
+    rng = numpy.random.default_rng(seed=seed)
 
     inArray = numpy.array(inArray, 'O')  # convert to array if necess
     # create a random array of the same shape

--- a/psychopy/tools/arraytools.py
+++ b/psychopy/tools/arraytools.py
@@ -149,12 +149,11 @@ def shuffleArray(inArray, shuffleAxis=-1, seed=None):
     """
     # arrAsList = shuffle(list(inArray))
     # return numpy.array(arrAsList)
-    if seed is not None:
-        numpy.random.seed(seed)
+    rng = numpy.random.RandomState(seed=seed)
 
     inArray = numpy.array(inArray, 'O')  # convert to array if necess
     # create a random array of the same shape
-    rndArray = numpy.random.random(inArray.shape)
+    rndArray = rng.random(inArray.shape)
     # and get the arguments that would sort it
     newIndices = numpy.argsort(rndArray, shuffleAxis)
     # return the array with the sorted random indices


### PR DESCRIPTION
Our own shuffleArray function was setting the seed for the entire
numpy.random module, not for just this run of the function.

Instead:
- just use numpy.random.shuffle(xx, seed) for most use-cases
- create a single generator of our own for repeated uses (e.g. for
simple random, where we have multiple repeats)
- fix our shuffleArray so that it doesn't alter numpy.random.seed