### PR TITLE
BF: Monitor Center hangs when calling "Plot gamma" after linearization

### DIFF
--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -1064,7 +1064,7 @@ class MainFrame(wx.Frame):
 
             lumsPost = self.currentMon.getLumsPost()
             levelsPost = self.currentMon.getLevelsPost()
-        if lumsPost != None:
+        if lumsPost.any() != None:
             for gun in range(4):  # includes lum,r,g,b
                 lums = lumsPost[gun, :]
                 gamma = gammaGrid[gun, 2]

--- a/psychopy/monitors/MonitorCenter.py
+++ b/psychopy/monitors/MonitorCenter.py
@@ -1064,7 +1064,7 @@ class MainFrame(wx.Frame):
 
             lumsPost = self.currentMon.getLumsPost()
             levelsPost = self.currentMon.getLevelsPost()
-        if lumsPost.any() != None:
+        if lumsPost is not None:
             for gun in range(4):  # includes lum,r,g,b
                 lums = lumsPost[gun, :]
                 gamma = gammaGrid[gun, 2]


### PR DESCRIPTION
The bug occurs when trying to plot the gamma functions measured *after* calibration / linearization. At that moment the Monitor Center hangs with 

```
Traceback (most recent call last):
  File "/home/guille/anaconda3/envs/psychopy/lib/python3.9/site-packages/psychopy/monitors/MonitorCenter.py", line 1067, in plotGamma
    if lumsPost != None:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This bug also relates to the discussion in:
https://discourse.psychopy.org/t/monitor-calibration-using-colorcal-ii-mk-questions/16364/4

That bug has been already fixed (line 1033). This is now the same bug but for the variable `lumsPost` instead of `lumsPre` (line 1067)

