### PR TITLE
RF: Transcriber changes

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -326,8 +326,9 @@ class PrefPropGrid(wx.Panel):
         if section not in self.sections.keys():
             self.sections[section] = []
 
-        self.sections[section].update(
-            {name: wx.propgrid.FileProperty(label, name, value)})
+        prop = wx.propgrid.FileProperty(label, name, value)
+        self.sections[section].update({name: prop})
+        prop.SetAttribute(wx.propgrid.PG_FILE_SHOW_FULL_PATH, True)
 
         self.helpText[name] = helpText
 
@@ -664,7 +665,7 @@ class PreferencesDlg(wx.Dialog):
                         sectionName, pLabel, prefName, thisPref,
                         helpText=helpText)
                 # single file
-                elif prefName in ('flac',):
+                elif prefName in ('flac', 'appKeyGoogleCloud',):
                     self.proPrefs.addFileItem(
                         sectionName, pLabel, prefName, thisPref,
                         helpText=helpText)

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -33,14 +33,11 @@ sampleRates = {r[1]: r[0] for r in sampleRateQualityLevels.values()}
 devices['default'] = None
 
 onlineTranscribers = {
-    "Google": "GOOGLE",
-    "Microsoft Azure": "AZURE",
+    "Google": "GOOGLE"
 }
 localTranscribers = {
     "Google": "google",
-    "Google Cloud": "googleCloud",
-    "Microsoft Azure": "azure",
-    "Built-in": "sphinx",
+    "Built-in": "sphinx"
 }
 allTranscribers = {**localTranscribers, **onlineTranscribers}
 

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -48,12 +48,8 @@
     gammaErrorPolicy = option('abort', 'warn', default='abort')
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
-    # Key for the audio transcription using Google Speech Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogle = string(default='')
-    # Key for the audio transcription using the Google Cloud Speech API. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogleCloud = string(default='')
-    # Key for the audio transcription using Microsoft Azure/Bing Voice Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyAzure = string(default='')
+    # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.
+    appKeyGoogleCloud = string(default='')
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -48,12 +48,8 @@
     gammaErrorPolicy = option('abort', 'warn', default='abort')
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
-    # Key for the audio transcription using Google Speech Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogle = string(default='')
-    # Key for the audio transcription using the Google Cloud Speech API. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogleCloud = string(default='')
-    # Key for the audio transcription using Microsoft Azure/Bing Voice Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyAzure = string(default='')
+    # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.
+    appKeyGoogleCloud = string(default='')
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -48,12 +48,8 @@
     gammaErrorPolicy = option('abort', 'warn', default='abort')
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
-    # Key for the audio transcription using Google Speech Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogle = string(default='')
-    # Key for the audio transcription using the Google Cloud Speech API. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogleCloud = string(default='')
-    # Key for the audio transcription using Microsoft Azure/Bing Voice Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyAzure = string(default='')
+    # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.
+    appKeyGoogleCloud = string(default='')
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -48,12 +48,8 @@
     gammaErrorPolicy = option('abort', 'warn', default='abort')
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
-    # Key for the audio transcription using Google Speech Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogle = string(default='')
-    # Key for the audio transcription using the Google Cloud Speech API. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogleCloud = string(default='')
-    # Key for the audio transcription using Microsoft Azure/Bing Voice Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyAzure = string(default='')
+    # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.
+    appKeyGoogleCloud = string(default='')
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -44,12 +44,8 @@
     gammaErrorPolicy = option('abort', 'warn', default='abort')
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
-    # Key for the audio transcription using Google Speech Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogle = string(default='')
-    # Key for the audio transcription using the Google Cloud Speech API. Can also be specified as a path to a file containing the key as text.
-    transcrKeyGoogleCloud = string(default='')
-    # Key for the audio transcription using Microsoft Azure/Bing Voice Recognition. Can also be specified as a path to a file containing the key as text.
-    transcrKeyAzure = string(default='')
+    # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.
+    appKeyGoogleCloud = string(default='')
 
 # Application settings, applied to coder, builder, & prefs windows
 [app]

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -26,8 +26,7 @@ __all__ = [
 import numpy as np
 import soundfile as sf
 from psychopy.tools.audiotools import *
-from .exceptions import AudioUnsupportedCodecError
-from .transcribe import transcribe
+from .exceptions import *
 
 # supported formats for loading and saving audio samples to file
 AUDIO_SUPPORTED_CODECS = [s.lower() for s in sf.available_formats().keys()]
@@ -806,13 +805,13 @@ class AudioClip(object):
                 # process results ...
 
         """
+        # avoid circular import
+        from psychopy.sound.transcribe import transcribe
         return transcribe(
-            self._samples,
-            self._sampleRateHz,
+            self,
             engine=engine,
             language=language,
             expectedWords=expectedWords,
-            key=key,
             config=config)
 
 

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -685,20 +685,16 @@ class AudioClip(object):
         self._samples = samplesMixed  # overwrite
 
     def transcribe(self, engine='sphinx', language='en-US', expectedWords=None,
-                   key=None, config=None):
+                   config=None):
         """Convert speech in audio to text.
 
-        This feature passes the audio clip samples to a text-to-speech engine
-        which will attempt to transcribe any speech within. The efficacy of the
-        transcription depends on the engine selected, recording hardware and
-        audio quality, and quality of the language support. By default, Pocket
-        Sphinx is used which provides decent transcription capabilities offline
-        for English and a few other languages. For more robust transcription
-        capabilities with s greater range of language support, online providers
-        such as Google may be used.
-
-        If the audio clip has multiple channels, they will be combined prior to
-        being passed to the transcription service.
+        This feature passes the audio clip samples to a specified text-to-speech
+        engine which will attempt to transcribe any speech within. The efficacy
+        of the transcription depends on the engine selected, audio quality, and
+        language support. By default, Pocket Sphinx is used which provides
+        decent transcription capabilities offline for English and a few other
+        languages. For more robust transcription capabilities with a greater
+        range of language support, online providers such as Google may be used.
 
         Speech-to-text conversion blocks the main application thread when used
         on Python. Don't transcribe audio during time-sensitive parts of your
@@ -708,8 +704,8 @@ class AudioClip(object):
         Parameters
         ----------
         engine : str
-            Speech-to-text engine to use. Can be one of 'sphinx', 'google',
-            'googleCloud', or 'bing'.
+            Speech-to-text engine to use. Can be one of 'sphinx' for CMU Pocket
+            Sphinx or 'google' for Google Cloud.
         language : str
             BCP-47 language code (eg., 'en-US'). Note that supported languages
             vary between transcription engines.
@@ -720,17 +716,12 @@ class AudioClip(object):
             this time). A warning will be logged if the engine selected does not
             support this feature. CMU PocketSphinx has an additional feature
             where the sensitivity can be specified for each expected word. You
