### PR TITLE
DOC: update SR Research forum links

### DIFF
--- a/docs/source/api/hardware/pylink.rst
+++ b/docs/source/api/hardware/pylink.rst
@@ -1,19 +1,20 @@
 .. _pylink:
 
-pylink (SR research)
-=============================================
+pylink (SR Research)
+====================
 
-For now the SR Research pylink module is packaged with the Standalone flavours of PsychoPy and can be imported with::
-    
+For now the SR Research ``pylink`` module is packaged with the Standalone flavours of PsychoPy and can be imported with::
+
     import pylink
 
-You do need to install the Display Software (which they also call Eyelink Developers Kit) for your particular platform. This can be found by following the threads from:
+You do need to install the Display Software (which they also call Eyelink Developers Kit) for your particular platform.
+This can be found by following the threads from the SR Research support forum (creating an account is required):
 
-https://www.sr-support.com/forums/forumdisplay.php?f=17
+https://www.sr-support.com/thread-13.html
 
-for pylink documentation see:
+For documentation of ``pylink``, see:
 
-https://www.sr-support.com/forums/showthread.php?t=14
+https://www.sr-support.com/thread-48.html
 
 .. automodule:: pylink
     :members:


### PR DESCRIPTION
SR Research have recently updated their forum. In this PR I want to fix the (now broken, i.e., leading nowhere specific) links that I found in the PsychoPy docs.