### PR TITLE
BF: Transpiler add JS version of a.extend() method

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -216,6 +216,16 @@ class pythonTransformer(ast.NodeTransformer):
             )
 
         # a = [1,2,3]
+        # a.extend([4, 5, 6]) --> a.concat([4, 5, 6])
+        if func.attr == 'extend':
+            func.attr = 'concat'
+            return ast.Call(
+                func=func,
+                args=args,
+                keywords=[]
+            )
+
+        # a = [1,2,3]
         # a.index(2) --> util.index(a,2)
         # value=Call(func=Attribute(value=Name(id='a', ctx=Load()), attr='index', ctx=Load()), args=[Num(n=2)], keywords=[])
         # value=Call(func=Attribute(value=Name(id='util', ctx=Load()), attr='index', ctx=Load()), args=[Name(id='a', ctx=Load()), Num(n=2)], keywords=[])


### PR DESCRIPTION
Add direct substitution method for JS equivilent of a.extend.

In python:
a = [1, 2, 3]
a.extend([4, 5, 6])

In JS:
a = [1, 2, 3]
a.concat([4, 5, 6])
