### PR TITLE
ENH: iohub GazePoint custom calibration graphics

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -22,7 +22,7 @@ if TRACKER == 'eyelink':
     devices_config['eyetracker.hw.sr_research.eyelink.EyeTracker'] = eyetracker_config
 elif TRACKER == 'gazepoint':
     eyetracker_config['device_timer'] = {'interval': 0.005}
-    eyetracker_config['calibration'] = {'use_builtin': False}
+    eyetracker_config['calibration'] = dict(use_builtin=False, target_attributes=dict(animate=dict(enable=True, expansion_ratio=1.0)))
     devices_config['eyetracker.hw.gazepoint.gp3.EyeTracker'] = eyetracker_config
 elif TRACKER == 'tobii':
     devices_config['eyetracker.hw.tobii.EyeTracker'] = eyetracker_config

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -11,7 +11,7 @@ from psychopy.iohub import launchHubServer
 
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
-TRACKER = 'mouse'
+TRACKER = 'gazepoint'
 
 eyetracker_config = dict(name='tracker')
 devices_config = {}
@@ -22,6 +22,7 @@ if TRACKER == 'eyelink':
     devices_config['eyetracker.hw.sr_research.eyelink.EyeTracker'] = eyetracker_config
 elif TRACKER == 'gazepoint':
     eyetracker_config['device_timer'] = {'interval': 0.005}
+    eyetracker_config['calibration'] = {'use_builtin': False}
     devices_config['eyetracker.hw.gazepoint.gp3.EyeTracker'] = eyetracker_config
 elif TRACKER == 'tobii':
     devices_config['eyetracker.hw.tobii.EyeTracker'] = eyetracker_config

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -11,7 +11,7 @@ from psychopy.iohub import launchHubServer
 
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
-TRACKER = 'gazepoint'
+TRACKER = 'mouse'
 
 eyetracker_config = dict(name='tracker')
 devices_config = {}
@@ -22,7 +22,7 @@ if TRACKER == 'eyelink':
     devices_config['eyetracker.hw.sr_research.eyelink.EyeTracker'] = eyetracker_config
 elif TRACKER == 'gazepoint':
     eyetracker_config['device_timer'] = {'interval': 0.005}
-    eyetracker_config['calibration'] = dict(use_builtin=False, target_attributes=dict(animate=dict(enable=True, expansion_ratio=1.0)))
+    #eyetracker_config['calibration'] = dict(use_builtin=False, target_attributes=dict(animate=dict(enable=True, expansion_ratio=1.25, contract_only=False)))
     devices_config['eyetracker.hw.gazepoint.gp3.EyeTracker'] = eyetracker_config
 elif TRACKER == 'tobii':
     devices_config['eyetracker.hw.tobii.EyeTracker'] = eyetracker_config
@@ -55,7 +55,6 @@ io = launchHubServer(window=win, **devices_config)
 
 # Get some iohub devices for future access.
 keyboard = io.getDevice('keyboard')
-display = io.getDevice('display')
 tracker = io.getDevice('tracker')
 
 win.winHandle.minimize()  # minimize the PsychoPy window
@@ -89,17 +88,13 @@ while t < TRIAL_COUNT:
     run_trial = True
     tstart_time = core.getTime()
     while run_trial is True:
-        # Get the latest gaze position in dispolay coord space..
+        # Get the latest gaze position in display coord space.
         gpos = tracker.getLastGazePosition()
-        #for evt in tracker.getEvents():
-        #    if evt.type != EventConstants.MONOCULAR_EYE_SAMPLE:
-        #        print(evt)
         # Update stim based on gaze position
         valid_gaze_pos = isinstance(gpos, (tuple, list))
         gaze_in_region = valid_gaze_pos and gaze_ok_region.contains(gpos)
         if valid_gaze_pos:
-            # If we have a gaze position from the tracker, update gc stim
-            # and text stim.
+            # If we have a gaze position from the tracker, update gc stim and text stim.
             if gaze_in_region:
                 gaze_in_region = 'Yes'
             else:

--- a/psychopy/iohub/changes.txt
+++ b/psychopy/iohub/changes.txt
@@ -32,3 +32,4 @@ Changes made to iohub for 2021.2 Release
   Return contents vary between eye tracker manufacturers. TODO: Doc return data for each eye tracker
 - eyetracker.runSetupProcedure accepts calibration_args dict, which must have the same structure as the eyetracker's
   calibration settings section.
