### PR TITLE
NF/RF: Add some basic shapes to ShapeStim

### DIFF
--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -98,7 +98,7 @@ class PolygonComponent(BaseVisualComponent):
                          "polygon...' you can set vertices")
         self.params['shape'] = Param(
             shape, valType='str', inputType="choice", categ='Basic',
-            allowedVals=["line", "triangle", "rectangle", "cross", "star",
+            allowedVals=["line", "triangle", "rectangle", "circle", "cross", "star",
                          "regular polygon...", "custom polygon..."],
             updates='constant',
             allowedUpdates=['constant'],
@@ -160,11 +160,15 @@ class PolygonComponent(BaseVisualComponent):
         elif vertices in ['triangle', '3']:
             code = ("%s = visual.ShapeStim(\n" % inits['name'] +
                     "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +
-                    "    vertices=[[-%(size)s[0]/2.0,-%(size)s[1]/2.0], [+%(size)s[0]/2.0,-%(size)s[1]/2.0], [0,%(size)s[1]/2.0]],\n" % inits)
+                    "    size=%(size)s, vertices='triangle',\n" % inits)
         elif vertices in ['rectangle', '4']:
             code = ("%s = visual.Rect(\n" % inits['name'] +
                     "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +
                     "    width=%(size)s[0], height=%(size)s[1],\n" % inits)
+        elif vertices in ['circle', '100']:
+            code = ("%s = visual.ShapeStim(\n" % inits['name'] +
+                    "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +
+                    "    size=%(size)s, vertices='circle',\n" % inits)
         elif vertices in ['star']:
             code = ("%s = visual.ShapeStim(\n" % inits['name'] +
                     "    win=win, name='%s', vertices='star7',%s\n" % (inits['name'], unitsStr) +

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -166,10 +166,7 @@ class Polygon(BaseShapeStim):
             colorSpace=colorSpace)
 
     def _calcVertices(self):
-        d = np.pi * 2 / self.edges
-        self.vertices = np.asarray(
-            [np.asarray((np.sin(e * d), np.cos(e * d))) * self.radius
-             for e in range(int(round(self.edges)))])
+        self._calcEquilateralVertices(self.edges, self.radius)
 
     @attributeSetter
     def edges(self, edges):

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -41,8 +41,20 @@ GL = pyglet.gl
 
 
 knownShapes = {
+    "triangle": [
+        (+0.0, 0.5),  # Point
+        (-0.5, -0.5),  # Bottom left
+        (+0.5, -0.5),  # Bottom right
+    ],
+    "rectangle": [
+        [-.5,  .5],  # Top left
+        [ .5,  .5],  # Top right
+        [ .5, -.5],  # Bottom left
+        [-.5, -.5],  # Bottom right
+    ],
+    "circle": 100,  # Make 100 point equilateral
     "cross": [
-        (-0.1, +0.5), # up
+        (-0.1, +0.5),  # up
         (+0.1, +0.5),
         (+0.1, +0.1),
         (+0.5, +0.1),  # right
@@ -349,6 +361,18 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         """
         setAttribute(self, 'vertices', value, log, operation)
 
+    @staticmethod
+    def _calcEquilateralVertices(edges, radius=0.5):
+        """
+        Get vertices for an equilateral shape with a given number of sides, will assume radius is 0.5 (relative) but
+        can be manually specified
+        """
+        d = numpy.pi * 2 / edges
+        vertices = numpy.asarray(
+            [numpy.asarray((numpy.sin(e * d), numpy.cos(e * d))) * radius
+             for e in range(int(round(edges)))])
+        return vertices
+
     def draw(self, win=None, keepMatrix=False):
         """Draw the stimulus in its relevant window.
 
@@ -637,6 +661,8 @@ class ShapeStim(BaseShapeStim):
         # check if this is a name of one of our known shapes
         if isinstance(newVerts, basestring) and newVerts in knownShapes:
             newVerts = knownShapes[newVerts]
+        if isinstance(newVerts, int):
+            newVerts = self._calcEquilateralVertices(newVerts)
 
         # Check shape
         self.__dict__['vertices'] = val2array(newVerts, withNone=True,


### PR DESCRIPTION
Adds rectangle, triangle & circle to list of knownShapes, and allows equilateral shapes to be specified by setting vertices to be the number of sides (using the same function as PolygonStim). This makes the boilerplate for Polygon components a bit more simple without removing any functionality.