### PR TITLE
BF: Ensure nonslip code is written at routine end, fixes #4118

### DIFF
--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -233,6 +233,8 @@ class Flow(list):
         for entry in self:
             self._currentRoutine = entry
             entry.writeMainCode(script)
+            if hasattr(entry, "writeRoutineEndCode"):
+                entry.writeRoutineEndCode(script)
         # tear-down code (very few components need this)
         for entry in self:
             self._currentRoutine = entry

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -140,6 +140,13 @@ class BaseStandaloneRoutine:
     def writeEachFrameCodeJS(self, buff, modular):
         return
 
+    def writeRoutineEndCode(self, buff):
+        # reset routineTimer at the *very end* of all non-nonSlip routines
+        code = ('# the Routine "%s" was not non-slip safe, so reset '
+                'the non-slip timer\n'
+                'routineTimer.reset()\n')
+        buff.writeIndentedLines(code % self.name)
+
     def writeRoutineEndCodeJS(self, buff, modular):
         return
 
@@ -440,14 +447,6 @@ class Routine(list):
         for event in self:
             event.writeRoutineEndCode(buff)
 
-        # reset routineTimer at the *very end* of all non-nonSlip routines
-        if not useNonSlip:
-            code = ('# the Routine "%s" was not non-slip safe, so reset '
-                    'the non-slip timer\n'
-                    'routineTimer.reset()\n')
-            buff.writeIndentedLines(code % self.name)
-
-
     def writeRoutineBeginCodeJS(self, buff, modular):
 
         # create the frame loop for this routine
@@ -581,6 +580,17 @@ class Routine(list):
         buff.writeIndentedLines("};\n")
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("}\n")
+
+    def writeRoutineEndCode(self, buff):
+        # can we use non-slip timing?
+        maxTime, useNonSlip = self.getMaxTime()
+
+        # reset routineTimer at the *very end* of all non-nonSlip routines
+        if not useNonSlip:
+            code = ('# the Routine "%s" was not non-slip safe, so reset '
+                    'the non-slip timer\n'
+                    'routineTimer.reset()\n')
+            buff.writeIndentedLines(code % self.name)
 
     def writeRoutineEndCodeJS(self, buff, modular):
         # can we use non-slip timing?


### PR DESCRIPTION
Otherwise, standalone routines don't write this code so don't reset the routine timer, leading to fixed-time routines after a standalone routine being skipped because the timer is at `-x + n`s (which is often less than 0) rather than `n`s