### PR TITLE
ENH: Properly shutdown existing ioHub connection on core.quit()

### DIFF
--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -26,6 +26,7 @@ from psychopy.clock import (MonotonicClock, Clock, CountdownTimer,
 from psychopy.platform_specific import rush  # pylint: disable=W0611
 from psychopy import logging
 from psychopy.constants import STARTED, NOT_STARTED, FINISHED, PY3
+from psychopy.iohub.client import ioHubConnection
 
 try:
     import pyglet
@@ -74,6 +75,10 @@ def quit():
     """
     # pygame.quit()  # safe even if pygame was never initialised
     logging.flush()
+
+    # properly shutdown ioHub server
+    if ioHubConnection.ACTIVE_CONNECTION:
+        ioHubConnection.ACTIVE_CONNECTION.quit()
 
     for thisThread in threading.enumerate():
         if hasattr(thisThread, 'stop') and hasattr(thisThread, 'running'):


### PR DESCRIPTION
Implementation suggested by @isolver https://github.com/psychopy/psychopy/pull/4216/#issuecomment-908418874