### PR TITLE
BF: Modification of parameter with default

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -3494,7 +3494,7 @@ class FlowPanel(wx.ScrolledWindow):
         dc.SetIdBounds(tmpId, wx.Rect(
             pos[0] - size, pos[1] - size, 2 * size, 2 * size))
 
-    def drawFlowRoutine(self, dc, routine, id, pos=[0, 0], draw=True):
+    def drawFlowRoutine(self, dc, routine, id, pos=(0, 0), draw=True):
         """Draw a box to show a routine on the timeline
         draw=False is for a dry-run, esp to compute and return size
         without drawing or setting a pdc ID
@@ -3534,8 +3534,8 @@ class FlowPanel(wx.ScrolledWindow):
         w, h = self.GetFullTextExtent(name)[0:2]
         pad = (5, 10, 20)[self.appData['flowSize']]
         # draw box
-        pos[1] += 2 - self.appData['flowSize']
-        rect = wx.Rect(pos[0], pos[1], w + pad, h + pad)
+        rect = wx.Rect(pos[0], pos[1] + 2 - self.appData['flowSize'],
+                       w + pad, h + pad)
         endX = pos[0] + w + pad
         # the edge should match the text
         if draw:

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -4420,7 +4420,7 @@ class DisplayPlusPlusTouch(DisplayPlusPlus):
         super(DisplayPlusPlusTouch,self).__del__()
 
 
-    def RTBoxEnable(self, mode=['CB6','Down','Trigger'], map=None):
+    def RTBoxEnable(self, mode=('CB6','Down','Trigger'), map=None):
         """ Overaload RTBoxEnable for Display++ with touch screen.
         Sets up the RTBox with preset or bespoke mappings 
         and enables event detection.
@@ -4482,6 +4482,8 @@ class DisplayPlusPlusTouch(DisplayPlusPlus):
             warning = ("Cannot use RTBox when touch screen is on")
             raise AssertionError(warning)
         else:
+            if type(mode) is tuple:
+                mode = list(mode)
             super(DisplayPlusPlusTouch, self).RTBoxEnable(mode = mode, map = map)
     
     def statusBoxEnable(self, mode=None, map=None, threshold = None):

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -136,9 +136,12 @@ class User(object):
 
     (from previous logins and from the current session)"""
 
-    def __init__(self, localData={}, gitlabData=None, rememberMe=True):
+    def __init__(self, localData=None, gitlabData=None, rememberMe=True):
         currentSession = getCurrentSession()
-        self.data = localData
+        if localData is None:
+            self.data = {}
+        else:
+            self.data = localData
         self.gitlabData = gitlabData
         # try looking for local data
         if gitlabData and not localData:


### PR DESCRIPTION
Fix series of the same LGTM.com error.

The default value of keyword arguments is mutable and is eventually mutated, changing the default value in future function calls. Perhaps it's currently not an issue in some cases, but it is a Python anti-pattern that may cause hard to detect problems in the future.

See for example [Python Mutable Defaults Are The Source of All Evil](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/).