### PR TITLE
BF: When compiling code for JS the html/js didn't honour useVersion

### DIFF
--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -16,8 +16,7 @@ from subprocess import PIPE, Popen
 from psychopy.constants import PY3
 from psychopy import __version__, logging
 
-# parse args for subprocess
-from psychopy.experiment.routines import BaseStandaloneRoutine
+# DO NOT IMPORT ANY OTHER PSYCHOPY SUB-PACKAGES OR THEY WON'T SWITCH VERSIONS
 
 parser = argparse.ArgumentParser(description='Compile your python file from here')
 parser.add_argument('infile', help='The input (psyexp) file to be compiled')
@@ -166,7 +165,7 @@ def compileScript(infile=None, version=None, outfile=None):
         # Leave original experiment unchanged.
         exp = deepcopy(exp)
         for key, routine in list(exp.routines.items()):  # PY2/3 compat
-            if isinstance(routine, BaseStandaloneRoutine):
+            if routine.type == 'StandaloneRoutine':
                 if routine.params['disabled']:
                     for node in exp.flow:
                         if node == routine:


### PR DESCRIPTION
As a result, in 2021.2.0 - 2021.2.1, the JS experiments would fail to run
if comiled with a different useVersion due to the change in import format
in 2021.2

Problem arose in Commit 9cda6f5bed because this led to psychopy.experiment
being imported before the useVersion had been set