### PR TITLE
WIP: iohub and event.getKeys should support same key mappings

### DIFF
--- a/psychopy/demos/coder/iohub/delaytest.py
+++ b/psychopy/demos/coder/iohub/delaytest.py
@@ -26,20 +26,22 @@ from collections import OrderedDict
 totalEventRequestsForTest = 1000
 numEventRequests = 0
 
+
 def run():
     global numEventRequests
-    io = launchHubServer(experiment_code='delay_test')
+    # create fullscreen pyglet window at current resolution, as well as required resources / drawings
+    psychoWindow, psychoStim = createPsychoGraphicsWindow()
+
+    io = launchHubServer(window=psychoWindow, experiment_code='delay_test')
+    io.devices.mouse.setPosition((0, 0))
 
     lastFlipTime = 0.0
 
-    # create fullscreen pyglet window at current resolution, as well as required resources / drawings
-    psychoWindow, psychoStim = createPsychoGraphicsWindow(io)
-
     # create stats numpy arrays, set experiment process to high priority.
     # Init Results numpy array
-    results= zeros((totalEventRequestsForTest,3),dtype='f4')
+    results = zeros((totalEventRequestsForTest, 3), dtype='f4')
 
-    numEventRequests=0
+    numEventRequests = 0
 
     # clear the ioHub event Buffer before starting the test.
     # This is VERY IMPORTANT, given an existing bug in ioHub.
@@ -79,83 +81,85 @@ def run():
     plotResults(results)
     printResults(results)
 
-def createPsychoGraphicsWindow(io):
-        #create a window
-        psychoStim = OrderedDict()
-        psychoWindow = visual.Window(io.devices.display.getPixelResolution(),
-                                    monitor=io.devices.display.getPsychopyMonitorName(),
-                                    units=io.devices.display.getCoordinateType(),
-                                    color=[128,128,128], colorSpace='rgb255',
-                                    fullscr=True, allowGUI=False,
-                                    screen=io.devices.display.getIndex()
-                        )
 
-        currentPosition= io.devices.mouse.setPosition((0,0))
-        psychoWindow.setMouseVisible(False)
+def createPsychoGraphicsWindow():
+    # create a window
+    psychoStim = OrderedDict()
+    psychoWindow = visual.Window((1920, 1080),
+                                 monitor='default',
+                                 units='pix',
+                                 color=[128, 128, 128], colorSpace='rgb255',
+                                 fullscr=True, allowGUI=False,
+                                 screen=0
+                                 )
 
-        fixation = visual.PatchStim(psychoWindow, size=25, pos=[0,0], sf=0,
-                                    color=[-1,-1,-1], colorSpace='rgb')
-        title = visual.TextStim(win=psychoWindow,
-                                text="ioHub getEvents Delay Test", pos = [0,125],
-                                height=36, color=[1,.5,0], colorSpace='rgb',
-                                wrapWidth=800.0)
+    psychoWindow.setMouseVisible(False)
 
-        instr = visual.TextStim(win=psychoWindow,
-                                text='Move the mouse around, press keyboard keys and mouse buttons',
-                                pos = [0,-125], height=32, color=[-1,-1,-1],
-                                colorSpace='rgb', wrapWidth=800.0)
+    fixation = visual.PatchStim(psychoWindow, size=25, pos=[0, 0], sf=0,
+                                color=[-1, -1, -1], colorSpace='rgb')
+    title = visual.TextStim(win=psychoWindow,
+                            text="ioHub getEvents Delay Test", pos=[0, 125],
+                            height=36, color=[1, .5, 0], colorSpace='rgb',
+                            wrapWidth=800.0)
 
-        psychoStim['static'] = visual.BufferImageStim(win=psychoWindow,
-                                         stim=(fixation, title, instr))
-        psychoStim['grating'] = visual.PatchStim(psychoWindow,
-                                        mask="circle", size=75,pos=[-100,0],
-                                        sf=.075)
-        psychoStim['keytext'] = visual.TextStim(win=psychoWindow,
-                                        text='key', pos = [0,300], height=48,
-                                        color=[-1,-1,-1], colorSpace='rgb',
-                                        wrapWidth=800.0)
-        psychoStim['mouseDot'] = visual.GratingStim(win=psychoWindow,
-                                        tex=None, mask="gauss",
-                                        pos=currentPosition,size=(50,50),
-                                        color='purple')
-        psychoStim['progress'] = visual.ShapeStim(win=psychoWindow,
-                                        vertices=[(0,0),(0,0),(0,0),(0,0)],
-                                        pos=(400, -300))
+    instr = visual.TextStim(win=psychoWindow,
+                            text='Move the mouse around, press keyboard keys and mouse buttons',
+                            pos=[0, -125], height=32, color=[-1, -1, -1],
+                            colorSpace='rgb', wrapWidth=800.0)
 