+- ioHub GazePoint interface now supports psychopy based calibration graphics.

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -566,7 +566,6 @@ class Display(Device):
             print2err(
                 ' *** Display device error: Unknown coordinate type: {0}'.format(coord_type))
             return
-        print2err("_calculateCoordMappingFunctions(")
         self._pix2coord = None
 
         # For now, use psychopy unit conversions so that drawing positions match

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
@@ -42,19 +42,27 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         port: 4242
    
     calibration:
+        # True: Use GazePoint Control app calibration window.
+        # False: Use custom calibration graphics.
         use_builtin: True
+
         # target_duration is the number of sec.msec that a calibration point should
-        # be displayed before moving onto the next point.
+        # be displayed before moving onto the next point. Target size expansion / contraction
+        # optionally occurs during this time period as well.
         # (Sets the GP3 CALIBRATE_TIMEOUT)
-        target_duration: 1.25
-        # target_delay specifies the target animation duration in sec.msec.
+        target_duration: 1.5
+
+        # target_delay specifies the time between target position presentations. Target position animation
+        # optionally occurs during this time period as well.
         # (Sets the GP3 CALIBRATE_DELAY)
-        target_delay: 0.5
-        # The Gazepoint ioHub Common Eye Tracker Interface currently support
-        # a 3, 5 and 9 point calibration mode.
-        # THREE_POINTS,FIVE_POINTS,NINE_POINTS
+        target_delay: 0.75
+
         #
-        type: NINE_POINTS
+        # Remaining calibration settings are only used if 'use_builtin' == False
+        #
+        # Number of calibration points to present.
+        # THREE_POINTS,FIVE_POINTS,NINE_POINTS
+        type: FIVE_POINTS
 
         # color_type: rgb, rgb255, named, hex, etc. Leave blank to use window's color space.
         color_type: rgb255
@@ -63,67 +71,52 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         unit_type: pix
 
         # Should the target positions be randomized?
-        #
         randomize: True
 
         # screen_background_color specifies the r,g,b background color to
-        # set the calibration, validation, etc, screens to. Each element of the color
-        # should be a value between 0 and 255. 0 == black, 255 == white.
-        #
+        # set the calibration, validation, etc, screens to.
         screen_background_color: [128,128,128]
 
         # The associated target attribute properties can be supplied
         # for the given target_type.
         target_attributes:
              # outer_diameter: The size of the outer circle of the calibration target
-             #
-             outer_diameter: 35.0
+             outer_diameter: 40.0
+
              # outer_stroke_width: The thickness of the outer circle edge.
-             #
              outer_stroke_width: 2.0
+
              # outer_fill_color: color to use to fill the outer circle.
-             #
-             outer_fill_color: [128,128,128]
+             outer_fill_color: [64,64,64]
+
              # outer_line_color: color to used for the outer circle edge.
-             #
              outer_line_color: [255,255,255]
+
              # inner_diameter: The size of the inner circle calibration target
-             #
-             inner_diameter: 7.0
+             inner_diameter: 15.0
+
              # inner_stroke_width: The thickness of the inner circle edge.
-             #
              inner_stroke_width: 1.0
+
              # inner_fill_color: color to use to fill the inner circle.
-             #
-             inner_fill_color: [0,0,0]
+             inner_fill_color: [0,255,0]
+
              # inner_line_color: color to used for the inner circle edge.
-             #
              inner_line_color: [0,0,0]
-             # The Tobii Calibration routine supports using moving target graphics.
-             # The following parameters control target movement (if any).
-             #
+
+             # 'animate' controls target movement and expansion / contraction (if any).
              animate:
-                 # enable: True if the calibration target should be animated.
-                 # False specifies that the calibration targets could just jump
-                 # from one calibration position to another.
-                 #
+                 # enable: True if the calibration target should be animated between target positions.
+                 # False specifies that the calibration targets could just jump from one calibration point to another.
                  enable: True
