### PR TITLE
BF: pyobjc needs to be < v8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,9 +91,9 @@ install_requires =
     pyqt5; python_version >= "3"
     wxPython != 4.0.2, != 4.0.3; platform_system != "Linux"
     pypiwin32; platform_system == "Windows"
-    pyobjc-core; platform_system == "Darwin"
-    pyobjc-framework-Quartz; platform_system == "Darwin"
-    pyobjc; platform_system == "Darwin"
+    pyobjc-core < 8.0; platform_system == "Darwin"
+    pyobjc-framework-Quartz < 8.0; platform_system == "Darwin"
+    pyobjc < 8.0; platform_system == "Darwin"
     python-xlib; platform_system == "Linux"
     distro; platform_system == "Linux"
     websocket_client


### PR DESCRIPTION
BF: pyobjc needs to be < v8.0  or iohub gives error (will investigate later)

```
psychopy/tests/test_iohub/test_launch.py:12: AttributeError
----------------------------- Captured stdout call -----------------------------
 *** iohub warning: Display / Monitor unit type has not been set.
Error during device creation ....
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/server.py", line 691, in createNewMonitoredDevice
    dev_data = self.addDeviceToMonitor(dev_cls_name, dev_conf)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/server.py", line 841, in addDeviceToMonitor
    DeviceClass, dev_cls_name, evt_classes = import_device(dev_mod_pth,
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/__init__.py", line 932, in import_device
    module = __import__(module_path, fromlist=["{}".format(device_class_name)])
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/keyboard/__init__.py", line 127, in <module>
    from .darwin import Keyboard
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/keyboard/darwin.py", line 51, in <module>
    _objc.PyObjCObject_New.restype = ctypes.py_object
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/ctypes/__init__.py", line 386, in __getattr__
    func = self.__getitem__(name)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/ctypes/__init__.py", line 391, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: dlsym(0x7ffc94119dc0, PyObjCObject_New): symbol not found
Error during device creation ....
Traceback (most recent call last):
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/server.py", line 691, in createNewMonitoredDevice
    dev_data = self.addDeviceToMonitor(dev_cls_name, dev_conf)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/server.py", line 841, in addDeviceToMonitor
    DeviceClass, dev_cls_name, evt_classes = import_device(dev_mod_pth,
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/__init__.py", line 932, in import_device
    module = __import__(module_path, fromlist=["{}".format(device_class_name)])
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/keyboard/__init__.py", line 127, in <module>
    from .darwin import Keyboard
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/psychopy/iohub/devices/keyboard/darwin.py", line 51, in <module>
    _objc.PyObjCObject_New.restype = ctypes.py_object
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/ctypes/__init__.py", line 386, in __getattr__
    func = self.__getitem__(name)
  File "/Users/runner/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/ctypes/__init__.py", line 391, in __getitem__
    func = self._FuncPtr((name_or_ordinal, self))
AttributeError: dlsym(0x7ffc94119dc0, PyObjCObject_New): symbol not found
```