### PR TITLE
BF: Remove alert 4550 from catalogue

### DIFF
--- a/psychopy/alerts/alertsCatalogue/alertCategories.yaml
+++ b/psychopy/alerts/alertsCatalogue/alertCategories.yaml
@@ -62,7 +62,6 @@
     4530: Auto pace param not used
     4540: Eyetracking requires window to be fullscreen
     4545: Eyetracking requires a monitor config
-    4550: ROI component with no record component
 
   4600:
     cat: Audio Transcription


### PR DESCRIPTION
Alert is already removed (#4330) but I forgot to remove the reference to it in the alerts catalogue