### PR TITLE
eye tracker calibration window display logic

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
+++ b/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
@@ -12,7 +12,7 @@ configuration dict for the eye tracker being used to modify it's settings.
 from psychopy import core, visual
 from psychopy.data import TrialHandler, importConditions
 from psychopy.iohub import launchHubServer
-from psychopy.iohub.util import getCurrentDateTimeString
+from psychopy.iohub.util import getCurrentDateTimeString, hideWindow, showWindow
 import os
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
@@ -156,17 +156,13 @@ if __name__ == "__main__":
     display = io_hub.devices.display
     kb = io_hub.devices.keyboard
 
-    # Start by running the eye tracker default setup / calibration.
-    #
-    window.winHandle.minimize()  # minimize the PsychoPy window
-    window.winHandle.set_fullscreen(False)
-
-    # run eyetracker calibration
-    cal_result = tracker.runSetupProcedure()
-    print("Calibration returned: ", cal_result)
-
-    window.winHandle.set_fullscreen(True)
-    window.winHandle.maximize()  # maximize the PsychoPy window
+    # Minimize the PsychoPy window if needed
+    hideWindow(window)
+    # Display calibration gfx window and run calibration.
+    result = tracker.runSetupProcedure()
+    print("Calibration returned: ", result)
+    # Maximize the PsychoPy window if needed
+    showWindow(window)
 
     flip_time = window.flip()
     io_hub.sendMessageEvent(text="EXPERIMENT_START", sec_time=flip_time)

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -8,6 +8,7 @@ Select which tracker to use by setting the TRACKER variable below.
 from __future__ import absolute_import, division, print_function
 from psychopy import core, visual
 from psychopy.iohub import launchHubServer
+from psychopy.iohub.util import hideWindow, showWindow
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
 TRACKER = 'mouse'
@@ -56,16 +57,13 @@ io = launchHubServer(window=win, **devices_config)
 keyboard = io.getDevice('keyboard')
 tracker = io.getDevice('tracker')
 
-win.winHandle.minimize()  # minimize the PsychoPy window
-win.winHandle.set_fullscreen(False)
-
-# run eyetracker calibration
+# Minimize the PsychoPy window if needed
+hideWindow(win)
+# Display calibration gfx window and run calibration.
 result = tracker.runSetupProcedure()
 print("Calibration returned: ", result)
-
-win.winHandle.set_fullscreen(True)
-win.winHandle.maximize()  # maximize the PsychoPy window
-
+# Maximize the PsychoPy window if needed
+showWindow(win)
 
 gaze_ok_region = visual.Circle(win, lineColor='black', radius=300, units='pix', colorSpace='named')
 

--- a/psychopy/demos/coder/iohub/eyetracking/validation.py
+++ b/psychopy/demos/coder/iohub/eyetracking/validation.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 from psychopy import core, visual
 from psychopy import iohub
 from psychopy.iohub.client.eyetracker.validation import TargetStim
+from psychopy.iohub.util import hideWindow, showWindow
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
 TRACKER = 'mouse'
@@ -133,15 +134,13 @@ io = iohub.launchHubServer(window=win, **devices_config)
 keyboard = io.getDevice('keyboard')
 tracker = io.getDevice('tracker')
 
-win.winHandle.minimize()  # minimize the PsychoPy window
-win.winHandle.set_fullscreen(False)
-
-# run eyetracker calibration
+# Minimize the PsychoPy window if needed
+hideWindow(win)
+# Display calibration gfx window and run calibration.
 result = tracker.runSetupProcedure()
 print("Calibration returned: ", result)
-
-win.winHandle.set_fullscreen(True)
-win.winHandle.maximize()  # maximize the PsychoPy window
+# Maximize the PsychoPy window if needed
+showWindow(win)
 
 # Validation
 

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -151,11 +151,11 @@ class EyetrackerCalibration:
             yield key, value
 
     def run(self):
+        from psychopy.iohub.util import hideWindow, showWindow
         tracker = self.eyetracker.getIOHubDeviceClass(full=True)
 
         # Minimise PsychoPy window
-        self.win.winHandle.set_fullscreen(False)
-        self.win.winHandle.minimize()
+        hideWindow(self.win)
 
         # Deliver any alerts as needed
         if tracker == 'eyetracker.hw.sr_research.eyelink.EyeTracker':
@@ -172,9 +172,7 @@ class EyetrackerCalibration:
         self.last = self.eyetracker.runSetupProcedure(dict(self))
 
         # Bring back PsychoPy window
-        self.win.winHandle.set_fullscreen(True)
-        self.win.winHandle.maximize()
-        # Not 100% sure activate is necessary, but does not seem to hurt.
-        self.win.winHandle.activate()
+        showWindow(self.win)
+
         # SS: Flip otherwise black screen has been seen, not sure why this just started....
         self.win.flip()

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -287,6 +287,44 @@ else:
     def win32MessagePump():
         pass
 
+# PsychoPy Window Hide / Show functions.
+# Windows 10 and macOS have different code that needs to be called
+# to show a second full screen window on top of an existing one, like
+# is done by most eye tracker calibration routines.
+def hideWindow(win, force=False):
+    """
+    If needed, hide / minimize the in.
+    :param win: PsychoPy window instance
+    :return: None
+    """
+    if force or sys.platform == 'win32':
+        win.winHandle.minimize()  # minimize the PsychoPy window
+        win.winHandle.set_fullscreen(False)
+    elif sys.platform == 'darwin':
+        pass
+    elif sys.platform == 'linux':
+        # TODO: test on Linux, assuming same as macOS right now
+        pass
+    else:
+        print("Warning: Unhandled sys.platform: ", sys.platform)
+
+def showWindow(win, force=False):
+    """
+    If needed, hide / minimize the in.
+    :param win: PsychoPy window instance
+    :return: None
+    """
+    if force or sys.platform == 'win32':
+        win.winHandle.set_fullscreen(True)
+        win.winHandle.maximize()  # minimize the PsychoPy window
+    elif sys.platform == 'darwin':
+        pass
+    elif sys.platform == 'linux':
+        # TODO: test on Linux, assuming same as macOS right now
+        pass
+    else:
+        print("Warning: Unhandled sys.platform: ", sys.platform)
+
 # Recursive updating of values from one dict into another if the key does not key exist.
 # Supported nested dicts and uses deep copy when setting values in the
 # target dict.

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -316,7 +316,7 @@ def showWindow(win, force=False):
     """
     if force or sys.platform == 'win32':
         win.winHandle.set_fullscreen(True)
-        win.winHandle.maximize()  # minimize the PsychoPy window
+        win.winHandle.maximize()  # maximize the PsychoPy window
     elif sys.platform == 'darwin':
         pass
     elif sys.platform == 'linux':


### PR DESCRIPTION
Handle platform differences when using two full screen windows in the same display (but at different times of course).

FF: Added platform dependent eye tracker calibration window display logic. Only windows 10 calls `win.minimize()` / `win.maximize()`. Not needed or useful on other platforms. This means macOS and Linux do not have the 'flash' when switching between windows anymore.
ENH: Added `hideWindow` and `showWindow` functions to `iohub.util`
FF: hardware/eyetracker.py EyetrackerCalibration class now uses `iohub.util.hideWindow` and `iohub.util.showWindow`