### PR TITLE
ioHub: Migrate to more common set of calibration settings

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -47,6 +47,12 @@ win = visual.Window((1920, 1080),
 
 win.setMouseVisible(False)
 
+text_stim = visual.TextStim(win, text="start of experiment",
+                            pos=[0, 0], height=24,
+                            color='black', units='pix', colorSpace='named',
+                            wrapWidth=win.size[0] * .9)
+text_stim.draw()
+win.flip()
 
 # Since no experiment or session code is given, no iohub hdf5 file
 # will be saved, but device events are still available at runtime.
@@ -58,13 +64,15 @@ keyboard = io.getDevice('keyboard')
 tracker = io.getDevice('tracker')
 
 win.winHandle.minimize()  # minimize the PsychoPy window
+win.winHandle.set_fullscreen(False)
 
 # run eyetracker calibration
 result = tracker.runSetupProcedure()
 print("Calibration returned: ", result)
 
+win.winHandle.set_fullscreen(True)
 win.winHandle.maximize()  # maximize the PsychoPy window
-win.winHandle.activate()
+
 
 gaze_ok_region = visual.Circle(win, lineColor='black', radius=300, units='pix', colorSpace='named')
 
@@ -75,10 +83,7 @@ text_stim_str = 'Eye Position: %.2f, %.2f. In Region: %s\n'
 text_stim_str += 'Press space key to start next trial.'
 missing_gpos_str = 'Eye Position: MISSING. In Region: No\n'
 missing_gpos_str += 'Press space key to start next trial.'
-text_stim = visual.TextStim(win, text=text_stim_str,
-                            pos=[0, 0], height=24,
-                            color='black', units='pix', colorSpace='named',
-                            wrapWidth=win.size[0] * .9)
+text_stim.setText(text_stim_str)
 
 # Run Trials.....
 t = 0

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -11,7 +11,7 @@ from psychopy.iohub import launchHubServer
 
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
-TRACKER = 'mouse'
+TRACKER = 'tobii'
 
 eyetracker_config = dict(name='tracker')
 devices_config = {}

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
@@ -102,7 +102,7 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
         # target_delay specifies the time between target position presentations.
         target_delay: 0.75
 
-        # **pacing_speed is deprecated. Please use 'target_duration' instead.**
+        # **pacing_speed is deprecated. Please use 'target_delay' instead.**
         pacing_speed:
         
         # screen_background_color: Specifies the background color to

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
@@ -94,11 +94,16 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
         # 
         auto_pace: True
 
-        # pacing_speed: The number of sec.msec that a calibration point should
-        # be displayed before moving onto the next point when auto_pace is set to true.
-        # If auto_pace is False, pacing_speed is ignored.
-        #
-        pacing_speed: 1.5
+
+        # target_duration is the number of sec that a calibration point should
+        # be displayed before moving onto the next point.
+        target_duration: 1.5
+
+        # target_delay specifies the time between target position presentations.
+        target_delay: 0.75
+
+        # **pacing_speed is deprecated. Please use 'target_duration' instead.**
+        pacing_speed:
         
         # screen_background_color: Specifies the background color to
         #   set the calibration, validation, etc, screens to.

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -349,8 +349,11 @@ class EyeTracker(EyeTrackerDevice):
                         eyelink.enableAutoCalibration()
                     elif cal_val is False:
                         eyelink.disableAutoCalibration()
-                elif cal_key == 'pacing_speed':  # in seconds.msec
-                    eyelink.setAutoCalibrationPacing(int(cal_val * 1000))
+                elif cal_key == 'pacing_speed' and cal_val:  # in seconds.msec
+                        eyelink.setAutoCalibrationPacing(int(cal_val * 1000))
+                elif cal_key == 'target_delay' and cal_val:  # in seconds.msec
+                        print2err("Setting eyelink setAutoCalibrationPacing using 'target_delay' of ", cal_val)
+                        eyelink.setAutoCalibrationPacing(int(cal_val * 1000))
                 elif cal_key == 'type':
                     VALID_CALIBRATION_TYPES = dict(THREE_POINTS='HV3', FIVE_POINTS='HV5', NINE_POINTS='HV9',
                                                    THIRTEEN_POINTS='HV13')

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
@@ -35,6 +35,15 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
                 min_length: 0
                 max_length: 1
         auto_pace: IOHUB_BOOL
+        target_duration:
+            IOHUB_FLOAT:
+                min: 0.5
+                max: 2.5
+        target_delay:
+            IOHUB_FLOAT:
+                min: 0.5
+                max: 2.5
+        # pacing_speed is deprecated. Please use 'target_delay' instead.
         pacing_speed:
             IOHUB_FLOAT:
                 min: 0.5

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
@@ -155,7 +155,7 @@ eyetracker.hw.tobii.EyeTracker:
                  # ** expansion_speed: Deprecated, target_duration is now used. **
                  #
                  expansion_speed:
-    
+
     runtime_settings:
         # The supported sampling rates for Tobii are model dependent. 
         # If the sampling rate specified here is not supported by the model being used,

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
@@ -68,12 +68,8 @@ eyetracker.hw.tobii.EyeTracker:
         # Target position animation optionally occurs during this time period as well.
         target_delay: 0.75
 
-        # **pacing_speed is deprecated. Please use 'target_duration' instead.**
-        # pacing_speed is the number of sec.msec that a calibration point should
-        # be displayed before moving onto the next point when auto_pace is set to true.
-        # If auto_pace is False, pacing_speed is ignored.
-        #
-        pacing_speed: 1.0
+        # **pacing_speed is deprecated. Please use 'target_delay' instead.**
+        pacing_speed:
 
         # screen_background_color specifies the r,g,b background color to 
         # set the calibration, validation, etc, screens to. Each element of the color

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
@@ -58,13 +58,23 @@ eyetracker.hw.tobii.EyeTracker:
         # the next point.
         #
         auto_pace: True
-        
+
+        # target_duration is the number of sec that a calibration point should
+        # be displayed before moving onto the next point.
+        # Target size expansion / contraction optionally occurs during this time period as well.
+        target_duration: 1.5
+
+        # target_delay specifies the time between target position presentations.
+        # Target position animation optionally occurs during this time period as well.
+        target_delay: 0.75
+
+        # **pacing_speed is deprecated. Please use 'target_duration' instead.**
         # pacing_speed is the number of sec.msec that a calibration point should
         # be displayed before moving onto the next point when auto_pace is set to true.
         # If auto_pace is False, pacing_speed is ignored.
         #
         pacing_speed: 1.0
-        
+
         # screen_background_color specifies the r,g,b background color to 
         # set the calibration, validation, etc, screens to. Each element of the color
         # should be a value between 0 and 255. 0 == black, 255 == white.
@@ -123,11 +133,6 @@ eyetracker.hw.tobii.EyeTracker:
                  # from one calibration position to another.
                  #
                  enable: True
-                 # movement_velocity: The velocity that a calibration target
-                 # graphic should use when gliding from one calibration
-                 # point to another. Always in pixels / second.
-                 #
-                 movement_velocity: 900.0 
                  # expansion_ratio: The outer circle of the calibration target
                  # can expand (and contract) when displayed at each position.
                  # expansion_ratio gives the largest size of the outer circle 
@@ -137,10 +142,6 @@ eyetracker.hw.tobii.EyeTracker:
                  # to 60 pixels. Set expansion_ratio to 1.0 for no expansion.
                  # 
                  expansion_ratio: 3.0
-                 # expansion_speed: The rate at which the outer circle
-                 # graphic should expand. Always in pixels / second. 
-                 # 
-                 expansion_speed: 60.0
                  # contract_only: If the calibration target should expand from
                  # the outer circle initial diameter to the larger diameter
                  # and then contract back to the original diameter, set 
@@ -148,6 +149,12 @@ eyetracker.hw.tobii.EyeTracker:
                  # go from an expanded state to the smaller size, set this to True.
                  #
                  contract_only: True
+                 # ** movement_velocity: Deprecated, please use target_delay instead. **
+                 #
+                 movement_velocity:
+                 # ** expansion_speed: Deprecated, target_duration is now used. **
+                 #
+                 expansion_speed:
     
     runtime_settings:
         # The supported sampling rates for Tobii are model dependent. 

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
@@ -89,7 +89,7 @@ eyetracker.hw.tobii.EyeTracker:
                 enable: IOHUB_BOOL
                 movement_velocity: # 300 pix / sec
                     IOHUB_FLOAT:
-                        min: 1.0
+                        min: -1.0
                         max: 1000.0
                 expansion_ratio: # expands to 3 x the starting size
                     IOHUB_FLOAT:
@@ -97,7 +97,7 @@ eyetracker.hw.tobii.EyeTracker:
                         max: 100.0
                 expansion_speed: # exapands at 30.0 pix / sec
                     IOHUB_FLOAT:
-                        min: 1.0
+                        min: -1.0
                         max: 100.0
                 contract_only: IOHUB_BOOL
     device_number: 0

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
@@ -49,6 +49,15 @@ eyetracker.hw.tobii.EyeTracker:
         randomize: IOHUB_BOOL
         target_positions: []
         auto_pace: IOHUB_BOOL
+        target_duration:
+            IOHUB_FLOAT:
+                min: 0.5
+                max: 2.5
+        target_delay:
+            IOHUB_FLOAT:
+                min: 0.5
+                max: 2.5
+        # pacing_speed is deprecated. Please use 'target_delay' instead.
         pacing_speed:
             IOHUB_FLOAT:
                 min: 0.5

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
@@ -373,16 +373,18 @@ class TobiiPsychopyCalibrationGraphics(object):
         pacing_speed = self.getCalibSetting('pacing_speed')
         randomize_points = self.getCalibSetting('randomize')
 
+        movement_velocity = self.getCalibSetting(['target_attributes', 'animate', 'movement_velocity'])
+        expansion_speed = self.getCalibSetting(['target_attributes', 'animate', 'expansion_speed'])
+        use_deprecated_gfx = movement_velocity or expansion_speed
+
         cal_target_list = self.CALIBRATION_POINT_LIST[1:]
         if randomize_points is True:
             import random
             random.seed(None)
             random.shuffle(cal_target_list)
-
         cal_target_list.insert(0, self.CALIBRATION_POINT_LIST[0])
 
         calibration = self._tobii.newScreenCalibration()
-
         calibration.enter_calibration_mode()
 
         i = 0
@@ -392,7 +394,10 @@ class TobiiPsychopyCalibrationGraphics(object):
             left, top, right, bottom = self._eyetrackerinterface._display_device.getCoordBounds()
             w, h = right - left, top - bottom
             x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
-            self.drawCalibrationTarget(i, (x, y))
+            if use_deprecated_gfx:
+                self.drawCalibrationTarget(i, (x, y))
+            else:
+                print2err("TODO: Implement new Tobii gfx logic for: ",i, " ", (x, y))
             self.clearAllEventBuffers()
             stime = currentTime()
 

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
@@ -353,22 +353,17 @@ class TobiiPsychopyCalibrationGraphics(object):
                 self.marker_heights[2]))
 
     def runCalibration(self):
