### PR TITLE
BF: removes errors when mask is not pow2 square size

### DIFF
--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -317,6 +317,7 @@ class ImageStim(BaseVisualStim, ContainerMixin, ColorMixin, TextureMixin):
                             stim=self,
                             res=self.texRes,
                             maskParams=self.maskParams,
+                            forcePOW2=False,
                             wrapping=True)
 
     def setMask(self, value, log=None):


### PR DESCRIPTION
solves #3752 