### PR TITLE
ENH: Builder experiments now support updating values on QUEST

### DIFF
--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -438,7 +438,7 @@ class JoyButtonsComponent(BaseComponent):
         if currLoop.type in ['StairHandler', 'MultiStairHandler']:
             # data belongs to a Staircase-type of object
             if self.params['storeCorrect'].val is True:
-                code = ("%s.addResponse(%s.corr)\n" %
+                code = ("%s.addResponse(%s.corr, level)\n" %
                         (currLoop.params['name'], name) +
                         "%s.addOtherData('%s.rt', %s.rt)\n"
                         % (currLoop.params['name'], name, name))

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -455,7 +455,7 @@ class KeyboardComponent(BaseComponent):
         if currLoop.type in ['StairHandler', 'MultiStairHandler']:
             # data belongs to a Staircase-type of object
             if self.params['storeCorrect'].val is True:
-                code = ("%s.addResponse(%s.corr)\n" %
+                code = ("%s.addResponse(%s., level)\n" %
                         (currLoop.params['name'], name) +
                         "%s.addOtherData('%s.rt', %s.rt)\n"
                         % (currLoop.params['name'], name, name))
@@ -520,7 +520,7 @@ class KeyboardComponent(BaseComponent):
 
         buff.setIndentLevel(1, relative=True)
         code = (
-                "currentLoop.addResponse(%(name)s.corr);\n"
+                "currentLoop.addResponse(%(name)s.corr, level);\n"
         )
         buff.writeIndentedLines(code % self.params)
 


### PR DESCRIPTION
Staircases and QUEST classes support the case where the level
that was presented was not actually the level suggested by the
staircase by updating in the addResponse() method. This was not
being exposed in Builder boilerplate, however.

In this PR we add `level` back during addResponse so that if a
Code Component does something like:
```
if level > 1:
    level = 1
```
then the level value will be passed back correctly during addResponse
and stored by the QUEST/StairHandler.

The operation is in place for both Py/JS engines