### PR TITLE
BF: Only replace \ in string params if they're valid paths

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -648,8 +648,6 @@ class ParamNotebook(wx.Notebook, ThemeMixin):
                     # use GetStringSelection()
                     # only if this control doesn't has _choices
                     param.val = ctrl.GetStringSelection()
-            elif hasattr(ctrl, "GetValue"):
-                param.val = ctrl.GetValue()
             # Get type
             if hasattr(ctrl, "typeCtrl"):
                 if ctrl.typeCtrl:

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -63,6 +63,7 @@ class TextComponent(BaseVisualComponent):
         self.params['text'] = Param(
             text, valType='str', inputType="multi", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
+            neverPathlike=True,
             hint=_translate("The text to be displayed"),
             label=_localized['text'])
         self.params['font'] = Param(

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -88,6 +88,7 @@ class TextboxComponent(BaseVisualComponent):
         self.params['text'] = Param(
             text, valType='str', inputType="multi", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
+            neverPathlike=True,
             hint=_translate("The text to be displayed"),
             label=_localized['text'])
         self.params['font'] = Param(

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -206,12 +206,11 @@ class Param(object):
                             # if target is python2.x then unicode will be u'something'
                             # but for other targets that will raise an annoying error
                             val = val[1:]
-                    if self.valType in ['file', 'table']:
+                    if self.valType in ['file', 'table'] or Path(val).is_file():
                         # If param is a file of any kind, use Path to make sure it's valid
                         val = Path(val).as_posix()  # Convert to a valid path with / not \
-                    val=re.sub("\n", "\\n", val)  # Replace line breaks with escaped line break character
-                    val=re.sub("\\\\", "/", val)  # handle older exps where files were valType=str not file
-                    return repr(val)                              
+                    val = re.sub("\n", "\\n", val)  # Replace line breaks with escaped line break character
+                    return repr(val)
             return repr(self.val)
         elif self.valType in ['code', 'extendedCode']:
             isStr = isinstance(self.val, basestring)

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -214,6 +214,8 @@ class Param(object):
                         # If param is a file of any kind, use Path to make sure it's valid
                         val = Path(val).as_posix()  # Convert to a valid path with / not \
                     val = re.sub("\n", "\\n", val)  # Replace line breaks with escaped line break character
+                    # Hide escape char on escaped $ (other escaped chars are handled by wx but $ is unique to us)
+                    val = re.sub(r"\\\$", "$", val)
                     return repr(val)
             return repr(self.val)
         elif self.valType in ['code', 'extendedCode']:

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -206,7 +206,11 @@ class Param(object):
                             # if target is python2.x then unicode will be u'something'
                             # but for other targets that will raise an annoying error
                             val = val[1:]
-                    if self.valType in ['file', 'table'] or Path(val).is_file():
+                    try:
+                        isFile = Path(val).is_file()
+                    except OSError:
+                        isFile = False
+                    if self.valType in ['file', 'table'] or isFile:
                         # If param is a file of any kind, use Path to make sure it's valid
                         val = Path(val).as_posix()  # Convert to a valid path with / not \
                     val = re.sub("\n", "\\n", val)  # Replace line breaks with escaped line break character

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -206,14 +206,12 @@ class Param(object):
                             # if target is python2.x then unicode will be u'something'
                             # but for other targets that will raise an annoying error
                             val = val[1:]
-                    try:
-                        isFile = Path(val).is_file()
-                    except OSError:
-                        isFile = False
-                    if self.valType in ['file', 'table'] or isFile:
-                        # If param is a file of any kind, use Path to make sure it's valid
-                        val = Path(val).as_posix()  # Convert to a valid path with / not \
-                    val = re.sub("\n", "\\n", val)  # Replace line breaks with escaped line break character
+                    # If param is a path or path-like, use Path to make sure it's valid (with / not \)
+                    isPathLike = bool(re.findall(r"[\\/](?!\W)", val))
+                    if self.valType in ['file', 'table'] or isPathLike:
+                        val = Path(val).as_posix()
+                    # Replace line breaks with escaped line break character
+                    val = re.sub("\n", "\\n", val)
                     # Hide escape char on escaped $ (other escaped chars are handled by wx but $ is unique to us)
                     val = re.sub(r"\\\$", "$", val)
                     return repr(val)

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -121,7 +121,7 @@ class Param(object):
 
     def __init__(self, val, valType, inputType=None, allowedVals=None, allowedTypes=None,
                  hint="", label="", updates=None, allowedUpdates=None,
-                 allowedLabels=None,
+                 allowedLabels=None, neverPathlike=False,
                  categ="Basic"):
         """
         @param val: the value for this parameter
@@ -146,6 +146,9 @@ class Param(object):
         @param categ: category for this parameter
             will populate tabs in Component Dlg
         @type allowedUpdates: string
+        @type neverPathlike: bool
+        @param neverPathlike: if True, then this param will never be interpreted as a path
+            (e.g. the text param of a TextBox should never be a path)
         """
         super(Param, self).__init__()
         self.label = label
@@ -161,6 +164,7 @@ class Param(object):
         self.categ = categ
         self.readOnly = False
         self.codeWanted = False
+        self.neverPathlike = neverPathlike
         if inputType:
             self.inputType = inputType
         elif valType in inputDefaults:
@@ -208,7 +212,7 @@ class Param(object):
                             val = val[1:]
                     # If param is a path or path-like, use Path to make sure it's valid (with / not \)
                     isPathLike = bool(re.findall(r"[\\/](?!\W)", val))
-                    if self.valType in ['file', 'table'] or isPathLike:
+                    if self.valType in ['file', 'table'] or (isPathLike and not self.neverPathlike):
                         val = Path(val).as_posix()
                     # Replace line breaks with escaped line break character
                     val = re.sub("\n", "\\n", val)

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -215,10 +215,22 @@ def test_param_str():
         {"obj": Param(__file__, "str"),
          "py": f"'{__file__.replace(_slash, '/')}'",
          "js": f"'{__file__.replace(_slash, '/')}'"},
+        # Nonexistant file path marked as str
+        {"obj": Param("C:\\\\Downloads\\file.csv", "str"),
+         "py": "'C:/Downloads/file.csv'",
+         "js": "'C:/Downloads/file.csv'"},
+        # Underscored file path marked as str
+        {"obj": Param("C:\\\\Downloads\\_file.csv", "str"),
+         "py": "'C:/Downloads/_file.csv'",
+         "js": "'C:/Downloads/_file.csv'"},
         # Escaped $ in str
         {"obj": Param("This costs \\$4.20", "str"),
          "py": "'This costs $4.20'",
          "js": "'This costs $4.20'"},
+        # Unescaped \ in str
+        {"obj": Param("This \\ that", "str"),
+         "py": "'This \\\\ that'",
+         "js": "'This \\\\ that'"},
     ]
 
     # Take note of what the script target started as

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -172,6 +172,10 @@ def test_param_str():
         {"obj": Param("Hello there", "str"),
          "py": "'Hello there'",
          "js": "'Hello there'"},
+        # Enforced string
+        {"obj": Param("\\, | or /", "str", neverPathlike=True),
+         "py": "'\\\\, | or /'",
+         "js": "'\\\\, | or /'"},
         # Dollar string
         {"obj": Param("$win.color", "str"),
          "py": "win.color",

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -209,7 +209,16 @@ def test_param_str():
          "py": "[1, 2, 3]",
          "js": "[1, 2, 3]"},
     ]
+    _slash = "\\"
     tykes = [
+        # Extant file path marked as str
+        {"obj": Param(__file__, "str"),
+         "py": f"'{__file__.replace(_slash, '/')}'",
+         "js": f"'{__file__.replace(_slash, '/')}'"},
+        # Escaped $ in str
+        {"obj": Param("This costs \\$4.20", "str"),
+         "py": "'This costs $4.20'",
+         "js": "'This costs $4.20'"},
     ]
 
     # Take note of what the script target started as


### PR DESCRIPTION
Fixes the bug highlighted here: https://discourse.psychopy.org/t/use-symbol-and-mulitple-colors-in-the-text/1500/10