### PR TITLE
Update setup.cfg so  psychtoolbox == 3.0.16

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     freetype-py
     python-vlc
     jedi >= 0.16
-    psychtoolbox; platform_system == "Windows"
+    psychtoolbox == 3.0.16; platform_system == "Windows"
     # Platform-specific dependencies.
     javascripthon; python_version >= "3.5"
     pyglet >= 1.5; platform_system == "Darwin"


### PR DESCRIPTION
Latest release of psychtoolbox causes a wrong argument type error. Using 3.0.16 works for now.