### PR TITLE
RF/NF: Add aliases for `start` and `stop` to microphone. Some other changes.

### DIFF
--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -14,7 +14,13 @@ __all__ = [
     'save',
     'AUDIO_SUPPORTED_CODECS',
     'AUDIO_CHANNELS_MONO',
-    'AUDIO_CHANNELS_STEREO'
+    'AUDIO_CHANNELS_STEREO',
+    'AUDIO_CHANNEL_LEFT',
+    'AUDIO_EAR_LEFT',
+    'AUDIO_CHANNEL_RIGHT',
+    'AUDIO_EAR_RIGHT',
+    'AUDIO_CHANNEL_COUNT',
+    'AUDIO_EAR_COUNT'
 ]
 
 import numpy as np
@@ -41,6 +47,11 @@ AUDIO_SUPPORTED_CODECS = [s.lower() for s in sf.available_formats().keys()]
 # constants for specifying the number of channels
 AUDIO_CHANNELS_MONO = 1
 AUDIO_CHANNELS_STEREO = 2
+
+# constants for indexing channels
+AUDIO_CHANNEL_LEFT = AUDIO_EAR_LEFT = 0
+AUDIO_CHANNEL_RIGHT = AUDIO_EAR_RIGHT = 1
+AUDIO_CHANNEL_COUNT = AUDIO_EAR_COUNT = 2
 
 
 class AudioClip(object):
@@ -628,7 +639,7 @@ class AudioClip(object):
         assert isinstance(value, dict)
         self._userData = value
 
-    def toText(self, engine='sphinx', config=None):
+    def transcribe(self, engine='sphinx', config=None):
         """Convert speech in audio to text.
 
         This feature passes the audio clip samples to a text-to-speech engine

--- a/psychopy/sound/audiodevice.py
+++ b/psychopy/sound/audiodevice.py
@@ -14,6 +14,8 @@ __all__ = [
     'NULL_AUDIO_DEVICE',
     'NULL_AUDIO_DEVICE_STATUS',
     'sampleRateQualityLevels',
+    'latencyClassLevels',
+    'runModeLevels',
     'SAMPLE_RATE_8kHz',
     'SAMPLE_RATE_TELCOM_QUALITY',
     'SAMPLE_RATE_16kHz',
@@ -35,6 +37,10 @@ __all__ = [
     'AUDIO_PTB_LATENCY_CLASS_EXCLUSIVE',
     'AUDIO_PTB_LATENCY_CLASS_AGGRESSIVE',
     'AUDIO_PTB_LATENCY_CLASS_CRITICAL',
+    'AUDIO_PTB_RUN_MODE0',
+    'AUDIO_PTB_RUN_MODE1',
+    'AUDIO_PTB_RUN_MODE_STANDBY',
+    'AUDIO_PTB_RUN_MODE_KEEP_HOT',
     'AUDIO_LIBRARY_PTB'
 ]
 
@@ -78,6 +84,15 @@ latencyClassLevels = {
     2: (AUDIO_PTB_LATENCY_CLASS2, 'Exclusive low-latency'),  # <<< default
     3: (AUDIO_PTB_LATENCY_CLASS3, 'Aggressive low-latency'),
     4: (AUDIO_PTB_LATENCY_CLASS4, 'Latency critical'),
+}
+
+# Run modes for the PsychPortAudio backend.
+AUDIO_PTB_RUN_MODE0 = AUDIO_PTB_RUN_MODE_STANDBY = 0
+AUDIO_PTB_RUN_MODE1 = AUDIO_PTB_RUN_MODE_KEEP_HOT = 1
+
+runModeLevels = {
+    0: (AUDIO_PTB_RUN_MODE0, 'Standby (low resource use, higher latency)'),
+    1: (AUDIO_PTB_RUN_MODE1, 'Keep hot (higher resource use, low latency)')
 }
 
 


### PR DESCRIPTION
Based on the last meeting.

- Added alias `pause` for `stop`.
- Added alias `record` for `start`.
- Added more PTB related symbolic constants.
- Added `audioRunMode` to `Microphone` to reduce latency. Removed `warmUp` hack.
- Fixed errors in and added doctrings.
- Renamed `toText` to `transcribe` in `AudioClip`.