### PR TITLE
BF: Mark integer-only num params as int, fixes #3778

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -459,7 +459,7 @@ def validate(obj, valType):
         # For now, ignore
         pass
     # Validate num
-    if valType == "num":
+    if valType in ["num", "int"]:
         try:
             # Try to convert value to a float
             float(val)

--- a/psychopy/experiment/components/dots/__init__.py
+++ b/psychopy/experiment/components/dots/__init__.py
@@ -69,7 +69,7 @@ class DotsComponent(BaseVisualComponent):
         msg = _translate("Number of dots in the field (for circular fields"
                          " this will be average number of dots)")
         self.params['nDots'] = Param(
-            nDots, valType='num', inputType="spin", categ='Dots',
+            nDots, valType='int', inputType="spin", categ='Dots',
             updates='constant',
             hint=msg,
             label=_localized['nDots'])

--- a/psychopy/experiment/components/noise/__init__.py
+++ b/psychopy/experiment/components/noise/__init__.py
@@ -136,7 +136,7 @@ class NoiseStimComponent(BaseVisualComponent):
             "etc. For most cases a value of 256 pixels will suffice")
         self.params['texture resolution'] = Param(
             texRes, categ='Texture',
-            valType='num', inputType="single", allowedVals=['32', '64', '128', '256', '512','1024'],
+            valType='int', inputType="single", allowedVals=['32', '64', '128', '256', '512','1024'],
             updates='constant', allowedUpdates=[],
             hint=msg,
             label=_localized['texture resolution'])


### PR DESCRIPTION
@mdcutone the change to `paramCtrls.py` might cause a merge conflict with what you're doing, but one that's easily resolved, so definitely worth rebasing when this is in :) 