### PR TITLE
BF: setting startValue for Slider should only change markerPos not rating

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -156,8 +156,7 @@ def logAttrib(obj, log, attrib, value=None):
 
         # for numpy arrays bigger than 2x2 repr is slow (up to 1ms) so just
         # say it was an array
-        if isinstance(value, numpy.ndarray) \
-                and (value.ndim > 2 or len(value) > 2):
+        if isinstance(value, numpy.ndarray) and (value.ndim > 2 or value.size > 2):
             valStr = repr(type(value))
         else:
             valStr = value.__repr__()

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -170,7 +170,7 @@ class Slider(MinimalStim, ColorMixin):
         self.readOnly = readOnly
 
         self.categorical = False  # will become True if no ticks set only labels
-        self.startValue = self.rating =  self.markerPos = startValue
+        self.startValue = self.markerPos = startValue
         self.rt = None
         self.history = []
         self.marker = None

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -456,7 +456,12 @@ class Slider(MinimalStim, ColorMixin):
             rating = min(rating, self.ticks[-1])
         return rating
 
-    @attributeSetter
+    @property
+    def rating(self):
+        if hasattr(self, "_rating"):
+            return self._rating
+
+    @rating.setter
     def rating(self, rating):
         """The most recent rating from the participant or None.
         Note that the position of the marker can be set using current without
@@ -465,7 +470,7 @@ class Slider(MinimalStim, ColorMixin):
         self.markerPos = rating
         if self.categorical and (rating is not None):
             rating = self.labels[int(round(rating))]
-        self.__dict__['rating'] = rating
+        self._rating = rating
 
     @property
     def value(self):


### PR DESCRIPTION
Slider.rating should only be set when the participant *has made a rating*
It indicates a response. MarkerPos indicates the current location of the
marker before a rating has occurred