### PR TITLE
BF: Check for empty lists when specifying vertices in `BaseShapeStim`

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -180,12 +180,8 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.ori = numpy.array(ori, float)
         self.size = numpy.array([0.0, 0.0]) + size  # make sure that it's 2D
 
-        # check if the vertices are a tuple
-        if isinstance(vertices, (tuple, list)):
-            if len(vertices):
-                # flag for when super-init'ing a ShapeStim
-                self.vertices = vertices  # call attributeSetter
-
+        if vertices != ():  # flag for when super-init'ing a ShapeStim
+            self.vertices = vertices  # call attributeSetter
         self.autoDraw = autoDraw  # call attributeSetter
 
         # set autoLog now that params have been initialised

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -179,8 +179,13 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.depth = depth
         self.ori = numpy.array(ori, float)
         self.size = numpy.array([0.0, 0.0]) + size  # make sure that it's 2D
-        if len(vertices):  # flag for when super-init'ing a ShapeStim
-            self.vertices = vertices  # call attributeSetter
+
+        # check if the vertices are a tuple
+        if isinstance(vertices, (tuple, list)):
+            if len(vertices):
+                # flag for when super-init'ing a ShapeStim
+                self.vertices = vertices  # call attributeSetter
+
         self.autoDraw = autoDraw  # call attributeSetter
 
         # set autoLog now that params have been initialised


### PR DESCRIPTION
Reverts back to checking if `vertices` passed to `BaseShapeStim` are an empty list or tuple. This should fix the deprecation warning as intended but also allow for scalar arguments to be passed without crashing out.