### PR TITLE
Link slider component's mouse to the correct window

### DIFF
--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -183,7 +183,7 @@ class Slider(MinimalStim, ColorMixin):
         self._lineAspectRatio = 0.01
         self._updateMarkerPos = True
         self._dragging = False
-        self.mouse = event.Mouse()
+        self.mouse = event.Mouse(win=win)
         self._mouseStateClick = None  # so we can rule out long click probs
         self._mouseStateXY = None  # so we can rule out long click probs
 


### PR DESCRIPTION
In an experiment, I have a slider component/object that's shown on a secondary display. I noticed however that rather than clicking on the slider itself directly, I had to click the corresponding area on the main display. This is because upon instantiation, the corresponding mouse object wasn't linked to the window that was specified for the slider component. I suspect this is simply a bug, since the behavior is unlike eg what happens with [the button component](https://github.com/psychopy/psychopy/blob/release/psychopy/visual/button.py) (which has `self.listener = event.Mouse(win=win)`). 

This one-line PR aims to fix the issue described above.