### PR TITLE
RF: Modularise XML writing

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -318,25 +318,6 @@ class Experiment(object):
     def _getShortName(self, longName):
         return longName.replace('(', '').replace(')', '').replace(' ', '')
 
-    def _setXMLparam(self, parent, param, name):
-        """Add a new child to a given xml node. name can include
-        spaces and parens, which will be removed to create child name
-        """
-        if hasattr(param, 'getType'):
-            thisType = param.getType()
-        else:
-            thisType = 'Param'
-        # creates and appends to parent
-        thisChild = xml.SubElement(parent, thisType)
-        thisChild.set('name', name)
-        if hasattr(param, 'val'):
-            thisChild.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
-        if hasattr(param, 'valType'):
-            thisChild.set('valType', param.valType)
-        if hasattr(param, 'updates'):
-            thisChild.set('updates', "{}".format(param.updates))
-        return thisChild
-
     def _getXMLparam(self, params, paramNode, componentNode=None):
         """params is the dict of params of the builder component
         (e.g. stimulus) into which the parameters will be inserted

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -276,54 +276,30 @@ class Experiment(object):
 
         return script
 
+    @property
+    def xml(self):
+        # Create experiment root element
+        experimentNode = xml.Element("PsychoPy2experiment")
+        experimentNode.set('version', __version__)
+        experimentNode.set('encoding', 'utf-8')
+        # Add settings node
+        settingsNode = self.settings.xml
+        experimentNode.append(settingsNode)
+        # Add routines node
+        routineNode = xml.Element("Routines")
+        for key, routine in self.routines.items():
+            routineNode.append(routine.xml)
+        experimentNode.append(routineNode)
+        # Add flow node
+        flowNode = self.flow.xml
+        experimentNode.append(flowNode)
+
+        return experimentNode
+
     def saveToXML(self, filename):
         self.psychopyVersion = psychopy.__version__  # make sure is current
         # create the dom object
-        self.xmlRoot = xml.Element("PsychoPy2experiment")
-        self.xmlRoot.set('version', __version__)
-        self.xmlRoot.set('encoding', 'utf-8')
-        # store settings
-        settingsNode = xml.SubElement(self.xmlRoot, 'Settings')
-        for settingName in sorted(self.settings.params):
-            setting = self.settings.params[settingName]
-            self._setXMLparam(
-                parent=settingsNode, param=setting, name=settingName)
-        # store routines
-        routinesNode = xml.SubElement(self.xmlRoot, 'Routines')
-        # routines is a dict of routines
-        for routineName, routine in self.routines.items():
-            routineNode = self._setXMLparam(
-                parent=routinesNode, param=routine, name=routineName)
-            # a routine is based on a list of components
-            for component in routine:
-                componentNode = self._setXMLparam(
-                    parent=routineNode, param=component,
-                    name=component.params['name'].val)
-                for paramName in sorted(component.params):
-                    param = component.params[paramName]
-                    self._setXMLparam(
-                        parent=componentNode, param=param, name=paramName)
-        # implement flow
-        flowNode = xml.SubElement(self.xmlRoot, 'Flow')
-        # a list of elements(routines and loopInit/Terms)
-        for element in self.flow:
-            elementNode = xml.SubElement(flowNode, element.getType())
-            if element.getType() == 'LoopInitiator':
-                loop = element.loop
-                name = loop.params['name'].val
-                elementNode.set('loopType', loop.getType())
-                elementNode.set('name', name)
-                for paramName in sorted(loop.params):
-                    param = loop.params[paramName]
-                    paramNode = self._setXMLparam(
-                        parent=elementNode, param=param, name=paramName)
-                    # override val with repr(val)
-                    if paramName == 'conditions':
-                        paramNode.set('val', repr(param.val))
-            elif element.getType() == 'LoopTerminator':
-                elementNode.set('name', element.loop.params['name'].val)
-            elif element.getType() == 'Routine':
-                elementNode.set('name', '%s' % element.params['name'])
+        self.xmlRoot = self.xml
         # convert to a pretty string
         # update our document to use the new root
         self._doc._setroot(self.xmlRoot)

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -280,8 +280,8 @@ class Experiment(object):
     def xml(self):
         # Create experiment root element
         experimentNode = xml.Element("PsychoPy2experiment")
-        experimentNode.set('version', __version__)
         experimentNode.set('encoding', 'utf-8')
+        experimentNode.set('version', __version__)
         # Add settings node
         settingsNode = self.settings.xml
         experimentNode.append(settingsNode)

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -133,15 +133,9 @@ class BaseComponent(object):
         # Add an element for each parameter
         for key, param in sorted(self.params.items()):
             # Create node
-            paramNode = Element("Param")
+            paramNode = param.xml
             paramNode.set("name", key)
-            # Assign values
-            if hasattr(param, 'updates'):
-                paramNode.set('updates', "{}".format(param.updates))
-            if hasattr(param, 'val'):
-                paramNode.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
-            if hasattr(param, 'valType'):
-                paramNode.set('valType', param.valType)
+            # Add node
             element.append(paramNode)
 
         return element

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, print_function
 from builtins import str, object, super
 from past.builtins import basestring
 from pathlib import Path
+from xml.etree.ElementTree import Element
 
 from psychopy import prefs
 from psychopy.constants import FOREVER
@@ -123,6 +124,24 @@ class BaseComponent(object):
             label=_translate('Disable component'))
 
         self.order = ['name']  # name first, then timing, then others
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element(self.__class__.__name__)
+        element.set("name", self.params['name'].val)
+        # Add an element for each parameter
+        for key, param in self.params.items():
+            if key == 'name':
+                continue
+            paramNode = Element("Param")
+            paramNode.set("name", key)
+            paramNode.set("updates", str(param.updates))
+            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
+            paramNode.set("valType", str(param.valType))
+            element.append(paramNode)
+
+        return element
 
     def integrityCheck(self):
         """

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -131,14 +131,17 @@ class BaseComponent(object):
         element = Element(self.__class__.__name__)
         element.set("name", self.params['name'].val)
         # Add an element for each parameter
