### PR TITLE
RF: Improve how subprocesses are spawned and managed

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -473,17 +473,35 @@ class Job:
     #         return None
     #
     #     return self._process.OutputStream
-    #
-    # @property
-    # def isInputAvailable(self):
-    #     """Check if there are bytes available to be read from the input stream
-    #     (`bool`).
-    #     """
-    #     if self._process is None:
-    #         return False
-    #
-    #     return self._process.IsInputAvailable()
-    #
+
+    @property
+    def isInputAvailable(self):
+        """Check if there are bytes available to be read from the input stream
+        (`bool`).
+        """
+        if self._process is None:
+            return False
+
+        return self._stdoutReader.isAvailable
+
+    def getInputData(self):
+        """Get any new data which has shown up on the input pipe (stdout of the
+        subprocess).
+
+        Returns
+        -------
+        str
+            Data as a string. Returns and empty string if there is no new data.
+
+        """
+        if self._process is None:
+            return
+
+        if self._stdoutReader.isAvailable:
+            return self._stdoutReader.read()
+
+        return ''
+
     # @property
     # def inputStream(self):
     #     """Handle to the file-like object handling the standard input stream
@@ -494,17 +512,35 @@ class Job:
     #         return None
     #
     #     return self._process.InputStream
-    #
-    # @property
-    # def isErrorAvailable(self):
-    #     """Check if there are bytes available to be read from the error stream
-    #     (`bool`).
-    #     """
-    #     if self._process is None:
-    #         return False
-    #
-    #     return self._process.IsErrorAvailable()
-    #
+
+    @property
+    def isErrorAvailable(self):
+        """Check if there are bytes available to be read from the error stream
+        (`bool`).
+        """
+        if self._process is None:
+            return False
+
+        return self._stderrReader.isAvailable
+
+    def getErrorData(self):
+        """Get any new data which has shown up on the error pipe (stderr of the
+        subprocess).
+
+        Returns
+        -------
+        str
+            Data as a string. Returns and empty string if there is no new data.
+
+        """
+        if self._process is None:
+            return
+
+        if self._stderrReader.isAvailable:
+            return self._stderrReader.read()
+
+        return ''
+
     # @property
     # def errorStream(self):
     #     """Handle to the file-like object handling the standard error stream
@@ -527,13 +563,13 @@ class Job:
         retCode = self._process.poll()
 
         # get data from pipes
-        if self._stdoutReader.isAvailable:
-            stdinText = self._stdoutReader.read()
+        if self.isInputAvailable:
+            stdinText = self.getInputData()
             if self._inputCallback is not None:
                 wx.CallAfter(self._inputCallback, stdinText)
 
-        if self._stderrReader.isAvailable:
-            stderrText = self._stderrReader.read()
+        if self.isErrorAvailable:
+            stderrText = self.getErrorData()
             if self._errorCallback is not None:
                 wx.CallAfter(self._errorCallback, stderrText)
 

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -11,6 +11,28 @@ asynchronously without blocking the main application loop which would otherwise
 render the UI unresponsive.
 """
 
+__all__ = [
+    'EXEC_SYNC',
+    'EXEC_ASYNC',
+    'EXEC_SHOW_CONSOLE',
+    'EXEC_HIDE_CONSOLE',
+    'EXEC_MAKE_GROUP_LEADER',
+    'EXEC_NODISABLE',
+    'EXEC_NOEVENTS',
+    'EXEC_BLOCK',
+    'SIGTERM',
+    'SIGKILL',
+    'SIGINT',
+    'KILL_NOCHILDREN',
+    'KILL_CHILDREN',
+    'KILL_OK',
+    'KILL_BAD_SIGNAL',
+    'KILL_ACCESS_DENIED',
+    'KILL_NO_PROCESS',
+    'KILL_ERROR',
+    'Job'
+]
+
 import wx
 
 # Aliases so we don't need to explicitly import `wx`.

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -116,9 +116,12 @@ class Job:
         self._pollTimer = wx.Timer()
 
         # user defined callbacks
-        self._inputCallback = inputCallback
-        self._errorCallback = errorCallback
-        self._terminateCallback = terminateCallback
+        self._inputCallback = None
+        self._errorCallback = None
+        self._terminateCallback = None
+        self.inputCallback = inputCallback
+        self.errorCallback = errorCallback
+        self.terminateCallback = terminateCallback
 
     def start(self):
         """Start the subprocess.
