### PR TITLE
ENH: Adding call to end_experiment function

### DIFF
--- a/psychopy/experiment/components/emotiv_record/__init__.py
+++ b/psychopy/experiment/components/emotiv_record/__init__.py
@@ -69,3 +69,16 @@ class EmotivRecordingComponent(BaseComponent):  # or (VisualComponent)
         )
         buff.writeIndentedLines(code)
 
+    def writeExperimentEndCodeJS(self, buff):
+        code = 'if (typeof emotiv != "undefined") {\n'
+        buff.writeIndented(code)
+        buff.setIndentLevel(1, relative=True)
+        code = 'if (typeof emotiv.end_experiment != "undefined") {\n'
+        buff.writeIndented(code)
+        buff.setIndentLevel(1, relative=True)
+        code = 'emotiv.end_experiment();\n'
+        buff.writeIndented(code)
+        buff.setIndentLevel(-1, relative=True)
+        buff.writeIndented('}\n')
+        buff.setIndentLevel(-1, relative=True)
+        buff.writeIndented('}\n')

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1296,7 +1296,7 @@ class SettingsComponent(object):
         for thisRoutine in list(self.exp.routines.values()):
             # a single routine is a list of components:
             for thisComp in thisRoutine:
-                if thisComp.type == 'Code':
+                if thisComp.type in ['Code', 'EmotivRecording']:
                     buff.writeIndented("\n")
                     thisComp.writeExperimentEndCodeJS(buff)
                     buff.writeIndented("\n")


### PR DESCRIPTION
At the end of the experiment if there is an emotiv object that has the end_experiment function psychojs will call the function to enable clean handling of end of experiment in hosting site.

Note to maintainers this does involve a change the core code. Code checks for the presence of the function before calling it so should be safe

