### PR TITLE
NF/RF/DOCS: Improvements to `AudioClip.transcribe()`

### DIFF
--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -791,7 +791,7 @@ class AudioClip(object):
                 else:
                     config['key'] = key
             else:
-                raise logging.warning(
+                logging.warning(
                     "Selected speech-to-text engine '{}' requires a key but "
                     "`None` is specified.")
 


### PR DESCRIPTION
Added the following to the Python speech-to-text feature of `AudioClip`.

* Parameter `expectedWords` for list of words or phrases to constrain the output to.
* Parameter `key` for the API key as a string, usually in JSON format. If the value for key is a valid file path, the key will be loaded from the file.
* Parameter `language`, where the transcription language as a BCP-47 code can be specified.
* Better documentation and some helpful notes.
* Better warnings and error messages.
* Added `AudioClip.convertToWAV()` method since we reuse that operation a lot.