### PR TITLE
BF: each-frame changes in visual objects were being autologged

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -478,7 +478,7 @@ class BaseComponent(object):
         # then write the line
         if updateType == 'set every frame' and target == 'PsychoPy':
             loggingStr = ', log=False'
-        if updateType == 'set every frame' and target == 'PsychoJS':
+        elif updateType == 'set every frame' and target == 'PsychoJS':
             loggingStr = ', false'  # don't give the keyword 'log' in JS
         else:
             loggingStr = ''


### PR DESCRIPTION
In d6a58f50e code was added to setting logging to be False when using
each-frame chagnes in PsychoJS boilerplate. Unfortunately that should
have been an elif, not an if and the result was we've been logging
each-frame changes in PsychoPy since 2020.2.7