-        for key, param in self.params.items():
-            if key == 'name':
-                continue
+        for key, param in sorted(self.params.items()):
+            # Create node
             paramNode = Element("Param")
             paramNode.set("name", key)
-            paramNode.set("updates", str(param.updates))
-            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
-            paramNode.set("valType", str(param.valType))
+            # Assign values
+            if hasattr(param, 'updates'):
+                paramNode.set('updates', "{}".format(param.updates))
+            if hasattr(param, 'val'):
+                paramNode.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
+            if hasattr(param, 'valType'):
+                paramNode.set('valType', param.valType)
             element.append(paramNode)
 
         return element

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -7,6 +7,7 @@ from builtins import str
 from builtins import object
 import os
 from pathlib import Path
+from xml.etree.ElementTree import Element
 import re
 import wx.__version__
 import psychopy
@@ -314,6 +315,20 @@ class SettingsComponent(object):
             allowedVals=['on Save', 'on Sync', 'manually'],
             hint=_translate("When to export experiment to the HTML folder."),
             label=_localized["Export HTML"], categ='Online')
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element("Settings")
+        # Add an eleent for each parameter
+        for key, param in self.params.items():
+            paramNode = Element("Param")
+            paramNode.set("name", key)
+            paramNode.set("updates", str(param.updates))
+            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
+            paramNode.set("valType", str(param.valType))
+            element.append(paramNode)
+        return element
 
     def getInfo(self):
         """Rather than converting the value of params['Experiment Info']

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -325,15 +325,9 @@ class SettingsComponent(object):
             if key == 'name':
                 continue
             # Create node
-            paramNode = Element("Param")
+            paramNode = param.xml
             paramNode.set("name", key)
-            # Assign values
-            if hasattr(param, 'updates'):
-                paramNode.set('updates', "{}".format(param.updates))
-            if hasattr(param, 'val'):
-                paramNode.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
-            if hasattr(param, 'valType'):
-                paramNode.set('valType', param.valType)
+            # Add node
             element.append(paramNode)
         return element
 

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -320,13 +320,20 @@ class SettingsComponent(object):
     def xml(self):
         # Make root element
         element = Element("Settings")
-        # Add an eleent for each parameter
-        for key, param in self.params.items():
+        # Add an element for each parameter
+        for key, param in sorted(self.params.items()):
+            if key == 'name':
+                continue
+            # Create node
             paramNode = Element("Param")
             paramNode.set("name", key)
-            paramNode.set("updates", str(param.updates))
-            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
-            paramNode.set("valType", str(param.valType))
+            # Assign values
+            if hasattr(param, 'updates'):
+                paramNode.set('updates', "{}".format(param.updates))
+            if hasattr(param, 'val'):
+                paramNode.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
+            if hasattr(param, 'valType'):
+                paramNode.set('valType', param.valType)
             element.append(paramNode)
         return element
 

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import, print_function
 from past.builtins import basestring
+from xml.etree.ElementTree import Element
 
 from psychopy.experiment.routine import Routine
 from psychopy.experiment.loops import LoopTerminator, LoopInitiator
@@ -53,6 +54,21 @@ class Flow(list):
 
     def __repr__(self):
         return "psychopy.experiment.Flow(%s)" % (str(list(self)))
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element("Flow")
+        # Add an element for every Routine, Loop Initiator, Loop Terminator
+        for item in self:
+            sub = item.xml
+            if isinstance(item, Routine):
+                # Remove all sub elements (we only need its name)
+                for comp in sub:
+                    sub.remove(comp)
+            element.append(sub)
+
+        return element
 
     def addLoop(self, loop, startPos, endPos):
         """Adds initiator and terminator objects for the loop

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -64,7 +64,8 @@ class Flow(list):
             sub = item.xml
             if isinstance(item, Routine):
                 # Remove all sub elements (we only need its name)
