### PR TITLE
ENH: Increase iohub eye tracker max event buffer size

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/supported_config_settings.yaml
@@ -22,7 +22,7 @@ eyetracker.hw.gazepoint.gp3.EyeTracker:
     event_buffer_length: 
         IOHUB_INT:
             min: 1
-            max: 2048
+            max: 8192
     device_timer:
         interval:
             IOHUB_FLOAT:

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/supported_config_settings.yaml
@@ -13,7 +13,7 @@ eyetracker.hw.mouse.EyeTracker:
     event_buffer_length:
         IOHUB_INT:
             min: 1
-            max: 2048
+            max: 8192
     monitor_event_types:
         IOHUB_LIST:
             valid_values: [MonocularEyeSampleEvent, FixationStartEvent, FixationEndEvent, SaccadeStartEvent, SaccadeEndEvent, BlinkStartEvent, BlinkEndEvent]

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/supported_config_settings.yaml
@@ -12,7 +12,7 @@ eyetracker.hw.sr_research.eyelink.EyeTracker:
     event_buffer_length: 
         IOHUB_INT:
             min: 1
-            max: 2048
+            max: 8192
     monitor_event_types:           
         IOHUB_LIST:
             valid_values: [ MonocularEyeSampleEvent, BinocularEyeSampleEvent, FixationStartEvent, FixationEndEvent, SaccadeStartEvent, SaccadeEndEvent, BlinkStartEvent, BlinkEndEvent]  

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/supported_config_settings.yaml
@@ -19,7 +19,7 @@ eyetracker.hw.tobii.EyeTracker:
     event_buffer_length: 
         IOHUB_INT:
             min: 1
-            max: 2048
+            max: 8192
     monitor_event_types: [BinocularEyeSampleEvent,]
     runtime_settings:
         sampling_rate:


### PR DESCRIPTION
ENH: Increased iohub eye tracker max settable event buffer size from 2048 to 8192. Default is still 1024.