-        return psychoWindow, psychoStim
+    psychoStim['static'] = visual.BufferImageStim(win=psychoWindow,
+                                                  stim=(fixation, title, instr))
+    psychoStim['grating'] = visual.PatchStim(psychoWindow,
+                                             mask="circle", size=75, pos=[-100, 0],
+                                             sf=.075)
+    psychoStim['keytext'] = visual.TextStim(win=psychoWindow,
+                                            text='key', pos=[0, 300], height=48,
+                                            color=[-1, -1, -1], colorSpace='rgb',
+                                            wrapWidth=800.0)
+    psychoStim['mouseDot'] = visual.GratingStim(win=psychoWindow,
+                                                tex=None, mask="gauss",
+                                                pos=(0,0), size=(50, 50),
+                                                color='purple')
+    psychoStim['progress'] = visual.ShapeStim(win=psychoWindow,
+                                              vertices=[(0, 0), (0, 0), (0, 0), (0, 0)],
+                                              pos=(400, -300))
+
+    return psychoWindow, psychoStim
+
 
 def drawAndFlipPsychoWindow(psychoStim, psychoWindow, io, events):
-    psychoStim['grating'].setPhase(0.05, '+')#advance phase by 0.05 of a cycle
-    currentPosition,currentDisplayIndex =io.devices.mouse.getPosition(return_display_index=True)
+    psychoStim['grating'].setPhase(0.05, '+')  # advance phase by 0.05 of a cycle
+    currentPosition, currentDisplayIndex = io.devices.mouse.getPosition(return_display_index=True)
 
-    if currentDisplayIndex == io.devices.display.getIndex():
-        currentPosition=(float(currentPosition[0]),float(currentPosition[1]))
+    if currentDisplayIndex == 0:
+        currentPosition = (float(currentPosition[0]), float(currentPosition[1]))
         psychoStim['mouseDot'].setPos(currentPosition)
 
     if events:
         diff = totalEventRequestsForTest - numEventRequests
         v = psychoWindow.size[1] / 2.0 * diff / totalEventRequestsForTest
-        vert = [[0,0], [0,v], [2,v],[2,0]]
+        vert = [[0, 0], [0, v], [2, v], [2, 0]]
         psychoStim['progress'].setVertices(vert)
 
         for r in events:
-            if r.type is EventConstants.KEYBOARD_PRESS: #keypress code
+            if r.type is EventConstants.KEYBOARD_PRESS:  # keypress code
                 psychoStim['keytext'].setText(r.key)
 
     [psychoStim[skey].draw() for skey in psychoStim]
 
-    flipTime=psychoWindow.flip()
+    flipTime = psychoWindow.flip()
     return flipTime
+
 
 def checkForEvents(io):
     # get the time we request events from the ioHub
-    stime=Computer.getTime()
+    stime = Computer.getTime()
     r = io.getEvents()
     if r and len(r) > 0:
         # so there were events returned in the request, so include this getEvent request in the tally
-        etime=Computer.getTime()
-        dur=etime-stime
-        return r, dur*1000.0
+        etime = Computer.getTime()
+        dur = etime - stime
+        return r, dur * 1000.0
     return None, None
 
 
@@ -164,63 +168,64 @@ def plotResults(results):
     from matplotlib.pyplot import axis, title, xlabel, hist, grid, show, ylabel, plot
     import pylab
 
-    durations=results[:,0]
-    flips=results[1:,2]
+    durations = results[:, 0]
+    flips = results[1:, 2]
 
-    dmean=durations.mean()
-    dstd=durations.std()
+    dmean = durations.mean()
+    dstd = durations.std()
 
-    fmean=flips.mean()
-    fstd=flips.std()
+    fmean = flips.mean()
+    fstd = flips.std()
 
-    pylab.figure(figsize=(7,5))
-    pylab.subplot(1,3,1)
+    pylab.figure(figsize=(7, 5))
+    pylab.subplot(1, 3, 1)
 
     # the histogram of the delay data
     n, bins, patches = hist(durations, 50, facecolor='blue', alpha=0.75)
     # add a 'best fit' line
-    y = norm.pdf( bins, dmean, dstd)
+    y = norm.pdf(bins, dmean, dstd)
     plot(bins, y, 'r--', linewidth=1)
     xlabel('ioHub getEvents Delay')
     ylabel('Percentage')
-    title('ioHub Event Delays (msec):\n'+r'$\ \mu={0:.3f},\ \sigma={1:.3f}$'.format(dmean, dstd))
-    axis([0, durations.max()+1.0, 0, 25.0])
+    title('ioHub Event Delays (msec):\n' + r'$\ \mu={0:.3f},\ \sigma={1:.3f}$'.format(dmean, dstd))
+    axis([0, durations.max() + 1.0, 0, 25.0])
     grid(True)
 
     # graphs of the retrace data ( taken from retrace example in psychopy demos folder)
     intervalsMS = flips
