### PR TITLE
RF/FF/NF/DOCS: Various audio changes

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -16,6 +16,7 @@ from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from psychopy.tools.filetools import pathToString
 from sys import platform
+from .audioclip import AudioClip
 
 
 if platform == 'win32':
@@ -141,13 +142,14 @@ class _SoundBase(object):
 
         Parameters
         ----------
-        value : ArrayLike, int or str
+        value : ArrayLike, AudioClip, int or str
             If it's a number between 37 and 32767 then a tone will be generated
             at that frequency in Hz. It could be a string for a note ('A',
             'Bfl', 'B', 'C', 'Csh'. ...). Then you may want to specify which
             octave.O r a string could represent a filename in the current
             location, or media location, or a full path combo. Or by giving an
-            Nx2 numpy array of floats (-1:1).
+            Nx2 numpy array of floats (-1:1) or
+            :class:`~psychopy.sound.AudioClip` instance.
         secs : float
             Duration of a tone if a note name is to `value`.
         octave : int
@@ -199,9 +201,13 @@ class _SoundBase(object):
                     raise ValueError(msg + value)
                 else:
                     self._setSndFromFile(p)
-        elif type(value) in [list, numpy.ndarray]:
+        elif isinstance(value, (list, numpy.ndarray,)):
             # create a sound from the input array/list
             self._setSndFromArray(numpy.array(value))
+        elif isinstance(value, AudioClip):
+            # from an audio clip object
+            self._setSndFromArray(value.samples)
+            self.sampleRate = value.sampleRateHz
         # did we succeed?
         if self._snd is None:
             pass  # raise ValueError, "Could not make a "+value+" sound"

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -653,7 +653,7 @@ class AudioClip(object):
         return np.asarray(
             self._samples * ((1 << 15) - 1), dtype=np.int16).tobytes()
 
-    def transcribe(self, engine='sphinx', language='en-US', expectedWords=(),
+    def transcribe(self, engine='sphinx', language='en-US', expectedWords=None,
                    rawResp=False, key=None, config=None):
         """Convert speech in audio to text.
 
@@ -668,6 +668,10 @@ class AudioClip(object):
 
         If the audio clip has multiple channels, they will be combined prior to
         being passed to the transcription service.
+
+        **This is an experimental beta feature, the use and function of this
+        may change in future releases without notice. Use this feature at your
+        discretion.**
 
         Parameters
         ----------
@@ -698,11 +702,12 @@ class AudioClip(object):
 
         Returns
         -------
-        list or str
-            List of transcribed words as strings. If `rawResp` is `True`, then
-            the raw API response as a string will be returned. You will need to
-            parse that for the information you need. An empty list is always
-            returned in the speech recognition module is not installed.
+        tuple
+            Returns a tuple with transcription related data. The first value is
+            a `bool` indicating whether the transcription was intelligible and
+            the engine was successfully able to extract a word. The second is
+            a list of words as strings which have been decoded from the audio
+            data.
 
         Notes
         -----
@@ -816,6 +821,7 @@ class AudioClip(object):
 
         # submit audio samples to the API
         respAPI = ''
+        transcriptionFailed = requestError = False
         try:
             if engine.lower() == 'sphinx':
                 respAPI = _recognizer.recognize_sphinx(audio, **config)
@@ -828,10 +834,17 @@ class AudioClip(object):
             else:
                 ValueError("Invalid value for `engine` specified.")
         except sr.UnknownValueError:
-            pass
+            transcriptionFailed = True
+        except sr.RequestError:
+            requestError = True
+
+        result = (
+            transcriptionFailed,
+            requestError,
+            respAPI.split(' ') if not rawResp else respAPI)
 
         # split only if the user does not want the raw API data
-        return respAPI.split(' ') if not rawResp else respAPI
+        return result
 
 
 def load(filename, codec=None):

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -862,8 +862,8 @@ class Microphone(object):
         `bufferSecs`. You do not need to call this if you call `stop` before
         the time specified by `bufferSecs` elapses since the `start` call.
 
-        Can only be called between called of `start` and `stop` (i.e.
-        ``Microphone.status == STARTED``.
+        Can only be called between called of `start` (or `record`) and `stop`
+        (or `pause`).
 
         Returns
         -------


### PR DESCRIPTION
This PR introduces the following changes:

- Adds support to the `Sound` class to play `AudioClip` objects directly.
- Fixes the `.transcribe()` method where expected words not being supplied prevents any transcription.
- Adds additional return values so the user can handle errors thrown by the API they are using to transcribe audio.
- Documentation fixes.