### PR TITLE
EN: Ask the user when closing a routine

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1556,24 +1556,27 @@ class RoutinesNotebook(aui.AuiNotebook, ThemeMixin):
             event.Skip()
             return
 
-        # message to display
-        msg = _translate(
-            "Do you want to remove routine '{}' from the experiment?")
+        # check if the user wants a prompt
+        showDlg = self.app.prefs.builder.get('confirmRoutineClose', False)
+        if showDlg:
+            # message to display
+            msg = _translate(
+                "Do you want to remove routine '{}' from the experiment?")
 
-        # dialog asking if the user wants to remove the routine
-        dlg = wx.MessageDialog(
-            self,
-            _translate(msg).format(name),
-            _translate('Close routine?'),
-            wx.YES_NO | wx.NO_DEFAULT | wx.CENTRE | wx.STAY_ON_TOP)
+            # dialog asking if the user wants to remove the routine
+            dlg = wx.MessageDialog(
+                self,
+                _translate(msg).format(name),
+                _translate('Remove routine?'),
+                wx.YES_NO | wx.NO_DEFAULT | wx.CENTRE | wx.STAY_ON_TOP)
 
-        # show the dialog and get the response
-        dlgResult = dlg.ShowModal()
-        dlg.Destroy()
+            # show the dialog and get the response
+            dlgResult = dlg.ShowModal()
+            dlg.Destroy()
 
-        if dlgResult == wx.ID_NO:  # if NO, stop the tab from closing
-            event.Veto()
-            return
+            if dlgResult == wx.ID_NO:  # if NO, stop the tab from closing
+                event.Veto()
+                return
 
         # remove names of the routine and its components from namespace
         _nsp = self.frame.exp.namespace

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=False)
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=True)
+    confirmRoutineClose = boolean(default=False)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -121,6 +121,8 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+    # Ask for confirmation when closing a routine tab.
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=False)
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=True)
+    confirmRoutineClose = boolean(default=False)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -121,6 +121,8 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+    # Ask for confirmation when closing a routine tab.
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=False)
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=True)
+    confirmRoutineClose = boolean(default=False)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -121,6 +121,8 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+    # Ask for confirmation when closing a routine tab.
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=False)
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -122,7 +122,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=True)
+    confirmRoutineClose = boolean(default=False)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -121,6 +121,8 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+    # Ask for confirmation when closing a routine tab.
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -118,7 +118,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=True)
+    confirmRoutineClose = boolean(default=False)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -118,7 +118,7 @@
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
     # Ask for confirmation when closing a routine tab.
-    confirmRoutineClose = boolean(default=False)
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -117,6 +117,8 @@
     alwaysShowReadme = boolean(default=True)
     # Upper limit on how many components can be in favorites
     maxFavorites = integer(default=10)
+    # Ask for confirmation when closing a routine tab.
+    confirmRoutineClose = boolean(default=True)
 
 [hardware]
     # choice of audio library


### PR DESCRIPTION
This resolves #2505 by adding a prompt when closing a routine.

![routine_prompt](https://user-images.githubusercontent.com/5150568/130121753-27c7d206-525d-40f6-939b-95ad56d30340.PNG)

You can enable this option in preferences. Disabled by default to prevent possible issues during automated testing.