-                for comp in sub:
+                comps = [comp for comp in sub]
+                for comp in comps:
                     sub.remove(comp)
             element.append(sub)
 

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -18,6 +18,8 @@ The code that writes out a *_lastrun.py experiment file is (in order):
 
 from __future__ import absolute_import, print_function
 from builtins import object
+from xml.etree.ElementTree import Element
+
 # from future import standard_library
 
 from psychopy.experiment import getInitVals
@@ -592,6 +594,22 @@ class LoopInitiator(object):
         self.exp = loop.exp
         loop.initiator = self
 
+    @property
+    def xml(self):
+        # Make root element
+        element = Element("LoopInitiator")
+        element.set("loopType", self.loop.__class__.__name__)
+        element.set("name", self.loop.params['name'].val)
+        # Add an element for each parameter
+        for key, param in self.loop.params.items():
+            paramNode = Element("Param")
+            paramNode.set("name", key)
+            paramNode.set("updates", str(param.updates))
+            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
+            paramNode.set("valType", str(param.valType))
+            element.append(paramNode)
+        return element
+
     def getType(self):
         return 'LoopInitiator'
 
@@ -624,6 +642,14 @@ class LoopTerminator(object):
         self.loop = loop
         self.exp = loop.exp
         loop.terminator = self
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element("LoopTerminator")
+        element.set("name", self.loop.params['name'].val)
+
+        return element
 
     def getType(self):
         return 'LoopTerminator'

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -601,12 +601,17 @@ class LoopInitiator(object):
         element.set("loopType", self.loop.__class__.__name__)
         element.set("name", self.loop.params['name'].val)
         # Add an element for each parameter
-        for key, param in self.loop.params.items():
+        for key, param in sorted(self.loop.params.items()):
+            # Create node
             paramNode = Element("Param")
             paramNode.set("name", key)
-            paramNode.set("updates", str(param.updates))
-            paramNode.set("val", str(param.val).replace("\n", "&#10;"))
-            paramNode.set("valType", str(param.valType))
+            # Assign values
+            if hasattr(param, 'updates'):
+                paramNode.set('updates', "{}".format(param.updates))
+            if hasattr(param, 'val'):
+                paramNode.set('val', u"{}".format(param.val).replace("\n", "&#10;"))
+            if hasattr(param, 'valType'):
+                paramNode.set('valType', param.valType)
             element.append(paramNode)
         return element
 

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -18,6 +18,8 @@ The code that writes out a *_lastrun.py experiment file is (in order):
 
 from __future__ import absolute_import, print_function
 # from future import standard_library
+from xml.etree.ElementTree import Element
+
 from past.builtins import basestring
 from builtins import object
 