-        """Performs a simple Tobii - like (@2010) calibration routine.
-
-        Result:
-            bool: True if calibration was successful. False if not.
-
+        """
+        Performs a Tobii calibration routine.
         """
 
         self._lastCalibrationOK = False
         calibration_sequence_completed = False
 
         instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
-        continue_calibration = self.showSystemSetupMessageScreen(
-            instuction_text, True)
+        continue_calibration = self.showSystemSetupMessageScreen(instuction_text, True)
         if not continue_calibration:
             return False
-
         auto_pace = self.getCalibSetting('auto_pace')
         pacing_speed = self.getCalibSetting('pacing_speed')
         randomize_points = self.getCalibSetting('randomize')
@@ -376,6 +371,10 @@ class TobiiPsychopyCalibrationGraphics(object):
         movement_velocity = self.getCalibSetting(['target_attributes', 'animate', 'movement_velocity'])
         expansion_speed = self.getCalibSetting(['target_attributes', 'animate', 'expansion_speed'])
         use_deprecated_gfx = movement_velocity or expansion_speed
+        if not use_deprecated_gfx:
+            # If using calibration option as of 2021.2, set pacing_speed
+            # to match target_delay
+            pacing_speed = self.getCalibSetting('target_delay')
 
         cal_target_list = self.CALIBRATION_POINT_LIST[1:]
         if randomize_points is True:
@@ -389,24 +388,83 @@ class TobiiPsychopyCalibrationGraphics(object):
 
         i = 0
         _quit = False
+        left, top, right, bottom = self._eyetrackerinterface._display_device.getCoordBounds()
+        w, h = right - left, top - bottom
         for pt in cal_target_list:
             self.clearAllEventBuffers()
-            left, top, right, bottom = self._eyetrackerinterface._display_device.getCoordBounds()
-            w, h = right - left, top - bottom
             x, y = left + w * pt[0], bottom + h * (1.0 - pt[1])
             if use_deprecated_gfx:
-                self.drawCalibrationTarget(i, (x, y))
+                self.drawCalibrationTargetDeprecated(i, (x, y))
             else:
-                print2err("TODO: Implement new Tobii gfx logic for: ",i, " ", (x, y))
-            self.clearAllEventBuffers()
-            stime = currentTime()
+                start_time = currentTime()
 
+                # Target animate / delay
+                animate_enable = self.getCalibSetting(['target_attributes', 'animate', 'enable'])
+                animate_expansion_ratio = self.getCalibSetting(['target_attributes', 'animate', 'expansion_ratio'])
+                animate_contract_only = self.getCalibSetting(['target_attributes', 'animate', 'contract_only'])
+                target_delay = self.getCalibSetting(['target_delay'])
+                target_duration = self.getCalibSetting(['target_duration'])
+                while currentTime()-start_time <= target_delay:
+                    if animate_enable and i > 0:
+                        t = (currentTime()-start_time) / target_delay
+                        v1 = cal_target_list[i-1]
+                        v2 = pt
+                        t = 60.0 * ((1.0 / 10.0) * t ** 5 - (1.0 / 4.0) * t ** 4 + (1.0 / 6.0) * t ** 3)
+                        mx, my = ((1.0 - t) * v1[0] + t * v2[0], (1.0 - t) * v1[1] + t * v2[1])
+                        moveTo = left + w * mx, bottom + h * (1.0 - my)
+                        self.drawCalibrationTarget(moveTo, reset=False)
+                    else:
+                        self.drawCalibrationTarget((x, y), False)
+
+                    self.getNextMsg()
+                    self.MsgPump()
+
+                self.drawCalibrationTarget((x, y))
+                start_time = currentTime()
+
+                outer_diameter = self.getCalibSetting(['target_attributes', 'outer_diameter'])
+                inner_diameter = self.getCalibSetting(['target_attributes', 'inner_diameter'])
+                while currentTime()-start_time <= target_duration:
+                    elapsed_time = currentTime()-start_time
+                    d = t = None
+                    if animate_contract_only:
+                        # Change target size from outer diameter to inner diameter over target_duration seconds.
+                        t = elapsed_time / target_duration
+                        d = outer_diameter - t * (outer_diameter - inner_diameter)
+                        self.calibrationPointOUTER.radius = d / 2
+                        self.calibrationPointOUTER.draw()
+                        self.calibrationPointINNER.draw()
+                        self.window.flip(clearBuffer=True)
+                    elif animate_expansion_ratio not in [1, 1.0]:
+                        if elapsed_time <= target_duration/2:
+                            # In expand phase
+                            t = elapsed_time / (target_duration/2)
+                            d = outer_diameter + t * (outer_diameter*animate_expansion_ratio - outer_diameter)
+                        else:
+                            # In contract phase
+                            t = (elapsed_time-target_duration/2) / (target_duration/2)
+                            d = outer_diameter*animate_expansion_ratio - t * (outer_diameter*animate_expansion_ratio - inner_diameter)
+                    if d:
+                        self.calibrationPointOUTER.radius = d / 2
+                        self.calibrationPointOUTER.draw()
+                        self.calibrationPointINNER.draw()
+                        self.window.flip(clearBuffer=True)
+
+                    self.getNextMsg()
+                    self.MsgPump()
+                    gevent.sleep(0.001)
+
+            self.clearAllEventBuffers()
+
+            stime = currentTime()
             def waitingForNextTargetTime():
                 return True
 
             if auto_pace is True:
                 def waitingForNextTargetTime():
-                    return currentTime() - stime < float(pacing_speed)
+                    if use_deprecated_gfx:
+                        return currentTime() - stime < float(pacing_speed)
+                    return False
 
             _quit = False
             while waitingForNextTargetTime():
@@ -425,13 +483,6 @@ class TobiiPsychopyCalibrationGraphics(object):
                 calibration.leave_calibration_mode()
                 calibration = None
                 break
-
-            # TODO: Switch to support per target status check available in tobii_research.
-            # if calibration.collect_data(pt[0], pt[1]) != self._tobii.CALIBRATION_STATUS_SUCCESS:
-            # Try again if it didn't go well the first time.
-            # Not all eye tracker models will fail at this point, but instead fail on ComputeAndApply.
-            #    print2err("Calibration failed for target {}. Recollecting data.... TODO: Give visual feedback.")
-            #    calibration.collect_data(pt[0], pt[1])
 
             self.clearCalibrationWindow()
             self.clearAllEventBuffers()
@@ -654,7 +705,7 @@ class TobiiPsychopyCalibrationGraphics(object):
             self.calibrationPointINNER.draw()
             ftime = self.window.flip(clearBuffer=True)
 
-    def drawCalibrationTarget(self, target_number, tp):
+    def drawCalibrationTargetDeprecated(self, target_number, tp):
         """
             outer_diameter: 35
             outer_stroke_width: 5
