### PR TITLE
BF/TEST: Managing editable textboxes

### DIFF
--- a/psychopy/tests/test_all_visual/test_textbox.py
+++ b/psychopy/tests/test_all_visual/test_textbox.py
@@ -184,9 +184,38 @@ class Test_textbox(object):
                 #self.win.getMovieFrame(buffer='back').save(Path(utils.TESTS_DATA_PATH) / case['screenshot'])
                 utils.compareScreenshot(Path(utils.TESTS_DATA_PATH) / case['screenshot'], self.win, crit=20)
 
-
     def test_basic(self):
         pass
+
+    def test_editable(self):
+        # Make textbox editable
+        self.textbox.editable = True
+        # Make a second textbox, which is editable from init
+        textbox2 = TextBox2(self.win, "", "Noto Sans",
+                                pos=(0.5, 0.5), size=(1, 1), units='height',
+                                letterHeight=0.1, colorSpace="rgb", editable=True)
+        # Check that both are editable children of the window
+        editables = []
+        for ref in self.win._editableChildren:
+            editables.append(ref())  # Actualise weakrefs
+        assert self.textbox in editables
+        assert textbox2 in editables
+        # Set current editable to textbox 1
+        self.win.currentEditable = self.textbox
+        # Make sure next editable is textbox 2
+        self.win.nextEditable()
+        assert self.win.currentEditable == textbox2
+        # Make each textbox no longer editable
+        self.textbox.editable = False
+        textbox2.editable = False
+        # Make sure they are no longer editable children of the window
+        editables = []
+        for ref in self.win._editableChildren:
+            editables.append(ref())  # Actualise weakrefs
+        assert self.textbox not in editables
+        assert textbox2 not in editables
+        # Cleanup
+        del textbox2
 
     def test_something(self):
         # to-do: test visual display, char position, etc

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -230,7 +230,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         self.text = self.startText = text if text is not None else ""
 
         # caret
-        self._editable = editable
+        self.editable = editable
         self.caret = Caret(self, color=self.color, width=5)
 
 

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -243,7 +243,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
     @editable.setter
     def editable(self, editable):
         self._editable = editable
-        if editable is False and self.hasFocus:
+        if editable is False:
             if self.win:
                 self.win.removeEditable(self)
         if editable is True:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1006,9 +1006,6 @@ class Window(object):
             else:
                 logging.warning(f"Request to remove editable object {editable} could not be completed as weakref "
                                 f"to this object could not be found in window.")
-                # todo: adding this solely for the test suite so we can see if it crashes
-                raise AssertionError(f"Request to remove editable object {editable} could not be completed as weakref "
-                                     f"to this object could not be found in window.")
         # Clean editables list
         self._cleanEditables()
 

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -932,6 +932,15 @@ class Window(object):
                             "In this case it was called with obj={}"
                             .format(repr(obj)))
 
+    def _cleanEditables(self):
+        """
+        Make sure there are no dead refs in the editables list
+        """
+        for ref in self._editableChildren:
+            obj = ref()
+            if obj is None:
+                self._editableChildren.remove(ref)
+
     @property
     def currentEditable(self):
         """The editable (Text?) object that currently has key focus"""
@@ -982,7 +991,8 @@ class Window(object):
         # If this is the first editable obj then make it the current
         if len(self._editableChildren) == 1:
             self._currentEditableRef = eRef
-
+        # Clean editables list
+        self._cleanEditables()
 
     def removeEditable(self, editable):
         # If editable is present, remove it from editables list
@@ -993,10 +1003,22 @@ class Window(object):
                     self.nextEditable()
                 self._editableChildren.remove(ref)
                 return True
+            else:
+                logging.warning(f"Request to remove editable object {editable} could not be completed as weakref "
+                                f"to this object could not be found in window.")
+                # todo: adding this solely for the test suite so we can see if it crashes
+                raise AssertionError(f"Request to remove editable object {editable} could not be completed as weakref "
+                                     f"to this object could not be found in window.")
+        # Clean editables list
+        self._cleanEditables()
+
         return False
     
     def nextEditable(self):
         """Moves focus of the cursor to the next editable window"""
+        # Clean editables list
+        self._cleanEditables()
+        # Progress
         if self.currentEditable is None:
             if len(self._editableChildren):
                 self._currentEditableRef = self._editableChildren[0]            
@@ -1084,6 +1106,8 @@ class Window(object):
                 if isinstance(thisObj, weakref.ref):
                     # Solidify weakref if necessary
                     thisObj = thisObj()
+                if thisObj is None:
+                    continue
                 if isinstance(thisObj.autoDraw, (bool, int, float)):
                     # Store whether this editable is on screen
                     editablesOnScreen.append(thisObj.autoDraw)


### PR DESCRIPTION
Setting textbox.editable didn't remove it from the window's list of editable children if the textbox didn't have focus - so even if you'd set editable to false, the textbox could still receive focus. Also adds a test for this.