-                 # expansion_ratio: The outer circle of the calibration target
-                 # can expand (and contract) when displayed at each position.
-                 # expansion_ratio gives the largest size of the outer circle
-                 # as a ratio of the outer_diameter length. For example,
-                 # if outer_diameter = 30, and expansion_ratio = 2.0, then
-                 # the outer circle of each calibration point will expand out
-                 # to 60 pixels. Set expansion_ratio to 1.0 for no expansion.
-                 #
-                 expansion_ratio: 3.0
-                 # contract_only: If the calibration target should expand from
-                 # the outer circle initial diameter to the larger diameter
-                 # and then contract back to the original diameter, set
-                 # contract_only to False. To only have the outer circle target
-                 # go from an expanded state to the smaller size, set this to True.
-                 #
-                 contract_only: True
+
+                 # expansion_ratio: If > 1.0, expansion_ratio specifies the maximum target
+                 # outer diameter size as outer_diameter * expansion_ratio.
+                 expansion_ratio: 1.25
+
+                 # contract_only: If True, only contract outer target circle into inner target circle;
+                 # expansion_ratio is ignored. If False, expand and then contract target using expansion_ratio setting.
+                 contract_only: False
 
     # The model name of the device.
     model_name: GP3

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
@@ -99,6 +99,31 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
              # inner_line_color: color to used for the inner circle edge.
              #
              inner_line_color: [0,0,0]
+             # The Tobii Calibration routine supports using moving target graphics.
+             # The following parameters control target movement (if any).
+             #
+             animate:
+                 # enable: True if the calibration target should be animated.
+                 # False specifies that the calibration targets could just jump
+                 # from one calibration position to another.
+                 #
+                 enable: True
+                 # expansion_ratio: The outer circle of the calibration target
+                 # can expand (and contract) when displayed at each position.
+                 # expansion_ratio gives the largest size of the outer circle
+                 # as a ratio of the outer_diameter length. For example,
+                 # if outer_diameter = 30, and expansion_ratio = 2.0, then
+                 # the outer circle of each calibration point will expand out
+                 # to 60 pixels. Set expansion_ratio to 1.0 for no expansion.
+                 #
+                 expansion_ratio: 3.0
+                 # contract_only: If the calibration target should expand from
+                 # the outer circle initial diameter to the larger diameter
+                 # and then contract back to the original diameter, set
+                 # contract_only to False. To only have the outer circle target
+                 # go from an expanded state to the smaller size, set this to True.
+                 #
+                 contract_only: True
 
     # The model name of the device.
     model_name: GP3

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
@@ -50,7 +50,56 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         # target_delay specifies the target animation duration in sec.msec.
         # (Sets the GP3 CALIBRATE_DELAY)
         target_delay: 0.5
-        
+        # The Gazepoint ioHub Common Eye Tracker Interface currently support
+        # a 3, 5 and 9 point calibration mode.
+        # THREE_POINTS,FIVE_POINTS,NINE_POINTS
+        #
+        type: NINE_POINTS
+
+        # color_type: rgb, rgb255, named, hex, etc. Leave blank to use window's color space.
+        color_type: rgb255
+
+        # unit_type: norm, pix, height, deg, etc. Leave blank to use window's unit type.
+        unit_type: pix
+
+        # Should the target positions be randomized?
+        #
+        randomize: True
+
+        # screen_background_color specifies the r,g,b background color to
+        # set the calibration, validation, etc, screens to. Each element of the color
+        # should be a value between 0 and 255. 0 == black, 255 == white.
+        #
+        screen_background_color: [128,128,128]
+
+        # The associated target attribute properties can be supplied
+        # for the given target_type.
+        target_attributes:
+             # outer_diameter: The size of the outer circle of the calibration target
+             #
+             outer_diameter: 35.0
+             # outer_stroke_width: The thickness of the outer circle edge.
+             #
+             outer_stroke_width: 2.0
+             # outer_fill_color: color to use to fill the outer circle.
+             #
+             outer_fill_color: [128,128,128]
+             # outer_line_color: color to used for the outer circle edge.
+             #
+             outer_line_color: [255,255,255]
+             # inner_diameter: The size of the inner circle calibration target
+             #
+             inner_diameter: 7.0
+             # inner_stroke_width: The thickness of the inner circle edge.
+             #
+             inner_stroke_width: 1.0
+             # inner_fill_color: color to use to fill the inner circle.
+             #
+             inner_fill_color: [0,0,0]
+             # inner_line_color: color to used for the inner circle edge.
+             #
+             inner_line_color: [0,0,0]
+
     # The model name of the device.
     model_name: GP3
 

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/eyetracker.py
@@ -3,7 +3,6 @@
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 from __future__ import division
-import gevent
 from ......errors import print2err, printExceptionDetailsToStdErr
 from ......constants import EyeTrackerConstants
 from ..... import Computer, Device

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/eyetracker.py
@@ -458,8 +458,6 @@ class EyeTracker(EyeTrackerDevice):
 
             calibration.runCalibration()
 
