### PR TITLE
BF: workaround for buglet in psychtoolbox.hid

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -395,7 +395,7 @@ class _KeyBuffer(object):
             self.dev = hid.Keyboard()  # a PTB keyboard object
         else:
             self.dev = hid.Keyboard(kb_id)  # a PTB keyboard object
-        self.dev._create_queue(bufferSize)
+        self.dev._create_queue(bufferSize, win_handle=None)
 
     def flush(self):
         """Flushes and processes events from the device to this software buffer


### PR DESCRIPTION
Psychtoolbox complains that the winHandle param is the wrong type.
Force it to None instead of the default 0 and it stops complaining