### PR TITLE
ENH: Enable scoring from ticks for choice/radio responses

### DIFF
--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -33,7 +33,7 @@ _knownFields = {
     'itemWidth': 0.8,  # fraction of the form
     'type': _REQUIRED,  # type of response box (see below)
     'options': ('Yes', 'No'),  # for choice box
-    'ticks': (1, 2, 3, 4, 5, 6, 7),
+    'ticks': None,#(1, 2, 3, 4, 5, 6, 7),
     'tickLabels': None,
     # for rating/slider
     'responseWidth': 0.8,  # fraction of the form
@@ -458,7 +458,10 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
 
         # what are the ticks for the scale/slider?
         if item['type'].lower() in ['radio', 'choice']:
-            ticks = None
+            if item['ticks']:
+                ticks = item['ticks']
+            else:
+                ticks = None
             tickLabels = item['tickLabels'] or item['options'] or item['ticks']
             granularity = 1
             style = 'radio'


### PR DESCRIPTION
If item type is choice/radio AND ticks are provided use the ticks as the response for output column form.response otherwise use the tick Lable (allows for easy negative scoring and scoring of choice responses with no code).

Note: Default values of ticks were previously (1, 2, 3, 4, 5, 6, 7) changed to None otherwise item[‘ticks’] is always true.