-            calibration.window.winHandle.set_visible(False)
-            calibration.window.winHandle.minimize()
             calibration.window.close()
 
             calibration._unregisterEventMonitors()

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -6,7 +6,6 @@
 
 from psychopy import visual
 import gevent
-import numpy as np
 from psychopy.iohub.util import convertCamelToSnake, updateDict
 from psychopy.iohub.devices import DeviceEvent, Computer
 from psychopy.iohub.constants import EventConstants as EC
@@ -42,7 +41,8 @@ class GazepointPsychopyCalibrationGraphics(object):
 
         calibration_methods = dict(THREE_POINTS=3,
                                    FIVE_POINTS=5,
-                                   NINE_POINTS=9)
+                                   NINE_POINTS=9,
+                                   THIRTEEN_POINT=13)
 
         cal_type = self.getCalibSetting('type')
 
@@ -69,6 +69,21 @@ class GazepointPsychopyCalibrationGraphics(object):
                                                                                (0.9, 0.9),
                                                                                (0.5, 0.9),
                                                                                (0.1, 0.9)]
+            elif num_points == 13:
+                GazepointPsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.5),
+                                                                               (0.9, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.5, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.5, 0.9),
+                                                                               (0.1, 0.9),
+                                                                               (0.25, 0.25),
+                                                                               (0.25, 0.75),
+                                                                               (0.75, 0.75),
+                                                                               (0.75, 0.25)
+                                                                               ]
             display = self._eyetracker._display_device
 
         self.window = visual.Window(

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -239,19 +239,41 @@ class GazepointPsychopyCalibrationGraphics(object):
         i = 0
         for pt in cal_target_list:
             start_time = currentTime()
-            self.clearAllEventBuffers()
-            # Target animate / delay
-            print2err("TODO: Animate to point: ", p, "over {} seconds...".format(target_delay))
-            while currentTime()-start_time <= target_delay:
-                self.getNextMsg()
-                self.MsgPump()
-                gevent.sleep(0.001)
 
             # Convert GazePoint normalized positions to psychopy window unit positions
             # by using iohub display/window getCoordBounds.
             x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
+
+            self.clearAllEventBuffers()
+
+            # Target animate / delay
+            # animate:
+            #    enable: True
+            #    expansion_ratio: 3.0
+            #    contract_only: True
+            animate_enable = self.getCalibSetting(['target_attributes', 'animate', 'enable'])
+            animate_expansion_ratio = self.getCalibSetting(['target_attributes', 'animate', 'expansion_ratio'])
+            animate_contract_only = self.getCalibSetting(['target_attributes', 'animate', 'contract_only'])
+
+            if animate_enable:
+                print2err("TODO: Animate to point: ", p, "over {} seconds...".format(target_delay))
+
+            while currentTime()-start_time <= target_delay:
+                # TODO: (Optional) Animate target during this period.
+                self.getNextMsg()
+                self.MsgPump()
+                gevent.sleep(0.001)
+
             self.drawCalibrationTarget(i, (x, y))
+
+            if animate_expansion_ratio not in [1, 1.0]:
+                print2err("TODO: Expand / contract target: ", p, "over {} seconds...".format(target_duration))
+                if animate_contract_only:
+                    pass
+                else:
+                    pass
             while currentTime()-start_time <= target_delay+target_duration:
+                # TODO: (Optional) Expand / contract target during this period.
                 self.getNextMsg()
                 self.MsgPump()
                 gevent.sleep(0.001)

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+# Part of the PsychoPy library
+# Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+
+from psychopy import visual
+import gevent
+import numpy as np
+from psychopy.iohub.util import convertCamelToSnake, updateDict
+from psychopy.iohub.devices import DeviceEvent, Computer
+from psychopy.iohub.constants import EventConstants as EC
+from psychopy.iohub.errors import print2err
+
+currentTime = Computer.getTime
+
+
+class GazepointPsychopyCalibrationGraphics(object):
+    IOHUB_HEARTBEAT_INTERVAL = 0.050
+    WINDOW_BACKGROUND_COLOR = None
+    CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)]
+
+    _keyboard_key_index = EC.getClass(EC.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
+
+    def __init__(self, eyetrackerInterface, calibration_args):
+        self._eyetracker = eyetrackerInterface
+
+        self.screenSize = eyetrackerInterface._display_device.getPixelResolution()
+        self.width = self.screenSize[0]
+        self.height = self.screenSize[1]
+        self._ioKeyboard = None
+        self._msg_queue = []
+
+        self._lastCalibrationOK = False
+        self._device_config = self._eyetracker.getConfiguration()
+
+        updateDict(calibration_args, self._device_config.get('calibration'))
+        self._calibration_args = calibration_args
+
+        screenColor = self.getCalibSetting('screen_background_color')
+        GazepointPsychopyCalibrationGraphics.WINDOW_BACKGROUND_COLOR = screenColor
+
+        calibration_methods = dict(THREE_POINTS=3,
+                                   FIVE_POINTS=5,
+                                   NINE_POINTS=9)
+
+        cal_type = self.getCalibSetting('type')
+
+        if cal_type in calibration_methods:
+            num_points = calibration_methods[cal_type]
+
+            if num_points == 3:
+                GazepointPsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.1),
+                                                                               (0.1, 0.9),
+                                                                               (0.9, 0.9)]
+            elif num_points == 5:
+                GazepointPsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.1, 0.9)]
+            elif num_points == 9:
+                GazepointPsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.5),
+                                                                               (0.9, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.5, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.5, 0.9),
+                                                                               (0.1, 0.9)]
+            display = self._eyetracker._display_device
+
+        self.window = visual.Window(
+            self.screenSize,
+            monitor=display.getPsychopyMonitorName(),
+            units=display.getCoordinateType(),
+            fullscr=True,
+            allowGUI=False,
+            screen=display.getIndex(),
+            color=self.WINDOW_BACKGROUND_COLOR[0:3],
+            colorSpace=display.getColorSpace())
+        self.window.flip(clearBuffer=True)
+
+        self._createStim()
+        self._registerEventMonitors()
+        self._lastMsgPumpTime = currentTime()
+
+        self.clearAllEventBuffers()
+
+    def getCalibSetting(self, setting):
+        if isinstance(setting, str):
+            setting = [setting, ]
+        calibration_args = self._calibration_args
+        if setting:
+            for s in setting[:-1]:
+                calibration_args = calibration_args.get(s)
+            return calibration_args.get(setting[-1])
+
+    def clearAllEventBuffers(self):
+        self._eyetracker._iohub_server.eventBuffer.clear()
+        for d in self._eyetracker._iohub_server.devices:
+            d.clearEvents()
+
+    def _registerEventMonitors(self):
+        kbDevice = None
+        if self._eyetracker._iohub_server:
+            for dev in self._eyetracker._iohub_server.devices:
+                if dev.__class__.__name__ == 'Keyboard':
+                    kbDevice = dev
+
+        if kbDevice:
+            eventIDs = []
+            for event_class_name in kbDevice.__class__.EVENT_CLASS_NAMES:
+                eventIDs.append(getattr(EC, convertCamelToSnake(event_class_name[:-5], False)))
+
+            self._ioKeyboard = kbDevice
+            self._ioKeyboard._addEventListener(self, eventIDs)
+        else:
+            print2err(
+                'Warning: GazePoint Cal GFX could not connect to Keyboard device for events.')
+
+    def _unregisterEventMonitors(self):
+        if self._ioKeyboard:
+            self._ioKeyboard._removeEventListener(self)
+
+    def _handleEvent(self, event):
+        event_type_index = DeviceEvent.EVENT_TYPE_ID_INDEX
+        if event[event_type_index] == EC.KEYBOARD_PRESS:
+            ek = event[self._keyboard_key_index]
+            if isinstance(ek, bytes):
+                ek = ek.decode('utf-8')
+            if ek == ' ':
+                self._msg_queue.append('SPACE_KEY_ACTION')
+                self.clearAllEventBuffers()
+            elif ek == 'escape':
+                self._msg_queue.append('QUIT')
+                self.clearAllEventBuffers()
+
+    def MsgPump(self):
+        # keep the psychopy window happy ;)
+        if currentTime() - self._lastMsgPumpTime > self.IOHUB_HEARTBEAT_INTERVAL:
+            # try to keep ioHub from being blocked. ;(
+            if self._eyetracker._iohub_server:
+                for dm in self._eyetracker._iohub_server.deviceMonitors:
+                    dm.device._poll()
+                self._eyetracker._iohub_server.processDeviceEvents()
+            self._lastMsgPumpTime = currentTime()
+
+    def getNextMsg(self):
+        if len(self._msg_queue) > 0:
+            msg = self._msg_queue[0]
+            self._msg_queue = self._msg_queue[1:]
+            return msg
+
+    def _createStim(self):
+        """
+            outer_diameter: 35
+            outer_stroke_width: 5
+            outer_fill_color: [255,255,255]
+            outer_line_color: [255,255,255]
+            inner_diameter: 5
+            inner_stroke_width: 0
+            inner_color: [0,0,0]
+            inner_fill_color: [0,0,0]
+            inner_line_color: [0,0,0]
+            calibration_prefs=self._eyetracker.getConfiguration()['calibration']['target_attributes']
+        """
+        color_type = self.getCalibSetting('color_type')
+        unit_type = self.getCalibSetting('unit_type')
+
+        lwidth = self.getCalibSetting(['target_attributes', 'outer_stroke_width'])
+        radius = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0
+        fcolor = self.getCalibSetting(['target_attributes', 'outer_fill_color'])
+        lcolor = self.getCalibSetting(['target_attributes', 'outer_line_color'])
+        self.calibrationPointOUTER = visual.Circle(self.window, pos=(0, 0), name='CP_OUTER',
+                                                   radius=radius, lineWidth=lwidth,
+                                                   fillColor=fcolor, lineColor=lcolor,
+                                                   opacity=1.0, interpolate=False,
+                                                   edges=64, units=unit_type, colorSpace=color_type)
+
+        lwidth = self.getCalibSetting(['target_attributes', 'inner_stroke_width'])
+        radius = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0
+        fcolor = self.getCalibSetting(['target_attributes', 'inner_fill_color'])
+        lcolor = self.getCalibSetting(['target_attributes', 'inner_line_color'])
+        self.calibrationPointINNER = visual.Circle(self.window, pos=(0, 0), name='CP_INNER',
+                                                   radius=radius, lineWidth=lwidth,
+                                                   fillColor=fcolor, lineColor=lcolor,
+                                                   opacity=1.0, interpolate=False,
+                                                   edges=64, units=unit_type, colorSpace=color_type)
+
+        instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
+        self.textLineStim = visual.TextStim(self.window, text=instuction_text,
+                                            pos=(0, 0), height=36,
+                                            color=(0, 0, 0), colorSpace='rgb255',
+                                            units='pix', wrapWidth=self.width * 0.9)
+
+    def runCalibration(self):
+        """Run calibration sequence
+        """
+
+        instuction_text = 'Press SPACE to Start Calibration.'
+        self.showSystemSetupMessageScreen(instuction_text)
+
+        target_delay = self.getCalibSetting('target_delay')
+        target_duration = self.getCalibSetting('target_duration')
+
+        # TODO: Decide how to handle gaze point target randomization.
+        cal_target_list = self.CALIBRATION_POINT_LIST
+        #randomize_points = self.getCalibSetting('randomize')
+        #cal_target_list = self.CALIBRATION_POINT_LIST[1:-1]
+        #if randomize_points is True:
+        #    import random
+        #    random.seed(None)
+        #    random.shuffle(cal_target_list)
+        #cal_target_list.insert(0, self.CALIBRATION_POINT_LIST[0])
+        #cal_target_list.append(self.CALIBRATION_POINT_LIST[-1])
+
+        self._eyetracker._gp3set('CALIBRATE_CLEAR')
+
+        print2err("TODO: Send screen coord info to gazepoint.")
+
+        # Inform GazePoint of target list to be used
+        for p in cal_target_list:
+            x, y = p
+            self._eyetracker._gp3set('CALIBRATE_ADDPOINT', X=x, Y=y)
+            self._eyetracker._waitForAck('CALIBRATE_ADDPOINT')
+
+        left, top, right, bottom = self._eyetracker._display_device.getCoordBounds()
+        w, h = right - left, top - bottom
+
+        self.clearCalibrationWindow()
+
+        # Start drawing calibration points
+        self._eyetracker._gp3set('CALIBRATE_SHOW', STATE=0)
+        self._eyetracker._gp3set('CALIBRATE_START', STATE=1)
+
+        # seems like gps expects animation at state of every target pos.
+        i = 0
+        for pt in cal_target_list:
+            start_time = currentTime()
+            self.clearAllEventBuffers()
+            # Target animate / delay
+            print2err("TODO: Animate to point: ", p, "over {} seconds...".format(target_delay))
+            while currentTime()-start_time <= target_delay:
+                self.getNextMsg()
+                self.MsgPump()
+                gevent.sleep(0.001)
+
+            # Convert GazePoint normalized positions to psychopy window unit positions
+            # by using iohub display/window getCoordBounds.
+            x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
+            self.drawCalibrationTarget(i, (x, y))
+            while currentTime()-start_time <= target_delay+target_duration:
+                self.getNextMsg()
+                self.MsgPump()
+                gevent.sleep(0.001)
+
+            self.clearCalibrationWindow()
+            self.clearAllEventBuffers()
+
+        instuction_text = "Calibration Complete. Press 'SPACE' key to continue."
+        self.showSystemSetupMessageScreen(instuction_text)
+
+
+    def clearCalibrationWindow(self):
+        self.window.flip(clearBuffer=True)
+
+    def showSystemSetupMessageScreen(self, text_msg='Press SPACE to Start Calibration; ESCAPE to Exit.'):
+
+        self.clearAllEventBuffers()
+
+        while True:
+            self.textLineStim.setText(text_msg)
+            self.textLineStim.draw()
+            self.window.flip()
+
+            msg = self.getNextMsg()
+            if msg == 'SPACE_KEY_ACTION':
+                self.clearAllEventBuffers()
+                return True
+            elif msg == 'QUIT':
+                self.clearAllEventBuffers()
+                return False
+            self.MsgPump()
+            gevent.sleep(0.001)
+
+    def drawDefaultTarget(self):
+        self.calibrationPointOUTER.radius = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0
+        self.calibrationPointOUTER.setLineColor(self.getCalibSetting(['target_attributes', 'outer_line_color']))
+        self.calibrationPointOUTER.setFillColor(self.getCalibSetting(['target_attributes', 'outer_fill_color']))
+        self.calibrationPointOUTER.lineWidth = int(self.getCalibSetting(['target_attributes', 'outer_stroke_width']))
+        self.calibrationPointINNER.radius = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0
+        self.calibrationPointINNER.setLineColor(self.getCalibSetting(['target_attributes', 'inner_line_color']))
+        self.calibrationPointINNER.setFillColor(self.getCalibSetting(['target_attributes', 'inner_fill_color']))
+        self.calibrationPointINNER.lineWidth = int(self.getCalibSetting(['target_attributes', 'inner_stroke_width']))
+
+        self.calibrationPointOUTER.draw()
+        self.calibrationPointINNER.draw()
+        return self.window.flip(clearBuffer=True)
+
+    def drawCalibrationTarget(self, target_number, tp):
+        self.calibrationPointOUTER.setPos(tp)
+        self.calibrationPointINNER.setPos(tp)
+        self.drawDefaultTarget()

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -205,20 +205,23 @@ class GazepointPsychopyCalibrationGraphics(object):
         target_delay = self.getCalibSetting('target_delay')
         target_duration = self.getCalibSetting('target_duration')
 
