### PR TITLE
RF: Remove `None` color from colorpicker

### DIFF
--- a/psychopy/app/colorpicker/panels.py
+++ b/psychopy/app/colorpicker/panels.py
@@ -49,6 +49,9 @@ class ColorPresets(ScrolledPanel):
         colorList = list(colorNames)
         btnSize = wx.Size(120, 24)
         for color in colorList:
+            if color == 'none':
+                continue
+
             btn = GenButton(self, size=btnSize, label=color, name=color)
             btn.colorData = col = Color(color, 'named')
 

--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -30,7 +30,6 @@ colorExamples = {
 
 # Dict of named colours
 colorNames = {
-    "none": (0, 0, 0),
     "aliceblue": (0.882352941176471, 0.945098039215686, 1),
     "antiquewhite": (0.96078431372549, 0.843137254901961, 0.686274509803922),
     "aqua": (-1, 1, 1),

--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -30,6 +30,7 @@ colorExamples = {
 
 # Dict of named colours
 colorNames = {
+    "none": (0, 0, 0),
     "aliceblue": (0.882352941176471, 0.945098039215686, 1),
     "antiquewhite": (0.96078431372549, 0.843137254901961, 0.686274509803922),
     "aqua": (-1, 1, 1),


### PR DESCRIPTION
Removes the transparent color preset from the color picker. Since we don't allow users to set transparency by setting the alpha channel directly, it doesn't make sense to have transparent presets.