### PR TITLE
WIP: iohub and event.getKeys should support same key mappings

### DIFF
--- a/psychopy/demos/coder/iohub/keyboard.py
+++ b/psychopy/demos/coder/iohub/keyboard.py
@@ -10,9 +10,12 @@ from __future__ import absolute_import, division, print_function
 
 from builtins import str
 from psychopy import core, visual, event
+from psychopy.hardware import keyboard as ptb_keyboard
 from psychopy.iohub import launchHubServer
 
 WINDOW_SIZE = 1024, 768
+
+ptb_keyboard = ptb_keyboard.Keyboard()
 
 # Start iohub process. The iohub process can be accessed using `io`.
 io = launchHubServer()
@@ -81,8 +84,13 @@ event_type_label = visual.TextStim(win, units=unit_type,
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 psychopy_key_label = visual.TextStim(win, units=unit_type,
-    text=u'event.getKeys():',
+    text=u'vs. event.getKeys():',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 8],
+    color='black', alignText='left', anchorHoriz='left',
+    height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
+ptb_key_label = visual.TextStim(win, units=unit_type,
+    text=u'vs. keyboard.getKeys():',
+    pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 9],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 
@@ -115,14 +123,18 @@ psychopy_key_stim = visual.TextStim(win, units=unit_type, text=u'',
     pos=[VALUE_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 8],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT,  wrapWidth=dw * 2)
+ptb_key_stim = visual.TextStim(win, units=unit_type, text=u'',
+    pos=[VALUE_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 9],
+    color='black', alignText='left', anchorHoriz='left',
+    height=TEXT_STIM_HEIGHT,  wrapWidth=dw * 2)
 
 # Having all the stim to update / draw in a list makes drawing code
 # more compact and reusable
 STIM_LIST = [title_label, title2_label, key_text_label, char_label,
     modifiers_label, keypress_duration_label, all_pressed__label,
-    event_type_label, psychopy_key_label,
+    event_type_label, psychopy_key_label, ptb_key_label,
     key_text_stim, char_stim, modifiers_stim, keypress_duration_stim,
-    all_pressed_stim, event_type_stim, psychopy_key_stim]
+    all_pressed_stim, event_type_stim, psychopy_key_stim, ptb_key_stim]
 
 # Clear all events from the global and device level ioHub Event Buffers.
 
@@ -155,6 +167,10 @@ while not 'q' in events and flip_time - demo_timeout_start < 15.0:
             psychopy_key_stim.text = psychopy_keys[0]
         elif kbe.type == "KEYBOARD_PRESS":
             psychopy_key_stim.text = ''
+
+        ptb_keys = ptb_keyboard.getKeys(waitRelease=False)
+        if ptb_keys:
+            ptb_key_stim.text = ptb_keys[0].name
 
         all_pressed_stim.text = str(list(keyboard.state.keys()))
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -251,8 +251,6 @@ class Keyboard:
                     keys.append(thisKey)
         elif Keyboard.backend == 'iohub':
             watchForKeys = keyList
-            if watchForKeys:
-                watchForKeys = [' ' if k == 'space' else k for k in watchForKeys]
             if waitRelease:
                 key_events = Keyboard._iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
             else:
@@ -260,8 +258,6 @@ class Keyboard:
 
             for k in key_events:
                 kname = k.key
-                if kname == ' ':
-                    kname = 'space'
 
                 if waitRelease:
                     tDown = k.time-k.duration

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -40,7 +40,7 @@ class ioHubKeyboardDevice(Device):
     originate from a single keyboard device in the experiment.
 
     """
-    use_psychopy_keymap = 'psychopy'
+    use_psychopy_keymap = False
     EVENT_CLASS_NAMES = [
         'KeyboardInputEvent',
         'KeyboardPressEvent',

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -13,6 +13,22 @@ from .. import Device, Computer
 
 getTime = Computer.getTime
 
+psychopy_key_mappings = {'`': 'quoteleft',
+                         '[': 'bracketleft',
+                         ']': 'bracketright',
+                         '\\': 'backslash',
+                         '/': 'slash',
+                         ';': 'semicolon',
+                         "'": 'apostrophe',
+                         ',': 'comma',
+                         '.': 'period',
+                         '-': 'minus',
+                         '=': 'equal',
+                         '+': 'num_add',
+                         '*': 'num_multiply',
+                         ' ': 'space'
+                         }
+
 
 class ioHubKeyboardDevice(Device):
     """The Keyboard device is used to receive events from a standard USB or PS2
