### PR TITLE
ENH: Add text_color setting to eye tracker calibration

### DIFF
--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -11,18 +11,23 @@ from psychopy.iohub.util import hideWindow, showWindow
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
 TRACKER = 'mouse'
+BACKGROUND_COLOR = [128, 0, 0]
 
+devices_config = dict()
 eyetracker_config = dict(name='tracker')
-devices_config = {}
 if TRACKER == 'mouse':
+    eyetracker_config['calibration'] = dict(screen_background_color=BACKGROUND_COLOR)
     devices_config['eyetracker.hw.mouse.EyeTracker'] = eyetracker_config
 elif TRACKER == 'eyelink':
     eyetracker_config['model_name'] = 'EYELINK 1000 DESKTOP'
     eyetracker_config['runtime_settings'] = dict(sampling_rate=1000, track_eyes='RIGHT')
+    eyetracker_config['calibration'] = dict(screen_background_color=BACKGROUND_COLOR)
     devices_config['eyetracker.hw.sr_research.eyelink.EyeTracker'] = eyetracker_config
 elif TRACKER == 'gazepoint':
+    eyetracker_config['calibration'] = dict(use_builtin=False, screen_background_color=BACKGROUND_COLOR)
     devices_config['eyetracker.hw.gazepoint.gp3.EyeTracker'] = eyetracker_config
 elif TRACKER == 'tobii':
+    eyetracker_config['calibration'] = dict(screen_background_color=BACKGROUND_COLOR)
     devices_config['eyetracker.hw.tobii.EyeTracker'] = eyetracker_config
 else:
     print("{} is not a valid TRACKER name; please use 'mouse', 'eyelink', 'gazepoint', or 'tobii'.".format(TRACKER))
@@ -38,7 +43,7 @@ win = visual.Window((1920, 1080),
                     allowGUI=False,
                     colorSpace='rgb255',
                     monitor='55w_60dist',
-                    color=[128, 128, 128]
+                    color=BACKGROUND_COLOR
                     )
 
 win.setMouseVisible(False)

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -132,6 +132,4 @@ while t < TRIAL_COUNT:
 # End experiment
 win.close()
 tracker.setConnectionState(False)
-
-io.quit()
 core.quit()

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -11,7 +11,7 @@ from psychopy.iohub.util import hideWindow, showWindow
 
 # Eye tracker to use ('mouse', 'eyelink', 'gazepoint', or 'tobii')
 TRACKER = 'mouse'
-BACKGROUND_COLOR = [128, 0, 0]
+BACKGROUND_COLOR = [128, 128, 128]
 
 devices_config = dict()
 eyetracker_config = dict(name='tracker')

--- a/psychopy/demos/coder/iohub/eyetracking/validation.py
+++ b/psychopy/demos/coder/iohub/eyetracking/validation.py
@@ -248,6 +248,4 @@ while t < TRIAL_COUNT:
 # All Trials are done
 # End experiment
 tracker.setConnectionState(False)
-
-io.quit()
 core.quit()

--- a/psychopy/demos/coder/iohub/serial/customparser.py
+++ b/psychopy/demos/coder/iohub/serial/customparser.py
@@ -81,5 +81,4 @@ while not keyboard.getPresses():
 serial_device.enableEventReporting(False)
 
 # Close the window and quit the program.
-io.quit()
 core.quit()

--- a/psychopy/demos/coder/iohub/serial/pstbox.py
+++ b/psychopy/demos/coder/iohub/serial/pstbox.py
@@ -89,7 +89,6 @@ win.flip()
 while not pstbox.getEvents():
     if core.getTime() - start_time > 30:
         print('Timeout waiting for button event. Exiting...')
-        io.quit()
         core.quit()
 
 # Clear the screen.
@@ -164,5 +163,4 @@ print('---')
 pstbox.setLampState([0, 0, 0, 0, 0])
 
 # Close the window and quit the program.
-io.quit()
 core.quit()