@@ -260,6 +263,48 @@ class Job:
 
         priority = max(min(int(priority), 100), 0)  # clip range
         self._process.SetPriority(priority)  # set it
+
+    @property
+    def inputCallback(self):
+        """Callback function called when data is available on the input stream
+        pipe (`callable` or `None`).
+        """
+        return self._inputCallback
+
+    @inputCallback.setter
+    def inputCallback(self, val):
+        if not callable(val) or None:
+            raise TypeError("Callback function must be `callable` or `None`.")
+
+        self._inputCallback = val
+
+    @property
+    def errorCallback(self):
+        """Callback function called when data is available on the error stream
+        pipe (`callable` or `None`).
+        """
+        return self._errorCallback
+
+    @errorCallback.setter
+    def errorCallback(self, val):
+        if not callable(val) or None:
+            raise TypeError("Callback function must be `callable` or `None`.")
+
+        self._errorCallback = val
+
+    @property
+    def terminateCallback(self):
+        """Callback function called when the subprocess is terminated
+        (`callable` or `None`).
+        """
+        return self._terminateCallback
+
+    @terminateCallback.setter
+    def terminateCallback(self, val):
+        if not callable(val) or None:
+            raise TypeError("Callback function must be `callable` or `None`.")
+
+        self._terminateCallback = val
 
     @property
     def isOutputAvailable(self):

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -308,10 +308,10 @@ class Job:
     def pollMillis(self, val):
         if isinstance(val, (int, float)):
             self._pollMillis = int(val)
+        elif val is None:
+            self._pollMillis = None
         else:
             raise TypeError("Value must be must be `int` or `None`.")
-
-        self._pollMillis = val
 
         if not self._pollTimer.IsRunning():
             return

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -405,7 +405,7 @@ class Job:
             if self._errorCallback is not None:
                 wx.CallAfter(self._errorCallback, stderrText)
 
-    def onTerminate(self, evt=None):
+    def onTerminate(self, evt):
         """Called when the process exits.
 
         Override for custom functionality. Right now we're just stopping the
@@ -418,7 +418,7 @@ class Job:
 
         Parameters
         ----------
-        evt : wx.Event
+        evt : wx.ProcessEvent
             Event object.
 
         """
@@ -430,7 +430,9 @@ class Job:
 
         # if callback is provided, else nop
         if self._terminateCallback is not None:
-            wx.CallAfter(self._terminateCallback)
+            pid = evt.GetPid()
+            exitCode = evt.GetExitCode()
+            wx.CallAfter(self._terminateCallback, pid, exitCode)
 
     def onNotify(self):
         """Called when the polling timer elapses.

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -183,7 +183,7 @@ class Job:
             return  # nop
 
         # kill the process, check if itm was successful
-        isOk = wx.Process.Kill(self._pid, signal, flags) == wx.KILL_OK
+        isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
         self._pollTimer.Stop()
 
         if isOk:
@@ -274,8 +274,8 @@ class Job:
 
     @inputCallback.setter
     def inputCallback(self, val):
-        if not callable(val) or None:
-            raise TypeError("Callback function must be `callable` or `None`.")
+        # if not callable(val) or val is not None:
+        #     raise TypeError("Callback function must be `callable` or `None`.")
 
         self._inputCallback = val
 
@@ -288,8 +288,8 @@ class Job:
 
     @errorCallback.setter
     def errorCallback(self, val):
-        if not callable(val) or None:
-            raise TypeError("Callback function must be `callable` or `None`.")
+        # if not callable(val) or val is not None:
+        #     raise TypeError("Callback function must be `callable` or `None`.")
 
         self._errorCallback = val
 
@@ -302,8 +302,8 @@ class Job:
 
     @terminateCallback.setter
     def terminateCallback(self, val):
-        if not callable(val) or None:
-            raise TypeError("Callback function must be `callable` or `None`.")
+        # if not callable(val) or val is not None:
+        #     raise TypeError("Callback function must be `callable` or `None`.")
 
         self._terminateCallback = val
 

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -348,7 +348,7 @@ class Job:
         (`ww.OutputStream`). This is used to write bytes which will show up in
         the 'stdin' pipe of the subprocess.
         """
