### PR TITLE
BF / ENH: Fix .setData() and add U3 'register' param to Parallel out component

### DIFF
--- a/docs/source/builder/components/parallelout.rst
+++ b/docs/source/builder/components/parallelout.rst
@@ -3,7 +3,7 @@
 Parallel Port Out Component
 ---------------------------------
 
-This component allows you to send triggers to a parallel port or to a LabJack device.
+This component allows you to send triggers to a parallel port, USB2TTL8, or LabJack U3 device.
 
 An example usage would be in EEG experiments to set the port to 0 when no stimuli are present and then set it to an identifier value for each stimulus synchronised to the start/stop of that stimulus. In that case you might set the `Start data` to be `$ID` (with ID being a column in your conditions file) and set the `Stop Data` to be 0.
 
@@ -39,6 +39,9 @@ Parameters for controlling hardware.
 Port address : select the appropriate option
     You need to know the address of the parallel port you wish to write to. The options that appear in this drop-down list are determined by the application preferences. You can add your particular port there if you prefer.
 
+Register : U3 register to write to
+     When using a LabJack U3, you can select which register is used to write a data byte to. Register EIO is the default.
+
 .. seealso::
 
-	API reference for :class:`~psychopy.hardware.iolab`
+	API reference for :class:`~psychopy.hardware.labjacks.U3`

--- a/psychopy/hardware/labjacks.py
+++ b/psychopy/hardware/labjacks.py
@@ -5,32 +5,34 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-"""This provides a basic ButtonBox class, and imports the
-   `ioLab python library <http://github.com/ioLab/python-ioLabs>`_.
+"""This provides a basic LabJack U3 class that can write a full byte of data,
+   by extending the labjack python library u3.U3 class.
 """
 
 try:
     from labjack import u3
 except ImportError:
     import u3
-# Could not load the Exodriver driver
-#    "dlopen(liblabjackusb.dylib, 6): image not found"
 
 
 class U3(u3.U3):
-
+    registerMappings = dict(FIO=6700, EIO=6701, CIO=6702)
     def setData(self, byte, endian='big', address=6701):
-        """Write 1 byte of data to the U3 port
+        """Write 1 byte of data to the U3 register address (EIO default)
 
         parameters:
 
             - byte: the value to write (must be an integer 0:255)
-            - endian: ['big' or 'small'] ignored from 1.84 onwards; automatic?
-            - address: the memory address to send the byte to
-                - 6700 = FIO
-                - 6701 (default) = EIO (the DB15 connector)
-                - 6702 = CIO
+            - endian: ['big' or 'small'] ignored from 1.84 onwards
+            - address: U3 register to write byte to. Both str and int constants are supported:
+                - 'FIO' == 6700
+                - 'EIO' == 6701 (default, accessed from DB15 breakout)
+                - 'CIO' == 6702 (4 bits wide (0 - 15))
         """
+        if isinstance(address, str):
+            # Map address (register) string to register number
+            address = self.registerMappings.get(address, 6701)
+
         # Upper byte is the writemask, lower byte is the 8 lines/bits to set.
         # Bit 0 = line 0, bit 1 = line 1, bit 2 = line 2, etc.
         self.writeRegister(address, 0xFF00 + (byte & 0xFF))

--- a/psychopy/hardware/labjacks.py
+++ b/psychopy/hardware/labjacks.py
@@ -17,6 +17,15 @@ except ImportError:
 
 class U3(u3.U3):
     registerMappings = dict(FIO=6700, EIO=6701, CIO=6702)
+    FIO0 = 6000  # FIO bit 0
+    EIO0 = 6008  # EIO bit 0
+    def __init__(self, debug = False, autoOpen = True, **kargs):
+        u3.U3.__init__(self, debug, autoOpen, **kargs)
+        # Unless 1 bit is written to a register first, future calls
+        # to setData() will not update U3.
+        self.writeRegister(self.EIO0, 0)
+        self.writeRegister(self.FIO0, 0)
+
     def setData(self, byte, endian='big', address=6701):
         """Write 1 byte of data to the U3 register address (EIO default)
 


### PR DESCRIPTION
BF: U3.setData() was not working
ENH: When U3 is selected device for Parallel Out component, show a 'Register' param that lets user select whether U3 EIO or FIO should be used to write data byte to. Default is EIO. Register param is not visible when parallel port address or USB2TTL8 is selected.
DOC: Update labjacks.py and parallelout.rst docs