### PR TITLE
BF: missing JS code for stopping Keyboard buffer and resetting Textbox text

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -500,6 +500,8 @@ class KeyboardComponent(BaseComponent):
         store = self.params['store'].val
         forceEnd = self.params['forceEndRoutine'].val
         if store == 'nothing':
+            # Still stop keyboard to prevent textbox from not working on single keypresses due to buffer
+            buff.writeIndentedLines("%(name)s.stop();\n" % self.params)
             return
         if len(self.exp.flow._loopList):
             currLoop = self.exp.flow._loopList[-1]  # last (outer-most) loop

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -252,13 +252,14 @@ class TextboxComponent(BaseVisualComponent):
         super().writeRoutineEndCode(buff)
 
     def writeRoutineEndCodeJS(self, buff):
+        name = self.params['name']
         if len(self.exp.flow._loopList):
             currLoop = self.exp.flow._loopList[-1]  # last (outer-most) loop
         else:
             currLoop = self.exp._expHandler
         if self.params['editable']:
-            buff.writeIndented("psychoJS.experiment.addData('%(name)s.text', %(name)s.text);\n" %
-                               self.params)
+            buff.writeIndentedLines(f"psychoJS.experiment.addData('{name}.text',{name}.text)\n"
+                                    f"{name}.reset()\n")
         # get parent to write code too (e.g. store onset/offset times)
         super().writeRoutineEndCodeJS(buff)
 


### PR DESCRIPTION
<ins>**Expected Behaviour**</ins>:
Textboxes and Keyboard responses work similarly in PsychoPy and PsychoJS.

<ins>**Current Behaviour**</ins>:
 In PsychoPy, everything works as intended. 
- **Bug 1**: On PsychoJS, **all Textboxes** stop registering single keypresses when a Keyboard has appeared before, but **only if the Keyboard component stores nothing**. If instead we change it to store e.g "last key", Textboxes still work (Example: https://gitlab.pavlovia.org/miguel.fradinho/testbox).
- **Bug 2**: Additionally, on PsychoJS Editable Texboxes within a loop have the previous trial's text present on following trials, while in PsychoPy every Textbox starts with the default text (as intended).

<ins>**Causes of the bugs**</ins>:
- **Bug 1**: Keyboard buffer conflicts with future Textboxes if it hasn't been stopped, function to stop (`kb_resp.reset()`) never gets called due to missing code gen.
- Bug 2:  Text is present due to missing code gen for the `textbox.reset()` function call, which is present in the python code gen.

<ins>**Proposed solution(s)**</ins> : 
- Bug 1: When storing nothing, insert the call to stop the buffer to prevent conflict with Textboxes, as happens with other values of "store".
- Bug 2: Insert the call, as is also present in the python code gen, thus mimicking behaviour across versions (python vs online).

<ins> Note</ins>: The proposed changes are only in the JS code gen, so while this PR doesn't directly fix any PsychoPy issue, this change potentially fixes https://github.com/psychopy/psychojs/issues/287.

<ins>Side note</ins>:
A similar situation with Textbox & Keyboard buffers conflicting seems to be the cause of https://github.com/psychopy/psychojs/issues/295, however that is when both Textbox and Keyboard components are present at the same time, and thus is a different issue from the one linked above.