### PR TITLE
BF: Clickable exception for clickables provided as singular

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -131,11 +131,15 @@ class MouseComponent(BaseComponent):
         code = (
             "# check if the mouse was inside our 'clickable' objects\n"
             "gotValidClick = False\n"
-            "for obj in %(clickable)s:\n"
+            "try:\n"
+            "    iter(%(clickable)s)\n"
+            "    clickableList = %(clickable)s\n"
+            "except:\n"
+            "    clickableList = [%(clickable)s]\n"
+            "for obj in clickableList:\n"
             "    if obj.contains(%(name)s):\n"
             "        gotValidClick = True\n")
         buff.writeIndentedLines(code % self.params)
-
         buff.setIndentLevel(+2, relative=True)
         code = ''
         for paramName in self._clickableParamsList:

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -395,7 +395,7 @@ class _KeyBuffer(object):
             self.dev = hid.Keyboard()  # a PTB keyboard object
         else:
             self.dev = hid.Keyboard(kb_id)  # a PTB keyboard object
-        self.dev._create_queue(bufferSize)
+        self.dev._create_queue(bufferSize, win_handle=None)
 
     def flush(self):
         """Flushes and processes events from the device to this software buffer

--- a/psychopy/tests/test_all_visual/test_textbox.py
+++ b/psychopy/tests/test_all_visual/test_textbox.py
@@ -119,7 +119,7 @@ class Test_textbox(object):
             self.textbox.fillColor = case['fillColor']
             self.textbox.borderColor = case['borderColor']
             for lineBreaking in ('default', 'uax14'):
-            self.win.flip()
+                self.win.flip()
                 self.textbox.draw()
             if case['screenshot']:
                 # Uncomment to save current configuration as desired


### PR DESCRIPTION
Until PsychoPy 2021.1.4 the "clickable stimuli" parameter of the mouse component could be a singular (e.g. "target") or list of objects (e.g. "target", "polygon") . In 2021.1.4 a comma had to be placed after the name of the clickable stimulus even if it was one thing. e.g. "target," - this isn't so clear from a user perspective so added an exception to handle cases where a single clickable thing is provided - note this isn't needed on the JS side. 