### PR TITLE
BF: fixed MovieStim3.reset() method to set _nextFrameT=0.0 vs. None

### DIFF
--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -183,7 +183,7 @@ class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
 
     def reset(self):
         self._numpyFrame = None
-        self._nextFrameT = None
+        self._nextFrameT = 0.0
         self._texID = None
         self.status = NOT_STARTED
         self.nDroppedFrames = 0


### PR DESCRIPTION
Current implementation of setting self._nextFrameT = None leads to a bug when trying to repeat videos in an experiment. 

We wanted to pre-load all of our movie stimuli for an fMRI experiment and be able to repeat them as necessary. Due to the status being set to FINISHED upon completion, a function such as _self.reset() was required, but led to an issue when calling .draw() in the second repetition giving TypeError: unsupported operand type(s) -: for 'NoneType' and 'float'. 

I have tested this change in our experiment code and it has not lead to any issues or unusual behaviour on the part of MovieStim3. I see that something similar was happening in the online experiment discourse https://discourse.psychopy.org/t/video-stimuli-not-resetting-to-beginning-in-online-experiment/10459. This has fixed it in the Python Coder for me.