### PR TITLE
DOCS: add API reference for Form documentation (and clean up indentat…

### DIFF
--- a/docs/source/api/visual/form.rst
+++ b/docs/source/api/visual/form.rst
@@ -1,0 +1,73 @@
+:class:`Form`
+------------------------------------------------------------------------
+
+Attributes
+=============
+
+.. currentmodule:: psychopy.visual
+
+.. autosummary:: 
+
+    Form
+    Form.win
+    Form.verticesPix
+    Form.values
+    Form.useShaders
+    Form.updateOpacity
+    Form.updateColors
+    Form.units
+    Form.style
+    Form.size
+    Form.setUseShaders
+    Form.setSize
+    Form.setScrollSpeed
+    Form.setRGB
+    Form.setPos
+    Form.setOri
+    Form.setOpacity
+    Form.setLineColor
+    Form.setLMS
+    Form.setForeColor
+    Form.setFillColor
+    Form.setDepth
+    Form.setDKL
+    Form.setContrast
+    Form.setColor
+    Form.setBorderColor
+    Form.setBackColor
+    Form.setAutoLog
+    Form.setAutoDraw
+    Form.pos
+    Form.overlaps
+    Form.ori
+    Form.opacity
+    Form.name
+    Form.lineColor
+    Form.legacyStyles
+    Form.knownStyles
+    Form.importItems
+    Form.getData
+    Form.formComplete
+    Form.foreColor
+    Form.fillColor
+    Form.draw
+    Form.depth
+    Form.contrast
+    Form.contains
+    Form.complete
+    Form.colorSpace
+    Form.color
+    Form.borderColor
+    Form.backColor
+    Form.autoLog
+    Form.autoDraw
+    Form.addDataToExp
+    
+        
+Details
+=============
+
+.. autoclass:: Form
+    :members:
+    :undoc-members:
+    :inherited-members:

--- a/docs/source/builder/components/dots.rst
+++ b/docs/source/builder/components/dots.rst
@@ -6,7 +6,6 @@ Dots (RDK) Component
 The Dots Component allows you to present a Random Dot Kinematogram (RDK) to the participant of your study. These are fields of dots that drift in different directions and subjects are typically required to identify the 'global motion' of the field. 
 
 There are many ways to define the motion of the signal and noise dots. In PsychoPy the way the dots are configured follows `Scase, Braddick & Raymond (1996) <http://www.sciencedirect.com/science/article/pii/0042698995003258>`_. Although Scase et al (1996) show that the choice of algorithm for your dots actually makes relatively little difference there are some **potential** gotchas. Think carefully about whether each of these will affect your particular case:
-
     * **limited dot lifetimes:** as your dots drift in one direction they go off the edge of the stimulus and are replaced randomly in the stimulus field. This could lead to a higher density of dots in the direction of motion providing subjects with an alternative cue to direction. Keeping dot lives relatively short prevents this.
     
     * **noiseDots='direction':** some groups have used noise dots that appear in a random location on each frame (noiseDots='location'). This has the disadvantage that the noise dots not only have a random direction but also a random speed (whereas signal dots have a constant speed and constant direction)

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -59,7 +59,7 @@ _synonyms = {
 
 
 class Form(BaseVisualStim, ContainerMixin, ColorMixin):
-    """A class to add Forms to a `psycopy.visual.Window`
+    """A class to add Forms to a `psychopy.visual.Window`
 
     The Form allows Psychopy to be used as a questionnaire tool, where
     participants can be presented with a series of questions requiring responses.


### PR DESCRIPTION
…ion on dots doc). There was no link from the forms documentation to an API reference on the website, which made it hard to understand. 