--- a/psychopy/demos/coder/iohub/wintab/pen_demo.py
+++ b/psychopy/demos/coder/iohub/wintab/pen_demo.py
@@ -255,6 +255,7 @@ if __name__ == '__main__':
 
             myWin.flip()#redraw the buffer
 
-        io.quit()
         if testTimeOutClock.getTime() >= test_timeout_sec:
             print("Test Time Out Occurred.")
+
+        core.quit()

--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -18,7 +18,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                  innerFillColor='green', innerBorderColor='black', innerBorderWidth=2, innerRadius=0.0035,
                  fillColor='', borderColor="black", borderWidth=2, outerRadius=0.01,
                  colorSpace="rgb", units='from exp settings',
-                 targetLayout="NINE_POINTS", randomisePos=True,
+                 targetLayout="NINE_POINTS", randomisePos=True, textColor='white',
                  disabled=False
                  ):
         # Initialise base routine
@@ -30,6 +30,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
         self.order += [
             "targetLayout",
             "randomisePos",
+            "textColor"
         ]
 
         del self.params['stopVal']
@@ -45,7 +46,10 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                             valType='bool', inputType="bool", categ='Basic',
                                             hint=_translate("Should the order of target positions be randomised?"),
                                             label=_translate("Randomise Target Positions"))
-
+        self.params['textColor'] = Param(textColor,
+                                     valType='color', inputType="color", categ='Basic',
+                                     hint=_translate("Text foreground color"),
+                                     label=_translate("Text Color"))
         # Target Params
         self.order += [
             "targetStyle",
@@ -254,7 +258,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                 "eyetracker, %(name)sTarget,\n"
                 "units=%(units)s, colorSpace=%(colorSpace)s,\n"
                 "progressMode=%(progressMode)s, targetDur=%(targetDur)s, expandScale=%(expandScale)s,\n"
-                "targetLayout=%(targetLayout)s, randomisePos=%(randomisePos)s,\n"
+                "targetLayout=%(targetLayout)s, randomisePos=%(randomisePos)s, textColor=%(textColor)s,\n"
                 "movementAnimation=%(movementAnimation)s, targetDelay=%(targetDelay)s\n"
         )
         buff.writeIndentedLines(code % inits)

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -47,7 +47,7 @@ class EyetrackerCalibration:
                  units="height", colorSpace="rgb",
                  progressMode="time", targetDur=1.5, expandScale=1.5,
                  targetLayout="NINE_POINTS", randomisePos=True,
-                 movementAnimation=False, targetDelay=1.0
+                 movementAnimation=False, targetDelay=1.0, textColor='Auto'
                  ):
         # Store params
         self.win = win
@@ -56,6 +56,7 @@ class EyetrackerCalibration:
         self.progressMode = progressMode
         self.targetLayout = targetLayout
         self.randomisePos = randomisePos
+        self.textColor = textColor
         self.units = units or self.win.units
         self.colorSpace = colorSpace or self.win.colorSpace
         # Animation
@@ -79,6 +80,11 @@ class EyetrackerCalibration:
             target.units = self.units
         # Get self as dict
         asDict = {}
+
+        textColor = self.textColor
+        if isinstance(textColor, str) and textColor.lower() == 'auto':
+            textColor = None
+
         if tracker == 'eyetracker.hw.sr_research.eyelink.EyeTracker':
             # As EyeLink
             asDict = {
@@ -86,6 +92,7 @@ class EyetrackerCalibration:
                 'type': self.targetLayout,
                 'auto_pace': self.progressMode == "time",
                 'pacing_speed': self.targetDelay,
+                'text_color': textColor,
                 'screen_background_color': getattr(self.win._color, self.colorSpace)
             }
         elif tracker == 'eyetracker.hw.tobii.EyeTracker':
@@ -139,6 +146,7 @@ class EyetrackerCalibration:
                 'target_duration': self.targetDur,
                 'unit_type': self.units,
                 'color_type': self.colorSpace,
+                'text_color': textColor,
                 'screen_background_color': getattr(self.win._color, self.colorSpace),
             }
         elif tracker == 'eyetracker.hw.gazepoint.gp3.EyeTracker':
