### PR TITLE
Added ioHub MouseGaze calibration screen

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -22,7 +22,7 @@ if TRACKER == 'eyelink':
     devices_config['eyetracker.hw.sr_research.eyelink.EyeTracker'] = eyetracker_config
 elif TRACKER == 'gazepoint':
     eyetracker_config['device_timer'] = {'interval': 0.005}
-    #eyetracker_config['calibration'] = dict(use_builtin=False, target_attributes=dict(animate=dict(enable=True, expansion_ratio=1.25, contract_only=False)))
+    eyetracker_config['calibration'] = dict(use_builtin=False, target_attributes=dict(animate=dict(enable=True, expansion_ratio=1.25, contract_only=False)))
     devices_config['eyetracker.hw.gazepoint.gp3.EyeTracker'] = eyetracker_config
 elif TRACKER == 'tobii':
     devices_config['eyetracker.hw.tobii.EyeTracker'] = eyetracker_config
@@ -46,7 +46,13 @@ win = visual.Window((1920, 1080),
                     )
 
 win.setMouseVisible(False)
+text_stim = visual.TextStim(win, text="Start of Experiment",
+                            pos=[0, 0], height=24,
+                            color='black', units='pix', colorSpace='named',
+                            wrapWidth=win.size[0] * .9)
 
+text_stim.draw()
+win.flip()
 
 # Since no experiment or session code is given, no iohub hdf5 file
 # will be saved, but device events are still available at runtime.
@@ -57,14 +63,16 @@ io = launchHubServer(window=win, **devices_config)
 keyboard = io.getDevice('keyboard')
 tracker = io.getDevice('tracker')
 
+win.winHandle.set_fullscreen(False)
 win.winHandle.minimize()  # minimize the PsychoPy window
 
 # run eyetracker calibration
 result = tracker.runSetupProcedure()
 print("Calibration returned: ", result)
 
+win.winHandle.set_fullscreen(True)
 win.winHandle.maximize()  # maximize the PsychoPy window
-win.winHandle.activate()
+
 
 gaze_ok_region = visual.Circle(win, lineColor='black', radius=300, units='pix', colorSpace='named')
 
@@ -75,10 +83,7 @@ text_stim_str = 'Eye Position: %.2f, %.2f. In Region: %s\n'
 text_stim_str += 'Press space key to start next trial.'
 missing_gpos_str = 'Eye Position: MISSING. In Region: No\n'
 missing_gpos_str += 'Press space key to start next trial.'
-text_stim = visual.TextStim(win, text=text_stim_str,
-                            pos=[0, 0], height=24,
-                            color='black', units='pix', colorSpace='named',
-                            wrapWidth=win.size[0] * .9)
+text_stim.setText(text_stim_str)
 
 # Run Trials.....
 t = 0

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -25,9 +25,6 @@ eyetracker.hw.mouse.EyeTracker:
         # Target position animation optionally occurs during this time period as well.
         target_delay: 0.75
 
-        #
-        # Remaining calibration settings are only used if 'use_builtin' == False
-        #
         # Number of calibration points to present.
         # THREE_POINTS,FIVE_POINTS,NINE_POINTS, THIRTEEN_POINTS
         type: NINE_POINTS

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -15,6 +15,76 @@ eyetracker.hw.mouse.EyeTracker:
         saccade_threshold: 0.5
     monitor_event_types: [MonocularEyeSampleEvent, FixationStartEvent, FixationEndEvent, SaccadeStartEvent, SaccadeEndEvent, BlinkStartEvent, BlinkEndEvent]
     model_name: MouseGaze
