### PR TITLE
documentation in multiple places says files will be overwritten but actually the default is 'rename'

### DIFF
--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -295,12 +295,15 @@ class _BaseTrialHandler(_ComparisonMixin):
 
             appendFile: True or False
                 If False any existing file with this name will be
-                overwritten. If True then a new worksheet will be appended.
+                kept and a new file will be created with a slightly different
+                name. If you want to overwrite the old file, pass 'overwrite'
+                to ``fileCollisionMethod``.
+                If True then a new worksheet will be appended.
                 If a worksheet already exists with that name a number will
                 be added to make it unique.
 
             fileCollisionMethod: string
-                Collision method passed to
+                Collision method (``rename``,``overwrite``, ``fail``) passed to
                 :func:`~psychopy.tools.fileerrortools.handleFileCollision`
                 This is ignored if ``append`` is ``True``.
 
@@ -337,7 +340,9 @@ class _BaseTrialHandler(_ComparisonMixin):
             newWorkbook = False
         else:
             if not appendFile:
-                # the file exists but we're not appending, will be overwritten
+                # the file exists but we're not appending, a new file will
+                # be saved with a slightly different name, unless 
+                # fileCollisionMethod = ``overwrite``
                 fileName = handleFileCollision(fileName,
                                                fileCollisionMethod)
             wb = Workbook()  # create new workbook

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -263,7 +263,9 @@ class ExperimentHandler(_ComparisonMixin):
 
         If `appendFile=True` then the data will be added to the bottom of
         an existing file. Otherwise, if the file exists already it will
-        be overwritten
+        be kept and a new file will be created with a slightly different
+        name. If you want to overwrite the old file, pass 'overwrite'
+        to ``fileCollisionMethod``.
 
         If `matrixOnly=True` then the file will not contain a header row,
         which can be handy if you want to append data to an existing file


### PR DESCRIPTION
Suggested fixes for the (automatically-generated) documentation