### PR TITLE
WIP: Add iohub support to keyboard.Keyboard

### DIFF
--- a/psychopy/demos/coder/input/keyNameFinder.py
+++ b/psychopy/demos/coder/input/keyNameFinder.py
@@ -1,14 +1,13 @@
 from psychopy import visual
 from psychopy.hardware import keyboard
 
-use_iohub = True
-
 # Make window
 win = visual.Window(units="height")
 
-if use_iohub:
-    from psychopy.iohub import launchHubServer
-    launchHubServer(window=win)
+# To have keyboard.Keyboard() use iohub backend, start the iohub server
+# prior to creating a Keyboard() instance.
+# from psychopy.iohub import launchHubServer
+# launchHubServer(window=win)
 
 # Make instructions textbox
 instr = visual.TextBox2(win,

--- a/psychopy/demos/coder/input/keyNameFinder.py
+++ b/psychopy/demos/coder/input/keyNameFinder.py
@@ -1,6 +1,5 @@
 from psychopy import visual
 from psychopy.hardware import keyboard
-from psychopy.iohub import launchHubServer
 
 use_iohub = True
 
@@ -8,6 +7,7 @@ use_iohub = True
 win = visual.Window(units="height")
 
 if use_iohub:
+    from psychopy.iohub import launchHubServer
     launchHubServer(window=win)
 
 # Make instructions textbox
@@ -34,5 +34,7 @@ while 'escape' not in keys:
     if keys:
         # If a key was pressed, display it
         output.text = f"That key was `{keys[-1].name}`. Press another key."
+        for k in keys:
+            print(k.name, k.code, k.tDown, k.rt, k.duration)
 # End the demo
 win.close()

--- a/psychopy/demos/coder/input/keyNameFinder.py
+++ b/psychopy/demos/coder/input/keyNameFinder.py
@@ -1,8 +1,14 @@
 from psychopy import visual
 from psychopy.hardware import keyboard
+from psychopy.iohub import launchHubServer
+
+use_iohub = True
 
 # Make window
 win = visual.Window(units="height")
+
+if use_iohub:
+    launchHubServer(window=win)
 
 # Make instructions textbox
 instr = visual.TextBox2(win,

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -65,7 +65,6 @@ from __future__ import absolute_import, division, print_function
 from collections import deque
 import sys
 import copy
-
 import psychopy.core
 import psychopy.clock
 from psychopy import logging
@@ -74,15 +73,15 @@ from psychopy.constants import NOT_STARTED
 try:
     import psychtoolbox as ptb
     from psychtoolbox import hid
-
     havePTB = True
 except ImportError as err:
     logging.warning(("Import Error: "
                      + err.args[0]
                      + ". Using event module for keyboard component."))
     from psychopy import event
-
     havePTB = False
+
+macPrefsBad = False
 
 defaultBufferSize = 10000
 
@@ -139,6 +138,7 @@ class Keyboard:
             setting this to True
 
         """
+        global havePTB, macPrefsBad
         self.status = NOT_STARTED
         # Initiate containers for storing responses
         self.keys = []  # the key(s) pressed
@@ -186,6 +186,16 @@ class Keyboard:
             # Is this right, waiting if waitForStart=False??
             if not waitForStart:
                 self.start()
+
+            # check if mac prefs are working; if not default
+            # to using event.getKeys()
+            if sys.platform == 'darwin':
+                try:
+                    Keyboard()
+                except OSError:
+                    macPrefsBad = True
+                    havePTB = False
+                    Keyboard.backend = 'event'
         elif Keyboard.backend == '':
             Keyboard.backend = 'event'
 
@@ -608,12 +618,3 @@ elif sys.platform == 'win32':
     keyNames = keyNamesWin
 else:
     keyNames = keyNamesLinux
-
-# check if mac prefs are working
-macPrefsBad = False
-if sys.platform == 'darwin' and havePTB:
-    try:
-        Keyboard()
-    except OSError:
-        macPrefsBad = True
-        havePTB = False

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -237,7 +237,6 @@ class Keyboard:
                 key_releases = Keyboard.iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
                 for k in key_releases:
                     kname = k.key
-                    print("kname: ", kname, kname == ' ')
                     if kname == ' ':
                         kname = 'space'
                     kp = KeyPress(code=None, tDown=k.time, name=kname)

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -230,17 +230,21 @@ class Keyboard:
                     thisKey.rt = thisKey.tDown - self.clock.getLastResetTime()
                     keys.append(thisKey)
         elif Keyboard.backend == 'iohub':
+            watchForKeys = keyList
+            if watchForKeys:
+               watchForKeys = [' ' if k == 'space' else k for k in watchForKeys]
             if waitRelease:
-                key_releases = Keyboard.iohubKeyboard.getReleases(keys=keyList, clear=clear)
+                key_releases = Keyboard.iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
                 for k in key_releases:
                     kname = k.key
+                    print("kname: ", kname, kname == ' ')
                     if kname == ' ':
                         kname = 'space'
                     kp = KeyPress(code=None, tDown=k.time, name=kname)
                     kp.duration = k.duration
-                    keys.append(KeyPress(code=None, tDown=k.time, name=k.key))
+                    keys.append(kp)
             else:
-                key_presses = Keyboard.iohubKeyboard.getPresses(keys=keyList, clear=clear)
+                key_presses = Keyboard.iohubKeyboard.getPresses(keys=watchForKeys, clear=clear)
                 for k in key_presses:
                     kname = k.key
                     if kname == ' ':


### PR DESCRIPTION
ENH: If iohub server is already running, keyboard.Keyboard will use iohub for keyboard events instead of PsychHID. This reduces the number of processes used by the experiment by one.