### PR TITLE
BF: defaultKeyboard boilerplate not executed unless iohub

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1123,13 +1123,14 @@ class SettingsComponent(object):
                 f"eyetracker = ioServer.getDevice('tracker')\n"
             )
             buff.writeIndentedLines(code % self.params)
-            # Make default keyboard
-            code = (
-                "\n"
-                "# create a default keyboard (e.g. to check for escape)\n"
-                "defaultKeyboard = keyboard.Keyboard()\n"
-            )
-            buff.writeIndentedLines(code % self.params)
+
+        # Make default keyboard
+        code = (
+            "\n"
+            "# create a default keyboard (e.g. to check for escape)\n"
+            "defaultKeyboard = keyboard.Keyboard()\n"
+        )
+        buff.writeIndentedLines(code % self.params)
 
     def writeWindowCode(self, buff):
         """Setup the window code.


### PR DESCRIPTION
In GH-3913 creation of defaultKeyboard was moved to after creation of
iohub so it could use that if needed. It was accidentally given the same
indentation as the iohb client code, so it was only created at all if
eyetracking was being used.