### PR TITLE
FF: Transcriber fixes

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -37,7 +37,8 @@ onlineTranscribers = {
     "Microsoft Azure": "AZURE",
 }
 localTranscribers = {
-    "Google": "googleCloud",
+    "Google": "google",
+    "Google Cloud": "googleCloud",
     "Microsoft Azure": "azure",
     "Built-in": "sphinx",
 }

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -355,6 +355,7 @@ class MicrophoneComponent(BaseComponent):
         code = (
             "# tell mic to keep hold of current recording in %(name)s.clips and transcript (if applicable) in %(name)s.scripts\n"
             "# this will also update %(name)s.lastClip and %(name)s.lastScript\n"
+            "%(name)s.stop()\n"
             "%(name)sClip, %(name)sScript = %(name)s.bank(\n"
         )
         buff.writeIndentedLines(code % inits)

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -700,7 +700,9 @@ class AudioClip(object):
             one specified.
         key : str or None
             API key or credentials, format depends on the API in use. If `None`,
-            the values will be obtained elsewhere (See Notes).
+            the values will be obtained elsewhere (See Notes). An alert will be
+            raised if the `engine` requested requires a key but is not
+            specified.
         config : dict or None
             Additional configuration options for the specified engine. These
             are specified using a dictionary (ex. `config={'pfilter': 1}` will
@@ -764,7 +766,8 @@ class AudioClip(object):
         Specifying expected words with sensitivity levels when using CMU Pocket
         Sphinx:
 
-            # expected words 90% confidence on the first two, default for others
+            # expected words 90% sensitivity on the first two, default for
+            # others
             expectedWords = ['right:90', 'left:90', 'up', 'down']
 
             transcribeResults = resp.transcribe(

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -662,20 +662,20 @@ class AudioClip(object):
 
         This feature passes the audio clip samples to a text-to-speech engine
         which will attempt to transcribe any speech within. The efficacy of the
-        transcription depends on the engine selected, recording hardware
-        and audio quality, and quality of the language support. By default,
-        `PocketSphinx` is used which provides decent transcription capabilities
-        offline for English and a few other languages. For more robust
-        transcription capabilities with a greater range of language support,
-        online providers such as Google may be used.
+        transcription depends on the engine selected, recording hardware and
+        audio quality, and quality of the language support. By default, Pocket
+        Sphinx is used which provides decent transcription capabilities offline
+        for English and a few other languages. For more robust transcription
+        capabilities with s greater range of language support, online providers
+        such as Google may be used.
 
         If the audio clip has multiple channels, they will be combined prior to
         being passed to the transcription service.
 
         Speech-to-text conversion blocks the main application thread when used
         on Python. Don't transcribe audio during time-sensitive parts of your
-        experiment! This issue is known to the developers and will be fixed in
-        a later release.
+        experiment! This issue is known to the developers and will be fixed in a
+        later release.
 
         Parameters
         ----------
@@ -694,13 +694,13 @@ class AudioClip(object):
             where the sensitivity can be specified for each expected word. You
             can indicate the sensitivity level to use by putting a ``:`` after
             each word in the list (see the Example below). Sensitivity levels
-            range between 50 and 100. A higher number results in the engine
-            being more conservative, resulting in a higher likelihood of false
+            range between 0 and 100. A higher number results in the engine being
+            more conservative, resulting in a higher likelihood of false
             rejections. The default sensitivity is 80% for words/phrases without
             one specified.
         key : str or None
-            API key or credentials, format depends on the API in use. If a file
-            path is provided, the key data will be loaded from it.
+            API key or credentials, format depends on the API in use. If `None`,
+            the values will be obtained elsewhere (See Notes).
         config : dict or None
             Additional configuration options for the specified engine. These
             are specified using a dictionary (ex. `config={'pfilter': 1}` will
@@ -721,9 +721,14 @@ class AudioClip(object):
           are being sent to a third-party. Also consider that a track of audio
           data being sent over the network can be large, users on metered
           connections may incur additional costs to run your experiment.
-        * Some errors may be emitted by the `SpeechRecognition` API, check that
-          project's documentation if you encounter such an error for more
-          information.
+        * Online transcription services (eg., Google, Bing, etc.) provide robust
+          and accurate speech recognition capabilities with broader language
+          support than offline solutions. However, these services may require a
+          paid subscription to use, reliable broadband internet connections, and
+          may not respect the privacy of your participants as their responses
+          are being sent to a third-party. Also consider that a track of audio
+          data being sent over the network can be large, users on metered
+          connections may incur additional costs to run your experiment.
         * If `key` is not specified (i.e. is `None`) then PsychoPy will look for
           the API key at other locations. By default, PsychoPy will look for an
           environment variables starting with `PSYCHOPY_TRANSCR_KEY_` first. If
@@ -732,6 +737,9 @@ class AudioClip(object):
           as a file path, if so, the key data will be loaded from the file.
           System administrators can specify keys this way to use them across a
           site installation without needing the user manage the keys directly.
+        * Use `expectedWords` if provided by the API. This will greatly speed up
+          recognition. CMU Pocket Sphinx gives the option for sensitivity levels
+          per phrase.
 
         Examples
         --------

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -893,6 +893,10 @@ class Microphone(object):
     def bank(self, tag=None, transcribe=False, **kwargs):
         """Store current buffer as a clip within the microphone object.
 
+        This method is used internally by the Microphone component in Builder,
+        don't use it for other applications. Either `stop()` or `pause()` must
+        be called before calling this method.
+
         Parameters
         ----------
         tag : str or None
@@ -911,12 +915,13 @@ class Microphone(object):
         if tag not in self.scripts:
             self.scripts[tag] = []
         # append current recording to clip list according to tag
-        self.lastClip = self._recording.getSegment()
+        self.lastClip = self.getRecording()
         self.clips[tag].append(self.lastClip)
         # append current clip's transcription according to tag
 
         if transcribe:
-            if transcribe in ['Built-in', True, 'BUILT_IN', 'BUILT-IN', 'Built-In', 'built-in']:
+            if transcribe in ('Built-in', True, 'BUILT_IN', 'BUILT-IN',
+                              'Built-In', 'built-in'):
                 engine = "sphinx"
             elif type(transcribe) == str:
                 engine = transcribe

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -491,15 +491,18 @@ def refreshTranscrKeys():
         # if an environment variable is not defined, look into prefs
         if envVal is None:
             keyVal = prefs.general[prefName]
+            if keyVal == '':  # empty string means None
+                keyVal = None
         else:
             keyVal = envVal
 
         # Check if we are dealing with a file path, if so load the data as the
         # key value.
-        if os.path.isfile(keyVal):
-            if engineName != 'googleCloud':
-                with open(keyVal, 'r') as keyFile:
-                    keyVal = keyFile.read()
+        if keyVal is not None:
+            if os.path.isfile(keyVal):
+                if engineName != 'googleCloud':
+                    with open(keyVal, 'r') as keyFile:
+                        keyVal = keyFile.read()
 
         _apiKeys[engineName] = keyVal
 

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -202,8 +202,9 @@ class TranscriptionResult(object):
     def engine(self, value):
         if value == 'sphinx':
             if not haveSphinx:
-                raise ModuleNotFoundError("To perform built-in (local) transcription you need"
-                                          "to have pocketsphinx installed (pip install pocketsphinx)")
+                raise ModuleNotFoundError(
+                    "To perform built-in (local) transcription you need to "
+                    "have pocketsphinx installed (pip install pocketsphinx)")
         self._engine = str(value)
 
     @property
@@ -219,7 +220,7 @@ class TranscriptionResult(object):
 
 
 def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
-               expectedWords=(), key=None, config=None):
+               expectedWords=None, key=None, config=None):
     """Convert speech in audio to text.
 
     This feature passes the audio clip samples to a text-to-speech engine which
@@ -339,8 +340,8 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
     # check if the engine parameter is valid
     if engine not in _recognizers.keys():
         raise ValueError(
-            f'transcribe() `engine` should be one of {list(_recognizers.keys())} not '
-            f'{engine}')
+            f'transcribe() `engine` should be one of '
+            f'{list(_recognizers.keys())} not {engine}')
 
     # check if we have necessary keys
     if engine in _apiKeys:
@@ -370,9 +371,10 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
         config['language'] = language.lower()  # sphinx users en-us not en-US
         if config['language'] not in sphinxLangs:
             url = "https://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/"
-            raise ValueError(f"Language `{config['language']}` is not installed for pocketsphinx. "
-                             f"You can download languages here: {url}"
-                             f"Install them here: {pocketsphinx.get_model_path()}")
+            raise ValueError(
+                f"Language `{config['language']}` is not installed for "
+                f"pocketsphinx. You can download languages here: {url}. "
+                f"Install them here: {pocketsphinx.get_model_path()}")
         # check expected words
         if expectedWords is not None:
             # sensitivity specified as `word:80`
@@ -402,8 +404,8 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
 
     if expectedWordsNotSupported:
         logging.warning(
-            f"Transcription engine '{engine}' does not allow for expected phrases to "
-            "be specified.")
+            f"Transcription engine '{engine}' does not allow for expected "
+            f"phrases to be specified.")
 
     # API requires a key
     if requiresKey:
@@ -415,9 +417,9 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
                     _apiKeys[engine] if key is None else key
         except KeyError:
             raise ValueError(
-                f"Selected speech-to-text engine '{engine}' requires an API key but one"
-                "cannot be found. Add key to PsychoPy prefs or try specifying "
-                "`key` directly.")
+                f"Selected speech-to-text engine '{engine}' requires an API "
+                f"key but one cannot be found. Add key to PsychoPy prefs or "
+                f"try specifying `key` directly.")
 
     # combine channels if needed
     samples = np.atleast_2d(samples)  # enforce 2D
