### PR TITLE
BF: eye tracker demo units change for look time

### DIFF
--- a/psychopy/demos/builder/Feature Demos/eyetracking/visualSearch.psyexp
+++ b/psychopy/demos/builder/Feature Demos/eyetracking/visualSearch.psyexp
@@ -144,7 +144,7 @@
         <Param name="disabled" updates="None" val="False" valType="bool"/>
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="endRoutineOn" updates="None" val="look at" valType="str"/>
-        <Param name="lookDur" updates="None" val="500" valType="num"/>
+        <Param name="lookDur" updates="None" val="0.5" valType="num"/>
         <Param name="nVertices" updates="constant" val="4" valType="int"/>
         <Param name="name" updates="None" val="progress_roi" valType="code"/>
         <Param name="ori" updates="constant" val="0" valType="num"/>
@@ -208,7 +208,7 @@
         <Param name="disabled" updates="None" val="False" valType="bool"/>
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="endRoutineOn" updates="None" val="look at" valType="str"/>
-        <Param name="lookDur" updates="None" val="1000" valType="num"/>
+        <Param name="lookDur" updates="None" val="1" valType="num"/>
         <Param name="nVertices" updates="constant" val="4" valType="int"/>
         <Param name="name" updates="None" val="fix_roi" valType="code"/>
         <Param name="ori" updates="constant" val="0" valType="num"/>
@@ -324,7 +324,7 @@
         <Param name="disabled" updates="None" val="False" valType="bool"/>
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="endRoutineOn" updates="None" val="look at" valType="str"/>
-        <Param name="lookDur" updates="None" val="300" valType="num"/>
+        <Param name="lookDur" updates="None" val="0.3" valType="num"/>
         <Param name="nVertices" updates="constant" val="6" valType="int"/>
         <Param name="name" updates="None" val="target_roi" valType="code"/>
         <Param name="ori" updates="constant" val="0" valType="num"/>


### PR DESCRIPTION
Change units of look time for eye tracker demo from ms to seconds