### PR TITLE
BF: Only treat `var` as a variable declaration if it has a space after

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -408,7 +408,7 @@ def transformPsychoJsCode(psychoJsCode, addons):
     else:
         startIndex = 0
 
-    if lines[startIndex].find('var') == 0:
+    if lines[startIndex].find('var ') == 0:
         startIndex += 1
 
     for index in range(startIndex, len(lines)):

--- a/psychopy/tests/test_app/test_builder/test_components.py
+++ b/psychopy/tests/test_app/test_builder/test_components.py
@@ -210,6 +210,10 @@ def test_param_str():
          "js": "[1, 2, 3]"},
     ]
     tykes = [
+        # Name containing "var" (should no longer return blank as of #4336)
+        {"obj": Param("variableName", "code"),
+         "py": "variableName",
+         "js": "variableName"}
     ]
 
     # Take note of what the script target started as

--- a/psychopy/tests/test_scripts/test_py2js_transpiler.py
+++ b/psychopy/tests/test_scripts/test_py2js_transpiler.py
@@ -19,6 +19,20 @@ class TestTranspiler(object):
         js = ("a = 1;\n")
         self.runTranspile(py, js)
 
+    def test_name(self):
+        # Some typical cases
+        exemplars = [
+            {'py': "normalName",
+             'js': "normalName;\n"}
+        ]
+        # Some problem cases
+        tykes = [
+            {'py': "variableName",
+             'js': "variableName;\n"}  # Name containing "var" (should no longer return blank as of #4336)
+        ]
+        for case in exemplars + tykes:
+            self.runTranspile(case['py'], case['js'])
+
     def test_if_statement(self):
         py = ("if True:\n    True")
         js = ("if (true) {\n    true;\n}\n")


### PR DESCRIPTION
Means that components with `var` in their name are no longer compiled as blank, as they were mistaken for variable declarations previously