-        if not self.isRunning():
+        if not self.isRunning:
             return None
 
         return self._process.OutputStream
@@ -369,7 +369,7 @@ class Job:
         (`wx.InputStream`). This is used to read bytes which the subprocess is
         writing to 'stdout'.
         """
-        if not self.isRunning():
+        if not self.isRunning:
             return None
 
         return self._process.InputStream
@@ -390,7 +390,7 @@ class Job:
         (`wx.InputStream`). This is used to read bytes which the subprocess is
         writing to 'stderr'.
         """
-        if not self.isRunning():
+        if not self.isRunning:
             return None
 
         return self._process.ErrorStream

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -279,22 +279,8 @@ class Job:
 
         return self._pid
 
-    def terminate(self, signal=SIGTERM, flags=KILL_NOCHILDREN):
-        """Stop/kill the subprocess associated with this object.
-
-        Parameters
-        ----------
-        signal : int
-            Signal to use (eg. `SIGTERM`, `SIGINT`, `SIGKILL`, etc.) These are
-            available as module level constants.
-        flags : int
-            Additional option flags, by default `KILL_NOCHILDREN` is specified
-            which prevents child processes of the active subprocess from being
-            signaled to terminate. Using `KILL_CHILDREN` will signal child
-            processes to terminate. Note that on UNIX, `KILL_CHILDREN` will only
-            have an effect if `EXEC_MAKE_GROUP_LEADER` was specified when the
-            process was spawned. These values are available as module level
-            constants.
+    def terminate(self):
+        """Terminate the subprocess associated with this object.
 
         Return
         ------
@@ -305,7 +291,7 @@ class Job:
 
         """
         if not self.isRunning:
-            return  # nop
+            return False  # nop
 
         # kill the process, check if itm was successful
         # isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
@@ -315,14 +301,17 @@ class Job:
         self._stdoutReader.stop()  # stop the threads now
         self._stderrReader.stop()
 
+        retcode = self._process.returncode
         self.onTerminate(self._process.returncode)
 
         self._process = self._pid = None  # reset
         self._flags = 0
 
+        return retcode is None
+
     @property
     def command(self):
-        """Shell command to execute (`str`). Same as the `command` argument.
+        """Shell command to execute (`list`). Same as the `command` argument.
         Raises an error if this value is changed after `start()` was called.
         """
         return self._command

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -328,7 +328,7 @@ class Job:
 
     def poll(self):
         """Poll input and error streams for data, pass them to callbacks if
-        specified.
+        specified. Input stream data is processed before error.
         """
         if self._process is None:  # do nothing if there is no process
             return

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -259,7 +259,7 @@ class Job:
             return
 
         priority = max(min(int(priority), 100), 0)  # clip range
-        self._process.SetPriority(int(priority))  # set it
+        self._process.SetPriority(priority)  # set it
 
     @property
     def isOutputAvailable(self):

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -112,7 +112,7 @@ class Job:
         self._pid = None
         self._flags = flags
         self._process = None
-        self._pollMillis = pollMillis
+        self._pollMillis = None
         self._pollTimer = wx.Timer()
 
         # user defined callbacks
@@ -122,6 +122,7 @@ class Job:
         self.inputCallback = inputCallback
         self.errorCallback = errorCallback
         self.terminateCallback = terminateCallback