+    calibration:
+        # target_duration is the number of sec that a calibration point should
+        # be displayed before moving onto the next point. Target size expansion / contraction
+        # optionally occurs during this time period as well.
+        target_duration: 1.5
+
+        # target_delay specifies the time between target position presentations.
+        # Target position animation optionally occurs during this time period as well.
+        target_delay: 0.75
+
+        #
+        # Remaining calibration settings are only used if 'use_builtin' == False
+        #
+        # Number of calibration points to present.
+        # THREE_POINTS,FIVE_POINTS,NINE_POINTS, THIRTEEN_POINTS
+        type: NINE_POINTS
+
+        # color_type: rgb, rgb255, named, hex, etc. Leave blank to use window's color space.
+        color_type: rgb255
+
+        # unit_type: norm, pix, height, deg, etc. Leave blank to use window's unit type.
+        unit_type: pix
+
+        # Should the target positions be randomized?
+        randomize: True
+
+        # screen_background_color specifies the r,g,b background color to
+        # set the calibration, validation, etc, screens to.
+        screen_background_color: [128,128,128]
+
+        # The associated target attribute properties can be supplied
+        # for the given target_type.
+        target_attributes:
+             # outer_diameter: The size of the outer circle of the calibration target
+             outer_diameter: 40.0
+
+             # outer_stroke_width: The thickness of the outer circle edge.
+             outer_stroke_width: 2.0
+
+             # outer_fill_color: color to use to fill the outer circle.
+             outer_fill_color: [64,64,64]
+
+             # outer_line_color: color to used for the outer circle edge.
+             outer_line_color: [255,255,255]
+
+             # inner_diameter: The size of the inner circle calibration target
+             inner_diameter: 15.0
+
+             # inner_stroke_width: The thickness of the inner circle edge.
+             inner_stroke_width: 1.0
+
+             # inner_fill_color: color to use to fill the inner circle.
+             inner_fill_color: [0,255,0]
+
+             # inner_line_color: color to used for the inner circle edge.
+             inner_line_color: [0,0,0]
+
+             # 'animate' controls target movement and expansion / contraction (if any).
+             animate:
+                 # enable: True if the calibration target should be animated between target positions.
+                 # False specifies that the calibration targets could just jump from one calibration point to another.
+                 enable: True
+
+                 # expansion_ratio: If > 1.0, expansion_ratio specifies the maximum target
+                 # outer diameter size as outer_diameter * expansion_ratio.
+                 expansion_ratio: 1.25
+
+                 # contract_only: If True, only contract outer target circle into inner target circle;
+                 # expansion_ratio is ignored. If False, expand and then contract target using expansion_ratio setting.
+                 contract_only: False
     manufacturer_name: MouseGaze
     auto_report_events: False
     device_number: 0

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -25,6 +25,12 @@ eyetracker.hw.mouse.EyeTracker:
         # Target position animation optionally occurs during this time period as well.
         target_delay: 0.75
 
+        # auto_pace: If True, the eye tracker will automatically progress from
+        # one calibration point to the next. If False, a manual key or button press
+        # is needed to progress to the next point.
+        #
+        auto_pace: True
+
         # Number of calibration points to present.
         # THREE_POINTS,FIVE_POINTS,NINE_POINTS, THIRTEEN_POINTS
         type: NINE_POINTS

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -398,8 +398,18 @@ class EyeTracker(EyeTrackerDevice):
         """
         runSetupProcedure does nothing in the Mouse Simulated eye tracker, as calibration is automatic. ;)
         """
-        print2err("Mouse Simulated eye tracker runSetupProcedure called.")
-        return True
+        from psychopy.iohub.devices.eyetracker.hw.mouse.moumouCalibrationGraphics import GazepointPsychopyCalibrationGraphics
+        calibration = GazepointPsychopyCalibrationGraphics(self, calibration_args)
+
+        calibration.runCalibration()
+
+        calibration.window.close()
+
+        calibration._unregisterEventMonitors()
+        calibration.clearAllEventBuffers()
+
+        return {"RESULT": "ALWAYS_OK"}
+
 
     def _getIOHubEventObject(self, native_event_data):
         """The _getIOHubEventObject method is called by the ioHub Process to

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -6,6 +6,7 @@ from psychopy.iohub.errors import print2err, printExceptionDetailsToStdErr
 from psychopy.iohub.constants import EyeTrackerConstants, EventConstants
 from psychopy.iohub.devices import Computer, Device
 from psychopy.iohub.devices.eyetracker import EyeTrackerDevice
+from psychopy.iohub.devices.eyetracker.hw.mouse.mousegazeCalibrationGraphics import MouseGazePsychopyCalibrationGraphics
 import math
 ET_UNDEFINED = EyeTrackerConstants.UNDEFINED
 getTime = Computer.getTime
@@ -394,15 +395,14 @@ class EyeTracker(EyeTrackerDevice):
         """
         return self._recording
 