@@ -158,6 +166,7 @@ class EyetrackerCalibration:
                 'randomize': self.randomisePos,
                 'unit_type': self.units,
                 'color_type': self.colorSpace,
+                'text_color': textColor,
                 'screen_background_color': getattr(self.win._color, self.colorSpace),
             }
 
@@ -178,6 +187,7 @@ class EyetrackerCalibration:
                 'pacing_speed': self.targetDelay,
                 'unit_type': self.units,
                 'color_type': self.colorSpace,
+                'text_color': textColor,
                 'screen_background_color': getattr(self.win._color, self.colorSpace),
             }
         # Return

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -96,44 +96,11 @@ class EyetrackerCalibration:
                 'screen_background_color': getattr(self.win._color, self.colorSpace)
             }
         elif tracker == 'eyetracker.hw.tobii.EyeTracker':
-            # calibration:
-            #     type: NINE_POINTS
-            #     color_type:
-            #     unit_type:
-            #     randomize: True
-            #     auto_pace: True
-            #     target_duration: 1.5
-            #     target_delay: 0.75
-            #
-            #     # **pacing_speed is deprecated. Please use 'target_delay' instead.**
-            #     pacing_speed:
-            #     screen_background_color: [128, 128, 128]
-            #     target_attributes:
-            #         outer_diameter: 35.0
-            #         outer_stroke_width: 2.0
-            #         outer_fill_color: [128, 128, 128]
-            #         outer_line_color: [255, 255, 255]
-            #         inner_diameter: 7.0
-            #         inner_stroke_width: 1.0
-            #         inner_fill_color: [0, 0, 0]
-            #         inner_line_color: [0, 0, 0]
-            #         animate:
-            #             enable: True
-            #             expansion_ratio: 3.0
-            #             contract_only: True
-            #             # ** movement_velocity: Deprecated, please use target_delay instead. **
-            #             #
-            #             movement_velocity:
-            #             # ** expansion_speed: Deprecated, target_duration is now used. **
-            #             #
-            #             expansion_speed:
-
             # As Tobii
             targetAttrs = dict(target)
             targetAttrs['animate'] = {
                 'enable': self.movementAnimation,
                 'expansion_ratio': self.expandScale,
-                #'expansion_speed': self.targetDur,
                 'contract_only': self.expandScale == 1
             }
             asDict = {
@@ -141,7 +108,6 @@ class EyetrackerCalibration:
                 'type': self.targetLayout,
                 'randomize': self.randomisePos,
                 'auto_pace': self.progressMode == "time",
-                #'pacing_speed': self.targetDelay,
                 'target_delay': self.targetDelay,
                 'target_duration': self.targetDur,
                 'unit_type': self.units,

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
@@ -77,6 +77,10 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         # set the calibration, validation, etc, screens to.
         screen_background_color: [128,128,128]
 
+        # text_color specifies the text color to use during calibration.
+        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        text_color:
+
         # The associated target attribute properties can be supplied
         # for the given target_type.
         target_attributes:

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/default_eyetracker.yaml
@@ -77,8 +77,8 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
         # set the calibration, validation, etc, screens to.
         screen_background_color: [128,128,128]
 
-        # text_color specifies the text color to use during calibration.
-        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        # text_color specifies the foreground color of any text used during calibration.
+        # If empty, text_color is calculated automatically based on screen_background_color.
         text_color:
 
         # The associated target attribute properties can be supplied

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -210,10 +210,23 @@ class GazepointPsychopyCalibrationGraphics:
                                                    opacity=1.0, interpolate=False,
                                                    edges=64, units=unit_type, colorSpace=color_type)
 