+        self.pollMillis = pollMillis
 
     def start(self):
         """Start the subprocess.
@@ -304,7 +305,7 @@ class Job:
         if not callable(val) or None:
             raise TypeError("Callback function must be `callable` or `None`.")
 
-        self._pollMillis = val
+        self._terminateCallback = val
 
     @property
     def pollMillis(self):

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -304,7 +304,30 @@ class Job:
         if not callable(val) or None:
             raise TypeError("Callback function must be `callable` or `None`.")
 
-        self._terminateCallback = val
+        self._pollMillis = val
+
+    @property
+    def pollMillis(self):
+        """Polling interval for input and error pipes (`int` or `None`).
+        """
+        return self._pollMillis
+
+    @pollMillis.setter
+    def pollMillis(self, val):
+        if isinstance(val, (int, float)):
+            self._pollMillis = int(val)
+        else:
+            raise TypeError("Value must be must be `int` or `None`.")
+
+        self._pollMillis = val
+
+        if not self._pollTimer.IsRunning():
+            return
+
+        if self._pollMillis is None:  # if `None`, stop the timer
+            self._pollTimer.Stop()
+        else:
+            self._pollTimer.Start(self._pollMillis, oneShot=wx.TIMER_CONTINUOUS)
 
     @property
     def isOutputAvailable(self):

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -182,7 +182,7 @@ class Job:
             return  # nop
 
         # kill the process, check if itm was successful
-        isOk = wx.Process.Kill(self._pid, signal, flags) != wx.KILL_OK
+        isOk = wx.Process.Kill(self._pid, signal, flags) == wx.KILL_OK
         self._pollTimer.Stop()
 
         if isOk:

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -274,9 +274,6 @@ class Job:
 
     @inputCallback.setter
     def inputCallback(self, val):
-        # if not callable(val) or val is not None:
-        #     raise TypeError("Callback function must be `callable` or `None`.")
-
         self._inputCallback = val
 
     @property
@@ -288,9 +285,6 @@ class Job:
 
     @errorCallback.setter
     def errorCallback(self, val):
-        # if not callable(val) or val is not None:
-        #     raise TypeError("Callback function must be `callable` or `None`.")
-
         self._errorCallback = val
 
     @property
@@ -302,9 +296,6 @@ class Job:
 
     @terminateCallback.setter
     def terminateCallback(self, val):
-        # if not callable(val) or val is not None:
-        #     raise TypeError("Callback function must be `callable` or `None`.")
-
         self._terminateCallback = val
 
     @property

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+"""Classes and functions for creating and managing subprocesses spawned by the
+GUI application. These subprocesses are mainly used to perform 'jobs'
+asynchronously without blocking the main application loop which would otherwise
+render the UI unresponsive.
+"""
+
+import wx
+
+# Aliases so we don't need to explicitly import `wx`.
+EXEC_ASYNC = wx.EXEC_ASYNC
+EXEC_SYNC = wx.EXEC_SYNC
+EXEC_SHOW_CONSOLE = wx.EXEC_SHOW_CONSOLE
+EXEC_HIDE_CONSOLE = wx.EXEC_HIDE_CONSOLE
+EXEC_MAKE_GROUP_LEADER = wx.EXEC_MAKE_GROUP_LEADER
+EXEC_NODISABLE = wx.EXEC_NODISABLE
+EXEC_NOEVENTS = wx.EXEC_NOEVENTS
+EXEC_BLOCK = wx.EXEC_BLOCK
+
+# Signal enumerations for `wx.Process.Kill`, only use the one here that work on
+# all platforms.
+SIGTERM = wx.SIGTERM
+SIGKILL = wx.SIGKILL
+SIGINT = wx.SIGINT
+
+# Flags for wx.Process.Kill`.
+KILL_NOCHILDREN = wx.KILL_NOCHILDREN
+KILL_CHILDREN = wx.KILL_CHILDREN  # yeesh ...
+
+# Error values for `wx.Process.Kill`
+KILL_OK = wx.KILL_OK
+KILL_BAD_SIGNAL = wx.KILL_BAD_SIGNAL
+KILL_ACCESS_DENIED = wx.KILL_ACCESS_DENIED
+KILL_NO_PROCESS = wx.KILL_NO_PROCESS
+KILL_ERROR = wx.KILL_ERROR
+
+
+class Job:
+    """General purpose class for running subprocesses using wxPython's
+    subprocess framework. This class should only be instanced and used if the
+    GUI is present.
+
+    Parameters
+    ----------
+    command : str
+    pollMillis : int or None
+        Time in milliseconds between polling intervals. When interval specified
+        by `pollMillis` elapses, the input and error streams will be read and
+        callback functions will be called. If `None`, then the timer will be
+        disabled and the `poll()` method will need to be invoked.
+
+    Examples
+    --------
+    Spawn a new subprocess::
+
+        # command to execute
+        command = 'python3 myScript.py'
+        # create a new job object
+        job = Job(command, flags=EXEC_ASYNC)
+        # start it
+        pid = job.start()  # returns a PID for the sub process
+        # read data from the subprocess
+
+    """
+    def __init__(self, command='', flags=EXEC_ASYNC, terminateCallback=None,
+                 inputCallback=None, errorCallback=None, pollMillis=None):
+
+        # command to be called, cannot be changed after spawning the process
+        self._command = command
+        self._pid = None
+        self._flags = flags
+        self._process = None
+        self._pollMillis = pollMillis
+        self._pollTimer = wx.Timer()
+
+        # user defined callbacks
+        self._inputCallback = inputCallback
+        self._errorCallback = errorCallback
+        self._terminateCallback = terminateCallback
+
+    def start(self):
+        """Start the subprocess.
+
+        Returns
+        -------
+        int
+            Process ID assigned by the operating system.
+
+        """
+        wx.BeginBusyCursor()  # visual feedback
+
+        # create a new process object, this handles streams and stuff
+        self._process = wx.Process(None, -1)
+        self._process.Redirect()  # redirect streams from subprocess
+
+        # start the sub-process
+        self._pid = wx.Execute(self._command, self._flags, self._process)
+
+        # bind the event called when the process ends
+        self._process.Bind(wx.EVT_END_PROCESS, self.onTerminate)
+
+        # start polling for data from the subprocesses
+        if self._pollMillis is not None:
+            self._pollTimer.Notify = self.onNotify  # override
+            self._pollTimer.Start(self._pollMillis, oneShot=wx.TIMER_CONTINUOUS)
+
+        wx.EndBusyCursor()
+
+        return self._pid
+
+    def terminate(self, signal=SIGTERM, flags=KILL_NOCHILDREN):
+        """Stop/kill the subprocess associated with this object.
+
+        Parameters
+        ----------
+        signal : int
+            Signal to use (eg. `SIGTERM`, `SIGINT`, `SIGKILL`, etc.) These are
+            available as module level constants.
+        flags : int
+            Additional option flags, by default `KILL_NOCHILDREN` is specified
+            which prevents child processes of the active subprocess from being
+            signaled to terminate. Using `KILL_CHILDREN` will signal child
+            processes to terminate. Note that on UNIX, `KILL_CHILDREN` will only
+            have an effect if `EXEC_MAKE_GROUP_LEADER` was specified when the
+            process was spawned. These values are available as module level
+            constants.
+
+        Return
+        ------
+        bool
+            `True` if the terminate call was successful in ending the
+            subprocess. If `False`, something went wrong and you should try and
+            figure it out.
+
+        """
+        if not self.isRunning:
+            return  # nop
+
+        wx.BeginBusyCursor()  # visual feedback
+
+        # kill the process, check if itm was successful
+        isOk = wx.Process.Kill(self._pid, signal, flags) != wx.KILL_OK
+        self._pollTimer.Stop()
+
+        if isOk:
+            self._process = self._pid = None
+
+        wx.EndBusyCursor()
+
+        return isOk
+
+    @property
+    def command(self):
+        """Shell command to execute (`str`). Same as the `command` argument.
+        Raises an error if this value is changed after `start()` was called.
+        """
+        return self._command
+
+    @command.setter
+    def command(self, val):
+        if self.isRunning:
+            raise AttributeError(
+                'Cannot set property `command` if the subprocess is running!')
+
+        self._command = val
+
+    @property
+    def flags(self):
+        """Shell command to execute (`str`). Same as the `command` argument.
+        Raises an error if this value is changed after `start()` was called.
+        """
+        return self._flags
+
+    @flags.setter
+    def flags(self, val):
+        if self.isRunning:
+            raise AttributeError(
+                'Cannot set property `flags` if the subprocess is running!')
+
+        self._flags = val
+
+    @property
+    def isRunning(self):
+        """Is the subprocess running (`bool`)? If `True` the value of the
+        `command` property cannot be changed.
+        """
+        return self._pid != 0 and self._process is not None
+
+    @property
+    def pid(self):
+        """Process ID for the active subprocess (`int`). Only valid after the
+        process has been started.
+        """
+        return self._pid
+
+    def getPid(self):
+        """Process ID for the active subprocess. Only valid after the process
+        has been started.
+
+        Returns
+        -------
+        int or None
+            Process ID assigned to the subprocess by the system. Returns `None`
+            if the process has not been started.
+
+        """
+        return self._pid
+
+    @property
+    def isOutputAvailable(self):
+        """`True` if the output pipe to the subprocess is opened (therefore
+        writeable). If not, you cannot write any bytes to 'outputStream'. Some
+        subprocesses may signal to the parent process that its done processing
+        data by closing its input.
+        """
+        if self._process is None:
+            return False
+
+        return self._process.IsInputOpened()
+
+    @property
+    def outputStream(self):
+        """Handle to the file-like object handling the standard output stream
+        (`ww.OutputStream`). This is used to write bytes which will show up in
+        the 'stdin' pipe of the subprocess.
+        """
+        if not self.isRunning():
+            return None
+
+        return self._process.OutputStream
+
+    @property
+    def isInputAvailable(self):
+        """Check if there are bytes available to be read from the input stream
+        (`bool`).
+        """
+        if self._process is None:
+            return False
+
+        return self._process.IsInputAvailable()
+
+    @property
+    def inputStream(self):
+        """Handle to the file-like object handling the standard input stream
+        (`wx.InputStream`). This is used to read bytes which the subprocess is
+        writing to 'stdout'.
+        """
+        if not self.isRunning():
+            return None
+
+        return self._process.InputStream
+
+    @property
+    def isErrorAvailable(self):
+        """Check if there are bytes available to be read from the error stream
+        (`bool`).
+        """
+        if self._process is None:
+            return False
+
+        return self._process.IsErrorAvailable()
+
+    @property
+    def errorStream(self):
+        """Handle to the file-like object handling the standard error stream
+        (`wx.InputStream`). This is used to read bytes which the subprocess is
+        writing to 'stderr'.
+        """
+        if not self.isRunning():
+            return None
+
+        return self._process.ErrorStream
+
+    def poll(self):
+        """Poll input and error streams for data, pass them to callbacks if
+        specified.
+        """
+        if self._process is None:  # do nothing if there is no process
+            return
+
+        # is there data in the input pipe?
+        if self._process.IsInputAvailable() and self._inputCallback is not None:
+            stdinText = self._process.InputStream.read()
+            wx.CallAfter(self._inputCallback, args=(stdinText,))
+
+        # same as above but with the error stream
+        if self._process.IsErrorAvailable() and self._errorCallback is not None:
+            stderrText = self._process.ErrorStream.read()
+            wx.CallAfter(self._errorCallback, args=(stderrText,))
+
+    def onTerminate(self, evt=None):
+        """Called when the process exits. Override for custom functionality."""
+        wx.CallAfter(self._terminateCallback)
+
+    def onNotify(self):
+        """Called when the polling timer elapses.
+
+        Default action is to read input and error streams and broadcast any data
+        to user defined callbacks (if `poll()` has not been overwritten).
+        """
+        self.poll()
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -89,7 +89,13 @@ class RunnerFrame(wx.Frame, ThemeMixin):
 
     @property
     def filename(self):
-        if self.panel.currentSelection or self.panel.currentSelection == 0:
+        """Presently selected file name in Runner (`str` or `None`). If `None`,
+        not file is presently selected or the task list is empty.
+        """
+        if not self.panel.currentSelection:  # no selection or empty list
+            return
+
+        if self.panel.currentSelection >= 0:  # has valid item selected
             return self.panel.expCtrl.GetItem(self.panel.currentSelection).Text
 
     def addTask(self, evt=None, fileName=None):

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -472,7 +472,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
                                           name=title,
                                           )
         ScriptProcess.__init__(self, app)
-        self.Bind(wx.EVT_END_PROCESS, self.onProcessEnded)
+        #self.Bind(wx.EVT_END_PROCESS, self.onProcessEnded)
 
         # double buffered better rendering except if retina
         self.SetDoubleBuffered(parent.IsDoubleBuffered())
@@ -639,9 +639,9 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
         self.SetSizerAndFit(self.mainSizer)
         self.SetMinSize(self.Size)
 
-    def onProcessEnded(self):
-        ScriptProcess.onProcessEnded(self)
-        self.stopTask()
+    # def onProcessEnded(self):
+    #     ScriptProcess.onProcessEnded(self)
+    #     self.stopTask()
 
     def setAlertsVisible(self, new=True):
         if type(new) == bool:

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -90,8 +90,9 @@ class ScriptProcess:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
 
         # build the shell command to run the script
-        pyExec = '"' + pyExec + '"'  # use quotes, needed for Windows
-        command = [pyExec, '-u', fullPath]
+        pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
+        fullPath = '"' + fullPath + '"'
+        command = [pyExec, '-u', fullPath]  # passed to the Job object
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -193,7 +193,7 @@ class ScriptProcess:
         """
         self._onInputCallback(streamBytes)
 
