### PR TITLE
BF: Catch `AttributeError` in `BitsSharp.__del__`

### DIFF
--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -1427,8 +1427,10 @@ class BitsSharp(BitsPlusPlus, serialdevice.SerialDevice):
         """If the user discards this object then close the serial port
         so it is released.
         """
-        if hasattr(self, 'com'):
+        try:
             self.com.close()
+        except AttributeError:
+            pass
 
     def isAwake(self):
         """Test whether we have an active connection on the virtual serial


### PR DESCRIPTION
Fixes the following error in the test suite:

```
psychopy/tests/test_hardware/test_CRS_bitsShaders.py::test_bitsShaders Exception ignored in: <function BitsSharp.__del__ at 0x7f62bb680040>
Traceback (most recent call last):
  File "/home/runner/work/psychopy/psychopy/psychopy/hardware/crs/bits.py", line 1431, in __del__
    self.com.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

Seems that attribute `com` is defined but is `None`, resulting in the error. Originally we checked if `com` is defined rather than checking if the value is `None`. An attribute error was raised since `None` has no attribute `close`. Using `try ... except` with `AttributeError` is a catchall for whether `com` is defined and it's value has attribute `close` at the time of shutdown or garbage collection.