### PR TITLE
BF: macOS app hanging on launch

### DIFF
--- a/setupApp.py
+++ b/setupApp.py
@@ -132,7 +132,7 @@ setup(
                       'functools32',
                       ],  # anything we need to forcibly exclude?
             resources=resources,
-            argv_emulation=True,
+            argv_emulation=False,  # must be False or app bundle pauses (py2app 0.21 and 0.24 tested)
             site_packages=True,
             frameworks=frameworks,
             iconfile='psychopy/app/Resources/psychopy.icns',


### PR DESCRIPTION
Turns out that py2app argv_emulation really needs to be False now!
Before this the macOS app bundle qould bounce in the dock but not show
a window until the dock icon was clicked!