### PR TITLE
BF: Have QuestHandler with method "mode" use first value of tuplet returned by QuestObject

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -969,7 +969,7 @@ class QuestHandler(StairHandler):
         if self.method == 'mean':
             self._questNextIntensity = self._quest.mean()
         elif self.method == 'mode':
-            self._questNextIntensity = self._quest.mode()
+            self._questNextIntensity = self._quest.mode()[0]
         elif self.method == 'quantile':
             self._questNextIntensity = self._quest.quantile()
         else:

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -865,6 +865,7 @@ class QuestHandler(StairHandler):
 
         self.startVal = startVal
         self.startValSd = startValSd
+        self.pThreshold = pThreshold
         self.stopInterval = stopInterval
         self._questNextIntensity = startVal
         self._range = range


### PR DESCRIPTION
Using the QuestHandler with method "mode" gave an error. That's because the QuestObject returned a tuple with two values, of which the first value is the mode of the posterior PDF that we are after. See [this line](https://github.com/psychopy/psychopy/blob/6118a09794404de17a7a2842fcf258822f5bbc94/psychopy/contrib/quest.py#L206). This bug-fix ensures that the mode returned by the QuestObject is indeed used.