### PR TITLE
ENH: Small performance changes to transcribe.

### DIFF
--- a/docs/source/api/sound/transcribe.rst
+++ b/docs/source/api/sound/transcribe.rst
@@ -1,0 +1,18 @@
+:class:`~psychopy.sound.TranscriptionResult` - results of an audio transcription
+--------------------------------------------------------------------------------
+
+.. currentmodule:: psychopy.sound
+
+Overview
+========
+
+.. autosummary::
+    TranscriptionResult
+
+Details
+=======
+
+.. autoclass:: TranscriptionResult
+    :members:
+    :undoc-members:
+    :inherited-members:


### PR DESCRIPTION
Small fix that can be pulled in at a later date directly into release. Allows for a recognizer client to be spawned without transcribing anything by passing `None` as audio data. This speeds up the first use of a given recognizer since the one-time authentication process might be slow. Might be worth calling `transcribe(None, engine='google')` in the code output after spawning the microphone to prevent slowdowns (if any) the first time transcribe is called. Also added manual pages for the transcription result object.