### PR TITLE
BF: Emotive Record causing standalone app not to load

### DIFF
--- a/psychopy/experiment/components/emotiv_record/__init__.py
+++ b/psychopy/experiment/components/emotiv_record/__init__.py
@@ -9,7 +9,6 @@ import json
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, getInitVals
 from psychopy.localization import _translate, _localized as __localized
-from psychopy.hardware.emotiv import Cortex
 
 _localized = __localized.copy()
 

--- a/psychopy/hardware/emotiv.py
+++ b/psychopy/hardware/emotiv.py
@@ -30,11 +30,13 @@ import time
 from pathlib import Path
 import logging  # NB this is the Python built-in logging not PsychoPy's
 import pandas as pd
+from psychopy import prefs
+
 # Set up logging for websockets library
 
 logger = logging.getLogger('test_logger')
 logger.setLevel(logging.INFO)
-fh = logging.FileHandler('cortex.log')
+fh = logging.FileHandler(Path(prefs.paths['userPrefsDir'])/'cortex.log')
 logger.addHandler(fh)
 
 


### PR DESCRIPTION
When the app was bundled into ProgramFiles for a release (rather than in
the developers folder) the EmotivRecord Component was causing the app
not to load.

The issue was the logging, which we've fixed with belt and braces:
1. the logging file was set to store as 'cortex.log' but when the
Standalone app is launched from the Start menu that gets saved into
ProgramFiles and would require admin privs. FIX: set the file to log in
the psychopy AppData folder, which is always in user space
2. the reason this was an issue at launch time (when cortex should not
need to be logging) was because the Emotiv Record component was
importing the hardware code itself. This isn't needed by the app - only
load the hardware at run-time, not within the app
