### PR TITLE
Updated ROI 'look away' logic 

### DIFF
--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -74,7 +74,7 @@ class RegionOfInterestComponent(PolygonComponent):
 
         self.params['lookDur'] = Param(lookDur,
             valType='num', inputType='single', categ='Basic',
-            hint=_translate("How long (s) does the participant need to look at the ROI to count as a look?"),
+            hint=_translate("Minimum dwell time within roi (look at) or outside roi (look away)."),
             label=_translate("Min. Look Time")
         )
 
@@ -98,7 +98,7 @@ class RegionOfInterestComponent(PolygonComponent):
             allowedVals=['roi onset', 'experiment', 'routine'],
             updates='constant', direct=False,
             hint=_translate(
-                "What should the values of mouse.time should be "
+                "What should the values of roi.time should be "
                 "relative to?"),
             label=_translate('Time Relative To...'))
 

--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -236,16 +236,29 @@ class RegionOfInterestComponent(PolygonComponent):
         )
         buff.writeIndentedLines(code % inits)
         if self.params['endRoutineOn'].val == "look away":
+            buff.setIndentLevel(-1, relative=True)
             code = (
-                "if %(name)s.lastLookTime > %(lookDur)s: # check if last look was long enough\n"
+                f"# check if last look outside roi was long enough\n"
+                f"if len(%(name)s.timesOff) == 0 and %(name)s.clock.getTime() > %(lookDur)s:\n"
             )
             buff.writeIndentedLines(code % inits)
             buff.setIndentLevel(1, relative=True)
             code = (
-                    "continueRoutine = False # end routine after sufficiently long look\n"
+                    f"continueRoutine = False # end routine after sufficiently long look outside roi\n"
             )
             buff.writeIndentedLines(code % inits)
             buff.setIndentLevel(-1, relative=True)
+
+            code = (
+                f"elif len(%(name)s.timesOff) > 0 and %(name)s.clock.getTime() - %(name)s.timesOff[-1] > %(lookDur)s:\n"
+            )
+            buff.writeIndentedLines(code % inits)
+            buff.setIndentLevel(1, relative=True)
+            code = (
+                    f"continueRoutine = False # end routine after sufficiently long look outside roi\n"
+            )
+            buff.writeIndentedLines(code % inits)
+
         buff.setIndentLevel(-1, relative=True)
         code = (
             f"%(name)s.wasLookedIn = False  # if %(name)s is looked at next frame, it is a new look\n"

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -110,7 +110,7 @@ class EyeTracker(EyeTrackerDevice):
         # Used to hold the last valid gaze position processed by ioHub.
         # If the last mouse tracker in a blink state, then this is set to None
         #
-        self._latest_gaze_position = 0.0, 0.0
+        self._latest_gaze_position = None
 
     def _connectMouse(self):
         if self._iohub_server:
@@ -122,7 +122,8 @@ class EyeTracker(EyeTrackerDevice):
         if self.isConnected() and self.isRecordingEnabled():
             if EyeTracker._last_mouse_event_time == 0:
                 EyeTracker._last_mouse_event_time = getTime() - self._ISI
-
+                # Start off mousegaze pos with current mouse position
+                self._latest_gaze_position = self._ioMouse.getPosition()
             while getTime() - EyeTracker._last_mouse_event_time >= self._ISI:
                 # Generate an eye sample every ISI seconds
                 button_states = self._ioMouse.getCurrentButtonStates()

--- a/psychopy/visual/roi.py
+++ b/psychopy/visual/roi.py
@@ -124,4 +124,5 @@ class ROI(ShapeStim):
         """Clear stored data"""
         self.timesOn = []
         self.timesOff = []
+        self.clock.reset()
         self.wasLookedIn = False


### PR DESCRIPTION
BF: If ROI ends routine using 'look away', eyes must be outside of roi for 'Min. Look Time' seconds before routine ends. ROI 'look at' routine end logic is unchanged.
BF: MouseGaze .getPos() was returning 0,0 until first mouse event occurred after starting to record, now it gets current mouse position and uses that if no events have been received yet.