### PR TITLE
FF: Only auto-close experiment settings dialogue in test mode

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1260,7 +1260,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             helpUrl = None
         title = '%s Properties' % self.exp.getExpName()
         dlg = DlgExperimentProperties(
-            frame=self, element=component, experiment=self.exp, timeout=2000)
+            frame=self, element=component, experiment=self.exp, timeout=timeout)
 
         if dlg.OK:
             self.addToUndoStack("EDIT experiment settings")

--- a/psychopy/tests/test_app/test_builder/test_BuilderFrame.py
+++ b/psychopy/tests/test_app/test_builder/test_BuilderFrame.py
@@ -53,7 +53,7 @@ class Test_BuilderFrame(object):
         expfile = path.join(prefs.paths['tests'],
                             'data', 'test001EntryImporting.psyexp')
         builderView.fileOpen(filename=expfile)
-        builderView.setExperimentSettings(timeout=2)
+        builderView.setExperimentSettings(timeout=2000)
         builderView.isModified = False
         builderView.runFile()
         builderView.closeFrame()


### PR DESCRIPTION
Context: https://github.com/psychopy/psychopy/pull/4097#issuecomment-886768714

It looks like the experiment settings dialogue should only auto-close during testing. This PR forwards the timeout argument set during testing to `DlgExperimentProperties` which is responsible for handling the timeout.