### PR TITLE
BF: Disable slider units

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -157,6 +157,9 @@ class SliderComponent(BaseVisualComponent):
         self.params['borderColor'].label = _translate("Line Color")
         self.params['borderColor'].hint = _translate("Color of all lines on this slider (might be overridden by the style setting)")
 
+        # Disable units
+        self.params['units'].allowedVals = ['from exp settings']
+
         self.params['font'] = Param(
                 font, valType='str', inputType="single", categ='Formatting',
                 updates='constant',


### PR DESCRIPTION
As this user found:
https://discourse.psychopy.org/t/slider-does-not-work-with-pixels-as-unit-of-measurement/23538

Slider units need to be the same as the window, as the positions given to Slider from its Mouse sub-component will be in this unit space. So e.g. if your Slider is in pix and the window is in height, the marker will just stay in the middle as it's receiving values around 1 and only moving 1 pixel.

Long term solution is to implement the Vector class, as this means the Mouse will supply `(Vector(x), Vector(y))` and Slider can interpret this according to its unit space, but for now it's best to just disable the list box.