-    def runSetupProcedure(self, **calibration_args):
+    def runSetupProcedure(self, calibration_args={}):
         """
-        runSetupProcedure does nothing in the Mouse Simulated eye tracker, as calibration is automatic. ;)
+        runSetupProcedure displays a mock calibration procedure. No calibration is actually done.
         """
-        from psychopy.iohub.devices.eyetracker.hw.mouse.moumouCalibrationGraphics import GazepointPsychopyCalibrationGraphics
-        calibration = GazepointPsychopyCalibrationGraphics(self, calibration_args)
-
+        calibration = MouseGazePsychopyCalibrationGraphics(self, calibration_args)
+        print2err("Created MouseGazePsychopyCalibrationGraphics")
         calibration.runCalibration()
-
+        print2err("Done calibration.runCalibration()")
         calibration.window.close()
 
         calibration._unregisterEventMonitors()

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -108,18 +108,10 @@ class MouseGazePsychopyCalibrationGraphics(object):
         if isinstance(setting, str):
             setting = [setting, ]
         calibration_args = self._calibration_args
-        device_calib_config = self._device_config.get('calibration')
         if setting:
             for s in setting[:-1]:
-                if calibration_args:
-                    calibration_args = calibration_args.get(s)
-                device_calib_config = device_calib_config.get(s)
-            v = None
-            if calibration_args:
-                v = calibration_args.get(setting[-1])
-            if v is None:
-                v = device_calib_config[setting[-1]]
-            return v
+                calibration_args = calibration_args.get(s)
+            return calibration_args.get(setting[-1])
 
     def clearAllEventBuffers(self):
         self._eyetracker._iohub_server.eventBuffer.clear()
@@ -222,10 +214,8 @@ class MouseGazePsychopyCalibrationGraphics(object):
     def runCalibration(self):
         """Run calibration sequence
         """
-        print2err("started runCalibration...")
         instuction_text = 'Press SPACE to Start Calibration.'
         self.showSystemSetupMessageScreen(instuction_text)
-        print2err("called showSystemSetupMessageScreen")
 
         target_delay = self.getCalibSetting('target_delay')
         target_duration = self.getCalibSetting('target_duration')
@@ -260,7 +250,6 @@ class MouseGazePsychopyCalibrationGraphics(object):
             animate_enable = self.getCalibSetting(['target_attributes', 'animate', 'enable'])
             animate_expansion_ratio = self.getCalibSetting(['target_attributes', 'animate', 'expansion_ratio'])
             animate_contract_only = self.getCalibSetting(['target_attributes', 'animate', 'contract_only'])
-            print2err("Drawing: ",x, ",",y)
             while currentTime()-start_time <= target_delay:
                 if animate_enable:
                     t = (currentTime()-start_time) / target_delay

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -241,7 +241,6 @@ class MouseGazePsychopyCalibrationGraphics(object):
             # Convert GazePoint normalized positions to psychopy window unit positions
             # by using iohub display/window getCoordBounds.
             x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
-            self.drawCalibrationTarget((x, y), False)
             start_time = currentTime()
 
             self.clearAllEventBuffers()