-    def _onTerminateCallback(self):
+    def _onTerminateCallback(self, pid, exitCode):
         """Callback invoked when the subprocess exits.
 
         Default behavior is to push remaining data to the Runner output window
@@ -201,9 +201,17 @@ class ScriptProcess:
         disabled in Runner (if available) since the process has ended and no
         longer can be stopped. Also restores the user's cursor to the default.
 
+        Parameters
+        ----------
+        pid : int
+            Process ID number for the terminated subprocess.
+        exitCode : int
+            Program exit code.
+
         """
-        # write a close message
-        closeMsg = "##### Experiment ended. #####\n"
+        # write a close message, shows the exit code
+        closeMsg = "##### Experiment ended with exit code {} #####\n".format(
+            exitCode)
         self._writeOutput(closeMsg)
 
         self.scriptProcess = None  # reset

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -90,8 +90,8 @@ class ScriptProcess:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
 
         # build the shell command to run the script
-        pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
-        fullPath = '"' + fullPath + '"'
+        # pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
+        # fullPath = '"' + fullPath + '"'
         command = [pyExec, '-u', fullPath]  # passed to the Job object
 
         # create a new job with the user script
@@ -101,7 +101,8 @@ class ScriptProcess:
             inputCallback=self._onInputCallback,  # both treated the same
             errorCallback=self._onErrorCallback,
             terminateCallback=self._onTerminateCallback,
