### PR TITLE
BF: bytes being received instead of str

### DIFF
--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -342,9 +342,13 @@ def updateDict(add_to, add_from):
 
 def updateSettings(d, u):
     for k, v in u.items():
+        if type(k) == bytes:
+            k = k.decode('UTF-8')
         if isinstance(v, collections.abc.Mapping):
             d[k] = updateSettings(d.get(k, {}), v)
         else:
+            if type(v) == bytes:
+                v = v.decode('UTF-8')
             d[k] = v
     return d
 


### PR DESCRIPTION
BF: Handle receiving bytes instead of str. Older versions of a (TBD) iohub dependency cause strings to be received as bytes by iohub.