### PR TITLE
Hotfix: iohub mouse set position

### DIFF
--- a/psychopy/demos/coder/iohub/mouse.py
+++ b/psychopy/demos/coder/iohub/mouse.py
@@ -20,8 +20,8 @@ io = launchHubServer(window=win)
 # some default devices have been created that can now be used
 keyboard = io.devices.keyboard
 mouse = io.devices.mouse
-
-win.setMouseVisible(False)
+mouse.setPosition((0.0, .250))
+#win.setMouseVisible(False)
 
 # Create some psychopy visual stim
 fixSpot = visual.GratingStim(win, tex="none", mask="gauss", pos=(0, 0), size=(.03, .03), color='black', autoLog=False)

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -583,7 +583,7 @@ class Display(Device):
             return (x - w / 2), -y + h / 2
 
         def psychopy2displayPix(cx, cy):
-            return l + (cx + w / 2), t + (cy + h / 2)
+            return l + (cx + w / 2), b - (cy + h / 2)
 
         if coord_type == 'pix':
             def pix2coord(self, x, y, display_index=None):

--- a/psychopy/iohub/devices/mouse/__init__.py
+++ b/psychopy/iohub/devices/mouse/__init__.py
@@ -124,7 +124,7 @@ class MouseDevice(Device):
             tuple: new (x,y) position of mouse in Display coordinate space.
         """
         try:
-            pos = int(pos[0]), int(pos[1])
+            pos = pos[0], pos[1]
         except Exception:
             print2err('Warning: Mouse.setPosition: pos must be a list of '
                       'two numbers, not: ', pos)
@@ -207,6 +207,9 @@ class MouseDevice(Device):
             self._initialMousePos()
             cpos = self._position
             lpos = self._lastPosition
+            if lpos is None:
+                lpos = cpos[0], cpos[1]
+
             change_x = cpos[0] - lpos[0]
             change_y = cpos[1] - lpos[1]
             if return_display_index is True:


### PR DESCRIPTION
Pull request to fix issue reported [on Discourse](https://discourse.psychopy.org/t/iohub-mouse-wrong-location-using-coder/24085/2) plus a couple others found in the process of fixing it.
BF:  iohub mouse.setPoition was not correctly converting y dimension of psychopy pixel space to operating system pixel space bounds. fixes #4156
BF: iohub mouse.setPoition was not handling float unit types properly
BF: handle case of no previous mouse event prior to first call to iohuub mouse.getPositionAndDelta
RF: display system mouse cursor in iohub mouse demo 