### PR TITLE
BF: Moved eyelink start / stop record to separate thread

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -471,6 +471,7 @@ class EyeTracker(EyeTrackerDevice):
                 starter_thread.start()
                 while starter_thread.is_alive():
                     gevent.sleep(0.001)
+                starter_thread.join()
                 EyeTrackerDevice.enableEventReporting(self, True)
                 return self.isRecordingEnabled()
 
@@ -480,6 +481,7 @@ class EyeTracker(EyeTrackerDevice):
                 stopper_thread.start()
                 while stopper_thread.is_alive() or Computer.getTime()-stime < 0.5:
                     gevent.sleep(0.001)
+                stopper_thread.join()
                 EyeTrackerDevice.enableEventReporting(self, False)
 
                 self._latest_sample = None

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyetracker.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 import os
+import gevent
+import threading
 import pylink
 
 try:
@@ -21,6 +23,16 @@ try:
 except Exception:
     pass
 
+def start_eyelink(eyelink):
+    error = eyelink.startRecording(1, 1, 1, 1)
+    if error:
+        print2err('Start Recording error : ', error)
+
+    if not eyelink.waitForBlockStart(100, 1, 0):
+        print2err('EYETRACKER_START_RECORD_EXCEPTION ')
+
+def stop_eyelink(eyelink):
+    eyelink.stopRecording()
 
 class EyeTracker(EyeTrackerDevice):
     """
@@ -455,18 +467,19 @@ class EyeTracker(EyeTrackerDevice):
                 printExceptionDetailsToStdErr()
 
             if recording is True and not self.isRecordingEnabled():
-                error = self._eyelink.startRecording(1, 1, 1, 1)
-                if error:
-                    print2err('Start Recording error : ', error)
-
-                if not self._eyelink.waitForBlockStart(100, 1, 0):
-                    print2err('EYETRACKER_START_RECORD_EXCEPTION ')
-
+                starter_thread = threading.Thread(target=start_eyelink, args=(EyeTracker._eyelink,))
+                starter_thread.start()
+                while starter_thread.is_alive():
+                    gevent.sleep(0.001)
                 EyeTrackerDevice.enableEventReporting(self, True)
                 return self.isRecordingEnabled()
 
             elif recording is False and self.isRecordingEnabled():
-                self._eyelink.stopRecording()
+                stopper_thread = threading.Thread(target=stop_eyelink, args=(EyeTracker._eyelink,))
+                stime = Computer.getTime()
+                stopper_thread.start()
+                while stopper_thread.is_alive() or Computer.getTime()-stime < 0.5:
+                    gevent.sleep(0.001)
                 EyeTrackerDevice.enableEventReporting(self, False)
 
                 self._latest_sample = None

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -7,7 +7,7 @@ try:
     import pyHook
 except ImportError:
     import pyWinhook as pyHook
-
+import win32api
 import ctypes
 from unicodedata import category as ucategory
 from . import ioHubKeyboardDevice
@@ -311,3 +311,12 @@ class Keyboard(ioHubKeyboardDevice):
             return kb_event
         except Exception:
             printExceptionDetailsToStdErr()
+
+    def _syncPressedKeyState(self):
+        remove_keys = []
+        for kid in self._key_states.keys():
+            if win32api.GetAsyncKeyState(kid) == 0:
+                # Key is no longer pressed, remove it from pressed key dict
+                remove_keys.append(kid)
+        for kid in remove_keys:
+            del self._key_states[kid]


### PR DESCRIPTION
When eyelink start / stop record is called, it blocks for 0.5 seconds. This was causing iohub to miss any kb events that occurred during the 0.5 seconds because it is too long of a time period to service the callback generated by pyWinHook.

This PR makes the blocking call to eyelink start / stop record run in a seperate thread on iohub so other events can be serviced.