### PR TITLE
BF: Syntax error in boiler plate for saving data from mic

### DIFF
--- a/docs/source/builder/components/microphone.rst
+++ b/docs/source/builder/components/microphone.rst
@@ -3,7 +3,7 @@
 Microphone Component
 -------------------------------
 
-Please note: This is a new component, and is subject to change.
+Please note: That features of this component are new and may be subject to change.
 
 The microphone component provides a way to record sound during an experiment. To do so, specify the
 starting time relative to the start of the routine (see `start` below) and a stop time (= duration in seconds).
@@ -25,6 +25,9 @@ For example, if `mic` is the name of your microphone component, then in the code
 Parameters
 ~~~~~~~~~~~~
 
+Basic
+====================
+
 name : string
     Everything in a PsychoPy experiment needs a unique name. The name should contain only letters, numbers and underscores (no punctuation marks or spaces).
     
@@ -35,6 +38,22 @@ stop (duration):
     The length of time (sec) to record for. An `expected duration` can be given for 
     visualisation purposes. See :ref:`startStop` for details; note that only seconds are allowed.
 
+Device:
+    Which microphone device to use
+
+Transcription
+====================
+
+Transcribe Audio: bool
+    Whether to transcribe audio recordings and store the data
+
+Online Transcription Backend: (relevant to online use only)
+    What transcription service to use to transcribe audio `Azure <https://azure.microsoft.com/en-us/services/cognitive-services/speech-to-text>`_ or `Google <https://cloud.google.com/speech-to-text>`_
+
+Transcription Language: string
+    The language code for your chosen transcription language e.g. English (United Kingdom) is "en-GB" see `list of codes here <https://cloud.google.com/speech-to-text/docs/languages>`_
+
+Expected Words: list
 channel : int
     What audio channel is mic connected through?
 

--- a/docs/source/builder/components/microphone.rst
+++ b/docs/source/builder/components/microphone.rst
@@ -3,7 +3,7 @@
 Microphone Component
 -------------------------------
 
-Please note: That features of this component are new and may be subject to change.
+Please note: This is a new component, and is subject to change.
 
 The microphone component provides a way to record sound during an experiment. To do so, specify the
 starting time relative to the start of the routine (see `start` below) and a stop time (= duration in seconds).
@@ -24,9 +24,6 @@ For example, if `mic` is the name of your microphone component, then in the code
 
 Parameters
 ~~~~~~~~~~~~
-
-Appearance
-==========
 
 name : string
     Everything in a PsychoPy experiment needs a unique name. The name should contain only letters, numbers and underscores (no punctuation marks or spaces).

--- a/docs/source/builder/components/microphone.rst
+++ b/docs/source/builder/components/microphone.rst
@@ -25,8 +25,8 @@ For example, if `mic` is the name of your microphone component, then in the code
 Parameters
 ~~~~~~~~~~~~
 
-Basic
-====================
+Appearance
+==========
 
 name : string
     Everything in a PsychoPy experiment needs a unique name. The name should contain only letters, numbers and underscores (no punctuation marks or spaces).
@@ -38,22 +38,6 @@ stop (duration):
     The length of time (sec) to record for. An `expected duration` can be given for 
     visualisation purposes. See :ref:`startStop` for details; note that only seconds are allowed.
 
-Device:
-    Which microphone device to use
-
-Transcription
-====================
-
-Transcribe Audio: bool
-    Whether to transcribe audio recordings and store the data
-
-Online Transcription Backend: (relevant to online use only)
-    What transcription service to use to transcribe audio `Azure <https://azure.microsoft.com/en-us/services/cognitive-services/speech-to-text>`_ or `Google <https://cloud.google.com/speech-to-text>`_
-
-Transcription Language: string
-    The language code for your chosen transcription language e.g. English (United Kingdom) is "en-GB" see `list of codes here <https://cloud.google.com/speech-to-text/docs/languages>`_
-
-Expected Words: list
 channel : int
     What audio channel is mic connected through?
 

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -329,7 +329,7 @@ class MicrophoneComponent(BaseComponent):
         # Alter inits
         if len(self.exp.flow._loopList):
             inits['loop'] = self.exp.flow._loopList[-1].params['name']
-            inits['filename'] = f"'recording_{inits['name']}_{inits['loop']}_%s.{inits['outputType']}' % {inits['loop']}.thisTrialN)"
+            inits['filename'] = f"'recording_{inits['name']}_{inits['loop']}_%s.{inits['outputType']}' % {inits['loop']}.thisTrialN"
         else:
             inits['loop'] = "thisExp"
             inits['filename'] = f"'recording_{inits['name']}'"

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -366,7 +366,7 @@ class MicrophoneComponent(BaseComponent):
         buff.setIndentLevel(-1, relative=True)
         code = (
             ")\n"
-            "%(loop)s.addData('%(name)s.clip', os.path.join(%(name)sRecFolder, %(filename)s)\n"
+            "%(loop)s.addData('%(name)s.clip', os.path.join(%(name)sRecFolder, %(filename)s))\n"
         )
         buff.writeIndentedLines(code % inits)
         if transcribe:


### PR DESCRIPTION
Syntax error when saving data from the mic if the routine is not in a loop, required closing bracket in different location. 