### PR TITLE
BF: Specify dtype when applying asarray to num/int params

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -171,12 +171,12 @@ class Param(object):
                 # will work if it can be represented as a float
                 return "{}".format(float(self.val))
             except Exception:  # might be an array
-                return "asarray(%s)" % (self.val)
+                return "asarray(%s, dytpe=float)" % self.val
         elif self.valType == 'int':
             try:
                 return "%i" % self.val  # int and float -> str(int)
             except TypeError:
-                return "{}".format(self.val)  # try array of float instead?
+                return "asarray(%s, dytpe=int)" % self.val  # try array of float instead?
         elif self.valType in ['extendedStr','str', 'file', 'table', 'color']:
             # at least 1 non-escaped '$' anywhere --> code wanted
             # return str if code wanted


### PR DESCRIPTION
Fixes this user's problem:
https://discourse.psychopy.org/t/builder-inserts-useless-asarray-calls-in-py-code/21901/8