-            pollMillis=120  # check input/error pipes every 120 ms
+            pollMillis=120,  # check input/error pipes every 120 ms
+            cwd=fullPath
         )
 
         BeginBusyCursor()  # visual feedback

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -101,8 +101,7 @@ class ScriptProcess:
             inputCallback=self._onInputCallback,  # both treated the same
             errorCallback=self._onErrorCallback,
             terminateCallback=self._onTerminateCallback,
-            pollMillis=120,  # check input/error pipes every 120 ms
-            cwd=fullPath
+            pollMillis=120  # check input/error pipes every 120 ms
         )
 
         BeginBusyCursor()  # visual feedback

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -210,8 +210,9 @@ class ScriptProcess:
 
         """
         # write a close message, shows the exit code
-        closeMsg = "##### Experiment ended with exit code {} #####\n".format(
-            exitCode)
+        closeMsg = \
+            "##### Experiment ended with exit code {} [pid:{}] #####\n".format(
+                exitCode, pid)
         self._writeOutput(closeMsg)
 
         self.scriptProcess = None  # reset

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -79,15 +79,19 @@ class ScriptProcess:
         stdOut.write(runMsg)
         stdOut.flush()
 
-        # build the shell command to run the script
-        command = [sys.executable, '-u', fullPath]
+        # interpreter path
+        pyExec = sys.executable
 
-        # option flags for the subprocess
+        # optional flags for the subprocess
         execFlags = jobs.EXEC_ASYNC  # all use `EXEC_ASYNC`
         if sys.platform == 'win32':
             execFlags |= jobs.EXEC_HIDE_CONSOLE
         else:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
+
+        # build the shell command to run the script
+        pyExec = '"' + pyExec + '"'  # use quotes, needed for Windows
+        command = [pyExec, '-u', fullPath]
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -70,7 +70,6 @@ class ScriptProcess:
         # if we have a runner frame, write to the output text box
         if hasattr(self.app, 'runner'):
             stdOut = self.app.runner.stdOut
-            stdOut.write(runMsg)
             stdOut.lenLastRun = len(self.app.runner.stdOut.getText())
         else:
             # if not, just write to the standard output pipe

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -212,6 +212,13 @@ class ScriptProcess:
         if hasattr(self, 'stopBtn'):  # relies on this being a mixin class
             self.stopBtn.Disable()
 
+        # reactivate the current selection after running
+        if hasattr(self, 'expCtrl') and hasattr(self, 'runBtn'):
+            itemIdx = self.expCtrl.GetFirstSelected()
+            if itemIdx >= 0:
+                self.expCtrl.Select(itemIdx)
+                self.runBtn.Enable()
+
         EndBusyCursor()
 
 

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -16,6 +16,7 @@ __all__ = ['ScriptProcess']
 
 import sys
 import psychopy.app.jobs as jobs
+from wx import BeginBusyCursor, EndBusyCursor
 
 
 class ScriptProcess:
@@ -98,6 +99,8 @@ class ScriptProcess:
             pollMillis=120  # check input/error pipes every 120 ms
         )
 
+        BeginBusyCursor()  # visual feedback
+
         # start the subprocess
         self.scriptProcess.start()
 
@@ -159,8 +162,8 @@ class ScriptProcess:
 
     def _onInputCallback(self, streamBytes):
         """Callback to process data from the input stream of the subprocess.
