### PR TITLE
BF: Slider start val shouldn't count as a response

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -303,7 +303,7 @@ class SliderComponent(BaseVisualComponent):
         forceEnd = self.params['forceEndRoutine'].val
         if forceEnd:
             code = ("\n# Check %(name)s for response to end routine\n"
-                    "if %(name)s.getRating() is not None and %(name)s.status == STARTED:\n"
+                    "if %(name)s.pressed:\n"
                     "    continueRoutine = False")
             buff.writeIndentedLines(code % (self.params))
 

--- a/psychopy/tests/test_all_visual/test_slider.py
+++ b/psychopy/tests/test_all_visual/test_slider.py
@@ -6,6 +6,7 @@ from __future__ import division
 import pytest
 
 from psychopy.colors import Color
+from psychopy.constants import NOT_STARTED, STARTED
 from psychopy.tests.test_all_visual.test_basevisual import _TestColorMixin
 from psychopy.visual.window import Window
 from psychopy.visual.slider import Slider
@@ -179,6 +180,19 @@ class Test_Slider(_TestColorMixin):
         assert len(RT) == counter
         assert max(RT) <= 1
         assert min(RT) >= 0
+
+    def test_pressed(self):
+        # Check that slider starts off not pressed
+        s = Slider(self.win, size=(1, 0.1))
+        assert not s.pressed
+        # Check that pressing when not started doesn't change this
+        s.status = NOT_STARTED
+        s.recordRating(1, 1)
+        assert not s.pressed
+        # Check that once it's started, recording responses does trigger pressed
+        s.status = STARTED
+        s.recordRating(1, 1)
+        assert s.pressed
 
     def test_getRating(self):
         s = Slider(self.win, size=(1, 0.1))

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -197,6 +197,7 @@ class Slider(MinimalStim, ColorMixin):
         if autoLog:
             logging.exp("Created %s = %s" % (self.name, repr(self)))
         self.status = NOT_STARTED
+        self.pressed = False
         self.responseClock = core.Clock()
 
         # set the style when everything else is set
@@ -492,6 +493,8 @@ class Slider(MinimalStim, ColorMixin):
         """
         rating = self._granularRating(rating)
         setAttribute(self, attrib='rating', value=rating, operation='', log=log)
+        if self.status == STARTED:
+            self.pressed = True
         if rt is None:
             self.rt = self.responseClock.getTime()
         else:


### PR DESCRIPTION
Counting the start val as a response meant that, when start val was specified and slider had "force end routine", the routine would end immediately.