### PR TITLE
BF: Check disabled against bool method, not value

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -195,7 +195,7 @@ class Experiment(object):
         self_copy = deepcopy(self)
         for key, routine in list(self_copy.routines.items()):  # PY2/3 compat
             if isinstance(routine, BaseStandaloneRoutine):
-                if routine.params['disabled'].val:
+                if routine.params['disabled']:
                     for node in self_copy.flow:
                         if node == routine:
                             self_copy.flow.removeComponent(node)

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -202,7 +202,7 @@ class Experiment(object):
             else:
                 for component in routine:
                     try:
-                        if component.params['disabled'].val:
+                        if component.params['disabled']:
                             routine.removeComponent(component)
                     except KeyError:
                         pass

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -174,7 +174,7 @@ def compileScript(infile=None, version=None, outfile=None):
             else:
                 for component in routine:
                     try:
-                        if component.params['disabled'].val:
+                        if component.params['disabled']:
                             routine.removeComponent(component)
                     except KeyError:
                         pass

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -167,7 +167,7 @@ def compileScript(infile=None, version=None, outfile=None):
         exp = deepcopy(exp)
         for key, routine in list(exp.routines.items()):  # PY2/3 compat
             if isinstance(routine, BaseStandaloneRoutine):
-                if routine.params['disabled'].val:
+                if routine.params['disabled']:
                     for node in exp.flow:
                         if node == routine:
                             exp.flow.removeComponent(node)


### PR DESCRIPTION
was causing standalone routines to always compile as if disabled until field was checked and unchecked again