### PR TITLE
NF: Added stdout/stderr output to Coder.

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -23,6 +23,7 @@ from psychopy.constants import PY3
 from . import urls
 from . import frametracker
 from . import themes
+from . import console
 
 import io
 
@@ -192,6 +193,7 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         self._stdout = sys.stdout
         self._stderr = sys.stderr
         self._stdoutFrame = None
+        self.stdStreamDispatcher = console.StdStreamDispatcher(self)
         self.iconCache = themes.IconCache()
 
         if not self.testMode:
@@ -403,7 +405,7 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         # wx-windows on some platforms (Mac 10.9.4) with wx-3.0:
         v = parse_version
         if sys.platform == 'darwin':
-            if v('3.0') <= v(wx.version()) <v('4.0'):
+            if v('3.0') <= v(wx.version()) < v('4.0'):
                 _Showgui_Hack()  # returns ~immediately, no display
                 # focus stays in never-land, so bring back to the app:
                 if prefs.app['defaultView'] in ['all', 'builder', 'coder', 'runner']:
@@ -423,6 +425,11 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
             logging.console.setLevel(logging.INFO)
 
         return True
+
+    @property
+    def appLoaded(self):
+        """`True` if the app has been fully loaded (`bool`)."""
+        return self._appLoaded
 
     def _wizard(self, selector, arg=''):
         from psychopy import core

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -193,14 +193,13 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
         self._stdout = sys.stdout
         self._stderr = sys.stderr
         self._stdoutFrame = None
-        self.stdStreamDispatcher = console.StdStreamDispatcher(self)
         self.iconCache = themes.IconCache()
 
         if not self.testMode:
             self._lastRunLog = open(os.path.join(
                     self.prefs.paths['userPrefsDir'], 'last_app_load.log'),
                     'w')
-            sys.stderr = sys.stdout = lastLoadErrs = self._lastRunLog
+            #sys.stderr = sys.stdout = lastLoadErrs = self._lastRunLog
             logging.console.setLevel(logging.DEBUG)
 
         # indicates whether we're running for testing purposes
@@ -352,6 +351,11 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
                 view.builder = True
                 view.coder = True
                 view.runner = True
+
+        # set the dispatcher for standard output
+        self.stdStreamDispatcher = console.StdStreamDispatcher(self)
+        sys.stderr = self.stdStreamDispatcher
+        sys.stdout = self.stdStreamDispatcher
 
         # Create windows
         if view.runner:
@@ -591,9 +595,8 @@ class PsychoPyApp(wx.App, themes.ThemeMixin):
             self.runner.Raise()
             self.SetTopWindow(self.runner)
         # Runner captures standard streams until program closed
-        if self.runner and not self.testMode:
-            sys.stdout = self.runner.stdOut
-            sys.stderr = self.runner.stdOut
+        # if self.runner and not self.testMode:
+        #     sys.stderr = sys.stdout = self.stdStreamDispatcher
 
     def newRunnerFrame(self, event=None):
         # have to reimport because it is only local to __init__ so far

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -48,6 +48,7 @@ from psychopy.app.coder.fileBrowser import FileBrowserPanel
 from psychopy.app.coder.sourceTree import SourceTreePanel
 from psychopy.app.themes import ThemeMixin
 from psychopy.app.coder.folding import CodeEditorFoldingMixin
+from psychopy.app.runner.runner import StdOutRich
 # from ..plugin_manager import PluginManagerFrame
 
 try:
@@ -1330,8 +1331,15 @@ class CoderFrame(wx.Frame, ThemeMixin):
             self.shell.SetName("PythonShell")
             self.shelf.AddPage(self.shell, _translate('Shell'))
             # Hide close button
