### PR TITLE
misc fixes

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -66,7 +66,6 @@ import copy
 import psychopy.core
 import psychopy.clock
 from psychopy import logging
-from psychopy.iohub.util import win32MessagePump
 from psychopy.constants import NOT_STARTED
 import time
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -159,7 +159,7 @@ class Keyboard:
                 if Keyboard._iohubKeyboard:
                     Keyboard.backend = 'iohub'
 
-        if Keyboard.backend == '' and havePTB:
+        if Keyboard.backend in ['', 'ptb'] and havePTB:
             Keyboard.backend = 'ptb'
             # get the necessary keyboard buffer(s)
             if sys.platform == 'win32':
@@ -202,15 +202,17 @@ class Keyboard:
 
     def start(self):
         """Start recording from this keyboard """
-        for buffer in self._buffers.values():
-            buffer.start()
+        if Keyboard.backend == 'ptb':
+            for buffer in self._buffers.values():
+                buffer.start()
 
     def stop(self):
         """Start recording from this keyboard"""
-        logging.warning("Stopping key buffers but this could be dangerous if"
-                        "other keyboards rely on the same.")
-        for buffer in self._buffers.values():
-            buffer.stop()
+        if Keyboard.backend == 'ptb':
+            logging.warning("Stopping key buffers but this could be dangerous if"
+                            "other keyboards rely on the same.")
+            for buffer in self._buffers.values():
+                buffer.stop()
 
     def getKeys(self, keyList=None, waitRelease=True, clear=True):
         """

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -252,7 +252,6 @@ class Keyboard:
             watchForKeys = keyList
             if watchForKeys:
                 watchForKeys = [' ' if k == 'space' else k for k in watchForKeys]
-            win32MessagePump()
             if waitRelease:
                 key_events = Keyboard._iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
             else:
@@ -453,7 +452,10 @@ class _KeyBuffer(object):
         self._processEvts()
 
     def _flushEvts(self):
-        win32MessagePump()
+        # SS: sleep is only needed on Windows, but test further before
+        # committing to this.
+        #if sys.platform == 'win32':
+        ptb.WaitSecs('YieldSecs', 0.00001)
         while self.dev.flush():
             evt, remaining = self.dev.queue_get_event()
             key = {}
@@ -461,7 +463,6 @@ class _KeyBuffer(object):
             key['down'] = bool(evt['Pressed'])
             key['time'] = evt['Time']
             self._evts.append(key)
-            win32MessagePump()
 
     def getKeys(self, keyList=[], waitRelease=True, clear=True):
         """Return the KeyPress objects from the software buffer

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -562,10 +562,13 @@ class Display(Device):
         coord_type = self.getCoordinateType()
         if coord_type in Display._coord_type_mappings:
             coord_type = Display._coord_type_mappings[coord_type]
-        else:
-            print2err(
-                ' *** Display device error: Unknown coordinate type: {0}'.format(coord_type))
+        elif coord_type is None:
+            print2err(' *** iohub warning: Display / Monitor unit type has not been set.')
             return
+        else:
+            print2err(' *** iohub error: Unknown Display / Monitor coordinate type: {0}'.format(coord_type))
+            return
+        
         self._pix2coord = None
 
         # For now, use psychopy unit conversions so that drawing positions match


### PR DESCRIPTION
FF: Fix pyglet missing events when win32MessagePump() is called by the psychopy process.
FF: Fix print warning when display unit type is None
RF: Removed unneeded import from keyboard.Keyboard
BF: keyboard.Keyboard .start / .stop when backend != ptb
FF: keyboard.Keyboard ._buffers only being created for first instance on Keyboard