### PR TITLE
BF: directly using iohub.client.ioHubConnection

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -9,6 +9,7 @@ import gevent
 from psychopy.iohub.util import convertCamelToSnake
 from psychopy.iohub.devices import DeviceEvent, Computer
 from psychopy.iohub.constants import EventConstants as EC
+from psychopy.iohub.devices.keyboard import KeyboardInputEvent
 from psychopy.iohub.errors import print2err
 
 currentTime = Computer.getTime
@@ -18,7 +19,7 @@ class GazepointPsychopyCalibrationGraphics(object):
     IOHUB_HEARTBEAT_INTERVAL = 0.050
     CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)]
 
-    _keyboard_key_index = EC.getClass(EC.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
+    _keyboard_key_index = KeyboardInputEvent.CLASS_ATTRIBUTE_NAMES.index('key')
 
     def __init__(self, eyetrackerInterface, calibration_args):
         self._eyetracker = eyetrackerInterface

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -9,6 +9,7 @@ import gevent
 from psychopy.iohub.util import convertCamelToSnake, updateSettings
 from psychopy.iohub.devices import DeviceEvent, Computer
 from psychopy.iohub.constants import EventConstants as EC
+from psychopy.iohub.devices.keyboard import KeyboardInputEvent
 from psychopy.iohub.errors import print2err
 
 currentTime = Computer.getTime
@@ -18,7 +19,7 @@ class MouseGazePsychopyCalibrationGraphics(object):
     IOHUB_HEARTBEAT_INTERVAL = 0.050
     CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)]
 
-    _keyboard_key_index = EC.getClass(EC.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
+    _keyboard_key_index = KeyboardInputEvent.CLASS_ATTRIBUTE_NAMES.index('key')
 
     def __init__(self, eyetrackerInterface, calibration_args):
         self._eyetracker = eyetrackerInterface

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
@@ -11,6 +11,8 @@ from collections import OrderedDict
 from .....util import convertCamelToSnake, updateSettings
 from .... import DeviceEvent, Computer
 from .....constants import EventConstants
+from psychopy.iohub.devices.keyboard import KeyboardInputEvent
+
 from .....errors import print2err, printExceptionDetailsToStdErr
 
 currentTime = Computer.getTime
@@ -23,8 +25,7 @@ class TobiiPsychopyCalibrationGraphics(object):
     TEXT_POS = [0, 0]
     TEXT_COLOR = [0, 0, 0]
     TEXT_HEIGHT = 36
-    _keyboard_key_index = EventConstants.getClass(
-        EventConstants.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
+    _keyboard_key_index = KeyboardInputEvent.CLASS_ATTRIBUTE_NAMES.index('key')
 
     def __init__(self, eyetrackerInterface, calibration_args={}):
         self._eyetrackerinterface = eyetrackerInterface


### PR DESCRIPTION
Experiment script use of `iohub.client.ioHubConnection` was failing as of 2021.2.x if using a Tobii, GazePoint, or Mousegaze tracker. This fixes that regression. Issue reported [here](https://discourse.psychopy.org/t/guidance-on-using-eyetracking-with-iohub-and-yaml-files-post-2021-2-0/24473)

Note that direct use of `iohub.client.ioHubConnection` is no longer suggested / supported in favor of `launchHubServer`.