### PR TITLE
BF: Routine never ends in PsychoJS

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -197,10 +197,10 @@ class SoundComponent(BaseComponent):
         else:
             # sounds with stop values
             self.writeStopTestCodeJS(buff)
-            code = ("if (%(stopVal)s > 0.5) {"
+            code = ("if (%(stopVal)s > 0.5) {\n"
                     "  %(name)s.stop();  // stop the sound (if longer than duration)\n"
-                    "  %(name)s.status = PsychoJS.Status.FINISHED;\n"
-                    "}\n")
+                    "}\n"
+                    "%(name)s.status = PsychoJS.Status.FINISHED;\n")
             buff.writeIndentedLines(code % self.params)
             # because of the 'if' statement of the time test
             buff.setIndentLevel(-1, relative=True)


### PR DESCRIPTION
If sound with duration less than 0.5 seconds …the routine never stops. 

To reproduce problem  play sound with 800 hertz for 0.4 seconds

Warning: I DONT UNDERSTAND THE PURPOSE OF THIS CODE
This change fixes my problem of the routine to never ending because status was never getting set to FINISHED.

There was a problem with the indentation which might have something to do with the problem.  I have fixed the indentation problem, and moved the status = FINISHED out of the "if" block.