### PR TITLE
FF: a typo in the boilerplate causing syntax error

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -412,7 +412,7 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (
-                "tag: '%(filename)s,\n"
+                "tag: %(filename)s,\n"
                 "flush: false\n"
         )
         buff.writeIndentedLines(code % inits)


### PR DESCRIPTION
there's an extra apostrophe