-        # TODO: Decide how to handle gaze point target randomization.
         cal_target_list = self.CALIBRATION_POINT_LIST
-        #randomize_points = self.getCalibSetting('randomize')
-        #cal_target_list = self.CALIBRATION_POINT_LIST[1:-1]
-        #if randomize_points is True:
-        #    import random
-        #    random.seed(None)
-        #    random.shuffle(cal_target_list)
-        #cal_target_list.insert(0, self.CALIBRATION_POINT_LIST[0])
-        #cal_target_list.append(self.CALIBRATION_POINT_LIST[-1])
+        randomize_points = self.getCalibSetting('randomize')
+        if randomize_points is True:
+            # Randomize all but first target position.
+            cal_target_list = self.CALIBRATION_POINT_LIST[1:]
+            import random
+            random.seed(None)
+            random.shuffle(cal_target_list)
+            cal_target_list.insert(0, self.CALIBRATION_POINT_LIST[0])
+
+        self._eyetracker._gp3set('CALIBRATE_SHOW', STATE=0)
+        self._eyetracker._gp3set('CALIBRATE_START', STATE=0)
 
         self._eyetracker._gp3set('CALIBRATE_CLEAR')
 
-        print2err("TODO: Send screen coord info to gazepoint.")
+        self._eyetracker._gp3set('SCREEN_SIZE', X=0, Y=0, WIDTH=self.width, HEIGHT=self.height)
+        #print2err("Set GP3 SCREEN_SIZE: ", self._eyetracker._waitForAck('SCREEN_SIZE'))
 
         # Inform GazePoint of target list to be used
         for p in cal_target_list:

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
@@ -85,5 +85,12 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
                     max: 1000.0
             inner_fill_color: IOHUB_COLOR
             inner_line_color: IOHUB_COLOR