-    m=fmean
-    sd=fstd
-    distString= "Mean={0:.1f}ms,    s.d.={1:.1f},    99%CI={2:.1f}-{3:.1f}".format(
-                            m, sd, m - 3 * sd, m + 3 * sd)
-    nTotal=len(intervalsMS)
-    nDropped=sum(intervalsMS>(1.5*m))
+    m = fmean
+    sd = fstd
+    distString = "Mean={0:.1f}ms,    s.d.={1:.1f},    99%CI={2:.1f}-{3:.1f}".format(
+        m, sd, m - 3 * sd, m + 3 * sd)
+    nTotal = len(intervalsMS)
+    nDropped = sum(intervalsMS > (1.5 * m))
     droppedString = "Dropped/Frames = {0:d}/{1:d} = {2:0.2f}%".format(
-                            nDropped, nTotal, int(nDropped) / float(nTotal))
+        nDropped, nTotal, int(nDropped) / float(nTotal))
 
-    pylab.subplot(1,3,2)
+    pylab.subplot(1, 3, 2)
 
-    #plot the frameintervals
+    # plot the frameintervals
     pylab.plot(intervalsMS, '-')
     pylab.ylabel('t (ms)')
     pylab.xlabel('frame N')
     pylab.title(droppedString)
 
-    pylab.subplot(1,3,3)
+    pylab.subplot(1, 3, 3)
     pylab.hist(intervalsMS, 50, histtype='stepfilled')
     pylab.xlabel('t (ms)')
     pylab.ylabel('n frames')
     pylab.title(distString)
     show()
 
+
 def printResults(results):
-    durations=results[:,0]
-    dmean=durations.mean()
-    dstd=durations.std()
+    durations = results[:, 0]
+    dmean = durations.mean()
+    dstd = durations.std()
     print("ioHub getEvent Delays:")
     print("\tMEAN: ", dmean)
     print("\tSDEV: ", dstd)
-         
+
 
 if __name__ == "__main__":
     run()

--- a/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
+++ b/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
@@ -201,7 +201,7 @@ if __name__ == "__main__":
         # start trial instuctions have been displayed.
         #
         io_hub.clearEvents('all')
-        kb.waitForPresses(keys=[' ', ])
+        kb.waitForPresses(keys=['space', ])
 
         # Space Key has been pressed, start the trial.
         # Set the current session and trial id values to be saved
@@ -278,7 +278,7 @@ if __name__ == "__main__":
             # Check any new keyboard press events by a space key.
             # If one is found, set the trial end variable and break.
             # from the loop
-            if kb.getPresses(keys=[' ', ]):
+            if kb.getPresses(keys=['space', ]):
                 run_trial = False
                 break
 

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -118,7 +118,7 @@ while t < TRIAL_COUNT:
         # Check any new keyboard char events for a space key.
         # If one is found, set the trial end variable.
         #
-        if keyboard.getPresses(keys=' '):
+        if keyboard.getPresses(keys='space'):
             run_trial = False
         elif core.getTime()-tstart_time > T_MAX:
             run_trial = False

--- a/psychopy/demos/coder/iohub/eyetracking/validation.py
+++ b/psychopy/demos/coder/iohub/eyetracking/validation.py
@@ -235,7 +235,7 @@ while t < TRIAL_COUNT:
         # Check any new keyboard char events for a space key.
         # If one is found, set the trial end variable.
         #
-        if keyboard.getPresses(keys=' '):
+        if keyboard.getPresses(keys='space'):
             run_trial = False
         elif core.getTime()-tstart_time > T_MAX:
             run_trial = False

