### PR TITLE
BF: pyobjc needs to be < v8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,9 +89,9 @@ install_requires =
     pyqt5; python_version >= "3"
     wxPython != 4.0.2, != 4.0.3; platform_system != "Linux"
     pypiwin32; platform_system == "Windows"
-    pyobjc-core; platform_system == "Darwin"
-    pyobjc-framework-Quartz; platform_system == "Darwin"
-    pyobjc; platform_system == "Darwin"
+    pyobjc-core < 8.0; platform_system == "Darwin"
+    pyobjc-framework-Quartz < 8.0; platform_system == "Darwin"
+    pyobjc < 8.0; platform_system == "Darwin"
     python-xlib; platform_system == "Linux"
     distro; platform_system == "Linux"
     websocket_client


### PR DESCRIPTION
BF: pyobjc needs to be < v8.0  or iohub gives error. Will investigate / fix support for pyobjc v8.0 later.