### PR TITLE
NF: Callback assignement for window events

### DIFF
--- a/psychopy/visual/backends/_base.py
+++ b/psychopy/visual/backends/_base.py
@@ -25,9 +25,9 @@ class BaseBackend(ABC):
     """The backend abstract base class that defines all the core low-level
     functions required by a :class:`~psychopy.visual.Window` class.
 
-    Such functions as the ability to create an OpenGL context, process events,
-    and flip the window. Sub-classes of this function must implement the
-    abstract methods shown here to be complete.
+    Such methods as the ability to create an OpenGL context, process events,
+    and flip the window are prototyped here. Sub-classes of this function must
+    implement the abstract methods shown here to be complete.
 
     Users simply call visual.Window(..., winType='pyglet') and the `winType` is
     then used by `backends.getBackend(winType)` which will locate the
@@ -114,7 +114,7 @@ class BaseBackend(ABC):
 
         Callback function must have the following signature::
 
-            callback(int: newPosX, int: newPosY, Any: winHandle) -> None
+            callback(Any: winHandle, int: newPosX, int: newPosY) -> None
 
         """
         return self._onMoveCallback
@@ -133,7 +133,7 @@ class BaseBackend(ABC):
 
         Callback function must have the following signature::
 
-            callback(int: newSizeW, int: newSizeH, Any: winHandle) -> None
+            callback(Any: winHandle, int: newSizeW, int: newSizeH) -> None
 
         """
         return self._onResizeCallback
@@ -156,7 +156,7 @@ class BaseBackend(ABC):
         # When overriding this function, at the very minimum we must call the
         # user's function, passing the data they expect.
         if self._onResizeCallback is not None:
-            self._onResizeCallback(width, height)
+            self._onResizeCallback(self.win, width, height)
 
     def onMove(self, posX, posY):
         """A method called when the window is moved by the user.
@@ -169,7 +169,7 @@ class BaseBackend(ABC):
             self.win.pos[:] = (posX, posY)
 
         if self._onMoveCallback is not None:
-            self._onMoveCallback(posX, posY)
+            self._onResizeCallback(self.win, posX, posY)
 
     # Helper methods that don't need converting
 

--- a/psychopy/visual/backends/_base.py
+++ b/psychopy/visual/backends/_base.py
@@ -111,12 +111,17 @@ class BaseBackend(ABC):
     @property
     def onMoveCallback(self):
         """Callback function for window move events (`callable` or `None`).
+
+        Callback function must have the following signature::
+
+            callback(int: newPosX, int: newPosY, Any: winHandle) -> None
+
         """
         return self._onMoveCallback
 
     @onMoveCallback.setter
     def onMoveCallback(self, value):
-        if not callable(value) or value is not None:
+        if not (callable(value) or value is None):
             raise TypeError(
                 'Value for `onMoveCallback` must be callable or `None`.')
 
@@ -125,18 +130,23 @@ class BaseBackend(ABC):
     @property
     def onResizeCallback(self):
         """Callback function for window resize events (`callable` or `None`).
+
+        Callback function must have the following signature::
+
+            callback(int: newSizeW, int: newSizeH, Any: winHandle) -> None
+
         """
         return self._onResizeCallback
 
     @onResizeCallback.setter
     def onResizeCallback(self, value):
-        if not callable(value) or value is not None:
+        if not (callable(value) or value is None):
             raise TypeError(
                 'Value for `onResizeCallback` must be callable or `None`.')
 
         self._onResizeCallback = value
 
-    def _onResize(self, width, height):
+    def onResize(self, width, height):
         """A method that will be called if the window detects a resize event.
 
         This method is bound to the window backend resize event, data is
@@ -146,17 +156,20 @@ class BaseBackend(ABC):
         # When overriding this function, at the very minimum we must call the
         # user's function, passing the data they expect.
         if self._onResizeCallback is not None:
-            self._onResizeCallback((width, height))
+            self._onResizeCallback(width, height)
 
-    def _onMove(self, posX, posY):
+    def onMove(self, posX, posY):
         """A method called when the window is moved by the user.
 
         This method is bound to the window backend move event, data is
         formatted and forwarded to the user's callback function.
 
         """
+        if hasattr(self.win, 'pos'):  # write the new position of the window
+            self.win.pos[:] = (posX, posY)
+
         if self._onMoveCallback is not None:
-            self._onMoveCallback((posX, posY))
+            self._onMoveCallback(posX, posY)
 
     # Helper methods that don't need converting
 

--- a/psychopy/visual/backends/_base.py
+++ b/psychopy/visual/backends/_base.py
@@ -108,23 +108,55 @@ class BaseBackend(ABC):
                         .format(self.win.winType)
                         )
 
-    def onResize(self, width, height):
-        """A method that will be called if the window detects a resize event
+    @property
+    def onMoveCallback(self):
+        """Callback function for window move events (`callable` or `None`).
         """
-        raise NotImplementedError(
-            "`onResize` is not yet implemented for this backend.")
+        return self._onMoveCallback
 
