### PR TITLE
BF: Slider start value was being overwritten by `.reset()` call

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -222,13 +222,12 @@ class SliderComponent(BaseVisualComponent):
 
         # build up an initialization string for Slider():
         initStr = ("{name} = visual.Slider(win=win, name='{name}',\n"
-                   "    size={size}, pos={pos}, units={units},\n"
+                   "    startValue={initVal}, size={size}, pos={pos}, units={units},\n"
                    "    labels={labels}, ticks={ticks}, granularity={granularity},\n"
                    "    style={styles}, styleTweaks={styleTweaks}, opacity={opacity},\n"
                    "    color={color}, fillColor={fillColor}, borderColor={borderColor}, colorSpace={colorSpace},\n"
                    "    font={font}, labelHeight={letterHeight},\n"
                    "    flip={flip}, depth={depth}, readOnly={readOnly})\n"
-                   "{name}.markerPos = {initVal}\n"
                    .format(**inits))
         buff.writeIndented(initStr)
 

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -51,6 +51,7 @@ class Slider(MinimalStim, ColorMixin):
                  win,
                  ticks=(1, 2, 3, 4, 5),
                  labels=None,
+                 startValue=None,
                  pos=None,
                  size=None,
                  units=None,
@@ -169,8 +170,7 @@ class Slider(MinimalStim, ColorMixin):
         self.readOnly = readOnly
 
         self.categorical = False  # will become True if no ticks set only labels
-        self.rating = None  # current value (from a response)
-        self.markerPos = None  # current value (maybe not from a response)
+        self.startValue = self.rating =  self.markerPos = startValue
         self.rt = None
         self.history = []
         self.marker = None
@@ -292,9 +292,8 @@ class Slider(MinimalStim, ColorMixin):
         """Resets the slider to its starting state (so that it can be restarted
         on each trial with a new stimulus)
         """
-        self.markerPos = None
+        self.markerPos = self.rating = self.startValue
         self.history = []
-        self.rating = None
         self.rt = None
         self.responseClock.reset()
         self.status = NOT_STARTED


### PR DESCRIPTION
fixes #4063 in Python

@thewhodidthis does the JS slider have a reset function? Is this something we should implement online too?