@@ -251,17 +250,17 @@ class MouseGazePsychopyCalibrationGraphics(object):
             animate_expansion_ratio = self.getCalibSetting(['target_attributes', 'animate', 'expansion_ratio'])
             animate_contract_only = self.getCalibSetting(['target_attributes', 'animate', 'contract_only'])
             while currentTime()-start_time <= target_delay:
-                if animate_enable:
+                if animate_enable and i > 0:
                     t = (currentTime()-start_time) / target_delay
-                    if i > 0:
-                        v1 = cal_target_list[i-1]
-                        v2 = pt
-                        t = 60.0 * ((1.0 / 10.0) * t ** 5 - (1.0 / 4.0) * t ** 4 + (1.0 / 6.0) * t ** 3)
-                        mx, my = ((1.0 - t) * v1[0] + t * v2[0], (1.0 - t) * v1[1] + t * v2[1])
-                        moveTo = left + w * mx, bottom + h * (1.0 - my)
-                        self.drawCalibrationTarget(moveTo, reset=False)
+                    v1 = cal_target_list[i-1]
+                    v2 = pt
+                    t = 60.0 * ((1.0 / 10.0) * t ** 5 - (1.0 / 4.0) * t ** 4 + (1.0 / 6.0) * t ** 3)
+                    mx, my = ((1.0 - t) * v1[0] + t * v2[0], (1.0 - t) * v1[1] + t * v2[1])
+                    moveTo = left + w * mx, bottom + h * (1.0 - my)
+                    self.drawCalibrationTarget(moveTo, reset=False)
                 else:
-                    gevent.sleep(0.01)
+                    self.drawCalibrationTarget((x, y), False)
+
                 self.getNextMsg()
                 self.MsgPump()
 

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+# Part of the PsychoPy library
+# Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+
+from psychopy import visual
+import gevent
+from psychopy.iohub.util import convertCamelToSnake, updateDict
+from psychopy.iohub.devices import DeviceEvent, Computer
+from psychopy.iohub.constants import EventConstants as EC
+from psychopy.iohub.errors import print2err
+
+currentTime = Computer.getTime
+
+
+class MouseGazePsychopyCalibrationGraphics(object):
+    IOHUB_HEARTBEAT_INTERVAL = 0.050
+    WINDOW_BACKGROUND_COLOR = None
+    CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)]
+
+    _keyboard_key_index = EC.getClass(EC.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
+
+    def __init__(self, eyetrackerInterface, calibration_args):
+        self._eyetracker = eyetrackerInterface
+
+        self.screenSize = eyetrackerInterface._display_device.getPixelResolution()
+        self.width = self.screenSize[0]
+        self.height = self.screenSize[1]
+        self._ioKeyboard = None
+        self._msg_queue = []
+
+        self._lastCalibrationOK = False
+        self._device_config = self._eyetracker.getConfiguration()
+
+        updateDict(calibration_args, self._device_config.get('calibration'))
+        self._calibration_args = calibration_args
+
+        screenColor = self.getCalibSetting('screen_background_color')
+        print2err('screenColor:', screenColor)
+        MouseGazePsychopyCalibrationGraphics.WINDOW_BACKGROUND_COLOR = screenColor
+
+        calibration_methods = dict(THREE_POINTS=3,
+                                   FIVE_POINTS=5,
+                                   NINE_POINTS=9,
+                                   THIRTEEN_POINTS=13)
+
+        cal_type = self.getCalibSetting('type')
+
+        if cal_type in calibration_methods:
+            num_points = calibration_methods[cal_type]
+
+            if num_points == 3:
+                MouseGazePsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.1),
+                                                                               (0.1, 0.9),
+                                                                               (0.9, 0.9)]
+            elif num_points == 5:
+                MouseGazePsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.1, 0.9)]
+            elif num_points == 9:
+                MouseGazePsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.5),
+                                                                               (0.9, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.5, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.5, 0.9),
+                                                                               (0.1, 0.9)]
+            elif num_points == 13:
+                MouseGazePsychopyCalibrationGraphics.CALIBRATION_POINT_LIST = [(0.5, 0.5),
+                                                                               (0.1, 0.5),
+                                                                               (0.9, 0.5),
+                                                                               (0.1, 0.1),
+                                                                               (0.5, 0.1),
+                                                                               (0.9, 0.1),
+                                                                               (0.9, 0.9),
+                                                                               (0.5, 0.9),
+                                                                               (0.1, 0.9),
+                                                                               (0.25, 0.25),
+                                                                               (0.25, 0.75),
+                                                                               (0.75, 0.75),
+                                                                               (0.75, 0.25)
+                                                                               ]
+            display = self._eyetracker._display_device
+
+        self.window = visual.Window(
+            self.screenSize,
+            monitor=display.getPsychopyMonitorName(),
+            units=display.getCoordinateType(),
+            fullscr=True,
+            allowGUI=False,
+            screen=display.getIndex(),
+            color=self.WINDOW_BACKGROUND_COLOR,
+            colorSpace=display.getColorSpace())
+        self.window.flip(clearBuffer=True)
+
+        self._createStim()
+        self._registerEventMonitors()
+        self._lastMsgPumpTime = currentTime()
+
+        self.clearAllEventBuffers()
+
+    def getCalibSetting(self, setting):
+        if isinstance(setting, str):
+            setting = [setting, ]
+        calibration_args = self._calibration_args
+        device_calib_config = self._device_config.get('calibration')
+        if setting:
+            for s in setting[:-1]:
+                if calibration_args:
+                    calibration_args = calibration_args.get(s)
+                device_calib_config = device_calib_config.get(s)
+            v = None
+            if calibration_args:
+                v = calibration_args.get(setting[-1])
+            if v is None:
+                v = device_calib_config[setting[-1]]
+            return v
+
+    def clearAllEventBuffers(self):
+        self._eyetracker._iohub_server.eventBuffer.clear()
+        for d in self._eyetracker._iohub_server.devices:
+            d.clearEvents()
+
+    def _registerEventMonitors(self):
+        kbDevice = None
+        if self._eyetracker._iohub_server:
+            for dev in self._eyetracker._iohub_server.devices:
+                if dev.__class__.__name__ == 'Keyboard':
+                    kbDevice = dev
+
+        if kbDevice:
+            eventIDs = []
+            for event_class_name in kbDevice.__class__.EVENT_CLASS_NAMES:
+                eventIDs.append(getattr(EC, convertCamelToSnake(event_class_name[:-5], False)))
+
+            self._ioKeyboard = kbDevice
+            self._ioKeyboard._addEventListener(self, eventIDs)
+        else:
+            print2err(
+                'Warning: GazePoint Cal GFX could not connect to Keyboard device for events.')
+
+    def _unregisterEventMonitors(self):
+        if self._ioKeyboard:
+            self._ioKeyboard._removeEventListener(self)
+
+    def _handleEvent(self, event):
+        event_type_index = DeviceEvent.EVENT_TYPE_ID_INDEX
+        if event[event_type_index] == EC.KEYBOARD_PRESS:
+            ek = event[self._keyboard_key_index]
+            if isinstance(ek, bytes):
+                ek = ek.decode('utf-8')
+            if ek == ' ':
+                self._msg_queue.append('SPACE_KEY_ACTION')
+                self.clearAllEventBuffers()
+            elif ek == 'escape':
+                self._msg_queue.append('QUIT')
+                self.clearAllEventBuffers()
+
+    def MsgPump(self):
+        # keep the psychopy window happy ;)
+        if currentTime() - self._lastMsgPumpTime > self.IOHUB_HEARTBEAT_INTERVAL:
+            # try to keep ioHub from being blocked. ;(
+            if self._eyetracker._iohub_server:
+                for dm in self._eyetracker._iohub_server.deviceMonitors:
+                    dm.device._poll()
+                self._eyetracker._iohub_server.processDeviceEvents()
+            self._lastMsgPumpTime = currentTime()
+
+    def getNextMsg(self):
+        if len(self._msg_queue) > 0:
+            msg = self._msg_queue[0]
+            self._msg_queue = self._msg_queue[1:]
+            return msg
+
+    def _createStim(self):
+        """
+            outer_diameter: 35
+            outer_stroke_width: 5
+            outer_fill_color: [255,255,255]
+            outer_line_color: [255,255,255]
+            inner_diameter: 5
+            inner_stroke_width: 0
+            inner_color: [0,0,0]
+            inner_fill_color: [0,0,0]
+            inner_line_color: [0,0,0]
+            calibration_prefs=self._eyetracker.getConfiguration()['calibration']['target_attributes']
+        """
+        color_type = self.getCalibSetting('color_type')
+        unit_type = self.getCalibSetting('unit_type')
+
+        lwidth = self.getCalibSetting(['target_attributes', 'outer_stroke_width'])
+        radius = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0
+        fcolor = self.getCalibSetting(['target_attributes', 'outer_fill_color'])
+        lcolor = self.getCalibSetting(['target_attributes', 'outer_line_color'])
+        self.calibrationPointOUTER = visual.Circle(self.window, pos=(0, 0), name='CP_OUTER',
+                                                   radius=radius, lineWidth=lwidth,
+                                                   fillColor=fcolor, lineColor=lcolor,
+                                                   opacity=1.0, interpolate=False,
+                                                   edges=64, units=unit_type, colorSpace=color_type)
+
+        lwidth = self.getCalibSetting(['target_attributes', 'inner_stroke_width'])
+        radius = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0
+        fcolor = self.getCalibSetting(['target_attributes', 'inner_fill_color'])
+        lcolor = self.getCalibSetting(['target_attributes', 'inner_line_color'])
+        self.calibrationPointINNER = visual.Circle(self.window, pos=(0, 0), name='CP_INNER',
+                                                   radius=radius, lineWidth=lwidth,
+                                                   fillColor=fcolor, lineColor=lcolor,
+                                                   opacity=1.0, interpolate=False,
+                                                   edges=64, units=unit_type, colorSpace=color_type)
+
+        instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
+        self.textLineStim = visual.TextStim(self.window, text=instuction_text,
+                                            pos=(0, 0), height=36,
+                                            color=(0, 0, 0), colorSpace='rgb255',
+                                            units='pix', wrapWidth=self.width * 0.9)
+
+    def runCalibration(self):
+        """Run calibration sequence
+        """
+        print2err("started runCalibration...")
+        instuction_text = 'Press SPACE to Start Calibration.'
+        self.showSystemSetupMessageScreen(instuction_text)
+        print2err("called showSystemSetupMessageScreen")
+
+        target_delay = self.getCalibSetting('target_delay')
+        target_duration = self.getCalibSetting('target_duration')
+
+        cal_target_list = self.CALIBRATION_POINT_LIST
+        randomize_points = self.getCalibSetting('randomize')
+        if randomize_points is True:
+            # Randomize all but first target position.
+            cal_target_list = self.CALIBRATION_POINT_LIST[1:]
+            import random
+            random.seed(None)
+            random.shuffle(cal_target_list)
+            cal_target_list.insert(0, self.CALIBRATION_POINT_LIST[0])
+
+        left, top, right, bottom = self._eyetracker._display_device.getCoordBounds()
+        w, h = right - left, top - bottom
+
+        self.clearCalibrationWindow()
+
+        # seems like gps expects animation at state of every target pos.
+        i = 0
+        for pt in cal_target_list:
+            # Convert GazePoint normalized positions to psychopy window unit positions
+            # by using iohub display/window getCoordBounds.
+            x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
+            self.drawCalibrationTarget((x, y), False)
+            start_time = currentTime()
+
+            self.clearAllEventBuffers()
+
+            # Target animate / delay
+            animate_enable = self.getCalibSetting(['target_attributes', 'animate', 'enable'])
+            animate_expansion_ratio = self.getCalibSetting(['target_attributes', 'animate', 'expansion_ratio'])
+            animate_contract_only = self.getCalibSetting(['target_attributes', 'animate', 'contract_only'])
+            print2err("Drawing: ",x, ",",y)
+            while currentTime()-start_time <= target_delay:
+                if animate_enable:
+                    t = (currentTime()-start_time) / target_delay
+                    if i > 0:
+                        v1 = cal_target_list[i-1]
+                        v2 = pt
+                        t = 60.0 * ((1.0 / 10.0) * t ** 5 - (1.0 / 4.0) * t ** 4 + (1.0 / 6.0) * t ** 3)
+                        mx, my = ((1.0 - t) * v1[0] + t * v2[0], (1.0 - t) * v1[1] + t * v2[1])
+                        moveTo = left + w * mx, bottom + h * (1.0 - my)
+                        self.drawCalibrationTarget(moveTo, reset=False)
+                else:
+                    gevent.sleep(0.01)
+                self.getNextMsg()
+                self.MsgPump()
+
+            self.drawCalibrationTarget((x, y))
+            start_time = currentTime()
+
+            outer_diameter = self.getCalibSetting(['target_attributes', 'outer_diameter'])
+            inner_diameter = self.getCalibSetting(['target_attributes', 'inner_diameter'])
+            while currentTime()-start_time <= target_duration:
+                elapsed_time = currentTime()-start_time
+                d = t = None
+                if animate_contract_only:
+                    # Change target size from outer diameter to inner diameter over target_duration seconds.
+                    t = elapsed_time / target_duration
+                    d = outer_diameter - t * (outer_diameter - inner_diameter)
+                    self.calibrationPointOUTER.radius = d / 2
+                    self.calibrationPointOUTER.draw()
+                    self.calibrationPointINNER.draw()
+                    self.window.flip(clearBuffer=True)
+                elif animate_expansion_ratio not in [1, 1.0]:
+                    if elapsed_time <= target_duration/2:
+                        # In expand phase
+                        t = elapsed_time / (target_duration/2)
+                        d = outer_diameter + t * (outer_diameter*animate_expansion_ratio - outer_diameter)
+                    else:
+                        # In contract phase
+                        t = (elapsed_time-target_duration/2) / (target_duration/2)
+                        d = outer_diameter*animate_expansion_ratio - t * (outer_diameter*animate_expansion_ratio - inner_diameter)
+                if d:
+                    self.calibrationPointOUTER.radius = d / 2
+                    self.calibrationPointOUTER.draw()
+                    self.calibrationPointINNER.draw()
+                    self.window.flip(clearBuffer=True)
+
+                self.getNextMsg()
+                self.MsgPump()
+                gevent.sleep(0.001)
+
+            self.clearCalibrationWindow()
+            self.clearAllEventBuffers()
+            i += 1
+        instuction_text = "Calibration Complete. Press 'SPACE' key to continue."
+        self.showSystemSetupMessageScreen(instuction_text)
+
+
+    def clearCalibrationWindow(self):
+        self.window.flip(clearBuffer=True)
+
+    def showSystemSetupMessageScreen(self, text_msg='Press SPACE to Start Calibration; ESCAPE to Exit.'):
+
+        self.clearAllEventBuffers()
+
+        while True:
+            self.textLineStim.setText(text_msg)
+            self.textLineStim.draw()
+            self.window.flip()
+
+            msg = self.getNextMsg()
+            if msg == 'SPACE_KEY_ACTION':
+                self.clearAllEventBuffers()
+                return True
+            elif msg == 'QUIT':
+                self.clearAllEventBuffers()
+                return False
+            self.MsgPump()
+            gevent.sleep(0.001)
+
+    def drawDefaultTarget(self):
+        self.calibrationPointOUTER.radius = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0
+        self.calibrationPointOUTER.setLineColor(self.getCalibSetting(['target_attributes', 'outer_line_color']))
+        self.calibrationPointOUTER.setFillColor(self.getCalibSetting(['target_attributes', 'outer_fill_color']))
+        self.calibrationPointOUTER.lineWidth = int(self.getCalibSetting(['target_attributes', 'outer_stroke_width']))
+        self.calibrationPointINNER.radius = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0
+        self.calibrationPointINNER.setLineColor(self.getCalibSetting(['target_attributes', 'inner_line_color']))
+        self.calibrationPointINNER.setFillColor(self.getCalibSetting(['target_attributes', 'inner_fill_color']))
+        self.calibrationPointINNER.lineWidth = int(self.getCalibSetting(['target_attributes', 'inner_stroke_width']))
+
+        self.calibrationPointOUTER.draw()
+        self.calibrationPointINNER.draw()
+        return self.window.flip(clearBuffer=True)
+
+    def drawCalibrationTarget(self, tp, reset=True):
+        self.calibrationPointOUTER.setPos(tp)
+        self.calibrationPointINNER.setPos(tp)
+        if reset:
+            return self.drawDefaultTarget()
+        else:
+            self.calibrationPointOUTER.draw()
+            self.calibrationPointINNER.draw()
+            return self.window.flip(clearBuffer=True)

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
@@ -41,5 +41,59 @@ eyetracker.hw.mouse.EyeTracker:
                 min_length: 1
                 max_length: 1
         track_eyes: RIGHT_EYE
