### PR TITLE
RF: Ignore add venvs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,4 @@ gource_psychopy.mkv
 #################################
 .coverage
 nonSphinx
-/venv/
+/venv*/


### PR DESCRIPTION
Add an asterisk to venv in gitignore so that all venvs are ignored (e.g. I use venv36 and venv38 to have multiple venvs to try stuff in)