+            animate:
+                enable: IOHUB_BOOL
+                expansion_ratio:
+                    IOHUB_FLOAT:
+                        min: 1.0
+                        max: 100.0
+                contract_only: IOHUB_BOOL
     device_number: 0
     manufacturer_name: GazePoint

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
@@ -49,7 +49,7 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         # Remaining calibration config settings only apply if use_builtin == False
         type:
             IOHUB_LIST:
-                valid_values: [THREE_POINTS,FIVE_POINTS,NINE_POINTS]
+                valid_values: [THREE_POINTS,FIVE_POINTS,NINE_POINTS, THIRTEEN_POINTS]
                 min_length: 1
                 max_length: 1
         unit_type:

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
@@ -37,14 +37,53 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         sampling_rate: Auto
         track_eyes: [BINOCULAR,]
     calibration:
-        use_builtin: IOHUB_BOOL
+        target_delay:
+            IOHUB_FLOAT:
+                min: 0.25
+                max: 2.5
         target_duration:
             IOHUB_FLOAT:
                 min: 0.25
                 max: 2.5
-        target_delay: 
-            IOHUB_FLOAT:
-                min: 0.25
-                max: 2.5
+        use_builtin: IOHUB_BOOL
+        # Remaining calibration config settings only apply if use_builtin == False
+        type:
+            IOHUB_LIST:
+                valid_values: [THREE_POINTS,FIVE_POINTS,NINE_POINTS]
+                min_length: 1
+                max_length: 1
+        unit_type:
+            IOHUB_LIST:
+                valid_values: [norm, pix, cm, height, deg, degFlatPos, degFlat]
+                min_length: 0
+                max_length: 1
+        color_type:
+            IOHUB_LIST:
+                valid_values: [rgb, dkl, lms, hsv, hex, named, rgb255]
+                min_length: 0
+                max_length: 1
+        randomize: IOHUB_BOOL
+        screen_background_color: IOHUB_COLOR
+        target_attributes:
+            outer_diameter:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            outer_stroke_width:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            outer_fill_color: IOHUB_COLOR
+            outer_line_color: IOHUB_COLOR
+            inner_diameter:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            inner_stroke_width:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            inner_fill_color: IOHUB_COLOR
+            inner_line_color: IOHUB_COLOR
     device_number: 0
     manufacturer_name: GazePoint