@@ -445,8 +447,9 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
     try:
         respAPI = _recognizers[engine](audio, **config)
     except KeyError:
-        raise ValueError(f"`{engine}` is not a valid transcribe() engine. "
-                         f"Please use one of {list(_recognizers.keys())}")
+        raise ValueError(
+            f"`{engine}` is not a valid transcribe() engine. Please use one of "
+            f"{list(_recognizers.keys())}")
     except sr.UnknownValueError:
         unknownValueError = True
     except sr.RequestError:

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -267,7 +267,8 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
         sensitivity is 80% for words/phrases without one specified.
     key : str or None
         API key or credentials, format depends on the API in use. If `None`,
-        the values will be obtained elsewhere (See Notes).
+        the values will be obtained elsewhere (See Notes). An alert will be
+        raised if the `engine` requested requires a key but is not specified.
     config : dict or None
         Additional configuration options for the specified engine. These
         are specified using a dictionary (ex. `config={'pfilter': 1}` will

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -184,7 +184,8 @@ class TranscriptionResult(object):
     @property
     def requestFailed(self):
         """`True` if there was an error with the transcriber itself (`bool`).
-        For instance, network error or improper formatting of the audio data.
+        For instance, network error or improper formatting of the audio data,
+        invalid key, or if there was network connection error.
         """
         return self._requestFailed
 

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -261,7 +261,7 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
         this feature. CMU PocketSphinx has an additional feature where the
         sensitivity can be specified for each expected word. You can indicate
         the sensitivity level to use by putting a ``:`` after each word in the
-        list (see the Example below). Sensitivity levels range between 50 and
+        list (see the Example below). Sensitivity levels range between 0 and
         100. A higher number results in the engine being more conservative,
         resulting in a higher likelihood of false rejections. The default
         sensitivity is 80% for words/phrases without one specified.
@@ -301,7 +301,7 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
       installation without needing the user manage the keys directly.
     * Use `expectedWords` if provided by the API. This will greatly speed up
       recognition. CMU Pocket Sphinx gives the option for sensitivity levels per
-      phrase. Higher levels
+      phrase.
 
     Examples
     --------
@@ -319,7 +319,7 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
     Specifying expected words with sensitivity levels when using CMU Pocket
     Sphinx:
 
-        # expected words 90% confidence on the first two, default for the rest
+        # expected words 90% sensitivity on the first two, default for the rest
         expectedWords = ['right:90', 'left:90', 'up', 'down']
 
         transcribeResults = transcribe(


### PR DESCRIPTION
Couple of changes here to get the voice stroop demo working on my end.

- Use `getRecording` in `bank` to prevent passing samples to the recognizer during a recording. `getRecording` raises an exception.
- Added `stop()` to microphone boilerplate before `bank`. We're passing samples to the recognizer *while* it was still recording them.
- Updated documentation to fix some inaccuracies.
- Speech-to-text API key loader properly handles empty prefs as `None`.  
- Put Google back in as a transcriber option. Might want to use longer names to better delineate plain Google and Google Cloud. See `psychopy.sound.transcribe.transcribeEngineValues` for my suggestions for Builder.
- Fixed `expectedWords` default value in `transcribe()` function.