-        This is called everytime `~psychopy.app.jobs.Jobs.poll` is called,
-        either manually or by the internal timer of the `Job` class.
+        This is called when `~psychopy.app.jobs.Jobs.poll` is called and only if
+        there is data in the associated pipe.
 
         The default behavior here is to convert the data to a UTF-8 string and
         write it to the Runner output window.
@@ -175,7 +178,8 @@ class ScriptProcess:
 
     def _onErrorCallback(self, streamBytes):
         """Callback to process data from the error stream of the subprocess.
-        This is called everytime `poll` is called.
+        This is called when `~psychopy.app.jobs.Jobs.poll` is called and only if
+        there is data in the associated pipe.
 
         The default behavior is to call `_onInputCallback`, forwarding argument
         `streamBytes` to it. Override this method if you want data from `stderr`
@@ -195,7 +199,7 @@ class ScriptProcess:
         Default behavior is to push remaining data to the Runner output window
         and show it by raising the Runner window. The 'Stop' button will be
         disabled in Runner (if available) since the process has ended and no
-        longer can be stopped.
+        longer can be stopped. Also restores the user's cursor to the default.
 
         """
         # write a close message
@@ -207,6 +211,8 @@ class ScriptProcess:
         # disable the stop button after exiting, no longer needed
         if hasattr(self, 'stopBtn'):  # relies on this being a mixin class
             self.stopBtn.Disable()