@@ -706,3 +757,27 @@ class TobiiPsychopyCalibrationGraphics(object):
 
         except Exception:
             printExceptionDetailsToStdErr()
+
+    def drawDefaultTarget(self):
+        self.calibrationPointOUTER.radius = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0
+        self.calibrationPointOUTER.setLineColor(self.getCalibSetting(['target_attributes', 'outer_line_color']))
+        self.calibrationPointOUTER.setFillColor(self.getCalibSetting(['target_attributes', 'outer_fill_color']))
+        self.calibrationPointOUTER.lineWidth = int(self.getCalibSetting(['target_attributes', 'outer_stroke_width']))
+        self.calibrationPointINNER.radius = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0
+        self.calibrationPointINNER.setLineColor(self.getCalibSetting(['target_attributes', 'inner_line_color']))
+        self.calibrationPointINNER.setFillColor(self.getCalibSetting(['target_attributes', 'inner_fill_color']))
+        self.calibrationPointINNER.lineWidth = int(self.getCalibSetting(['target_attributes', 'inner_stroke_width']))
+
+        self.calibrationPointOUTER.draw()
+        self.calibrationPointINNER.draw()
+        return self.window.flip(clearBuffer=True)
+
+    def drawCalibrationTarget(self, tp, reset=True):
+        self.calibrationPointOUTER.setPos(tp)
+        self.calibrationPointINNER.setPos(tp)
+        if reset:
+            return self.drawDefaultTarget()
+        else:
+            self.calibrationPointOUTER.draw()
+            self.calibrationPointINNER.draw()
+            return self.window.flip(clearBuffer=True)


### PR DESCRIPTION
Moving to a more common set of eyetracker calibration settings for different devices.

RF: EyeLink: deprecated 'pacing_speed'. Use 'target_delay'
RF: Tobii: deprecated 'expansion_speed'. Use 'target_duration'
RF: Tobii: deprecated 'pacing_speed' and 'movement_velocity'. Use 'target_delay'.
ENH: Tobii uses same gfx logic as GazePoint and MouseGaze if deprecated setting are None (the new default)