### PR TITLE
FF: Page titles in the Preference Dialog is not translated

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -576,7 +576,7 @@ class ParamNotebook(wx.Notebook, ThemeMixin):
             page = self.CategoryPage(self, self.parent, params)
             self.paramCtrls.update(page.ctrls)
             # Add page to notebook
-            self.AddPage(page, categ)
+            self.AddPage(page, _translate(categ))
 
     def checkDepends(self, event=None):
         """


### PR DESCRIPTION
These texts are not translated in the latest Release branch.
(I think this code is not released yet, but this fix is for Release branch.  Should I use BF tag in this case?)
![image](https://user-images.githubusercontent.com/2094930/121638082-5ba77000-cac5-11eb-8d3d-eea1a887ea18.png)
