### PR TITLE
BF: Check for excessively long paths before compiling JS

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -812,7 +812,7 @@ class Experiment(object):
             else:
                 thisFile['rel'] = filePath
                 thisFile['abs'] = os.path.normpath(join(srcRoot, filePath))
-                if os.path.isfile(thisFile['abs']):
+                if len(thisFile['abs']) <= 256 and os.path.isfile(thisFile['abs']):
                     return thisFile
 
         def findPathsInFile(filePath):


### PR DESCRIPTION
Was causing errors when a long string (such as along list) was being passed to this function on JS compile.

256 was chosen specifically as it's the max path length in Windows 