### PR TITLE
RF/BF: Fix a bunch of warnings cropping up during builds

### DIFF
--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -879,13 +879,13 @@ def makeXYZ2RGB(red_xy,
 
     """
     # convert CIE-xy chromaticity coordinates to xyY and put them into a matrix
-    mat_xyY_primaries = np.asmatrix((
+    mat_xyY_primaries = np.asarray((
         (red_xy[0], red_xy[1], 1.0 - red_xy[0] - red_xy[1]),
         (green_xy[0], green_xy[1], 1.0 - green_xy[0] - green_xy[1]),
         (blue_xy[0], blue_xy[1], 1.0 - blue_xy[0] - blue_xy[1])
     )).T
     # convert white point to CIE-XYZ
-    whtp_XYZ = np.asmatrix(
+    whtp_XYZ = np.asarray(
         np.dot(1.0 / whitePoint_xy[1],
             np.asarray((
                 whitePoint_xy[0],

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -272,7 +272,7 @@ def cielab2rgb(lab,
     if conversionMatrix is None:
         # XYZ -> sRGB conversion matrix, assumes D65 white point
         # mdc - computed using makeXYZ2RGB with sRGB primaries
-        conversionMatrix = numpy.asmatrix([
+        conversionMatrix = numpy.asarray([
             [3.24096994, -1.53738318, -0.49861076],
             [-0.96924364, 1.8759675, 0.04155506],
             [0.05563008, -0.20397696, 1.05697151]

--- a/psychopy/tools/imagetools.py
+++ b/psychopy/tools/imagetools.py
@@ -20,7 +20,7 @@ from psychopy.tools.typetools import float_uint8
 
 
 def array2image(a):
-    """Takes an array and returns an image object (PIL)"""
+    """Takes an array and returns an image object (PIL)."""
     # fredrik lundh, october 1998
     #
     # fredrik@pythonware.com
@@ -34,35 +34,34 @@ def array2image(a):
         raise ValueError("unsupported image mode")
 
     im = Image.frombytes(mode, (a.shape[1], a.shape[0]), a.tobytes())
-    
+
     return im
 
 
 def image2array(im):
-    """Takes an image object (PIL) and returns a numpy array
+    """Takes an image object (PIL) and returns a numpy array.
     """
-#     fredrik lundh, october 1998
-#
-#     fredrik@pythonware.com
-#     http://www.pythonware.com
-
+    #     fredrik lundh, october 1998
+    #
+    #     fredrik@pythonware.com
+    #     http://www.pythonware.com
+    #
     if im.mode not in ("L", "F"):
         raise ValueError("can only convert single-layer images")
-    try:
-        imdata = im.tostring()
-    except Exception:
-        imdata = im.tobytes()
+
+    imdata = im.tobytes()
+
     if im.mode == "L":
-        a = numpy.fromstring(imdata, numpy.uint8)
+        a = numpy.frombuffer(imdata, numpy.uint8)
     else:
-        a = numpy.fromstring(imdata, numpy.float32)
+        a = numpy.frombuffer(imdata, numpy.float32)
 
     a.shape = im.size[1], im.size[0]
     return a
 
 
 def makeImageAuto(inarray):
-    """Combines float_uint8 and image2array operations
-    ie. scales a numeric array from -1:1 to 0:255 and
-    converts to PIL image format"""
+    """Combines float_uint8 and image2array operations ie. scales a numeric
+    array from -1:1 to 0:255 and converts to PIL image format.
+    """
     return image2array(float_uint8(inarray))

--- a/psychopy/tools/imagetools.py
+++ b/psychopy/tools/imagetools.py
@@ -32,10 +32,9 @@ def array2image(a):
         mode = "F"
     else:
         raise ValueError("unsupported image mode")
-    try:
-        im = Image.fromstring(mode, (a.shape[1], a.shape[0]), a.tostring())
-    except Exception:
-        im = Image.frombytes(mode, (a.shape[1], a.shape[0]), a.tostring())
+
+    im = Image.frombytes(mode, (a.shape[1], a.shape[0]), a.tobytes())
+    
     return im
 
 

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -240,7 +240,7 @@ def setColor(obj, color, colorSpace=None, operation='',
 
 # set for groupFlipVert:
 immutables = {int, float, str, tuple, int, bool,
-              np.float64, np.float, np.int, np.long}
+              np.float64, np.int, np.long}
 
 
 def findImageFile(filename):

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -239,8 +239,7 @@ def setColor(obj, color, colorSpace=None, operation='',
 
 
 # set for groupFlipVert:
-immutables = {int, float, str, tuple, int, bool,
-              np.float64, np.int}
+immutables = {int, float, str, tuple, int, bool, np.float32, np.float64}
 
 
 def findImageFile(filename):

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -240,7 +240,7 @@ def setColor(obj, color, colorSpace=None, operation='',
 
 # set for groupFlipVert:
 immutables = {int, float, str, tuple, int, bool,
-              np.float64, np.int, np.long}
+              np.float64, np.int}
 
 
 def findImageFile(filename):

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -218,7 +218,6 @@ class RadialStim(GratingStim):
             res = im.size[0]
             im = im.convert("L")  # force to intensity (in case it was rgb)
             intensity = numpy.asarray(im)
-            fromFile = 1
 
         data = intensity.astype(numpy.uint8)
         mask = data.tobytes()  # serialise

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -221,7 +221,7 @@ class RadialStim(GratingStim):
             fromFile = 1
 
         data = intensity.astype(numpy.uint8)
-        mask = data.tostring()  # serialise
+        mask = data.tobytes()  # serialise
 
         # do the openGL binding
         if self.interpolate:

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -180,11 +180,11 @@ class RadialStim(GratingStim):
         res = self.texRes  # resolution of texture - 128 is bearable
         step = 1.0/res
         rad = numpy.arange(0, 1 + step, step)
-        if type(self.mask) == numpy.ndarray:
+        if isinstance(self.mask, numpy.ndarray):
             # handle a numpy array
             intensity = 255 * self.mask.astype(float)
             res = len(intensity)
-        elif type(self.mask) == list:
+        elif isinstance(self.mask, list):
             # handle a numpy array
             intensity = 255 * numpy.array(self.mask, float)
             res = len(intensity)

--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -1008,8 +1008,10 @@ class RatingScale(MinimalStim):
         self.accept.font = textFont
 
         self.acceptTextColor = markerColor
-        if markerColor in ['White']:
-            self.acceptTextColor = 'Black'
+        if isinstance(markerColor, str):
+            # warning raised if color not specified as a string
+            if markerColor in ['White']:
+                self.acceptTextColor = 'Black'
 
     def _getMarkerFromPos(self, mouseX):
         """Convert mouseX into units of tick marks, 0 .. high-low.

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -179,7 +179,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.depth = depth
         self.ori = numpy.array(ori, float)
         self.size = numpy.array([0.0, 0.0]) + size  # make sure that it's 2D
-        if vertices != ():  # flag for when super-init'ing a ShapeStim
+        if vertices:  # flag for when super-init'ing a ShapeStim
             self.vertices = vertices  # call attributeSetter
         self.autoDraw = autoDraw  # call attributeSetter
 

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -179,7 +179,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.depth = depth
         self.ori = numpy.array(ori, float)
         self.size = numpy.array([0.0, 0.0]) + size  # make sure that it's 2D
-        if vertices:  # flag for when super-init'ing a ShapeStim
+        if len(vertices):  # flag for when super-init'ing a ShapeStim
             self.vertices = vertices  # call attributeSetter
         self.autoDraw = autoDraw  # call attributeSetter
 

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -211,7 +211,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         if op is None:
             op = ''
         # format the input value as float vectors
-        if type(val) in (tuple, list):
+        if isinstance(val, (tuple, list)):
             val = numpy.array(val, float)
 
         setAttribute(self, attrib, val, log, op)

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -148,7 +148,7 @@ class SimpleImageStim(MinimalStim, WindowMixin):
         setAttribute(self, 'flipVert', newVal, log)
 
     def _updateImageStr(self):
-        self._imStr = self.imArray.tostring()
+        self._imStr = self.imArray.tobytes()
         self._needStrUpdate = False
 
     def draw(self, win=None):


### PR DESCRIPTION
Fixes a large chunk of warnings related to deprecated functionality that have been caught by our test suite. These warnings are numerous and clog up our build logs. However they are easy, one-line fixes in most cases that shouldn't break anything.