+        tctype = color_type
+        tcolor = self.getCalibSetting(['text_color'])
+        if tcolor is None:
+            # If no calibration text color provided, base it on the window background color
+            from psychopy.iohub.util import complement
+            sbcolor = self.getCalibSetting(['screen_background_color'])
+            if sbcolor is None:
+                sbcolor = self.window.color
+            from psychopy.colors import Color
+            tcolor_obj = Color(sbcolor, color_type)
+            tcolor = complement(*tcolor_obj.rgb255)
+            tctype = 'rgb255'
+
         instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
         self.textLineStim = visual.TextStim(self.window, text=instuction_text,
                                             pos=(0, 0), height=36,
-                                            color=(0, 0, 0), colorSpace='rgb255',
+                                            color=tcolor, colorSpace=tctype,
                                             units='pix', wrapWidth=self.width * 0.9)
 
     def runCalibration(self):

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
@@ -64,6 +64,7 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
                 max_length: 1
         randomize: IOHUB_BOOL
         screen_background_color: IOHUB_COLOR
+        text_color: IOHUB_COLOR
         target_attributes:
             outer_diameter:
                 IOHUB_FLOAT:

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -48,8 +48,8 @@ eyetracker.hw.mouse.EyeTracker:
         # set the calibration screens to.
         screen_background_color: [128,128,128]
 
-        # text_color specifies the text color to use during calibration.
-        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        # text_color specifies the foreground color of any text used during calibration.
+        # If empty, text_color is calculated automatically based on screen_background_color.
         text_color:
 
         # The associated target attribute properties can be supplied

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -44,9 +44,13 @@ eyetracker.hw.mouse.EyeTracker:
         # Should the target positions be randomized?
         randomize: True
 
-        # screen_background_color specifies the r,g,b background color to
-        # set the calibration, validation, etc, screens to.
+        # screen_background_color specifies the background color to
+        # set the calibration screens to.
         screen_background_color: [128,128,128]
+
+        # text_color specifies the text color to use during calibration.
+        # If None / empty, text_color will be set to inverse of screen_background_color.
+        text_color:
 
         # The associated target attribute properties can be supplied
         # for the given target_type.

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/default_eyetracker.yaml
@@ -49,7 +49,7 @@ eyetracker.hw.mouse.EyeTracker:
         screen_background_color: [128,128,128]
 
         # text_color specifies the text color to use during calibration.
-        # If None / empty, text_color will be set to inverse of screen_background_color.
+        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
         text_color:
 
         # The associated target attribute properties can be supplied

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -13,7 +13,6 @@ from psychopy.iohub.errors import print2err
 
 currentTime = Computer.getTime
 
-
 class MouseGazePsychopyCalibrationGraphics:
     IOHUB_HEARTBEAT_INTERVAL = 0.050
     CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9)]
@@ -135,8 +134,7 @@ class MouseGazePsychopyCalibrationGraphics:
             self._ioKeyboard = kbDevice
             self._ioKeyboard._addEventListener(self, eventIDs)
         else:
-            print2err(
-                'Warning: GazePoint Cal GFX could not connect to Keyboard device for events.')
+            print2err('Warning: GazePoint Cal GFX could not connect to Keyboard device for events.')
 
     def _unregisterEventMonitors(self):
         if self._ioKeyboard:
@@ -207,10 +205,23 @@ class MouseGazePsychopyCalibrationGraphics:
                                                    opacity=1.0, interpolate=False,
                                                    edges=64, units=unit_type, colorSpace=color_type)
 
+        tctype = color_type
+        tcolor = self.getCalibSetting(['text_color'])
+        if tcolor is None:
+            # If no calibration text color provided, base it on the window background color
+            from psychopy.iohub.util import complement
+            sbcolor = self.getCalibSetting(['screen_background_color'])
+            if sbcolor is None:
+                sbcolor = self.window.color
+            from psychopy.colors import Color
+            tcolor_obj = Color(sbcolor, color_type)
+            tcolor = complement(*tcolor_obj.rgb255)
+            tctype = 'rgb255'
+
         instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
         self.textLineStim = visual.TextStim(self.window, text=instuction_text,
                                             pos=(0, 0), height=36,
-                                            color=(0, 0, 0), colorSpace='rgb255',
+                                            color=tcolor, colorSpace=tctype,
                                             units='pix', wrapWidth=self.width * 0.9)
 
     def runCalibration(self):

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
@@ -68,6 +68,7 @@ eyetracker.hw.mouse.EyeTracker:
         auto_pace: IOHUB_BOOL
         randomize: IOHUB_BOOL
         screen_background_color: IOHUB_COLOR