-            can indicate the sensitivity level to use by putting a ``:`` after
-            each word in the list (see the Example below). Sensitivity levels
-            range between 0 and 100. A higher number results in the engine being
-            more conservative, resulting in a higher likelihood of false
-            rejections. The default sensitivity is 80% for words/phrases without
-            one specified.
-        key : str or None
-            API key or credentials, format depends on the API in use. If `None`,
-            the values will be obtained elsewhere (See Notes). An alert will be
-            raised if the `engine` requested requires a key but is not
-            specified.
+            can indicate the sensitivity level to use by putting a ``:`` (colon)
+            after each word in the list (see the Example below). Sensitivity
+            levels range between 0 and 100. A higher number results in the
+            engine being more conservative, resulting in a higher likelihood of
+            false rejections. The default sensitivity is 80% for words/phrases
+            without one specified.
         config : dict or None
             Additional configuration options for the specified engine. These
             are specified using a dictionary (ex. `config={'pfilter': 1}` will
@@ -743,66 +734,16 @@ class AudioClip(object):
 
         Notes
         -----
-        * Online transcription services (eg., Google, Bing, etc.) provide robust
-          and accurate speech recognition capabilities with broader language
-          support than offline solutions. However, these services may require a
-          paid subscription to use, reliable broadband internet connections, and
-          may not respect the privacy of your participants as their responses
-          are being sent to a third-party. Also consider that a track of audio
-          data being sent over the network can be large, users on metered
-          connections may incur additional costs to run your experiment.
-        * Online transcription services (eg., Google, Bing, etc.) provide robust
-          and accurate speech recognition capabilities with broader language
-          support than offline solutions. However, these services may require a
-          paid subscription to use, reliable broadband internet connections, and
-          may not respect the privacy of your participants as their responses
-          are being sent to a third-party. Also consider that a track of audio
-          data being sent over the network can be large, users on metered
-          connections may incur additional costs to run your experiment.
-        * If `key` is not specified (i.e. is `None`) then PsychoPy will look for
-          the API key at other locations. By default, PsychoPy will look for an
-          environment variables starting with `PSYCHOPY_TRANSCR_KEY_` first. If
-          there is no appropriate API key for the given `engine`, then the
-          preference *General -> transcrKeyXXX* is used. Keys can be specified
-          as a file path, if so, the key data will be loaded from the file.
-          System administrators can specify keys this way to use them across a
-          site installation without needing the user manage the keys directly.
-        * Use `expectedWords` if provided by the API. This will greatly speed up
-          recognition. CMU Pocket Sphinx gives the option for sensitivity levels
-          per phrase.
-
-        Examples
-        --------
-        Use a voice command as a response to a task::
-
-            # after doing  microphone recording
-            resp = mic.getRecording()
-
-            transcribeResults = transcribe(resp.samples, resp.sampleRateHz)
-            if transcribeResults.success:  # successful transcription
-                words = transcribeResults.words
-                if words:
-                    if 'right' in resp:
-                        print("You responded right is bigger.")
-                    elif 'left' in resp:
-                        print("You responded left is bigger.")
-                    else:
-                        print("Please indicate 'left' or 'right'.")
-            else:
-                print("Sorry I don't understand what you said.")
-
-        Specifying expected words with sensitivity levels when using CMU Pocket
-        Sphinx:
-
-            # expected words 90% sensitivity on the first two, default for
-            # others
-            expectedWords = ['right:90', 'left:90', 'up', 'down']
-
-            transcribeResults = resp.transcribe(
-                expectedWords=expectedWords)
-
-            if transcribeResults.success:  # successful transcription
-                # process results ...
+        * Online transcription services (eg., Google) provide robust and
+          accurate speech recognition capabilities with broader language support
+          than offline solutions. However, these services may require a paid
+          subscription to use, reliable broadband internet connections, and may
+          not respect the privacy of your participants as their responses are
+          being sent to a third-party. Also consider that a track of audio data
+          being sent over the network can be large, users on metered connections
+          may incur additional costs to run your experiment.
+        * If the audio clip has multiple channels, they will be combined prior
+          to being passed to the transcription service if needed.
 
         """
         # avoid circular import

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -656,6 +656,35 @@ class AudioClip(object):
         return np.asarray(
             self._samples * ((1 << 15) - 1), dtype=np.int16).tobytes()
 
+    def asMono(self, copy=True):
+        """Convert the audio clip to mono (single channel audio).
+
+        Parameters
+        ----------
+        copy : bool
+            If `True` an :class:`~psychopy.sound.AudioClip` containing a copy
+            of the samples will be returned. If `False`, channels will be
+            mixed inplace resulting a the same object being returned. User data
+            is not copied.
+
+        Returns
+        -------
+        :class:`~psychopy.sound.AudioClip`
+            Mono version of this object.
+
+        """
+        samples = np.atleast_2d(self._samples)  # enforce 2D
+        if samples.shape[1] > 1:
+            samplesMixed = \
+                np.sum(samples, axis=1, dtype=np.float32) / np.float32(2.)
+        else:
+            samplesMixed = samples
+
+        if copy:
+            return AudioClip(samplesMixed, self.sampleRateHz)
+
+        self._samples = samplesMixed  # overwrite
+
     def transcribe(self, engine='sphinx', language='en-US', expectedWords=None,
                    key=None, config=None):
         """Convert speech in audio to text.

--- a/psychopy/sound/exceptions.py
+++ b/psychopy/sound/exceptions.py
@@ -16,9 +16,16 @@ __all__ = [
     'AudioUnsupportedCodecError',
     'AudioInvalidCaptureDeviceError',
     'AudioInvalidPlaybackDeviceError',
-    'AudioRecordingBufferFullError'
+    'AudioRecordingBufferFullError',
+    'RecognizerAPICredentialsError',
+    'RecognizerLanguageNotSupportedError',
+    'RecognizerEngineNotFoundError'
 ]
 
+
+# ------------------------------------------------------------------------------
+# Audio hardware and software exceptions
+#
 
 class AudioUnsupportedCodecError(Exception):
     """Error raise when trying to save or load and unsupported audio
@@ -74,6 +81,30 @@ class AudioInvalidPlaybackDeviceError(AudioInvalidDeviceError):
 class AudioRecordingBufferFullError(Exception):
     """Error raised when the recording buffer is full."""
     pass
+
+
+# ------------------------------------------------------------------------------
+# Transcriber exceptions
+#
+
+class RecognizerAPICredentialsError(ValueError):
+    """Raised when a given speech recognition is being given improper
+    credentials (i.e. API key is invalid or not found).
+    """
+
+
+class RecognizerLanguageNotSupportedError(ValueError):
+    """Raised when the specified language is not supported by the engine. If you
+    get this, you need to install the appropriate language support or select
+    another language.
+    """
+
+
+class RecognizerEngineNotFoundError(ModuleNotFoundError):
+    """Raised when the specified recognizer cannot be found. Usually get this
+    error if the required packages are not installed for a recognizer that is
+    invoked.
+    """
 
 
 if __name__ == "__main__":

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -266,14 +266,6 @@ def transcribe(audioClip, engine='sphinx', language='en-US', expectedWords=None,
       Also consider that a track of audio data being sent over the network can
       be large, users on metered connections may incur additional costs to run
       your experiment.
-    * If `key` is not specified (i.e. is `None`) then PsychoPy will look for the
-      API key at other locations. By default, PsychoPy will look for an
-      environment variables starting with `PSYCHOPY_TRANSCR_KEY_` first. If
-      there is no appropriate API key for the given `engine`, then the
-      preference *General -> transcrKeyXXX* is used. Keys can be specified as a
-      file path, if so, the key data will be loaded from the file. System
-      administrators can specify keys this way to use them across a site
-      installation without needing the user manage the keys directly.
     * If the audio clip has multiple channels, they will be combined prior to
       being passed to the transcription service if needed.
 

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -18,7 +18,7 @@ __all__ = [
 
 import os
 import psychopy.logging as logging
-from psychopy.alerts import alert
+# from psychopy.alerts import alert
 from pathlib import Path
 from psychopy.preferences import prefs
 from .audioclip import *
@@ -339,9 +339,9 @@ def transcribe(audioClip, engine='sphinx', language='en-US', expectedWords=None,
     engine = engine.lower()  # make lower case
 
     # check if we have necessary keys
-    if engine in _apiKeys:
-        if not _apiKeys[engine]:
-            alert(4615, strFields={'engine': engine})
+    # if engine in _apiKeys:
+    #     if not _apiKeys[engine]:
+    #         alert(4615, strFields={'engine': engine})
 
     # if we got a tuple, convert to audio clip object
     if isinstance(audioClip, (tuple, list,)):

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -14,7 +14,9 @@ __all__ = [
     'TRANSCR_LANG_DEFAULT',
     'transcriberEngineValues',
     'apiKeyNames',
-    'refreshTranscrKeys'
+    'refreshTranscrKeys',
+    'RecognizerLanguageNotSupportedError',
+    'RecognizerEngineNotFoundError'
 ]
 
 import os
@@ -23,6 +25,7 @@ from psychopy.alerts import alert
 import numpy as np
 from pathlib import Path
 from psychopy.preferences import prefs
+from psychopy.sound import AudioClip
 
 # ------------------------------------------------------------------------------
 # Initialize the speech recognition system
@@ -37,6 +40,14 @@ except (ImportError, ModuleNotFoundError):
         "install SpeechRecognition` to get it. Transcription will be "
         "unavailable.")
     _hasSpeechRecognition = False
+
+# Google Cloud API
+_hasGoogleCloud = True
+_googleCloudClient = None  # client for Google Cloud, instanced on first use
+try:
+    import google.cloud.speech
+except (ImportError, ModuleNotFoundError):
+    _hasGoogleCloud = False
 
 try:
     import pocketsphinx
@@ -87,6 +98,24 @@ if _hasSpeechRecognition:
     # variables, they will be obtained from preferences.
     _apiKeys['google'] = _apiKeys['googleCloud'] = _apiKeys['bing'] = None
     _apiKeys['azure'] = _apiKeys['bing']
+
+
+# ------------------------------------------------------------------------------
+# Exceptions
+#
+
+class RecognizerLanguageNotSupportedError(ValueError):
+    """Raised when the specified language is not supported by the engine. If you
+    get this, you need to install the appropriate language support or select
+    another language.
+    """
+
+
+class RecognizerEngineNotFoundError(ModuleNotFoundError):
+    """Raised when the specified recognizer cannot be found. Usually get this
+    error if the required packages are not installed for a recognizer that is
+    invoked.
+    """
 
 
 # ------------------------------------------------------------------------------
@@ -220,8 +249,8 @@ class TranscriptionResult(object):
         self._language = str(value)
 
 
-def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
-               expectedWords=None, key=None, config=None):
+def transcribe(audioClip, engine='sphinx', language='en-US', expectedWords=None,
+               key=None, config=None):
     """Convert speech in audio to text.
 
     This feature passes the audio clip samples to a text-to-speech engine which
@@ -243,14 +272,14 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
 
     Parameters
     ----------
-    samples : ArrayLike
+    audioClip : :class:`~psychopy.sound.AudioClip` or tuple
         Audio clip containing speech to transcribe (e.g., recorded from a
-        microphone) as a Nx1 or Nx2 array.
-    sampleRate : int or float
-        Sample rate which `samples` was recorded in Hertz (Hz).
+        microphone). Can be either an :class:`~psychopy.sound.AudioClip` object
+        or tuple where the first values is as a Nx1 or Nx2 array of audio
+        samples and the second the sample rate in Hertz (e.g.,
+        ``(samples, 480000)``).
     engine : str
