### PR TITLE
BF: Coder's "Find" fails when non-ASCII characters are included

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1102,8 +1102,9 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
         backward = not (findData.GetFlags() & wx.FR_DOWN)
         matchcase = (findData.GetFlags() & wx.FR_MATCHCASE) != 0
         end = self.GetLength()
-        textstring = self.GetTextRange(0, end)
-        findstring = findData.GetFindString()
+        # Byte string is necessary to let SetSelection() work properly
+        textstring = self.GetTextRangeRaw(0, end)
+        findstring = findData.GetFindString().encode('utf-8')
         if not matchcase:
             textstring = textstring.lower()
             findstring = findstring.lower()
@@ -1126,7 +1127,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
         # was it still not found?
         if loc == -1:
             dlg = dialogs.MessageDialog(self, message=_translate(
-                'Unable to find "%s"') % findstring, type='Info')
+                'Unable to find "%s"') % findstring.decode('utf-8'), type='Info')
             dlg.ShowModal()
             dlg.Destroy()
         else:


### PR DESCRIPTION
Here attaches a sample file for the issue.
[min_sample.zip](https://github.com/psychopy/psychopy/files/7142138/min_sample.zip)

Please open min_sample.py in this Zip file with Coder and search for a string "target".  The first three "target" (Line 3, 6, 9) are properly found, but "target" after non-ASCII characters (Line 12) are found at wrong position. 
![fig1](https://user-images.githubusercontent.com/2094930/132826455-4eca2a66-ba68-4e2d-9ebd-0da2eb9638ea.png)

The cause of this issue is that `SetSelection()` doesn't recognize a non-ASCII multi-byte character as a single character.  For example, `'日'` is thee byte character in UTF-8 (`E697A5`) and treated as three characters by `SetSelection()`.  I tried to find a way to make `SetSelection()` recognize multi-byte characters, but that seemed quite hard.  So I tried to convert text to Bytes string before running `find()`.  This solution worked fine on my Japanese Windows10 and Ubuntu PCs.