+
+        EndBusyCursor()
 
 
 if __name__ == "__main__":

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -134,7 +134,6 @@ class ScriptProcess:
             Flush text so it shows up immediately on the pipe.
 
         """
-
         # Make sure we have a string, data from pipes usually comes out as bytes
         # so we make the conversion if needed.
         if isinstance(text, bytes):
@@ -159,8 +158,9 @@ class ScriptProcess:
     #
 
     def _onInputCallback(self, streamBytes):
-        """Callback to process data from the input stream from the subprocess.
-        This is called everytime `poll` is called.
+        """Callback to process data from the input stream of the subprocess.
+        This is called everytime `~psychopy.app.jobs.Jobs.poll` is called,
+        either manually or by the internal timer of the `Job` class.
 
         The default behavior here is to convert the data to a UTF-8 string and
         write it to the Runner output window.
@@ -171,10 +171,10 @@ class ScriptProcess:
             Data from the 'stdin' streams connected to the subprocess.
 
         """
-        self._writeOutput(streamBytes, flush=True)
+        self._writeOutput(streamBytes)
 
     def _onErrorCallback(self, streamBytes):
-        """Callback to process data from the error stream from the subprocess.
+        """Callback to process data from the error stream of the subprocess.
         This is called everytime `poll` is called.
 
         The default behavior is to call `_onInputCallback`, forwarding argument
@@ -193,14 +193,20 @@ class ScriptProcess:
         """Callback invoked when the subprocess exits.
 
         Default behavior is to push remaining data to the Runner output window
-        and show it by raising the Runner window.
+        and show it by raising the Runner window. The 'Stop' button will be
+        disabled in Runner (if available) since the process has ended and no
+        longer can be stopped.
 
         """
         # write a close message
         closeMsg = "##### Experiment ended. #####\n"
-        self._writeOutput(closeMsg, flush=True)
+        self._writeOutput(closeMsg)
 
         self.scriptProcess = None  # reset
+
+        # disable the stop button after exiting, no longer needed
+        if hasattr(self, 'stopBtn'):  # relies on this being a mixin class
+            self.stopBtn.Disable()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR introduces the `psychopy.app.jobs.Job` class and some other changes which simplifies spawning sub-processes off the main UI process, mainly for running local scripts. Right now, the `Job` class has been applied to running local Python scripts from Runner. 

This is part of a larger project to improve parallelism in the UI.