-        Speech-to-text engine to use. Can be one of 'sphinx', 'google',
-        'googleCloud', or 'bing'.
+        Speech-to-text engine to use. Can be one of 'sphinx' or 'google'.
     language : str
         BCP-47 language code (eg., 'en-US'). Note that supported languages
         vary between transcription engines.
@@ -333,16 +362,11 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
             # process results ...
 
     """
-    # Bunch of checks to make sure the parameters specified are correct.
-    if not _hasSpeechRecognition:  # don't have speech recognition
-        raise ModuleNotFoundError(
-            "Cannot use `.transcribe()`, missing required module "
-            "`speech_recognition` from package `SpeechRecognition`.")
-
     # check if the engine parameter is valid
+    engine = engine.lower()  # make lower case
     if engine not in _recognizers.keys():
         raise ValueError(
-            f'transcribe() `engine` should be one of '
+            f'Parameter `engine` for `transcribe()` should be one of '
             f'{list(_recognizers.keys())} not {engine}')
 
     # check if we have necessary keys
@@ -350,126 +374,18 @@ def transcribe(samples, sampleRate, engine='sphinx', language='en-US',
         if not _apiKeys[engine]:
             alert(4615, strFields={'engine': engine})
 
-    # engine configuration
-    config = {} if config is None else config
-    if not isinstance(config, dict):
-        raise TypeError(
-            "Invalid type for parameter `config` specified, must be `dict` "
-            "or `None`.")
-
-    if not isinstance(language, str):
-        raise TypeError(
-            "Invalid type for parameter `language`, must be type `str`.")
-
-    # common engine configuration options
-    config['language'] = language  # set language code
-    config['show_all'] = False
-
-    # API specific config
-    expectedWordsNotSupported = requiresKey = False
     if engine in ('sphinx', 'built-in'):
-        expectedWordsTemp = None
-        # check valid language
-        config['language'] = language.lower()  # sphinx users en-us not en-US
-        if config['language'] not in sphinxLangs:
-            url = "https://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Models/"
-            raise ValueError(
-                f"Language `{config['language']}` is not installed for "
-                f"pocketsphinx. You can download languages here: {url}. "
-                f"Install them here: {pocketsphinx.get_model_path()}")
-        # check expected words
-        if expectedWords is not None:
-            # sensitivity specified as `word:80`
-            expectedWordsTemp = []
-            for word in expectedWords:
-                wordAndSense = word.split(':')
-                if len(wordAndSense) == 2:  # specified as `word:80`
-                    word, sensitivity = wordAndSense
-                    sensitivity = int(sensitivity) / 100.
-                else:
-                    word = wordAndSense[0]
-                    sensitivity = 0.8  # default is 80% confidence
-
-                expectedWordsTemp.append((word, sensitivity))
-
-        config['keyword_entries'] = expectedWordsTemp
-
-    elif engine == 'googleCloud':
-        config['preferred_phrases'] = expectedWords
-        requiresKey = True
+        return recognizeSphinx(
+            audioClip,
+            language=language,
+            expectedWords=expectedWords,
+            config=config)
     elif engine == 'google':
-        expectedWordsNotSupported = True
-        requiresKey = True
-    elif engine in ('bing', 'azure'):
-        expectedWordsNotSupported = True
-        requiresKey = True
-
-    if expectedWordsNotSupported:
-        logging.warning(
-            f"Transcription engine '{engine}' does not allow for expected "
-            f"phrases to be specified.")
-
-    # API requires a key
-    if requiresKey:
-        try:
-            if engine != 'googleCloud':
-                config['key'] = _apiKeys[engine] if key is None else key
-            else:
-                config['credentials_json'] = \
-                    _apiKeys[engine] if key is None else key
-        except KeyError:
-            raise ValueError(
-                f"Selected speech-to-text engine '{engine}' requires an API "
-                f"key but one cannot be found. Add key to PsychoPy prefs or "
-                f"try specifying `key` directly.")
-
-    # combine channels if needed
-    samples = np.atleast_2d(samples)  # enforce 2D
-    if samples.shape[1] > 1:
-        samplesMixed = \
-            np.sum(samples, axis=1, dtype=np.float32) / np.float32(2.)
-    else:
-        samplesMixed = samples
-
-    # convert samples to WAV PCM format
-    clipDataInt16 = np.asarray(
-        samplesMixed * ((1 << 15) - 1), dtype=np.int16).tobytes()
-
-    sampleWidth = 2  # two bytes per sample
-    audio = sr.AudioData(clipDataInt16,
-                         sample_rate=sampleRate,
-                         sample_width=sampleWidth)
-
-    config = {} if config is None else config
-    assert isinstance(config, dict)
-
-    # submit audio samples to the API
-    respAPI = ''
-    unknownValueError = requestError = False
-    try:
-        respAPI = _recognizers[engine](audio, **config)
-    except KeyError:
-        raise ValueError(
-            f"`{engine}` is not a valid transcribe() engine. Please use one of "
-            f"{list(_recognizers.keys())}")
-    except sr.UnknownValueError:
-        unknownValueError = True
-    except sr.RequestError:
-        requestError = True
-
-    # remove empty words
-    result = [word for word in respAPI.split(' ') if word != '']
-
-    # object to return containing transcription data
-    toReturn = TranscriptionResult(
-        words=result,
-        unknownValue=unknownValueError,
-        requestFailed=requestError,
-        engine=engine,
-        language=language)
-
-    # split only if the user does not want the raw API data
-    return toReturn
+        return recognizeGoogle(
+            audioClip,
+            language=language,
+            expectedWords=expectedWords,
+            config=config)
 
 
 def refreshTranscrKeys():
@@ -501,15 +417,232 @@ def refreshTranscrKeys():
         # key value.
         if keyVal is not None:
             if os.path.isfile(keyVal):
-                if engineName != 'googleCloud':
-                    with open(keyVal, 'r') as keyFile:
-                        keyVal = keyFile.read()
+                with open(keyVal, 'r') as keyFile:
+                    keyVal = keyFile.read()
 
         _apiKeys[engineName] = keyVal
 
     # hack to get 'bing' and 'azure' recognized as the same
     if 'bing' in _apiKeys.keys():
         _apiKeys['azure'] = _apiKeys['bing']
+
+
+def _parseExpectedWords(wordList, defaultSensitivity=80):
+    """Parse expected words list.
+
+    This function is used internally by other functions and classes within the
+    `transcribe` module.
+
+    Expected words or phrases are usually specified as a list of strings. CMU
+    Pocket Sphinx allows for additional 'sensitivity' values for each phrase
+    ranging from *0* to *100*. This function will generate to lists, first with
+    just words and another with specified sensitivity values. This allows the
+    user to specify sensitivity levels which can be ignored if the recognizer
+    engine does not support it.
+
+    Parameters
+    ----------
+    wordList : list of str
+        List of words of phrases. Sensitivity levels for each can be specified
+        by putting a value at the end of each string separated with a colon `:`.
+        For example, ``'hello:80'`` for 80% sensitivity on 'hello'. Values are
+        normalized between *0.0* and *1.0* when returned.
+    defaultSensitivity : int or float
+        Default sensitivity to use if a word does not have one specified between
+        0 and 100%.
+
+    Returns
+    -------
+    tuple
+        Returns list of expected words and list of normalized sensitivities for
+        each.
+
+    Examples
+    --------
+    Specifying expected words to CMU Pocket Sphinx::
+
+        words = [('hello:95', 'bye:50')]
+        expectedWords = zip(_parseExpectedWords(words))
+
+    """
+    defaultSensitivity = defaultSensitivity / 100.  # normalized
+
+    sensitivities = []
+    if wordList is not None:
+        # sensitivity specified as `word:80`
+        wordListTemp = []
+        for word in wordList:
+            wordAndSense = word.split(':')
+            if len(wordAndSense) == 2:  # specified as `word:80`
+                word, sensitivity = wordAndSense
+                sensitivity = int(sensitivity) / 100.
+            else:
+                word = wordAndSense[0]
+                sensitivity = defaultSensitivity  # default is 80% confidence
+
+            wordListTemp.append(word)
+            sensitivities.append(sensitivity)
+
+        wordList = wordListTemp
+
+    return wordList, sensitivities
+
+
+# ------------------------------------------------------------------------------
+# Recognizers
+#
+# These functions are used to send off audio and configuration data to the
+# indicated speech-to-text engine. Most of these functions are synchronous,
+# meaning they block the application until they return. Don't run these in any
+# time critical parts of your program.
+#
+
+def recognizeSphinx(audioClip, language='en-US', expectedWords=None,
+                    config=None):
+    """Perform speech-to-text conversion on the provided audio samples using
+    CMU Pocket Sphinx.
+
+    Parameters
+    ----------
+    audioClip : :class:`~psychopy.sound.AudioClip`
+        Audio clip containing speech to transcribe (e.g., recorded from a
+        microphone).
+    language : str
+        BCP-47 language code (eg., 'en-US'). Should match the language which the
+        speaker is using. Pocket Sphinx requires language packs to be installed
+        locally.
+    expectedWords : list or None
+        List of strings representing expected words or phrases. This will
+        attempt bias the possible output words to the ones specified if the
+        engine is uncertain. Note not all engines support this feature (only Sphinx and Google Cloud do at
+        this time). A warning will be logged if the engine selected does not
+        support this feature. CMU PocketSphinx has an additional feature where
+        the sensitivity can be specified for each expected word. You can
+        indicate the sensitivity level to use by putting a ``:`` after each word
+        in the list (see the Example below). Sensitivity levels range between 0
+        and 100. A higher number results in the engine being more conservative,
+        resulting in a higher likelihood of false rejections. The default
+        sensitivity is 80% for words/phrases without one specified.
+    config : dict or None
+        Additional configuration options for the specified engine.
+
+    Returns
+    -------
+    TranscriptionResult
+        Transcription result object.
+
+    """
+    if not haveSphinx:  # does not have Sphinx
+        raise RecognizerEngineNotFoundError()
+
+    if language not in sphinxLangs:  # missing a language pack error
+        url = "https://sourceforge.net/projects/cmusphinx/files/" \
+              "Acoustic%20and%20Language%20Models/"
+        msg = (f"Language `{config['language']}` is not installed for "
+               f"`pocketsphinx`. You can download languages here: {url}. "
+               f"Install them here: {pocketsphinx.get_model_path()}")
+        raise RecognizerLanguageNotSupportedError(msg)
+
+    # check if we have a valid audio clip
+    if not isinstance(audioClip, AudioClip):
+        raise TypeError(
+            "Expected parameter `audioClip` to have type "
+            "`psychopy.sound.AudioClip`.")
+
+    # engine configuration
+    config = {} if config is None else config
+    if not isinstance(config, dict):
+        raise TypeError(
+            "Invalid type for parameter `config` specified, must be `dict` "
+            "or `None`.")
+
+    if not isinstance(language, str):
+        raise TypeError(
+            "Invalid type for parameter `language`, must be type `str`.")
+
+    # configure the recognizer
+    config['language'] = language.lower()  # sphinx users en-us not en-US
+    config['show_all'] = False
+    if expectedWords is not None:
+        config['keyword_entries'] = zip(_parseExpectedWords(expectedWords))
+
+    # convert audio to format for transcription
+    sampleWidth = 2  # two bytes per sample
+    audioData = sr.AudioData(
+        audioClip.asMono().convertToWAV(),
+        sample_rate=audioClip.sampleRateHz,
+        sample_width=sampleWidth)
+
+    # submit audio samples to the API
+    respAPI = ''
+    unknownValueError = requestError = False
+    try:
+        respAPI = _recogBase.recognize_sphinx(audioData, **config)
+    except sr.UnknownValueError:
+        unknownValueError = True
+    except sr.RequestError:
+        requestError = True
+
+    # remove empty words
+    result = [word for word in respAPI.split(' ') if word != '']
+
+    # object to return containing transcription data
+    toReturn = TranscriptionResult(
+        words=result,
+        unknownValue=unknownValueError,
+        requestFailed=requestError,
+        engine='sphinx',
+        language=language)
+
+    # split only if the user does not want the raw API data
+    return toReturn
+
+
+def recognizeGoogle(audioClip, language='en-US', expectedWords=None,
+                    config=None):
+    """Perform speech-to-text conversion on the provided audio samples using
+    the Google Cloud API.
+
+    The first invocation of this function will take considerably longer to run
+    that successive calls as the client has not been started yet. Call
+    `initClient` prior to
+
+    Parameters
+    ----------
+    audioClip : :class:`~psychopy.sound.AudioClip`
+        Audio clip containing speech to transcribe (e.g., recorded from a
+        microphone).
+    language : str
+        BCP-47 language code (eg., 'en-US'). Should match the language which the
+        speaker is using.
+
+    """
+    global _googleCloudClient
+    if _googleCloudClient is None:
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = _apiKeys['googleCloud']
+        _googleCloudClient = \
+            google.cloud.speech.SpeechClient.from_service_account_file(
+                _apiKeys['googleCloud'])
+
+    # check if we have a valid audio clip
+    if not isinstance(audioClip, AudioClip):
+        raise TypeError(
+            "Expected parameter `audioClip` to have type "
+            "`psychopy.sound.AudioClip`.")
+
+    # convert to the correct format for upload
+    params = {
+        'encoding': google.cloud.speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        'sample_rate_hertz': audioClip.sampleRateHz,
+        'language_code': language}
+    audio = google.cloud.speech.RecognitionAudio(
+        content=audioClip.asMono().convertToWAV())
+    config = google.cloud.speech.RecognitionConfig(**params)
+
+    # Detects speech in the audio file
+    response = _googleCloudClient.recognize(config=config, audio=audio)
+
+    return [result.alternatives[0].transcript for result in response.results]
 
 
 # initial call to populate the API key values


### PR DESCRIPTION
This PR changes how transcription operates under-the-hood, using the official Google Cloud API library instead of SpeechRecognition. I removed some options from the components dialog, only Pocket Sphinx and Google Cloud are supported. You may need to update demos to only use those options.

To use Google Cloud, set the property `appKeyGoogleCloud` in prefs to point to your key.json file. Select "Google" in the microphone component to use that transcriber. You can no longer specify a key through the `transcriber()` functions directly, only through environment variables and prefs.