### PR TITLE
Add error for incorrectly requested QUEST methods

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -972,7 +972,8 @@ class QuestHandler(StairHandler):
             self._questNextIntensity = self._quest.mode()
         elif self.method == 'quantile':
             self._questNextIntensity = self._quest.quantile()
-        # else: maybe raise an error
+        else:
+            raise TypeError(f"Requested method for QUEST: {self.method} is not a valid method. Please use mean, mode or quantile")
         self._nextIntensity = self._questNextIntensity
 
     def mean(self):


### PR DESCRIPTION
Added an error to raise if the requested method for quest staircase is incorrect - accidental typos  were causing some headaches for users as errors were not being raised https://discourse.psychopy.org/t/quest-staircase/8325/2