+        text_color: IOHUB_COLOR
         target_attributes:
             outer_diameter:
                 IOHUB_FLOAT:

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
@@ -108,7 +108,11 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
         # screen_background_color: Specifies the background color to
         #   set the calibration, validation, etc, screens to.
         screen_background_color: [128,128,128]
-        
+
+        # text_color specifies the text color to use during calibration.
+        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        text_color:
+
         # target_type: Defines what form of calibration graphic should be used
         #   during calibration, validation, etc. modes. sr_research.eyelink.EyeTracker
         #   supports the CIRCLE_TARGET type.

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/default_eyetracker.yaml
@@ -109,8 +109,8 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
         #   set the calibration, validation, etc, screens to.
         screen_background_color: [128,128,128]
 
-        # text_color specifies the text color to use during calibration.
-        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        # text_color specifies the foreground color of any text used during calibration.
+        # If empty, text_color is calculated automatically based on screen_background_color.
         text_color:
 
         # target_type: Defines what form of calibration graphic should be used

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
@@ -88,23 +88,17 @@ class BlankScreen():
 
 # Intro Screen
 class TextLine():
-
-    def __init__(self, psychopy_win):
-        self.display_size = psychopy_win.size
-        win = psychopy_win
-
+    def __init__(self, parent):
+        self.display_size = parent.window.size
+        win = parent.window
+        tcolor, tctype = parent.getTextColorAndType()
         self.textLine = visual.TextStim(
             win,
             text='***********************',
-            pos=(
-                0,
-                0),
+            pos=(0, 0),
             height=30,
-            color=(
-                0,
-                0,
-                0),
-            colorSpace='rgb255',
+            color=tcolor,
+            colorSpace=tctype,
             opacity=1.0,
             contrast=1.0,
             units='pix',
@@ -122,9 +116,9 @@ class TextLine():
 
 # Intro Screen
 class IntroScreen():
-    def __init__(self, psychopy_win):
-        self.display_size = psychopy_win.size
-        window = psychopy_win
+    def __init__(self, parent):
+        window = parent.window
+        self.display_size = window.size
         font_height = 24
         space_per_lines = font_height * 2.5
         if window.useRetina:
@@ -133,19 +127,16 @@ class IntroScreen():
             topline_y = window.size[1] / 2 - font_height * 2
         wrap_width = window.size[1] * .8
 
+        tcolor, tctype = parent.getTextColorAndType()
+
         self.introlines = []
 
         self.introlines.append(visual.TextStim(window,
                                                text='>>>> Eyelink System Setup:  Keyboard Actions <<<<',
-                                               pos=(
-                                                   0,
-                                                   topline_y),
+                                               pos=(0, topline_y),
                                                height=font_height * 1.2,
-                                               color=(
-                                                   0,
-                                                   0,
-                                                   0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -163,13 +154,10 @@ class IntroScreen():
         topline_y = topline_y - space_per_lines / 3
         self.introlines.append(visual.TextStim(window,
                                                text='* ENTER: Begin Camera Setup Mode',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -186,10 +174,8 @@ class IntroScreen():
                                                pos=(left_margin,
                                                     topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -203,13 +189,10 @@ class IntroScreen():
 
         self.introlines.append(visual.TextStim(window,
                                                text='* V: Start Validation Procedure',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -223,13 +206,10 @@ class IntroScreen():
 
         self.introlines.append(visual.TextStim(window,
                                                text='* ESCAPE: Exit EyeLink System Setup',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -244,13 +224,10 @@ class IntroScreen():
         topline_y = topline_y - space_per_lines / 3
         self.introlines.append(visual.TextStim(window,
                                                text='------ Camera Setup Mode Specific Actions ------',
-                                               pos=(0,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(0, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height * 1.2,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -261,15 +238,11 @@ class IntroScreen():
                                                wrapWidth=wrap_width))
 
         topline_y = topline_y - space_per_lines / 3
-        self.introlines.append(visual.TextStim(window,
-                                               text='* Left / Right Arrow: Switch Between Camera Views',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+        self.introlines.append(visual.TextStim(window, text='* Left / Right Arrow: Switch Between Camera Views',
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -283,13 +256,10 @@ class IntroScreen():
 
         self.introlines.append(visual.TextStim(window,
                                                text='* A: Auto-Threshold Image',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -303,13 +273,10 @@ class IntroScreen():
 
         self.introlines.append(visual.TextStim(window,
                                                text='* Up / Down Arrow: Manually Adjust Pupil Threshold',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -323,13 +290,10 @@ class IntroScreen():
 
         self.introlines.append(visual.TextStim(window,
                                                text='* + or -: Manually Adjust CR Threshold.',
-                                               pos=(left_margin,
-                                                    topline_y - space_per_lines * (len(self.introlines))),
+                                               pos=(left_margin, topline_y - space_per_lines * (len(self.introlines))),
                                                height=font_height,
-                                               color=(0,
-                                                      0,
-                                                      0),
-                                               colorSpace='rgb255',
+                                               color=tcolor,
+                                               colorSpace=tctype,
                                                opacity=1.0,
                                                contrast=1.0,
                                                units='pix',
@@ -415,8 +379,8 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
                                     )
 
         self.blankdisplay = BlankScreen(self.window, self.getCalibSetting(['screen_background_color']))
-        self.textmsg = TextLine(self.window)
-        self.introscreen = IntroScreen(self.window)
+        self.textmsg = TextLine(self)
+        self.introscreen = IntroScreen(self)
         self.fixationpoint = FixationTarget(self)
         self.imagetitlestim = None
         self.eye_image = None
@@ -435,6 +399,23 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
             for s in setting[:-1]:
                 calibration_args = calibration_args.get(s)
             return calibration_args.get(setting[-1])
+
+    def getTextColorAndType(self):
+        color_type = self.getCalibSetting('color_type')
+        if color_type is None:
+            color_type = self.window.colorSpace
+        tcolor = self.getCalibSetting(['text_color'])
+        if tcolor is None:
+            # If no calibration text color provided, base it on the window background color
+            from psychopy.iohub.util import complement
+            sbcolor = self.getCalibSetting(['screen_background_color'])
+            if sbcolor is None:
+                sbcolor = self.window.color
+            from psychopy.colors import Color
+            tcolor_obj = Color(sbcolor, color_type)
+            tcolor = complement(*tcolor_obj.rgb255)
+            color_type = 'rgb255'
+        return tcolor, color_type
 
     def clearAllEventBuffers(self):
         pylink.flushGetkeyQueue()
@@ -606,18 +587,14 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
         """Display the current camera, Pupil, and CR thresholds above the
         camera image when in Camera Setup Mode."""
         if self.imagetitlestim is None:
+            tcolor, tctype = self.getTextColorAndType()
             self.imagetitlestim = visual.TextStim(
                 self.window,
                 text=text,
-                pos=(
-                    0,
-                    self.window.size[1] / 2 - 15),
+                pos=(0, self.window.size[1] / 2 - 15),
                 height=28,
-                color=(
-                    0,
-                    0,
-                    0),
-                colorSpace='rgb255',
+                color=tcolor,
+                colorSpace=tctype,
                 opacity=1.0,
                 contrast=1.0,
                 units='pix',

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
@@ -49,6 +49,7 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
                 min: 0.5
                 max: 2.5
         screen_background_color: IOHUB_COLOR
+        text_color: IOHUB_COLOR
         target_type: [CIRCLE_TARGET,]
         target_attributes:
             outer_diameter:

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
@@ -76,7 +76,11 @@ eyetracker.hw.tobii.EyeTracker:
         # should be a value between 0 and 255. 0 == black, 255 == white.
         #
         screen_background_color: [128,128,128]
-        
+
+        # text_color specifies the text color to use during calibration.
+        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        text_color:
+
         # Target type defines what form of calibration graphic should be used
         # during calibration, validation, etc. modes.
         # Currently the Tobii implementation supports the following

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/default_eyetracker.yaml
@@ -77,8 +77,8 @@ eyetracker.hw.tobii.EyeTracker:
         #
         screen_background_color: [128,128,128]
 
-        # text_color specifies the text color to use during calibration.
-        # If None / empty, text_color will be set to a complimentary color of screen_background_color.
+        # text_color specifies the foreground color of any text used during calibration.
+        # If empty, text_color is calculated automatically based on screen_background_color.
         text_color:
 
         # Target type defines what form of calibration graphic should be used

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
@@ -63,6 +63,7 @@ eyetracker.hw.tobii.EyeTracker:
                 min: 0.5
                 max: 2.5
         screen_background_color: IOHUB_COLOR
+        text_color: IOHUB_COLOR
         target_type: [CIRCLE_TARGET,]
         target_attributes:
             outer_diameter:

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
@@ -21,7 +21,6 @@ class TobiiPsychopyCalibrationGraphics:
     CALIBRATION_POINT_LIST = [(0.5, 0.5), (0.1, 0.1), (0.9, 0.1), (0.9, 0.9), (0.1, 0.9), (0.5, 0.5)]
 
     TEXT_POS = [0, 0]
-    TEXT_COLOR = [0, 0, 0]
     TEXT_HEIGHT = 36
     _keyboard_key_index = EventConstants.getClass(
         EventConstants.KEYBOARD_RELEASE).CLASS_ATTRIBUTE_NAMES.index('key')
@@ -238,13 +237,26 @@ class TobiiPsychopyCalibrationGraphics:
             edges=64,
             units=unit_type, colorSpace=color_type)
 
+        tctype = color_type
+        tcolor = self.getCalibSetting(['text_color'])
+        if tcolor is None:
+            # If no calibration text color provided, base it on the window background color
+            from psychopy.iohub.util import complement
+            sbcolor = self.getCalibSetting(['screen_background_color'])
+            if sbcolor is None:
+                sbcolor = self.window.color
+            from psychopy.colors import Color
+            tcolor_obj = Color(sbcolor, color_type)
+            tcolor = complement(*tcolor_obj.rgb255)
+            tctype = 'rgb255'
+
         instuction_text = 'Press SPACE to Start Calibration; ESCAPE to Exit.'
         self.textLineStim = visual.TextStim(self.window,
                                             text=instuction_text,
                                             pos=self.TEXT_POS,
                                             height=self.TEXT_HEIGHT,
-                                            color=self.TEXT_COLOR,
-                                            colorSpace='rgb255',
+                                            color=tcolor,
+                                            colorSpace=tctype,
                                             units='pix',
                                             wrapWidth=self.width * 0.9)
 

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -367,6 +367,26 @@ getCurrentDateTime = datetime.datetime.now
 getCurrentDateTimeString = lambda: getCurrentDateTime().strftime("%Y-%m-%d %H:%M")
 
 
+# rgb255 color utils
+def hilo(a, b, c):
+    if c < b:
+        b, c = c, b
+    if b < a:
+        a, b = b, a
+    if c < b:
+        b, c = c, b
+    return a + c
+
+
+def complement(r, g, b):
+    if r == g == b:
+        # handle mono color
+        if r >= 128:
+            return 0, 0, 0
+        return 255, 255, 255
+    k = hilo(r, g, b)
+    return tuple(k - u for u in (r, g, b))
+
 class NumPyRingBuffer():
     """NumPyRingBuffer is a circular buffer implemented using a one dimensional
     numpy array on the backend. The algorithm used to implement the ring buffer


### PR DESCRIPTION
RF: Remove io.quit() from iohub demos that use core.quit()

ENH: Adds `text_color` setting to iohub eye tracker calibration settings. If none is specified (the default), `text_color` is a comlementary color of the window background color.  `text_color` is supported by MouseGaze, EyeLink, GazePoint, and Tobii PsychoPy based calibrations.  
ENH: Add 'Text Color' param to Builder ETCalibration routine. Depends on PR #4232 for Builder demo to work with colors that are not named (not strings).

Fixes #4262