-            for i in range(self.shelf.GetPageCount()):
-                self.shelf.SetCloseButton(i, False)
+
+        # script output panel
+        self.scriptOutput = wx.richtext.RichTextCtrl(self.shelf)
+        self.scriptOutput.SetName("ConsoleOutput")
+        self.shelf.AddPage(self.scriptOutput, _translate('Console Output'))
+
+        for i in range(self.shelf.GetPageCount()):
+            self.shelf.SetCloseButton(i, False)
+
         # Add shelf panel
         self.paneManager.AddPane(self.shelf,
                                  aui.AuiPaneInfo().
@@ -1351,7 +1359,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
         # Link to Runner output
         if self.app.runner is None:
             self.app.showRunner()
-        self.outputWindow = self.app.runner.stdOut
+        self.outputWindow = self.app.stdStreamDispatcher
         self.outputWindow.write(_translate('Welcome to PsychoPy3!') + '\n')
         self.outputWindow.write("v%s\n" % self.app.version)
 
@@ -1364,7 +1372,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
         else:
             self.SetMinSize(wx.Size(480, 640))  # min size for whole window
             self.SetSize(wx.Size(1024, 800))
-            # self.Fit()
+            self.Fit()
         # Update panes PsychopyToolbar
         isExp = filename.endswith(".py") or filename.endswith(".psyexp")
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -48,7 +48,7 @@ from psychopy.app.coder.fileBrowser import FileBrowserPanel
 from psychopy.app.coder.sourceTree import SourceTreePanel
 from psychopy.app.themes import ThemeMixin
 from psychopy.app.coder.folding import CodeEditorFoldingMixin
-from psychopy.app.runner.runner import StdOutRich
+from psychopy.app.coder.scriptOutput import ScriptOutputPanel
 # from ..plugin_manager import PluginManagerFrame
 
 try:
@@ -1333,9 +1333,9 @@ class CoderFrame(wx.Frame, ThemeMixin):
             # Hide close button
 
         # script output panel
-        self.scriptOutput = wx.richtext.RichTextCtrl(self.shelf)
-        self.scriptOutput.SetName("ConsoleOutput")
-        self.shelf.AddPage(self.scriptOutput, _translate('Console Output'))
+        self.consoleOutput = ScriptOutputPanel(self.shelf)
+        self.consoleOutput.SetName("ConsoleOutput")
+        self.shelf.AddPage(self.consoleOutput, _translate('Output'))
 
         for i in range(self.shelf.GetPageCount()):
             self.shelf.SetCloseButton(i, False)

--- a/psychopy/app/coder/scriptOutput.py
+++ b/psychopy/app/coder/scriptOutput.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Classes and functions for the script output."""
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import re
+import locale
+import wx
+import wx.richtext
+from psychopy.localization import _translate
+from psychopy.alerts._alerts import AlertEntry
+
+_prefEncoding = locale.getpreferredencoding()
+
+
+class ScriptOutputPanel(wx.richtext.RichTextCtrl):
+    """Class for the script output window in Coder.
+
+    Parameters
+    ----------
+    parent : :class:`wx.Window`
+        Window this object belongs to.
+    style : int
+        Symbolic constants for style flags.
+    size : ArrayLike or None
+        Size of the control in pixels `(w, h)`. Use `None` for default.
+    font : str or None
+        Font to use for output, fixed-width is preferred. If `None`, the theme
+        defaults will be used.
+    fontSize : int or None
+        Point size of the font. If `None`, the theme defaults will be used.
+
+    """
+    def __init__(self,
+                 parent,
+                 style=wx.TE_READONLY | wx.TE_MULTILINE | wx.BORDER_NONE,
+                 size=None,
+                 font=None,
+                 fontSize=None):
+
+        wx.richtext.RichTextCtrl.__init__(
+            self,
+            parent,
+            id=wx.ID_ANY,
+            value="",
+            pos=wx.DefaultPosition,
+            size=wx.DefaultSize if size is None else size,
+            style=style,
+            validator=wx.DefaultValidator,
+            name=wx.TextCtrlNameStr)
+
+        self.parent = parent
+        self._font = font
+        self._fontSize = fontSize
+
+    def write(self, inStr):
+        """Write (append) text to the control.
+
+        Formatting is automatically applied to the text assuming the text
+        follows PsychoPy's standard formatting conventions.
+
+        Parameters
+        ----------
+        inStr : str
+            Text to append.
+
+        """
+        # mostly taken from the existing StdOutRich class used by runner
+        self.MoveEnd()  # always 'append' text rather than 'writing' it
+
+        if isinstance(inStr, AlertEntry):
+            alert = inStr
+            # Write Code
+            self.BeginBold()
+            self.BeginTextColour(wx.BLUE)
+            self.BeginURL(alert.url)
+            self.WriteText("Alert {}:".format(alert.code))
+            self.EndURL()
+            self.EndBold()
+            self.EndTextColour()
+
+            # Write Message
+            self.BeginTextColour([0, 0, 0])
+            self.WriteText(alert.msg)
+            self.EndTextColour()
+
+            # Write URL
+            self.WriteText("\n\t"+_translate("For further info see "))
+            self.BeginBold()
+            self.BeginTextColour(wx.BLUE)
+            self.BeginURL(alert.url)
+            self.WriteText("{:<15}".format(alert.url))
+            self.EndURL()
+            self.EndBold()
+            self.EndTextColour()
+
+            self.Newline()
+            self.ShowPosition(self.GetLastPosition())
+
+            return
+
+        # convert to unicode if needed
+        if isinstance(inStr, bytes):
+            try:
+                inStr = inStr.decode('utf-8')
+            except UnicodeDecodeError:
+                inStr = inStr.decode(_prefEncoding)
+
+        # process the line, apply formatting and append
+        for thisLine in inStr.splitlines(True):
+            try:
+                thisLine = thisLine.replace("\t", "    ")
+            except Exception as e:
+                self.WriteText(str(e))
+
+            if len(re.findall('".*", line.*', thisLine)) > 0:
+                # this line contains a file/line location so write as URL
+                # self.BeginStyle(self.urlStyle)  # this should be done with
+                # styles, but they don't exist in wx as late as 2.8.4.0
+                self.BeginBold()
+                self.BeginTextColour(wx.BLUE)
+                self.BeginURL(thisLine)
+                self.WriteText(thisLine)
+                self.EndURL()
+                self.EndBold()
+                self.EndTextColour()
+            elif len(re.findall('WARNING', thisLine)) > 0:
+                self.BeginTextColour([0, 150, 0])
+                self.WriteText(thisLine)
+                self.EndTextColour()
+            elif len(re.findall('ERROR', thisLine)) > 0:
+                self.BeginTextColour([150, 0, 0])
+                self.WriteText(thisLine)
+                self.EndTextColour()
+            else:
+                # line to write as simple text
+                self.WriteText(thisLine)
+
+        self.MoveEnd()  # go to end of stdout so user can see updated text
+        self.ShowPosition(self.GetLastPosition())
+
+    def _applyAppTheme(self):
+        pass
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -21,12 +21,10 @@ class StdStreamDispatcher(object):
     """Class for broadcasting standard output to text boxes.
 
     This class serves to redirect and log standard streams within the PsychoPy
-    GUI suite. An instance of this class is created on-startup and referenced by
+    GUI suite, usually from sub-processes (e.g., a running script) to display
+    somewhere. An instance of this class is created on-startup and referenced by
     the main application instance. Only one instance of this class can be
     created per-session (singleton).
-
-    Callbacks can be registered so that console output gets broadcast when
-    received.
 
     Parameters
     ----------
@@ -39,7 +37,6 @@ class StdStreamDispatcher(object):
     # and coder output panel. This will allow changes being made on those
     # objects not requiring any changes here.
     #
-
     _instance = None
     _initialized = False
     _app = None  # reference to parent app
@@ -117,7 +114,8 @@ class StdStreamDispatcher(object):
 
         coder = self._app.coder
         if coder is not None:
-            pass   # write output to coder output window
+            if hasattr(coder, 'consoleOutput'):
+                pass   # write output to coder output window
 
         runner = self._app.runner
         if runner is not None:
@@ -131,7 +129,8 @@ class StdStreamDispatcher(object):
 
         coder = self._app.coder
         if coder is not None:
-            pass   # write output to coder output window
+            if hasattr(coder, 'consoleOutput'):
+                pass   # write output to coder output window
 
         runner = self._app.runner
         if runner is not None:

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+
+"""Classes and functions for broadcasting standard streams from external
+consoles/terminals within the PsychoPy GUI suite.
+"""
+
+# This module can be expanded to centralize management for all console related
+# actions in the future.
+#
+
+import sys
+
+
+class StdStreamDispatcher(object):
+    """Class for broadcasting standard output to text boxes.
+
+    This class serves to redirect and log standard streams within the PsychoPy
+    GUI suite. An instance of this class is created on-startup and referenced by
+    the main application instance. Only one instance of this class can be
+    created per-session (singleton).
+
+    Callbacks can be registered so that console output gets broadcast when
+    received.
+
+    Parameters
+    ----------
+    app : :class:`~psychopy.app._psychopyApp.PsychoPyApp`
+        Reference to the application instance.
+
+    """
+    # Developer note: In the future we should be able to attach other listeners
+    # dynamically. Right now they are hard-coded, being the runner output box
+    # and coder output panel. This will allow changes being made on those
+    # objects not requiring any changes here.
+    #
+
+    _instance = None
+    _initialized = False
+    _app = None  # reference to parent app
+
+    def __init__(self, app):
+        # only setup if previously not instanced
+        if not self._initialized:
+            self._app = app
+        else:
+            raise RuntimeError(
+                "Cannot create a new `psychopy.app.console.StdOutManager` "
+                "instance. Already initialized.")
+
+        self._initialized = True
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(StdStreamDispatcher, cls).__new__(cls)
+
+        return cls._instance
+
+    @classmethod
+    def getInstance(cls):
+        """Get the (singleton) instance of the `StdStreamDispatcher` class.
+
+        Getting a reference to the `StdOutManager` class outside of the scope of
+        the user's scripts should be done through this class method.
+
+        Returns
+        -------
+        StdStreamDispatcher or None
+            Instance of the `Mouse` class created by the user.
+
+        """
+        return cls._instance
+
+    @classmethod
+    def initialized(cls):
+        """Check if this class has been initialized.
+
+        Returns
+        -------
+        bool
+            `True` if the `StdStreamDispatcher` class has been already
+            instanced.
+
+        """
+        return cls._initialized
+
+    def write(self, text):
+        """Send text standard output to all listeners (legacy). This method is
+        used for compatibility for older code. This makes it so an instance of
+        this object looks like a ...
+
+        Parameters
+        ----------
+        text : str
+            Text to broadcast to all standard output windows.
+
+        """
+        self.broadcast(text=text)
+
+    def broadcast(self, text):
+        """Send text standard output to all listeners.
+
+        Parameters
+        ----------
+        text : str
+            Text to broadcast to all standard output windows.
+
+        """
+        # do nothing is the app isn't fully realized
+        if not self._app.appLoaded:
+            return
+
+        coder = self._app.coder
+        if coder is not None:
+            pass   # write output to coder output window
+
+        runner = self._app.runner
+        if runner is not None:
+            runner.write(text)
+
+    def clear(self):
+        """Clear all output windows."""
+        # do nothing is the app isn't fully realized
+        if not self._app.appLoaded:
+            return
+
+        coder = self._app.coder
+        if coder is not None:
+            pass   # write output to coder output window
+
+        runner = self._app.runner
+        if runner is not None:
+            runner.Clear()
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -115,11 +115,14 @@ class StdStreamDispatcher(object):
         coder = self._app.coder
         if coder is not None:
             if hasattr(coder, 'consoleOutput'):
-                pass   # write output to coder output window
+                coder.consoleOutput.write(text)
 
         runner = self._app.runner
         if runner is not None:
-            runner.write(text)
+            runner.stdOut.write(text)
+
+    def flush(self):
+        pass
 
     def clear(self):
         """Clear all output windows."""
@@ -130,11 +133,11 @@ class StdStreamDispatcher(object):
         coder = self._app.coder
         if coder is not None:
             if hasattr(coder, 'consoleOutput'):
-                pass   # write output to coder output window
+                coder.consoleOutput.Clear()
 
         runner = self._app.runner
         if runner is not None:
-            runner.Clear()
+            runner.stdOut.Clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reintroduces a feature removed but missed when Runner was added. Adds an output panel to Coder which displays the output from a running script, mostly mirroring what Runner shows. Also fixes various bugs associated with how this was done before.

Key changes:

* Added running script output to Coder.
* Fixes #3610 where copy/paste raises an error.
* Persistent object for capturing standard streams, so data isn't lost if there is no widget to log to.