### PR TITLE
DOC: Fix deprecation documentation of ShapeStim color parameter

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -532,9 +532,7 @@ class ShapeStim(BaseShapeStim):
         Enable auto drawing. When `True`, the stimulus will be drawn every
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.ShapeStim.draw` method.
-    color : array_like, str, :class:`~psychopy.colors.Color` or None
-        Sets both the initial `lineColor` and `fillColor` of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
+    color, lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
         *Deprecated*. Please use `lineColor` and `fillColor`. These
         arguments may be removed in a future version.
     lineColorSpace, fillColorSpace : str


### PR DESCRIPTION
The `color` parameter for the constructor of the `psychopy.visual.shape.ShapeStim` class was wrongly not documented as deprecated. However, this parameter is simply ignored which caused a weird bug for me, thinking I could use this as a shorthand for `lineColor` and `fillColor`.