### PR TITLE
FF: Various mouse fixes in `psychopy.event`

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -648,11 +648,15 @@ class Mouse(object):
         """Returns the current position of the mouse,
         in the same units as the :class:`~visual.Window` (0,0) is at centre
         """
+        lastPosPix = numpy.zeros((2,), dtype=numpy.float32)
         if usePygame:  # for pygame top left is 0,0
             lastPosPix = numpy.array(mouse.get_pos())
             # set (0,0) to centre
             lastPosPix[1] = self.win.size[1] / 2 - lastPosPix[1]
             lastPosPix[0] = lastPosPix[0] - self.win.size[0] / 2
+            self.lastPos = self._pix2windowUnits(lastPosPix)
+        elif useGLFW:
+            lastPosPix[:] = self.win.backend.getMousePos()
         else:  # for pyglet bottom left is 0,0
             # use default window if we don't have one
             if self.win:
@@ -662,12 +666,14 @@ class Mouse(object):
                 w = defDisplay.get_windows()[0]
 
             # get position in window
-            lastPosPix = numpy.array([w._mouse_x, w._mouse_y])
+            lastPosPix[:] = w._mouse_x, w._mouse_y
+
             # set (0,0) to centre
             if self.win.useRetina:
-                lastPosPix = lastPosPix*2 - numpy.array(self.win.size) / 2
+                lastPosPix = lastPosPix * 2 - numpy.array(self.win.size) / 2
             else:
                 lastPosPix = lastPosPix - numpy.array(self.win.size) / 2
+
         self.lastPos = self._pix2windowUnits(lastPosPix)
 
         return copy.copy(self.lastPos)

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -657,6 +657,8 @@ class Mouse(object):
             self.lastPos = self._pix2windowUnits(lastPosPix)
         elif useGLFW:
             lastPosPix[:] = self.win.backend.getMousePos()
+            if self.win.useRetina:
+                lastPosPix *= 2.0
         else:  # for pyglet bottom left is 0,0
             # use default window if we don't have one
             if self.win:

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -22,6 +22,7 @@ import numpy as np
 from psychopy import logging, event, prefs, core
 from psychopy.tools.attributetools import attributeSetter
 from psychopy.visual import window
+import psychopy.event as event
 from .gamma import createLinearRamp
 import psychopy.hardware.mouse as mouse
 from .. import globalVars
@@ -700,6 +701,7 @@ class GLFWBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onGLFWMouseButton(*args, **kwargs)
             return
 
         _, _, action, _ = args
@@ -715,6 +717,7 @@ class GLFWBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onGLFWMouseButton(*args, **kwargs)
             return
 
         win_handle, button, _, _ = args
@@ -729,6 +732,7 @@ class GLFWBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onGLFWMouseButton(*args, **kwargs)
             return
 
         win_handle, button, _, _ = args
@@ -738,11 +742,12 @@ class GLFWBackend(BaseBackend):
         mouseEventHandler.setMouseButtonState(
             _GLFW_MOUSE_BUTTONS_[button], False, absPos, absTime)
 
-    def onMouseScroll(self, *args):
+    def onMouseScroll(self, *args, **kwargs):
         """Event handler for mouse scroll events."""
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onGLFWMouseScroll(*args, **kwargs)
             return
 
         _, xoffset, yoffset = args
@@ -752,7 +757,7 @@ class GLFWBackend(BaseBackend):
         mouseEventHandler.win = self.win
         mouseEventHandler.setMouseScrollState(absPos, relOffset, absTime)
 
-    def onMouseMove(self, *args):
+    def onMouseMove(self, *args, **kwargs):
         """Event handler for mouse move events."""
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
@@ -765,7 +770,7 @@ class GLFWBackend(BaseBackend):
         mouseEventHandler.win = self.win
         mouseEventHandler.setMouseMotionState(absPos, absTime)
 
-    def onMouseEnter(self, *args):
+    def onMouseEnter(self, *args, **kwargs):
         """Event called when the mouse enters the window."""
         win_handle, entered = args
 
@@ -781,7 +786,7 @@ class GLFWBackend(BaseBackend):
             else:
                 mouseEventHandler.win = None
 
-    def onMouseLeave(self, *args):
+    def onMouseLeave(self, *args, **kwargs):
         """Event called when the mouse leaves the window. This does nothing
         since `onMouseEnter` handles both enter and leave events. This is
         implemented for completeness.

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -781,6 +781,13 @@ class GLFWBackend(BaseBackend):
             else:
                 mouseEventHandler.win = None
 
+    def onMouseLeave(self, *args):
+        """Event called when the mouse leaves the window. This does nothing
+        since `onMouseEnter` handles both enter and leave events. This is
+        implemented for completeness.
+        """
+        pass
+
     def setMouseExclusive(self, exclusive):
         """Set mouse exclusivity.
 

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -703,6 +703,7 @@ class PygletBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onPygletMousePress(*args, **kwargs)
             return
 
         x, y, button, _ = args
@@ -717,6 +718,7 @@ class PygletBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onPygletMouseRelease(*args, **kwargs)
             return
 
         x, y, button, _ = args
@@ -731,6 +733,7 @@ class PygletBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onPygletMouseWheel(*args, **kwargs)
             return
 
         # register mouse position associated with event
@@ -745,6 +748,7 @@ class PygletBackend(BaseBackend):
         # don't process mouse events until ready
         mouseEventHandler = mouse.Mouse.getInstance()
         if mouseEventHandler is None:
+            event._onPygletMouseMotion(*args, **kwargs)
             return
 
         x, y, _, _ = args


### PR DESCRIPTION
Fixes bugs in the `psychopy.event` module where mouse events are not being registered. These problems were due to changes in how window backends handle mouse events after reworking it for the new hardware mouse class. This fixes the problem for `pyglet` and `glfw` backends.