### PR TITLE
BF: workaround for difference in JS/Py implementation of TextBox.reset()

### DIFF
--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -255,11 +255,21 @@ class TextboxComponent(BaseVisualComponent):
         BaseVisualComponent.writeRoutineStartCode(self, buff)
 
     def writeRoutineStartCodeJS(self, buff):
-        code = (
-            "%(name)s.reset();"
-        )
-        buff.writeIndentedLines(code % self.params)
-        BaseVisualComponent.writeRoutineStartCode(self, buff)
+        if self.params['editable']:
+            # replaces variable params with sensible defaults
+            inits = getInitVals(self.params, 'PsychoJS')
+            # check for NoneTypes
+            for param in inits:
+                if inits[param] in [None, 'None', '']:
+                    inits[param].val = 'undefined'
+                    if param == 'text':
+                        inits[param].val = ""
+
+            code = (
+                "%(name)s.setText(%(text)s);"
+            )
+            buff.writeIndentedLines(code % inits)
+        BaseVisualComponent.writeRoutineStartCodeJS(self, buff)
 
     def writeRoutineEndCode(self, buff):
         name = self.params['name']


### PR DESCRIPTION
The JS TextBox.reset() resets to ""
The Py TextBox.reset() resets to initial text value

In this commit the boilerplate uses TextBox.setText(original) instead
and only resets if TextBox is editable, on the basis that otherwise it
won't change anyway