### PR TITLE
BF: monkey-patch broken psychtoolbox function

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -83,6 +83,15 @@ except ImportError as err:
 
 defaultBufferSize = 10000
 
+# monkey-patch bug in PTB keyboard where winHandle=0 is documented but crashes
+if havePTB and sys.platform=='win':
+    from psychtoolbox import PsychHID
+    # make a new function where we set default win_handle to be None instead of 0
+    def _replacement_create_queue(self, num_slots=10000, flags=0, win_handle=None):
+        PsychHID('KbQueueCreate', self.device_number,
+                 None, 0, num_slots, flags, win_handle)
+    # replace the broken function with ours
+    hid.Keyboard._create_queue = _replacement_create_queue
 
 def getKeyboards():
     """Get info about the available keyboards.

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -84,7 +84,7 @@ except ImportError as err:
 defaultBufferSize = 10000
 
 # monkey-patch bug in PTB keyboard where winHandle=0 is documented but crashes
-if havePTB and sys.platform=='win':
+if havePTB and sys.platform == 'win32':
     from psychtoolbox import PsychHID
     # make a new function where we set default win_handle to be None instead of 0
     def _replacement_create_queue(self, num_slots=10000, flags=0, win_handle=None):
@@ -92,6 +92,7 @@ if havePTB and sys.platform=='win':
                  None, 0, num_slots, flags, win_handle)
     # replace the broken function with ours
     hid.Keyboard._create_queue = _replacement_create_queue
+
 
 def getKeyboards():
     """Get info about the available keyboards.


### PR DESCRIPTION
Docs for KbQueueCreate suggest that win_handle defaults to 0 so we use
that as default but since PTB 3.0.17 a value of 0 causes a crash.

Full details at
https://github.com/Psychtoolbox-3/Psychtoolbox-3/issues/723

We'l remove this hack (or set it to operate only on known-bad versions)
when we hear it's fixed upstream