### PR TITLE
NF: Intial work on new plugin system

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -47,7 +47,7 @@ import psychopy.experiment.components as components
 # package dotted path which loaded plugins appear
 PLUGIN_PACKAGE = 'psychopy.plugins'
 # prefix for temporary directories for plugins extracted from Zip files
-PLUGIN_TEMP_FILE_PREFIX = 'psychopy_plugin_'
+PLUGIN_TEMP_FILE_PREFIX = 'psychopy_plugin'
 # Keep track of plugins that have been loaded. Keys are plugin names and values
 # are their entry point mappings.
 _loaded_plugins_ = collections.OrderedDict()
@@ -113,6 +113,7 @@ def _getPluginSearchPaths():
     pluginPaths = [p for p in pluginPaths if p is not INVALID_PLUGIN_PATH]
 
     # scan for top-level folders in plugin directories
+    pluginPathsDeep = []
     for _dir in pluginPaths:
         items = os.listdir(_dir)
         for item in items:
@@ -123,18 +124,29 @@ def _getPluginSearchPaths():
                 fileName = item.split('.')[0]  # remove ext
                 tempPluginDir = tempfile.mkdtemp(
                     suffix=None,
-                    prefix=fileName + '_')
+                    prefix=PLUGIN_TEMP_FILE_PREFIX + '-' + fileName + '-')
                 with zipfile.ZipFile(absPath, 'r') as zipFile:
                     zipFile.extractall(tempPluginDir)
+
+                # tell the user we extracted a zip file
+                msg = ("Found zip file in plugin directory, extracted contents "
+                       "to temporary directory `{}`".format(tempPluginDir))
+                logging.debug(msg)
+
+                # add temp dir to search path for plugins
                 absPath = tempPluginDir
 
             # ignore if not a directory
             if not os.path.isdir(absPath):
                 continue
 
-            pluginPaths.append(absPath)
+            # tell the user we extracted a zip file
+            msg = ("Added plugin search path `{}`".format(absPath))
+            logging.debug(msg)
 
-    return pluginPaths
+            pluginPathsDeep.append(absPath)
+
+    return pluginPaths + pluginPathsDeep
 
 
 # Specify the directories where the plugins are stored on the system.

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -560,7 +560,7 @@ def loadPlugin(pluginName, *args, **kwargs):
     result = True
     if hasattr(plugin_obj, 'setup_plugin'):
         app_instance = app.getAppInstance()
-        result = plugin_obj.setup(app_instance, *args, **kwargs)
+        result = plugin_obj.setup_plugin(app_instance, *args, **kwargs)
 
     if result:
         _loaded_plugins_[pluginName] = plugin_obj

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -18,7 +18,8 @@ __all__ = [
     'scanPlugins',
     'requirePlugin',
     'isPluginLoaded',
-    'isStartUpPlugin']
+    'isStartUpPlugin',
+    'registerAttribute']
 
 # ------------------------------------------------------------------------------
 # Imports
@@ -342,6 +343,17 @@ def scanPlugins():
     called automatically when this module is imported, so you do not need to
     call this unless packages have been added since the session began.
 
+    Returns
+    -------
+    tuple
+        Found plugin names.
+
+    Examples
+    --------
+    Scan for plugins and get the number found on the system::
+
+        num_plugins_found = len(scanPlugins())
+
     """
     global _plugin_paths_
     global _plugin_source_
@@ -358,6 +370,8 @@ def scanPlugins():
 
     # find all packages with entry points defined
     _installed_plugins_ = _plugin_source_.list_plugins()
+
+    return tuple(_installed_plugins_)  # prevents the user from modifying this
 
 
 def listPlugins(which='all'):
@@ -804,6 +818,25 @@ def pluginEntryPoints(plugin, parse=False):
                   " installed or reachable.")
 
     return None
+
+
+def registerAttribute(fqn, name, obj):
+    """Register a specified object to an attribute name somewhere in PsychoPy's
+    namespace.
+
+    Parameters
+    ----------
+    fqn : str
+        Fully-qualified name (e.g., `psychopy.visual.Window`) to a module or
+        class.
+    name : str
+        Attribute name to set.
+    obj : object
+        Reference to an object.
+
+    """
+    target = resolveObjectFromName(fqn, basename=None, resolve=True, error=True)
+    setattr(target, name, obj)
 
 
 def _registerWindowBackend(attr, ep):

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -46,6 +46,8 @@
     shutdownKeyModifiers = list(default=list())
     # What to do if gamma-correction not possible
     gammaErrorPolicy = option('abort', 'warn', default='abort')
+    # Paths to plugin directories.
+    pluginPaths = list(default=list())
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
     # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -46,6 +46,8 @@
     shutdownKeyModifiers = list(default=list())
     # What to do if gamma-correction not possible
     gammaErrorPolicy = option('abort', 'warn', default='abort')
+    # Paths to plugin directories.
+    pluginPaths = list(default=list())
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
     # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -46,6 +46,8 @@
     shutdownKeyModifiers = list(default=list())
     # What to do if gamma-correction not possible
     gammaErrorPolicy = option('abort', 'warn', default='abort')
+    # Paths to plugin directories.
+    pluginPaths = list(default=list())
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
     # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -46,6 +46,8 @@
     shutdownKeyModifiers = list(default=list())
     # What to do if gamma-correction not possible
     gammaErrorPolicy = option('abort', 'warn', default='abort')
+    # Paths to plugin directories.
+    pluginPaths = list(default=list())
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
     # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -42,6 +42,8 @@
     shutdownKeyModifiers = list(default=list())
     # What to do if gamma-correction not possible
     gammaErrorPolicy = option('abort', 'warn', default='abort')
+    # Paths to plugin directories.
+    pluginPaths = list(default=list())
     # Add plugin names here to load when a PsychoPy session starts.
     startUpPlugins = list(default=list())
     # Google Cloud Platform key, required for the audio transcription using Google Speech Recognition. Specified as a path to a JSON file containing the key data.


### PR DESCRIPTION
This plugin system is based on `PluginBase` rather than `distutils` or `setuptools` like before. This should allow us to use plugins without needing to add/install packages to the Python environment. PsychoPy looks for plugins in directories specified by the user in preferences. Plugins can be either a Python file, folder, or zip file. 

We still need to work out a formal specification for plugins so developers can extend PsychoPy. Plugins can be used to create third-party builder components, add window backends, etc.