### PR TITLE
FF: Fixed exception when trying to open ET Record component dialog

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -434,9 +434,9 @@ class StartStopCtrls(wx.GridBagSizer):
         # Set value to None if hidden (specific to start/stop)
         if not visible:
             if "startVal" in self.ctrls:
-                self.ctrls["startVal"].Value = None
+                self.ctrls["startVal"].Value = "0"
             if "stopVal" in self.ctrls:
-                self.ctrls["stopVal"].Value = None
+                self.ctrls["stopVal"].Value = ""
         # Layout
         self.parent.Layout()
 


### PR DESCRIPTION
FF: Fixed exception when trying to open ET Record component dialog
FF: Set start to '0' when ET Record is in Stop Only mode.