-    def onMove(self, newPos):
+    @onMoveCallback.setter
+    def onMoveCallback(self, value):
+        if not callable(value) or value is not None:
+            raise TypeError(
+                'Value for `onMoveCallback` must be callable or `None`.')
+
+        self._onMoveCallback = value
+
+    @property
+    def onResizeCallback(self):
+        """Callback function for window resize events (`callable` or `None`).
+        """
+        return self._onResizeCallback
+
+    @onResizeCallback.setter
+    def onResizeCallback(self, value):
+        if not callable(value) or value is not None:
+            raise TypeError(
+                'Value for `onResizeCallback` must be callable or `None`.')
+
+        self._onResizeCallback = value
+
+    def _onResize(self, width, height):
+        """A method that will be called if the window detects a resize event.
+
+        This method is bound to the window backend resize event, data is
+        formatted and forwarded to the user's callback function.
+
+        """
+        # When overriding this function, at the very minimum we must call the
+        # user's function, passing the data they expect.
+        if self._onResizeCallback is not None:
+            self._onResizeCallback((width, height))
+
+    def _onMove(self, posX, posY):
         """A method called when the window is moved by the user.
 
-        Parameters
-        ----------
-        cbfunc : callable
-            Callback function.
+        This method is bound to the window backend move event, data is
+        formatted and forwarded to the user's callback function.
 
         """
-        raise NotImplementedError(
-            "`onMove` is not yet implemented for this backend.")
+        if self._onMoveCallback is not None:
+            self._onMoveCallback((posX, posY))
 
     # Helper methods that don't need converting
 

--- a/psychopy/visual/backends/_base.py
+++ b/psychopy/visual/backends/_base.py
@@ -50,6 +50,11 @@ class BaseBackend(ABC):
         :param: win is a PsychoPy Window (usually not fully created yet)
         """
         self.win = win  # this will use the @property to make/use a weakref
+
+        # callback functions
+        self._onMoveCallback = None
+        self._onResizeCallback = None
+
         super().__init__()
 
     @abstractmethod
@@ -106,10 +111,20 @@ class BaseBackend(ABC):
     def onResize(self, width, height):
         """A method that will be called if the window detects a resize event
         """
-        logging.warning("dispatchEvents() method in {} was called "
-                        "but is not implemented. Is it needed?"
-                        .format(self.win.winType)
-                        )
+        raise NotImplementedError(
+            "`onResize` is not yet implemented for this backend.")
+
+    def onMove(self, newPos):
+        """A method called when the window is moved by the user.
+
+        Parameters
+        ----------
+        cbfunc : callable
+            Callback function.
+
+        """
+        raise NotImplementedError(
+            "`onMove` is not yet implemented for this backend.")
 
     # Helper methods that don't need converting
 

--- a/psychopy/visual/backends/glfwbackend.py
+++ b/psychopy/visual/backends/glfwbackend.py
@@ -396,6 +396,8 @@ class GLFWBackend(BaseBackend):
         # Assign event callbacks, these are dispatched when 'poll_events' is
         # called.
         glfw.set_mouse_button_callback(self.winHandle, self.onMouseButton)
+        glfw.set_window_size_callback(self.winHandle, self._onResize)
+        glfw.set_window_pos_callback(self.winHandle, self._onMove)
         glfw.set_cursor_pos_callback(self.winHandle, self.onMouseMove)
         glfw.set_cursor_enter_callback(self.winHandle, self.onMouseEnter)
         glfw.set_scroll_callback(self.winHandle, self.onMouseScroll)

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -303,6 +303,8 @@ class PygletBackend(BaseBackend):
         self.winHandle.getGammaRamp = getGammaRamp
         self.winHandle.set_vsync(True)
         self.winHandle.on_text = self.onText
+        self.winHandle.on_move = self._onMove
+        self.winHandle.on_resize = self._onResize
         self.winHandle.on_text_motion = self.onCursorKey
         self.winHandle.on_key_press = self.onKey
         self.winHandle.on_mouse_press = self.onMouseButtonPress

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -303,8 +303,8 @@ class PygletBackend(BaseBackend):
         self.winHandle.getGammaRamp = getGammaRamp
         self.winHandle.set_vsync(True)
         self.winHandle.on_text = self.onText
-        self.winHandle.on_move = self._onMove
-        self.winHandle.on_resize = self._onResize
+        self.winHandle.on_move = self.onMove
+        self.winHandle.on_resize = self.onResize
         self.winHandle.on_text_motion = self.onCursorKey
         self.winHandle.on_key_press = self.onKey
         self.winHandle.on_mouse_press = self.onMouseButtonPress
@@ -414,8 +414,33 @@ class PygletBackend(BaseBackend):
         for win in wins:
             win.dispatch_events()
 
+    def onResize(self, width, height):
+        """A method that will be called if the window detects a resize event.
+
+        This method is bound to the window backend resize event, data is
+        formatted and forwarded to the user's callback function.
+
+        """
+        # When overriding this function, at the very minimum we must call the
+        # user's function, passing the data they expect.
+        if self._onResizeCallback is not None:
+            self._onResizeCallback(width, height)
+
+    def onMove(self, posX, posY):
+        """A method called when the window is moved by the user.
+
+        This method is bound to the window backend move event, data is
+        formatted and forwarded to the user's callback function.
+
+        """
+        if hasattr(self.win, 'pos'):
+            self.win.pos[:] = (posX, posY)
+
+        if self._onMoveCallback is not None:
+            self._onMoveCallback(posX, posY)
+
     def onKey(self, evt, modifiers):
-        "Check for tab key then pass all events to event package"
+        """Check for tab key then pass all events to event package."""
         if evt is not None:
             thisKey = pyglet.window.key.symbol_string(evt).lower()
             if thisKey == 'tab':


### PR DESCRIPTION
This PR adds callbacks for window move and resize events. These are intended to notify iohub of these events. Some other changes were made to clean up the backend code a bit. 

Adding a callback is easy:

```
def moveCallback(win, x, y):  # callback function, gets window object and new X,Y coords
    print(x, y)

myWindow.backend.onMoveCallback = moveCallback  # called every time the window is moved, frequency depends on the backend
```