### PR TITLE
TESTS/BF: Fix test suite

### DIFF
--- a/psychopy/tests/test_app/test_builder/test_compileJS.py
+++ b/psychopy/tests/test_app/test_builder/test_compileJS.py
@@ -14,6 +14,7 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 """
 import psychopy
 from psychopy import experiment
+from psychopy.app import getAppInstance
 import psychopy.scripts.psyexpCompile as psyexpCompile
 
 import codecs
@@ -32,12 +33,13 @@ class Test_PsychoJS_from_Builder(object):
     """Some tests just for the window - we don't really care about what's drawn inside it
     """
     @pytest.mark.usefixtures("get_app")
-    def setup_class(self, get_app):
+    def setup_class(self):
         if keepFiles:
             self.temp_dir = Path.home() / "Desktop" / "tmp"
         else:
             self.temp_dir = Path(mkdtemp(prefix='psychopy-test_psychojs'))
-        self.builderView = get_app().newBuilderFrame()  # self._app comes from requires_app
+            
+        self.builderView = getAppInstance().newBuilderFrame()  # self._app comes from requires_app
 
     def teardown_class(self):
         if not keepFiles:

--- a/psychopy/tests/test_app/test_builder/test_compileJS.py
+++ b/psychopy/tests/test_app/test_builder/test_compileJS.py
@@ -38,7 +38,7 @@ class Test_PsychoJS_from_Builder(object):
             self.temp_dir = Path.home() / "Desktop" / "tmp"
         else:
             self.temp_dir = Path(mkdtemp(prefix='psychopy-test_psychojs'))
-            
+
         self.builderView = getAppInstance().newBuilderFrame()  # self._app comes from requires_app
 
     def teardown_class(self):

--- a/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
+++ b/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
@@ -7,7 +7,7 @@ class Test_RunnerFrame(object):
     """
     This test opens Runner, and several processes.
     """
-    def setup(self, get_app):
+    def setup(self):
         self.tempFile = os.path.join(prefs.paths['tests'], 'data', 'test001EntryImporting.psyexp')
 
     def _getRunnerView(self, app):


### PR DESCRIPTION
Just my attempt to get the test suite to work again. **Don't pull this in until all the CI tests pass.** I recommend using the new `psychopy.app` API for spawning instances of the app for testing. This eliminates the need for the test scripts to explicitly manage an instance.