### PR TITLE
BF: Replace backslashes in params by slashes

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -205,6 +205,7 @@ class Param(object):
                         # If param is a file of any kind, escape any \
                         val = re.sub(r"\\", r"\\\\", val)
                     val=re.sub("\n", "\\n", val) # Replace line breaks with escaped line break character
+                    val=re.sub("\\\\", "/", val) # Replace any backslashes by slashes
                     return repr(val)
             return repr(self.val)
         elif self.valType in ['code', 'extendedCode']:

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -202,10 +202,10 @@ class Param(object):
                             # but for other targets that will raise an annoying error
                             val = val[1:]
                     if self.valType in ['file', 'table']:
-                        # If param is a file of any kind, escape any \
-                        val = re.sub(r"\\", r"\\\\", val)
+                        # If param is a file of any kind, replace \ by /
+                        val = re.sub(r"\\", r"/", val)
                     val=re.sub("\n", "\\n", val) # Replace line breaks with escaped line break character
-                    val=re.sub("\\\\", "/", val) # Replace any backslashes by slashes
+                    val=re.sub("\\\\", "/", val) # handle older exps where files were valType=str not file
                     return repr(val)
             return repr(self.val)
         elif self.valType in ['code', 'extendedCode']:


### PR DESCRIPTION
This bug-fix replaces backslashes in experiment parameters by slashes. This fixes the "missing resources in JS" issues, where resource keys in the resources list used slashes, but resource keys in the timeline used backslashes. I tested it by running [wdio_img](https://github.com/psychopy/psychojs_testing/tree/main/tests/wdio_img) online and offline.

Note that I added the conversion from backslashes to slashes after the if block that checks whether a valType is "file" or "table" (at line 204). I noticed that the file parameters in wdio_img weren't recognized as type "file", but as type "str".