### PR TITLE
NF: Get `setFullScr` working correctly for glfw and pyglet backends

### DIFF
--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -687,10 +687,18 @@ class GLFWBackend(BaseBackend):
             pass
 
     def setFullScr(self, value):
-        """Sets the window to/from full-screen mode"""
+        """Sets the window to/from full-screen mode.
+
+        Parameters
+        ----------
+        value : bool or int
+            If `True`, resize the window to be fullscreen.
+
+        """
+        # convert value to correct type
+        value = bool(value)
         # get monitor handle for the window
         monitor = glfw.get_window_monitor(self.winHandle)
-
         # get the video mode for the monitor
         # get monitors, with GLFW the primary display is ALWAYS at index 0
         allScrs = glfw.get_monitors()
@@ -707,15 +715,16 @@ class GLFWBackend(BaseBackend):
         nativeVidmode = glfw.get_video_mode(thisScreen)
         refreshRateHz = nativeVidmode.refresh_rate
         scrWidth, scrHeight = nativeVidmode.size
-        winWidth, winHeight = nativeVidmode.size if value else self.win.clientSize
+        winWidth, winHeight = nativeVidmode.size if value else self.win.windowedSize
 
         # set the monitor
+        # glfw.window_hint(glfw.DECORATED, glfw.FALSE)
         glfw.set_window_monitor(
             self.winHandle,
             monitor if value else None,  # if `None` windowed, else fullscreen
             0, 0,  # position keep zero and set later
-            nativeVidmode.size[0] if value else self.win.clientSize[0],
-            nativeVidmode.size[1] if value else self.win.clientSize[1],
+            nativeVidmode.size[0] if value else self.win.windowedSize[0],
+            nativeVidmode.size[1] if value else self.win.windowedSize[1],
             refreshRateHz)
 
         if not value:  # extra stuff for non-fullscreen
@@ -733,15 +742,19 @@ class GLFWBackend(BaseBackend):
                 int(self.win.pos[0] + px),
                 int(self.win.pos[1] + py))
 
-        self.win.clientSize = np.array((winWidth, winHeight), dtype=int)
-        self._frameBufferSize = np.array(
-            glfw.get_framebuffer_size(self.winHandle))
+        # get the reported client size
+        self.win.clientSize[:] = glfw.get_window_size(self.winHandle)
+        self.frameBufferSize[:] = glfw.get_framebuffer_size(self.winHandle)
         self.win.viewport = (
             0, 0,
-            self._frameBufferSize[0], self._frameBufferSize[1])
+            self._frameBufferSize[0],
+            self._frameBufferSize[1])
         self.win.scissor = (
             0, 0,
-            self._frameBufferSize[0], self._frameBufferSize[1])
+            self._frameBufferSize[0],
+            self._frameBufferSize[1])
+
+        self.win.resetEyeTransform()
 
     # --------------------------------------------------------------------------
     # Mouse button event handlers

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -560,10 +560,16 @@ class PygletBackend(BaseBackend):
             pass
 
     def setFullScr(self, value):
-        """Sets the window to/from full-screen mode"""
+        """Sets the window to/from full-screen mode.
+
+        Parameters
+        ----------
+        value : bool or int
+            If `True`, resize the window to be fullscreen.
+
+        """
         self.winHandle.set_fullscreen(value)
-        self.win.clientSize = np.array(
-            (self.winHandle.width, self.winHandle.height), dtype=int)
+        self.win.clientSize[:] = (self.winHandle.width, self.winHandle.height)
 
         # special handling for retina displays, if needed
         global retinaContext
@@ -574,9 +580,11 @@ class PygletBackend(BaseBackend):
         else:
             backWidth, backHeight = self.win.clientSize
 
-        self._frameBufferSize = np.array((backWidth, backHeight))
+        self._frameBufferSize[:] = (backWidth, backHeight)
         self.win.viewport = (0, 0, backWidth, backHeight)
         self.win.scissor = (0, 0, backWidth, backHeight)
+
+        self.win.resetEyeTransform()
 
     def setMouseType(self, name='arrow'):
         """Change the appearance of the cursor for this window. Cursor types

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -562,6 +562,21 @@ class PygletBackend(BaseBackend):
     def setFullScr(self, value):
         """Sets the window to/from full-screen mode"""
         self.winHandle.set_fullscreen(value)
+        self.win.clientSize = np.array(
+            (self.winHandle.width, self.winHandle.height), dtype=int)
+
+        # special handling for retina displays, if needed
+        global retinaContext
+        if retinaContext is not None:
+            view = retinaContext.view()
+            bounds = view.convertRectToBacking_(view.bounds()).size
+            backWidth, backHeight = (int(bounds.width), int(bounds.height))
+        else:
+            backWidth, backHeight = self.win.clientSize
+
+        self._frameBufferSize = np.array((backWidth, backHeight))
+        self.win.viewport = (0, 0, backWidth, backHeight)
+        self.win.scissor = (0, 0, backWidth, backHeight)
 
     def setMouseType(self, name='arrow'):
         """Change the appearance of the cursor for this window. Cursor types

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -328,6 +328,9 @@ class Window(object):
         self.autoLog = False  # to suppress log msg during init
         self.name = name
         self.clientSize = numpy.array(size, int)  # size of window, not buffer
+        # size of the window when restored (not fullscreen)
+        self._windowedSize = self.clientSize.copy()
+
         self.pos = pos
         # this will get overridden once the window is created
         self.winHandle = None
@@ -1421,6 +1424,16 @@ class Window(object):
         """Size of the framebuffer in pixels (w, h)."""
         # Dimensions should match window size unless using a retina display
         return self.backend.frameBufferSize
+
+    @property
+    def windowedSize(self):
+        """Size of the window to use when not fullscreen (w, h)."""
+        return self._windowedSize
+
+    @windowedSize.setter
+    def windowedSize(self, value):
+        """Size of the window to use when not fullscreen (w, h)."""
+        self._windowedSize[:] = value
 
     def getContentScaleFactor(self):
         """Get the scaling factor required for scaling correctly on high-DPI


### PR DESCRIPTION
This PR implements for `seFullScr` for the Pyglet and GLFW backends. Currently that method is non-existent for GLFW and broken for Pyglet. 

Resolves part of issue #2479.