### PR TITLE
BF: recursion error trying to load Keyboard

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -73,14 +73,13 @@ try:
     import psychtoolbox as ptb
     from psychtoolbox import hid
     havePTB = True
+
 except ImportError as err:
     logging.warning(("Import Error: "
                      + err.args[0]
                      + ". Using event module for keyboard component."))
     from psychopy import event
     havePTB = False
-
-macPrefsBad = False
 
 defaultBufferSize = 10000
 
@@ -137,7 +136,7 @@ class Keyboard:
             setting this to True
 
         """
-        global havePTB, macPrefsBad
+        global havePTB
         self.status = NOT_STARTED
         # Initiate containers for storing responses
         self.keys = []  # the key(s) pressed
@@ -186,15 +185,6 @@ class Keyboard:
             if not waitForStart:
                 self.start()
 
-            # check if mac prefs are working; if not default
-            # to using event.getKeys()
-            if sys.platform == 'darwin':
-                try:
-                    Keyboard()
-                except OSError:
-                    macPrefsBad = True
-                    havePTB = False
-                    Keyboard.backend = 'event'
         elif Keyboard.backend == '':
             Keyboard.backend = 'event'
 


### PR DESCRIPTION
I wrote a check a long time ago to see if we needed permissions
to collect keyboard from Accessibility mode on Mac.

@isolver recently moved that to be inside `Keyboard.__init__` but that
caused a recursion error f88fa3bd3e

BUT this shouldn't be needed now anyway, at least for the Standalone,
due to the code-signing and notarization process - we get the permission
from that. Question mark about what happens for dev users on mac