### PR TITLE
BF: Fixed path specification for movie in VLC demo

### DIFF
--- a/docs/source/api/visual/index.rst
+++ b/docs/source/api/visual/index.rst
@@ -65,6 +65,7 @@ Multiple stimuli:
 Other stimuli:
 
 * :class:`.MovieStim` to show movies
+* :class:`.VlcMovieStim` to show movies using VLC
 * :class:`.Slider` a new improved class to collect ratings
 * :class:`.RatingScale` to collect ratings
 * :class:`.CustomMouse` to change the cursor in windows with GUI. OBS: will be deprecated soon

--- a/docs/source/api/visual/vlcmoviestim.rst
+++ b/docs/source/api/visual/vlcmoviestim.rst
@@ -1,0 +1,67 @@
+
+:class:`VlcMovieStim`
+---------------------
+
+Attributes
+=============
+
+.. currentmodule:: psychopy.visual
+
+.. autosummary:: 
+
+    VlcMovieStim
+    VlcMovieStim.win
+    VlcMovieStim.units
+    VlcMovieStim.pos
+    VlcMovieStim.ori
+    VlcMovieStim.size
+    VlcMovieStim.opacity
+    VlcMovieStim.name
+    VlcMovieStim.autoLog
+    VlcMovieStim.draw
+    VlcMovieStim.autoDraw
+    VlcMovieStim.setMovie
+    VlcMovieStim.loadMovie
+    VlcMovieStim.isPlaying
+    VlcMovieStim.isNotStarted
+    VlcMovieStim.isStopped
+    VlcMovieStim.isPaused
+    VlcMovieStim.isFinished
+    VlcMovieStim.play
+    VlcMovieStim.pause
+    VlcMovieStim.stop
+    VlcMovieStim.seek
+    VlcMovieStim.rewind
+    VlcMovieStim.fastForward
+    VlcMovieStim.replay
+    VlcMovieStim.volume
+    VlcMovieStim.setVolume
+    VlcMovieStim.getVolume
+    VlcMovieStim.increaseVolume
+    VlcMovieStim.decreaseVolume
+    VlcMovieStim.frameIndex
+    VlcMovieStim.getCurrentFrameNumber
+    VlcMovieStim.duration
+    VlcMovieStim.loopCount
+    VlcMovieStim.fps
+    VlcMovieStim.getFPS
+    VlcMovieStim.frameTime
+    VlcMovieStim.getCurrentFrameTime
+    VlcMovieStim.percentageComplete
+    VlcMovieStim.getPercentageComplete
+    VlcMovieStim.videoSize
+    VlcMovieStim.interpolate
+    VlcMovieStim.setFlipHoriz
+    VlcMovieStim.setFlipVert
+    VlcMovieStim.filename
+    VlcMovieStim.autoStart
+    
+        
+Details
+=============
+
+.. autoclass:: VlcMovieStim
+    :members:
+    :undoc-members:
+    :inherited-members:
+    

--- a/docs/source/api/visual/vlcmoviestim.rst
+++ b/docs/source/api/visual/vlcmoviestim.rst
@@ -2,6 +2,12 @@
 :class:`VlcMovieStim`
 ---------------------
 
+A stimulus class for playing movies (mpeg, avi, etc...) in PsychoPy using a
+local installation of VLC media player (https://www.videolan.org/).
+
+Requires version ``3.0.11115`` of ``python-vlc`` on Windows. Other platforms
+(MacOS and Linux) may use a newer version.
+
 Attributes
 ==========
 

--- a/docs/source/api/visual/vlcmoviestim.rst
+++ b/docs/source/api/visual/vlcmoviestim.rst
@@ -3,7 +3,7 @@
 ---------------------
 
 Attributes
-=============
+==========
 
 .. currentmodule:: psychopy.visual
 
@@ -58,7 +58,7 @@ Attributes
     
         
 Details
-=============
+=======
 
 .. autoclass:: VlcMovieStim
     :members:

--- a/psychopy/demos/coder/stimuli/VlcMovieStim.py
+++ b/psychopy/demos/coder/stimuli/VlcMovieStim.py
@@ -19,7 +19,7 @@ import os
 from psychopy import visual, core, event
 
 # get the video from the demo resources directory
-videopath = r'./jwpIntro.mp4'
+videopath = r'jwpIntro.mp4'
 videopath = os.path.join(os.getcwd(), videopath)
 if not os.path.exists(videopath):
     raise RuntimeError("Video File could not be found:" + videopath)


### PR DESCRIPTION
This fixes a bug in the VLC movie demo. Worked fine in PyCharm but not in Coder. Also added manual pages for the VLC movie stim class since it has more features than the other Movie classes tht are not advertised.