@@ -269,6 +271,20 @@ class Param(object):
         """Return a bool, so we can do `if thisParam`
         rather than `if thisParam.val`"""
         return bool(self.val)
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element('Param')
+        # Assign values
+        if hasattr(self, 'val'):
+            element.set('val', u"{}".format(self.val).replace("\n", "&#10;"))
+        if hasattr(self, 'valType'):
+            element.set('valType', self.valType)
+        if hasattr(self, 'updates'):
+            element.set('updates', "{}".format(self.updates))
+
+        return element
 
     def dollarSyntax(self):
         """

--- a/psychopy/experiment/routine.py
+++ b/psychopy/experiment/routine.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, print_function
 
 from psychopy.constants import FOREVER
+from xml.etree.ElementTree import Element
 
 
 class Routine(list):
@@ -36,6 +37,17 @@ class Routine(list):
     def __repr__(self):
         _rep = "psychopy.experiment.Routine(name='%s', exp=%s, components=%s)"
         return _rep % (self.name, self.exp, str(list(self)))
+
+    @property
+    def xml(self):
+        # Make root element
+        element = Element("Routine")
+        element.set("name", self.name)
+        # Add each component's element
+        for comp in self:
+            element.append(comp.xml)
+
+        return element
 
     @property
     def name(self):

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -92,7 +92,8 @@ class TestExpt(object):
             # Compile again
             test = exp.writeScript()
             # Compare two scripts to make sure saving and loading hasn't changed anything
-            assert target == test
+            diff = difflib.unified_diff(target.splitlines(), test.splitlines())
+            assert list(diff) == []
 
     def test_xsd(self):
         # get files

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -20,6 +20,7 @@ import locale
 from lxml import etree
 import numpy
 import sys
+import re
 
 # Jeremy Gray March 2011
 
@@ -32,6 +33,7 @@ import sys
 #   load should change things
 
 allComponents = psychopy.experiment.getComponents(fetchIcons=False)
+isTime = re.compile(r"\d+:\d+(:\d+)?( [AP]M)?")
 
 
 def _filterout_legal(lines):
@@ -91,6 +93,9 @@ class TestExpt(object):
             exp.loadFromXML(temp)
             # Compile again
             test = exp.writeScript()
+            # Remove any timestamps from script (these can cause false errors if compile takes longer than a second)
+            test = re.sub(isTime, "", test)
+            target = re.sub(isTime, "", target)
             # Compare two scripts to make sure saving and loading hasn't changed anything
             diff = difflib.unified_diff(target.splitlines(), test.splitlines())
             assert list(diff) == []

--- a/psychopy/tests/test_app/test_builder/test_Experiment.py
+++ b/psychopy/tests/test_app/test_builder/test_Experiment.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 from past.builtins import execfile
 from builtins import object
+from pathlib import Path
+import xml.etree.ElementTree as xml
 
 import psychopy.experiment
 from psychopy.experiment.components.text import TextComponent
@@ -72,6 +74,25 @@ class TestExpt(object):
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls.tmp_dir, ignore_errors=True)
+
+    def test_xml(self):
+        # Get all psyexp files in demos folder
+        demosFolder = Path(self.exp.prefsPaths['demos']) / 'builder'
+        for file in demosFolder.glob("**/*.psyexp"):
+            # Create experiment and load from psyexp
+            exp = psychopy.experiment.Experiment()
+            exp.loadFromXML(file)
+            # Compile to get what script should look like
+            target = exp.writeScript()
+            # Save as XML
+            temp = str(Path(self.tmp_dir) / "testXML.psyexp")
+            exp.saveToXML(temp)
+            # Load again
+            exp.loadFromXML(temp)
+            # Compile again
+            test = exp.writeScript()
+            # Compare two scripts to make sure saving and loading hasn't changed anything
+            assert target == test
 
     def test_xsd(self):
         # get files


### PR DESCRIPTION
Use methods within classes to write XML output rather than one function for the whole experiment, makes it easier to add new types of node (i.e. standalone routines). Output is identical (apart from unrelated changes, e.g. version number and `extendedCode` only existing when based off `release` not `dev`) to 2021.1.3 on the following demos:
BART
BFI
adaptiveDecisionMaking
dragAndDrop

~~Awaiting 1 more commit with formalised test for writing experiment files~~