--- a/psychopy/demos/coder/iohub/keyboard.py
+++ b/psychopy/demos/coder/iohub/keyboard.py
@@ -6,10 +6,16 @@ Example of how to access Keyboard events using iohub.
 Displays information from ioHub Keyboard Events vs. psychopy.event.geKeys().
 """
 
+from __future__ import absolute_import, division, print_function
+
+from builtins import str
 from psychopy import core, visual, event
+from psychopy.hardware import keyboard as ptb_keyboard
 from psychopy.iohub import launchHubServer
 
 WINDOW_SIZE = 1024, 768
+
+ptb_keyboard = ptb_keyboard.Keyboard()
 
 # Start iohub process. The iohub process can be accessed using `io`.
 io = launchHubServer()
@@ -78,8 +84,13 @@ event_type_label = visual.TextStim(win, units=unit_type,
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 psychopy_key_label = visual.TextStim(win, units=unit_type,
-    text=u'event.getKeys():',
+    text=u'vs. event.getKeys():',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 8],
+    color='black', alignText='left', anchorHoriz='left',
+    height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
+ptb_key_label = visual.TextStim(win, units=unit_type,
+    text=u'vs. keyboard.getKeys():',
+    pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 9],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 
@@ -112,14 +123,18 @@ psychopy_key_stim = visual.TextStim(win, units=unit_type, text=u'',
     pos=[VALUE_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 8],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT,  wrapWidth=dw * 2)
+ptb_key_stim = visual.TextStim(win, units=unit_type, text=u'',
+    pos=[VALUE_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 9],
+    color='black', alignText='left', anchorHoriz='left',
+    height=TEXT_STIM_HEIGHT,  wrapWidth=dw * 2)
 
 # Having all the stim to update / draw in a list makes drawing code
 # more compact and reusable
 STIM_LIST = [title_label, title2_label, key_text_label, char_label,
     modifiers_label, keypress_duration_label, all_pressed__label,
-    event_type_label, psychopy_key_label,
+    event_type_label, psychopy_key_label, ptb_key_label,
     key_text_stim, char_stim, modifiers_stim, keypress_duration_stim,
-    all_pressed_stim, event_type_stim, psychopy_key_stim]
+    all_pressed_stim, event_type_stim, psychopy_key_stim, ptb_key_stim]
 
 # Clear all events from the global and device level ioHub Event Buffers.
 
@@ -152,6 +167,10 @@ while not 'q' in events and flip_time - demo_timeout_start < 15.0:
             psychopy_key_stim.text = psychopy_keys[0]
         elif kbe.type == "KEYBOARD_PRESS":
             psychopy_key_stim.text = ''
+
+        ptb_keys = ptb_keyboard.getKeys(waitRelease=False)
+        if ptb_keys:
+            ptb_key_stim.text = ptb_keys[0].name
 
         all_pressed_stim.text = str(list(keyboard.state.keys()))
 

--- a/psychopy/demos/coder/iohub/keyboard.py
+++ b/psychopy/demos/coder/iohub/keyboard.py
@@ -14,20 +14,21 @@ from psychopy.hardware import keyboard as ptb_keyboard
 from psychopy.iohub import launchHubServer
 
 WINDOW_SIZE = 1024, 768
-
-ptb_keyboard = ptb_keyboard.Keyboard()
-
-# Start iohub process. The iohub process can be accessed using `io`.
-io = launchHubServer()
-
-# A `keyboard` variable is used to access the iohub Keyboard device.
-keyboard = io.devices.keyboard
-
 dw = WINDOW_SIZE[0] / 2
 dh = WINDOW_SIZE[1] / 2
 unit_type = 'pix'
 win = visual.Window(WINDOW_SIZE, units=unit_type,
     color=[128, 128, 128], colorSpace='rgb255')
+
+# Create a Keyboard class with ptb as the backend
+ptb_keyboard = ptb_keyboard.Keyboard()
+
+# Start iohub process. The iohub process can be accessed using `io`.
+io = launchHubServer(window=win)
+
+# A `keyboard` variable is used to access the iohub Keyboard device.
+keyboard = io.devices.keyboard
+
 
 # constants for text element spacing:
 ROW_COUNT = 10
@@ -55,16 +56,16 @@ title2_label = visual.TextStim(win, units=unit_type,
     color=[0.25, 0.2, 1],
     alignText='center', anchorHoriz='center', anchorVert='top',
     wrapWidth=dw * 2)
-key_text_label = visual.TextStim(win, units=unit_type, text=u'event.key:',
+key_text_label = visual.TextStim(win, units=unit_type, text=u'iohub .key:',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 2],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
-char_label = visual.TextStim(win, units=unit_type, text=u'event.char:',
+char_label = visual.TextStim(win, units=unit_type, text=u'iohub .char:',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 3],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 modifiers_label = visual.TextStim(win, units=unit_type,
-    text=u'event.modifiers',
+    text=u'iohub .modifiers',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 4],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
@@ -89,7 +90,7 @@ psychopy_key_label = visual.TextStim(win, units=unit_type,
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)
 ptb_key_label = visual.TextStim(win, units=unit_type,
-    text=u'vs. keyboard.getKeys():',
+    text=u'vs. ptb_kb.getKeys():',
     pos=[LABEL_COLUMN_X, TEXT_ROWS_START_Y - TEXT_ROW_HEIGHT * 9],
     color='black', alignText='left', anchorHoriz='left',
     height=TEXT_STIM_HEIGHT, wrapWidth=LABEL_WRAP_LENGTH)

--- a/psychopy/demos/coder/iohub/keyboardreactiontime.py
+++ b/psychopy/demos/coder/iohub/keyboardreactiontime.py
@@ -13,10 +13,9 @@ from psychopy import core,  visual
 from psychopy.iohub import launchHubServer
 from math import fabs
 
-io = launchHubServer(psychopy_monitor_name='default')
-display = io.devices.display
-win = visual.Window(display.getPixelResolution(), monitor='default',
-    units='pix', fullscr=True, allowGUI=False)
+win = visual.Window((1920, 1080), monitor='default', units='pix', fullscr=True, allowGUI=False)
+
+io = launchHubServer(window=win)
 
 # save some 'dots' during the trial loop
 keyboard = io.devices.keyboard
@@ -50,7 +49,7 @@ io.clearEvents('all')
 
 # Run until space bar is pressed, or larger than window
 spacebar_rt = last_len = 0.0
-while spacebar_rt == 0.0 or last_len >=  win.size[0]:
+while spacebar_rt == 0.0 or last_len >= win.size[0]:
     # check for RT
     for kb_event in keyboard.getEvents():
         if kb_event.char == ' ':

--- a/psychopy/experiment/routines/eyetracker_validate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_validate/__init__.py
@@ -287,7 +287,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
             inits['movementDur'] = inits['targetDelay']
         # Convert progress mode to ioHub format
         if inits['progressMode'].val == 'space key':
-            inits['progressKey'] = "' '"
+            inits['progressKey'] = "'space'"
         else:
             inits['progressKey'] = "None"
         # If positions are preset, override param value

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -58,6 +58,8 @@ Example usage
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
+from __future__ import absolute_import, division, print_function
+
 from collections import deque
 import sys
 import copy
@@ -249,8 +251,6 @@ class Keyboard:
                     keys.append(thisKey)
         elif Keyboard.backend == 'iohub':
             watchForKeys = keyList
-            if watchForKeys:
-                watchForKeys = [' ' if k == 'space' else k for k in watchForKeys]
             if waitRelease:
                 key_events = Keyboard._iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
             else:
@@ -258,8 +258,6 @@ class Keyboard:
 
             for k in key_events:
                 kname = k.key
-                if kname == ' ':
-                    kname = 'space'
 
                 if waitRelease:
                     tDown = k.time-k.duration
@@ -336,7 +334,7 @@ class Keyboard:
             event.clearEvents(eventType)
 
 
-class KeyPress:
+class KeyPress(object):
     """Class to store key presses, as returned by `Keyboard.getKeys()`
 
     Unlike keypresses from the old event.getKeys() which returned a list of
