### PR TITLE
BF: `mic.bank` values from Builder

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -356,8 +356,16 @@ class MicrophoneComponent(BaseComponent):
             "# tell mic to keep hold of current recording in %(name)s.clips and transcript (if applicable) in %(name)s.scripts\n"
             "# this will also update %(name)s.lastClip and %(name)s.lastScript\n"
             "%(name)s.stop()\n"
-            "%(name)sClip, %(name)sScript = %(name)s.bank(\n"
         )
+        buff.writeIndentedLines(code % inits)
+        if inits['transcribeBackend'].val:
+            code = (
+                "%(name)sClip, %(name)sScript = %(name)s.bank(\n"
+            )
+        else:
+            code = (
+                "%(name)sClip = %(name)s.bank(\n"
+            )
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -919,7 +919,7 @@ class Microphone(object):
         self.clips[tag].append(self.lastClip)
         # append current clip's transcription according to tag
 
-        if transcribe:
+        if transcribe and transcribe not in ('undefined', 'NONE', 'None', 'none', 'False', 'false', 'FALSE'):
             if transcribe in ('Built-in', True, 'BUILT_IN', 'BUILT-IN',
                               'Built-In', 'built-in'):
                 engine = "sphinx"

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -917,9 +917,11 @@ class Microphone(object):
         # append current recording to clip list according to tag
         self.lastClip = self.getRecording()
         self.clips[tag].append(self.lastClip)
+        # synonymise null values
+        if transcribe in ('undefined', 'NONE', 'None', 'none', 'False', 'false', 'FALSE'):
+            transcribe = False
         # append current clip's transcription according to tag
-
-        if transcribe and transcribe not in ('undefined', 'NONE', 'None', 'none', 'False', 'false', 'FALSE'):
+        if transcribe:
             if transcribe in ('Built-in', True, 'BUILT_IN', 'BUILT-IN',
                               'Built-In', 'built-in'):
                 engine = "sphinx"


### PR DESCRIPTION
1. Accept `'None'` as a synonym for `False` when `mic.bank` is called
2. Don't try to unpack values from `mic.bank` in Builder when transcription is disabled