### PR TITLE
DOC: fixed the installation command for macOS in download.rst

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -95,7 +95,7 @@ brew install
 
 On a MacOS machine, `brew` can be used to install PsychoPy::
 
-  brew cask install psychopy
+  brew install --cask psychopy
 
 .. _linux_install:
 


### PR DESCRIPTION
`brew cask install` is disabled, use `brew install --cask`

fix GH-3682