### PR TITLE
BF: Builder crashes if custom categories are defined in custom compon…

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2483,7 +2483,8 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel):
         del self.components['SettingsComponent']
         self.routines = experiment.getAllStandaloneRoutines()
         # Get categories
-        self.categories = getAllCategories()
+        self.categories = getAllCategories(
+            self.app.prefs.builder['componentsFolders'])
         for name, rt in self.routines.items():
             for cat in rt.categories:
                 if cat not in self.categories:


### PR DESCRIPTION
…ents
When `componentsFolders` is set to load custom components and custom categories are defined in the custom components, Builder window crashes immediately after opening.  I confirmed that this issue happens in 2021.2.0 and later.
The value of `componentsFolders` must be passed to `getAllCategories()` to deal with custom categories.

By the way, newly added `getAllStandaloneRoutines()` doesn't have `folderList` option.  Does this mean that custom standalone routines will not be supported?