### PR TITLE
FF: Google Cloud trascription key fixes

### DIFF
--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -74,11 +74,12 @@ apiKeyNames = {
 _recognizers = {}
 _apiKeys = {}  # API key loaded
 if _hasSpeechRecognition:
-    _recognizers['sphinx'] = sr.Recognizer().recognize_sphinx
+    _recogBase = sr.Recognizer()
+    _recognizers['sphinx'] = _recogBase.recognize_sphinx
     _recognizers['built-in'] = _recognizers['sphinx']  # aliased
-    _recognizers['google'] = sr.Recognizer().recognize_google
-    _recognizers['googleCloud'] = sr.Recognizer().recognize_google_cloud
-    _recognizers['bing'] = sr.Recognizer().recognize_bing
+    _recognizers['google'] = _recogBase.recognize_google
+    _recognizers['googleCloud'] = _recogBase.recognize_google_cloud
+    _recognizers['bing'] = _recogBase.recognize_bing
     _recognizers['azure'] = _recognizers['bing']
 
     # Get API keys for each engine here. Calling `refreshTranscrKeys()`

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -492,8 +492,9 @@ def refreshTranscrKeys():
         # Check if we are dealing with a file path, if so load the data as the
         # key value.
         if os.path.isfile(keyVal):
-            with open(keyVal, 'r') as keyFile:
-                keyVal = keyFile.read()
+            if engineName != 'googleCloud':
+                with open(keyVal, 'r') as keyFile:
+                    keyVal = keyFile.read()
 
         _apiKeys[engineName] = keyVal
 


### PR DESCRIPTION
Allows the raw JSON file path to be specified instead of loaded. Also reduces the number of recognizer instances per session to 1.