--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -619,14 +619,15 @@ class ioServer(object):
             print2err('Error PubSub Device listener association ....')
             printExceptionDetailsToStdErr()
 
-    def processDeviceConfigDictionary(self, dev_mod_path, dev_cls_name,
-                                      dev_conf, def_dev_conf):
+    def processDeviceConfigDictionary(self, dev_mod_path, dev_cls_name, dev_conf, def_dev_conf):
         for dparam, dvalue in def_dev_conf.items():
-            if dparam not in dev_conf:
+            if dparam in dev_conf:
+                if isinstance(dvalue, (dict, OrderedDict)):
+                    self.processDeviceConfigDictionary(None, None, dev_conf.get(dparam), dvalue)
+            elif dparam not in dev_conf:
                 if isinstance(dvalue, (dict, OrderedDict)):
                     sub_param = dict()
-                    self.processDeviceConfigDictionary(None, None, sub_param,
-                                                       dvalue)
+                    self.processDeviceConfigDictionary(None, None, sub_param, dvalue)
                     dev_conf[dparam] = sub_param
                 else:
                     dev_conf[dparam] = dvalue


### PR DESCRIPTION
ENH:  iohub GazePoint interface now supports use of PsychoPy drawn calibration graphics, similar (in concept) to Tobii and EyeLink implementations. 3, 5, 9 and 13 point calibrations are supported.  Set the gazepoint 'calibration : use_builtin' to False to use PsychoPy based calibration graphics.