@@ -418,7 +416,7 @@ class _KeyBuffers(dict):
         return self[kb_id]
 
 
-class _KeyBuffer:
+class _KeyBuffer(object):
     """This is our own local buffer of events with more control over clearing.
 
     The user shouldn't use this directly. It is fetched from the _keybuffers

--- a/psychopy/iohub/client/eyetracker/validation/procedure.py
+++ b/psychopy/iohub/client/eyetracker/validation/procedure.py
@@ -342,15 +342,15 @@ class ValidationProcedure:
 
         if self.show_results_screen:
             self.showResultsScreen()
-            kb_presses = keyboard.waitForPresses(keys=[' ', self.terminate_key, self.targetsequence.gaze_cursor_key])
-            while ' ' not in kb_presses:
+            kb_presses = keyboard.waitForPresses(keys=['space', self.terminate_key, self.targetsequence.gaze_cursor_key])
+            while 'space' not in kb_presses:
                 if self.targetsequence.gaze_cursor_key in kb_presses:
                     self.targetsequence.display_gaze = not self.targetsequence.display_gaze
                     self.showResultsScreen()
                 if self.terminate_key in kb_presses:
                     print("Escape key pressed. Exiting validation")
                     break
-                kb_presses = keyboard.waitForPresses(keys=[' ',
+                kb_presses = keyboard.waitForPresses(keys=['space',
                                                            self.terminate_key,
                                                            self.targetsequence.gaze_cursor_key])
 

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/gazepointCalibrationGraphics.py
@@ -151,7 +151,7 @@ class GazepointPsychopyCalibrationGraphics:
             ek = event[self._keyboard_key_index]
             if isinstance(ek, bytes):
                 ek = ek.decode('utf-8')
-            if ek == ' ':
+            if ek == ' ' or ek == 'space':
                 self._msg_queue.append('SPACE_KEY_ACTION')
                 self.clearAllEventBuffers()
             elif ek == 'escape':

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/mousegazeCalibrationGraphics.py
@@ -146,7 +146,7 @@ class MouseGazePsychopyCalibrationGraphics:
             ek = event[self._keyboard_key_index]
             if isinstance(ek, bytes):
                 ek = ek.decode('utf-8')
-            if ek == ' ':
+            if ek == ' ' or ek == 'space':
                 self._msg_queue.append('SPACE_KEY_ACTION')
                 self.clearAllEventBuffers()
             elif ek == 'escape':

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
@@ -484,8 +484,8 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
             elif char == 'return':
                 pylink_key = pylink.ENTER_KEY
                 self.state = None
-            elif char == ' ':
-                pylink_key = ord(char)
+            elif char == ' ' or char == 'space':
+                pylink_key = ord(' ')
             elif char == 'c':
                 pylink_key = ord(char)
                 self.state = 'calibration'
@@ -500,10 +500,10 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
                 pylink_key = pylink.PAGE_UP
             elif char == 'pagedown':
                 pylink_key = pylink.PAGE_DOWN
-            elif char == '-':
-                pylink_key = ord(char)
-            elif char == '=':
-                pylink_key = ord(char)
+            elif char == '-' or char == 'minus':
+                pylink_key = ord('-')
+            elif char == '=' or char == 'equal':
+                pylink_key = ord('=')
             elif char == 'up':
                 pylink_key = pylink.CURS_UP
             elif char == 'down':

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/tobiiCalibrationGraphics.py
@@ -168,7 +168,7 @@ class TobiiPsychopyCalibrationGraphics:
             ek = event[self._keyboard_key_index]
             if isinstance(ek, bytes):
                 ek = ek.decode('utf-8')
-            if ek == ' ':
+            if ek == ' ' or ek == 'space':
                 self._msg_queue.append('SPACE_KEY_ACTION')
                 self.clearAllEventBuffers()
             elif ek == 'escape':

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -40,7 +40,7 @@ class ioHubKeyboardDevice(Device):
     originate from a single keyboard device in the experiment.
 
     """