@@ -24,7 +40,7 @@ class ioHubKeyboardDevice(Device):
     originate from a single keyboard device in the experiment.
 
     """
-
+    use_psychopy_keymap = 'psychopy'
     EVENT_CLASS_NAMES = [
         'KeyboardInputEvent',
         'KeyboardPressEvent',
@@ -49,6 +65,8 @@ class ioHubKeyboardDevice(Device):
         self._log_events_file = None
 
         Device.__init__(self, *args, **kwargs)
+
+        ioHubKeyboardDevice.use_psychopy_keymap = self.getConfiguration().get('use_keymap') == 'psychopy'
 
     @classmethod
     def getModifierState(cls):

--- a/psychopy/iohub/devices/keyboard/darwin.py
+++ b/psychopy/iohub/devices/keyboard/darwin.py
@@ -5,7 +5,7 @@
 from copy import copy
 import Quartz as Qz
 from AppKit import NSEvent  # NSKeyUp, NSSystemDefined, NSEvent
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from ...constants import KeyboardConstants, DeviceConstants, EventConstants
 from .. import Computer, Device
 
@@ -26,7 +26,24 @@ import unicodedata
 
 from .darwinkey import code2label
 
-#print2err("code2label: ",code2label)
+psychopy_numlock_key_mappings = dict()
+psychopy_numlock_key_mappings['1'] = 'num_1'
+psychopy_numlock_key_mappings['2'] = 'num_2'
+psychopy_numlock_key_mappings['3'] = 'num_3'
+psychopy_numlock_key_mappings['4'] = 'num_4'
+psychopy_numlock_key_mappings['5'] = 'num_5'
+psychopy_numlock_key_mappings['6'] = 'num_6'
+psychopy_numlock_key_mappings['7'] = 'num_7'
+psychopy_numlock_key_mappings['8'] = 'num_8'
+psychopy_numlock_key_mappings['9'] = 'num_9'
+psychopy_numlock_key_mappings['0'] = 'num_0'
+psychopy_numlock_key_mappings['/'] = 'num_divide'
+psychopy_numlock_key_mappings['*'] = 'num_multiple'
+psychopy_numlock_key_mappings['-'] = 'num_minus'
+psychopy_numlock_key_mappings['+'] = 'num_add'
+psychopy_numlock_key_mappings['='] = 'num_equal'
+psychopy_numlock_key_mappings['.'] = 'num_decimal'
+
 carbon_path = ctypes.util.find_library('Carbon')
 carbon = ctypes.cdll.LoadLibrary(carbon_path)
 
@@ -308,12 +325,19 @@ class Keyboard(ioHubKeyboardDevice):
                     elif key_value == 'return':
                         char_value = '\n'
 
-                    is_auto_repeat = Qz.CGEventGetIntegerValueField(
-                        event, Qz.kCGKeyboardEventAutorepeat)
+                    if Keyboard.use_psychopy_keymap:
+                        if keyFromNumpad(key_mods) and key_value in psychopy_numlock_key_mappings.keys():
+                            key_value = psychopy_numlock_key_mappings[key_value]
+                        elif key_value in psychopy_key_mappings.keys():
+                            key_value = psychopy_key_mappings[key_value]
+
+
+
+                    is_auto_repeat = Qz.CGEventGetIntegerValueField(event, Qz.kCGKeyboardEventAutorepeat)
 
                     # TODO: CHeck WINDOW BOUNDS
 
-                    # report_system_wide_events=self.getConfiguration().get('report_system_wide_events',True)
+                    # report_system_wide_events=s elf.getConfiguration().get('report_system_wide_events',True)
                     # Can not seem to figure out how to get window handle id from evt to match with pyget in darwin, so
                     # Comparing event target process ID to the psychopy windows process ID,
                     # yglet_window_hnds=self._iohub_server._pyglet_window_hnds

--- a/psychopy/iohub/devices/keyboard/default_keyboard.yaml
+++ b/psychopy/iohub/devices/keyboard/default_keyboard.yaml
@@ -39,6 +39,11 @@ Keyboard:
     #       is the intended event target will be reported.
     report_system_wide_events: True
 
+    # use_keymap: What key map set / heuristics should be used? Options:
+    #   psychopy: Use key map that is the same as used by event.getKeys()
+    #   original: Use original iohub key map
+    use_keymap: psychopy
+
     # save_events: *If* the ioHubDataStore is enabled for the experiment, then
     #   indicate if events for this device should be saved to the
     #   data_collection/keyboard event group in the hdf5 event file.

--- a/psychopy/iohub/devices/keyboard/linux2.py
+++ b/psychopy/iohub/devices/keyboard/linux2.py
@@ -3,13 +3,27 @@
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from .. import Computer, Device
 from ...constants import EventConstants
-from ...errors import printExceptionDetailsToStdErr
+from ...errors import printExceptionDetailsToStdErr, print2err
 
 getTime = Computer.getTime
 
+NUMLOCK_MODIFIER = 8192
+
+psychopy_numlock_key_mappings = dict()
+psychopy_numlock_key_mappings['num_end'] = 'num_1'
+psychopy_numlock_key_mappings['num_down'] = 'num_2'
+psychopy_numlock_key_mappings['num_page_down'] = 'num_3'
+psychopy_numlock_key_mappings['num_left'] = 'num_4'
+psychopy_numlock_key_mappings['num_begin'] = 'num_5'
+psychopy_numlock_key_mappings['num_right'] = 'num_6'
+psychopy_numlock_key_mappings['num_home'] = 'num_7'
+psychopy_numlock_key_mappings['num_up'] = 'num_8'
+psychopy_numlock_key_mappings['num_page_up'] = 'num_9'
+psychopy_numlock_key_mappings['num_insert'] = 'num_0'
+psychopy_numlock_key_mappings['num_delete'] = 'num_decimal'
 
 class Keyboard(ioHubKeyboardDevice):
     event_id_index = None
@@ -37,7 +51,23 @@ class Keyboard(ioHubKeyboardDevice):
             self._last_callback_time = getTime()
             if self.isReportingEvents():
                 event_array = event[0]
+                
+                key = event_array[Keyboard.key_index]
+                if isinstance(key, bytes):
+                    event_array[Keyboard.key_index] = key = str(key, 'utf-8')                
+                
+                if Keyboard.use_psychopy_keymap:
+                    if key in psychopy_key_mappings.keys():
+                        key = event_array[Keyboard.key_index] = psychopy_key_mappings[key]
+                    elif key == 'num_next':
+                        key = event_array[Keyboard.key_index] = 'num_page_down'
+                    elif key == 'num_prior':
+                        key = event_array[Keyboard.key_index] = 'num_page_up'
 
+                    if (event_array[Keyboard.event_modifiers_index]&NUMLOCK_MODIFIER) > 0:
+                        if key in psychopy_numlock_key_mappings:
+                            key = event_array[Keyboard.key_index] = psychopy_numlock_key_mappings[key]  
+                            
                 # Check if key event window id is in list of psychopy
                 # windows and what report_system_wide_events value is
                 report_system_wide_events = self.getConfiguration().get(

--- a/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
@@ -20,6 +20,11 @@
             valid_values: [ KeyboardPressEvent, KeyboardReleaseEvent]
             min_length: 0
             max_length: 3
+    use_keymap:
+        IOHUB_LIST:
+            valid_values: [psychopy, original]
+            min_length: 0
+            max_length: 1
     device_number:
         IOHUB_INT:
             min: 0

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -225,6 +225,12 @@ class Keyboard(ioHubKeyboardDevice):
         if Keyboard.use_psychopy_keymap and key in psychopy_key_mappings.keys():
             key = psychopy_key_mappings[key]
 
+            # win32 specific handling of keypad / and - keys
+            if event.Key == 'Subtract':
+                key = 'num_subtract'
+            elif event.Key == 'Divide':
+                key = 'num_divide'
+
         return key, char
 
     def _evt2json(self, event):
@@ -309,6 +315,7 @@ class Keyboard(ioHubKeyboardDevice):
                 key = modKeyName
                 char = ''
             else:
+                print2err(event.Key," ",event.Ascii," ", event.KeyID," ", event.ScanCode," ", event.flags)
                 key, char = self._getKeyCharValue(event)
 
             kb_event = [0,

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import ctypes
 from unicodedata import category as ucategory
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from ...constants import KeyboardConstants, EventConstants
 from .. import Computer, Device
 from ...errors import print2err, printExceptionDetailsToStdErr
@@ -42,21 +42,6 @@ numpad_key_value_mappings = dict(Numpad0='insert',
                                  Decimal='delete'
                                  )
 
-psychopy_key_mappings = {'`': 'quoteleft',
-                         '[': 'bracketleft',
-                         ']': 'bracketright',
-                         '\\': 'backslash',
-                         '/': 'slash',
-                         ';': 'semicolon',
-                         "'": 'apostrophe',
-                         ',': 'comma',
-                         '.': 'period',
-                         '-': 'minus',
-                         '=': 'equal',
-                         '+': 'num_add',
-                         '*': 'num_multiply',
-                         ' ': 'space'
-                         }
 
 def updateToPsychopyKeymap():
     global numpad_key_value_mappings
@@ -74,7 +59,6 @@ def updateToPsychopyKeymap():
                                      )
 
 class Keyboard(ioHubKeyboardDevice):
-    use_psychopy_keymap = 'psychopy'
     _win32_modifier_mapping = {
         win32_vk.VK_LCONTROL: 'lctrl',
         win32_vk.VK_RCONTROL: 'rctrl',
@@ -97,7 +81,6 @@ class Keyboard(ioHubKeyboardDevice):
         self._keyboard_state = (ctypes.c_ubyte * 256)()
         self._unichar = (ctypes.c_wchar * 8)()
 
-        Keyboard.use_psychopy_keymap = self.getConfiguration().get('use_keymap') == 'psychopy'
         if self.use_psychopy_keymap:
             updateToPsychopyKeymap()
 

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -29,19 +29,33 @@ except Exception:
 
 # Map key value when numlock is ON
 # to value when numlock is OFF.
-numpad_key_value_mappings = dict(Numpad0='num_0',
-                                 Numpad1='num_1',
-                                 Numpad2='num_2',
-                                 Numpad3='num_3',
-                                 Numpad4='num_4',
-                                 Numpad5='num_5',
-                                 Numpad6='num_6',
-                                 Numpad7='num_7',
-                                 Numpad8='num_8',
-                                 Numpad9='num_9',
-                                 Decimal='num_decimal'
+numpad_key_value_mappings = dict(Numpad0='insert',
+                                 Numpad1='end',
+                                 Numpad2='down',
+                                 Numpad3='pagedown',
+                                 Numpad4='left',
+                                 Numpad5=' ',
+                                 Numpad6='right',
+                                 Numpad7='home',
+                                 Numpad8='up',
+                                 Numpad9='pageup',
+                                 Decimal='delete'
                                  )
 
+def updateToPsychopyKeymap():
+    global numpad_key_value_mappings
+    numpad_key_value_mappings = dict(Numpad0='num_0',
+                                     Numpad1='num_1',
+                                     Numpad2='num_2',
+                                     Numpad3='num_3',
+                                     Numpad4='num_4',
+                                     Numpad5='num_5',
+                                     Numpad6='num_6',
+                                     Numpad7='num_7',
+                                     Numpad8='num_8',
+                                     Numpad9='num_9',
+                                     Decimal='num_decimal'
+                                     )
 
 class Keyboard(ioHubKeyboardDevice):
     _win32_modifier_mapping = {
@@ -65,6 +79,9 @@ class Keyboard(ioHubKeyboardDevice):
         self._user32 = ctypes.windll.user32
         self._keyboard_state = (ctypes.c_ubyte * 256)()
         self._unichar = (ctypes.c_wchar * 8)()
+
+        if self.getConfiguration().get('use_keymap') == 'psychopy':
+            updateToPsychopyKeymap()
 
         self.resetKeyAndModState()
 

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -29,17 +29,17 @@ except Exception:
 
 # Map key value when numlock is ON
 # to value when numlock is OFF.
-numpad_key_value_mappings = dict(Numpad0='insert',
-                                 Numpad1='end',
-                                 Numpad2='down',
-                                 Numpad3='pagedown',
-                                 Numpad4='left',
-                                 Numpad5=' ',
-                                 Numpad6='right',
-                                 Numpad7='home',
-                                 Numpad8='up',
-                                 Numpad9='pageup',
-                                 Decimal='delete'
+numpad_key_value_mappings = dict(Numpad0='num_0',
+                                 Numpad1='num_1',
+                                 Numpad2='num_2',
+                                 Numpad3='num_3',
+                                 Numpad4='num_4',
+                                 Numpad5='num_5',
+                                 Numpad6='num_6',
+                                 Numpad7='num_7',
+                                 Numpad8='num_8',
+                                 Numpad9='num_9',
+                                 Decimal='num_decimal'
                                  )
 
 

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -228,6 +228,9 @@ class Keyboard(ioHubKeyboardDevice):
 
         if isinstance(key, bytes):
             key = str(key, 'utf-8')
+        if isinstance(char, bytes):
+            char = str(char, 'utf-8')
+
         key = key.lower()
 
         # misc. char value cleanup.

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -315,7 +315,6 @@ class Keyboard(ioHubKeyboardDevice):
                 key = modKeyName
                 char = ''
             else:
-                print2err(event.Key," ",event.Ascii," ", event.KeyID," ", event.ScanCode," ", event.flags)
                 key, char = self._getKeyCharValue(event)
 
             kb_event = [0,


### PR DESCRIPTION
ENH: Add 'use_mapping' setting to iohub keyboard device. 'original' and 'psychopy' are supported, with psychopy being the default.
ENH: When 'use_mapping'=='psychopy' match iohub and event.getKeys() key mappings. Mainly numpad and some punctuation keys have been updated. For example, space key is ' ' in original mapping and 'space' in psychopy mapping.

NOTE: This means by default old iohub experiments must be updated to expect new key mappings or keyboard device must be set to use original mappings when moving to this release.