### PR TITLE
BF: set default color space to be RGB not RGBA for Color Picker

### DIFF
--- a/psychopy/app/colorpicker/__init__.py
+++ b/psychopy/app/colorpicker/__init__.py
@@ -12,7 +12,7 @@ from psychopy.colors import Color
 from psychopy.localization import _translate
 
 LAST_COLOR = Color((0, 0, 0, 1), space='rgba')
-LAST_OUTPUT_SPACE = 0
+LAST_OUTPUT_SPACE = 1
 
 
 class PsychoColorPicker(wx.Dialog):


### PR DESCRIPTION
If RGBA then it inserts a 4-item color into objects that expect an RGB triplet and they then crash