+    calibration:
+        target_delay:
+            IOHUB_FLOAT:
+                min: 0.25
+                max: 2.5
+        target_duration:
+            IOHUB_FLOAT:
+                min: 0.25
+                max: 2.5
+        type:
+            IOHUB_LIST:
+                valid_values: [THREE_POINTS,FIVE_POINTS,NINE_POINTS, THIRTEEN_POINTS]
+                min_length: 1
+                max_length: 1
+        unit_type:
+            IOHUB_LIST:
+                valid_values: [norm, pix, cm, height, deg, degFlatPos, degFlat]
+                min_length: 0
+                max_length: 1
+        color_type:
+            IOHUB_LIST:
+                valid_values: [rgb, dkl, lms, hsv, hex, named, rgb255]
+                min_length: 0
+                max_length: 1
+        randomize: IOHUB_BOOL
+        screen_background_color: IOHUB_COLOR
+        target_attributes:
+            outer_diameter:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            outer_stroke_width:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            outer_fill_color: IOHUB_COLOR
+            outer_line_color: IOHUB_COLOR
+            inner_diameter:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            inner_stroke_width:
+                IOHUB_FLOAT:
+                    min: 0.01
+                    max: 1000.0
+            inner_fill_color: IOHUB_COLOR
+            inner_line_color: IOHUB_COLOR
+            animate:
+                enable: IOHUB_BOOL
+                expansion_ratio:
+                    IOHUB_FLOAT:
+                        min: 1.0
+                        max: 100.0
+                contract_only: IOHUB_BOOL
     device_number: 0
     manufacturer_name: MouseGaze

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
@@ -65,6 +65,7 @@ eyetracker.hw.mouse.EyeTracker:
                 valid_values: [rgb, dkl, lms, hsv, hex, named, rgb255]
                 min_length: 0
                 max_length: 1
+        auto_pace: IOHUB_BOOL
         randomize: IOHUB_BOOL
         screen_background_color: IOHUB_COLOR
         target_attributes:


### PR DESCRIPTION
Added calibration graphics to the ioHub MouseGaze runSetupProcedure, allowing inspection of calibration gfx when not using a real eye tracker. MouseGaze calibration settings mimic those of GazePoint custom calibration gfx, which is what will eventually be standardized on for all eye trackers.