-    use_psychopy_keymap = False
+    use_psychopy_keymap = True
     EVENT_CLASS_NAMES = [
         'KeyboardInputEvent',
         'KeyboardPressEvent',

--- a/psychopy/iohub/devices/keyboard/__init__.py
+++ b/psychopy/iohub/devices/keyboard/__init__.py
@@ -13,6 +13,22 @@ from .. import Device, Computer
 
 getTime = Computer.getTime
 
+psychopy_key_mappings = {'`': 'quoteleft',
+                         '[': 'bracketleft',
+                         ']': 'bracketright',
+                         '\\': 'backslash',
+                         '/': 'slash',
+                         ';': 'semicolon',
+                         "'": 'apostrophe',
+                         ',': 'comma',
+                         '.': 'period',
+                         '-': 'minus',
+                         '=': 'equal',
+                         '+': 'num_add',
+                         '*': 'num_multiply',
+                         ' ': 'space'
+                         }
+
 
 class ioHubKeyboardDevice(Device):
     """The Keyboard device is used to receive events from a standard USB or PS2
@@ -24,7 +40,7 @@ class ioHubKeyboardDevice(Device):
     originate from a single keyboard device in the experiment.
 
     """
-
+    use_psychopy_keymap = False
     EVENT_CLASS_NAMES = [
         'KeyboardInputEvent',
         'KeyboardPressEvent',
@@ -49,6 +65,8 @@ class ioHubKeyboardDevice(Device):
         self._log_events_file = None
 
         Device.__init__(self, *args, **kwargs)
+
+        ioHubKeyboardDevice.use_psychopy_keymap = self.getConfiguration().get('use_keymap') == 'psychopy'
 
     @classmethod
     def getModifierState(cls):

--- a/psychopy/iohub/devices/keyboard/darwin.py
+++ b/psychopy/iohub/devices/keyboard/darwin.py
@@ -5,7 +5,7 @@
 from copy import copy
 import Quartz as Qz
 from AppKit import NSEvent  # NSKeyUp, NSSystemDefined, NSEvent
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from ...constants import KeyboardConstants, DeviceConstants, EventConstants
 from .. import Computer, Device
 
@@ -26,7 +26,24 @@ import unicodedata
 
 from .darwinkey import code2label
 
-#print2err("code2label: ",code2label)
+psychopy_numlock_key_mappings = dict()
+psychopy_numlock_key_mappings['1'] = 'num_1'
+psychopy_numlock_key_mappings['2'] = 'num_2'
+psychopy_numlock_key_mappings['3'] = 'num_3'
+psychopy_numlock_key_mappings['4'] = 'num_4'
+psychopy_numlock_key_mappings['5'] = 'num_5'
+psychopy_numlock_key_mappings['6'] = 'num_6'
+psychopy_numlock_key_mappings['7'] = 'num_7'
+psychopy_numlock_key_mappings['8'] = 'num_8'
+psychopy_numlock_key_mappings['9'] = 'num_9'
+psychopy_numlock_key_mappings['0'] = 'num_0'
+psychopy_numlock_key_mappings['/'] = 'num_divide'
+psychopy_numlock_key_mappings['*'] = 'num_multiple'
+psychopy_numlock_key_mappings['-'] = 'num_minus'
+psychopy_numlock_key_mappings['+'] = 'num_add'
+psychopy_numlock_key_mappings['='] = 'num_equal'
+psychopy_numlock_key_mappings['.'] = 'num_decimal'
+
 carbon_path = ctypes.util.find_library('Carbon')
 carbon = ctypes.cdll.LoadLibrary(carbon_path)
 
@@ -308,12 +325,19 @@ class Keyboard(ioHubKeyboardDevice):
                     elif key_value == 'return':
                         char_value = '\n'
 
-                    is_auto_repeat = Qz.CGEventGetIntegerValueField(
-                        event, Qz.kCGKeyboardEventAutorepeat)
+                    if Keyboard.use_psychopy_keymap:
+                        if keyFromNumpad(key_mods) and key_value in psychopy_numlock_key_mappings.keys():
+                            key_value = psychopy_numlock_key_mappings[key_value]
+                        elif key_value in psychopy_key_mappings.keys():
+                            key_value = psychopy_key_mappings[key_value]
+
+
+
+                    is_auto_repeat = Qz.CGEventGetIntegerValueField(event, Qz.kCGKeyboardEventAutorepeat)
 
                     # TODO: CHeck WINDOW BOUNDS
 
-                    # report_system_wide_events=self.getConfiguration().get('report_system_wide_events',True)
+                    # report_system_wide_events=s elf.getConfiguration().get('report_system_wide_events',True)
                     # Can not seem to figure out how to get window handle id from evt to match with pyget in darwin, so
                     # Comparing event target process ID to the psychopy windows process ID,
                     # yglet_window_hnds=self._iohub_server._pyglet_window_hnds

--- a/psychopy/iohub/devices/keyboard/default_keyboard.yaml
+++ b/psychopy/iohub/devices/keyboard/default_keyboard.yaml
@@ -39,6 +39,11 @@ Keyboard:
     #       is the intended event target will be reported.
     report_system_wide_events: True
 
+    # use_keymap: What key map set / heuristics should be used? Options:
+    #   psychopy: Use key map that is the same as used by event.getKeys()
+    #   original: Use original iohub key map
+    use_keymap: psychopy
+
     # save_events: *If* the ioHubDataStore is enabled for the experiment, then
     #   indicate if events for this device should be saved to the
     #   data_collection/keyboard event group in the hdf5 event file.

--- a/psychopy/iohub/devices/keyboard/default_keyboard.yaml
+++ b/psychopy/iohub/devices/keyboard/default_keyboard.yaml
@@ -41,7 +41,7 @@ Keyboard:
 
     # use_keymap: What key map set / heuristics should be used? Options:
     #   psychopy: Use key map that is the same as used by event.getKeys()
-    #   original: Use original iohub key map
+    #   legacy: Use original iohub key map
     use_keymap: psychopy
 
     # save_events: *If* the ioHubDataStore is enabled for the experiment, then

--- a/psychopy/iohub/devices/keyboard/linux2.py
+++ b/psychopy/iohub/devices/keyboard/linux2.py
@@ -3,13 +3,27 @@
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from .. import Computer, Device
 from ...constants import EventConstants
-from ...errors import printExceptionDetailsToStdErr
+from ...errors import printExceptionDetailsToStdErr, print2err
 
 getTime = Computer.getTime
 
+NUMLOCK_MODIFIER = 8192
+
+psychopy_numlock_key_mappings = dict()
+psychopy_numlock_key_mappings['num_end'] = 'num_1'
+psychopy_numlock_key_mappings['num_down'] = 'num_2'
+psychopy_numlock_key_mappings['num_page_down'] = 'num_3'
+psychopy_numlock_key_mappings['num_left'] = 'num_4'
+psychopy_numlock_key_mappings['num_begin'] = 'num_5'
+psychopy_numlock_key_mappings['num_right'] = 'num_6'
+psychopy_numlock_key_mappings['num_home'] = 'num_7'
+psychopy_numlock_key_mappings['num_up'] = 'num_8'
+psychopy_numlock_key_mappings['num_page_up'] = 'num_9'
+psychopy_numlock_key_mappings['num_insert'] = 'num_0'
+psychopy_numlock_key_mappings['num_delete'] = 'num_decimal'
 
 class Keyboard(ioHubKeyboardDevice):
     event_id_index = None
@@ -37,7 +51,23 @@ class Keyboard(ioHubKeyboardDevice):
             self._last_callback_time = getTime()
             if self.isReportingEvents():
                 event_array = event[0]
+                
+                key = event_array[Keyboard.key_index]
+                if isinstance(key, bytes):
+                    event_array[Keyboard.key_index] = key = str(key, 'utf-8')                
+                
+                if Keyboard.use_psychopy_keymap:
+                    if key in psychopy_key_mappings.keys():
+                        key = event_array[Keyboard.key_index] = psychopy_key_mappings[key]
+                    elif key == 'num_next':
+                        key = event_array[Keyboard.key_index] = 'num_page_down'
+                    elif key == 'num_prior':
+                        key = event_array[Keyboard.key_index] = 'num_page_up'
 
+                    if (event_array[Keyboard.event_modifiers_index]&NUMLOCK_MODIFIER) > 0:
+                        if key in psychopy_numlock_key_mappings:
+                            key = event_array[Keyboard.key_index] = psychopy_numlock_key_mappings[key]  
+                            
                 # Check if key event window id is in list of psychopy
                 # windows and what report_system_wide_events value is
                 report_system_wide_events = self.getConfiguration().get(

--- a/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
@@ -22,7 +22,7 @@
             max_length: 3
     use_keymap:
         IOHUB_LIST:
-            valid_values: [psychopy, original]
+            valid_values: [psychopy, legacy]
             min_length: 0
             max_length: 1
     device_number:

--- a/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/keyboard/supported_config_settings.yaml
@@ -20,6 +20,11 @@
             valid_values: [ KeyboardPressEvent, KeyboardReleaseEvent]
             min_length: 0
             max_length: 3
+    use_keymap:
+        IOHUB_LIST:
+            valid_values: [psychopy, original]
+            min_length: 0
+            max_length: 1
     device_number:
         IOHUB_INT:
             min: 0

--- a/psychopy/iohub/devices/keyboard/win32.py
+++ b/psychopy/iohub/devices/keyboard/win32.py
@@ -10,7 +10,7 @@ except ImportError:
 
 import ctypes
 from unicodedata import category as ucategory
-from . import ioHubKeyboardDevice
+from . import ioHubKeyboardDevice, psychopy_key_mappings
 from ...constants import KeyboardConstants, EventConstants
 from .. import Computer, Device
 from ...errors import print2err, printExceptionDetailsToStdErr
@@ -43,6 +43,21 @@ numpad_key_value_mappings = dict(Numpad0='insert',
                                  )
 
 
+def updateToPsychopyKeymap():
+    global numpad_key_value_mappings
+    numpad_key_value_mappings = dict(Numpad0='num_0',
+                                     Numpad1='num_1',
+                                     Numpad2='num_2',
+                                     Numpad3='num_3',
+                                     Numpad4='num_4',
+                                     Numpad5='num_5',
+                                     Numpad6='num_6',
+                                     Numpad7='num_7',
+                                     Numpad8='num_8',
+                                     Numpad9='num_9',
+                                     Decimal='num_decimal'
+                                     )
+
 class Keyboard(ioHubKeyboardDevice):
     _win32_modifier_mapping = {
         win32_vk.VK_LCONTROL: 'lctrl',
@@ -65,6 +80,9 @@ class Keyboard(ioHubKeyboardDevice):
         self._user32 = ctypes.windll.user32
         self._keyboard_state = (ctypes.c_ubyte * 256)()
         self._unichar = (ctypes.c_wchar * 8)()
+
+        if self.use_psychopy_keymap:
+            updateToPsychopyKeymap()
 
         self.resetKeyAndModState()
 
@@ -191,13 +209,29 @@ class Keyboard(ioHubKeyboardDevice):
         if key is None:
             key = KeyboardConstants._getKeyName(event)
 
+        if isinstance(key, bytes):
+            key = str(key, 'utf-8')
+        if isinstance(char, bytes):
+            char = str(char, 'utf-8')
+
+        key = key.lower()
+
         # misc. char value cleanup.
         if key == 'return':
             char = '\n'.encode('utf-8')
         elif key in ('escape', 'backspace'):
             char = ''
 
-        return key.lower(), char
+        if Keyboard.use_psychopy_keymap and key in psychopy_key_mappings.keys():
+            key = psychopy_key_mappings[key]
+
+            # win32 specific handling of keypad / and - keys
+            if event.Key == 'Subtract':
+                key = 'num_subtract'
+            elif event.Key == 'Divide':
+                key = 'num_divide'
+
+        return key, char
 
     def _evt2json(self, event):
         return jdumps(dict(Type=event.Type,


### PR DESCRIPTION
ENH: Add 'use_mapping' setting to iohub keyboard device. 'original' and 'psychopy' are supported, with psychopy being the default.
ENH: When 'use_mapping'=='psychopy' match iohub and event.getKeys() key mappings. Mainly numpad and some punctuation keys have been updated. For example, space key is ' ' in original mapping and 'space' in psychopy mapping.

NOTE: This means by default old iohub experiments must be updated to expect new key mappings or keyboard device must be set to use original mappings when moving to this release.