### PR TITLE
Fixing pocketsphinx compile on macOS

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -36,6 +36,8 @@ jobs:
     - name: Install PsychoPy and dependencies
       run: |
         # for pocketsphinx we need this adapted package:
+        brew install swig
+        brew install openal-soft
         pip install git+https://github.com/Im-Fran/pocketsphinx-python
         # then use the standard requirements:
         pip install .

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -35,6 +35,9 @@ jobs:
 
     - name: Install PsychoPy and dependencies
       run: |
+        # for pocketsphinx we need this adapted package:
+        pip install git+https://github.com/Im-Fran/pocketsphinx-python
+        # then use the standard requirements:
         pip install .
 
 #    - name: Lint with flake8


### PR DESCRIPTION
Pocketsphinx doesn't have wheels beyond py3.6 so needs compiling. On macOS that fails due to this:
  https://github.com/bambocher/pocketsphinx-python/issues/28
