### PR TITLE
RF: Remove use of PyOpenGL from windowwarp.py

### DIFF
--- a/psychopy/tests/test_Installation.py
+++ b/psychopy/tests/test_Installation.py
@@ -8,9 +8,9 @@ def test_essential_imports():
     import matplotlib
     #import pygame  # soft dependency only
     import pyglet
-    import OpenGL
     import openpyxl
     import pandas
+
 
 def test_extra_imports():
     # only Jon needs to run this, so test first if you are him!

--- a/psychopy/visual/windowwarp.py
+++ b/psychopy/visual/windowwarp.py
@@ -14,9 +14,9 @@ You should have received a copy of the GNU General Public License along
 with this program. If not, see http://www.gnu.org/licenses/
 """
 
+import ctypes
 import numpy as np
 from psychopy import logging
-from OpenGL.arrays import ArrayDatatype as ADT
 import pyglet
 GL = pyglet.gl
 
@@ -412,28 +412,44 @@ class Warper:
 
         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
 
+        # type and size for arrays
+        arrType = ctypes.c_float
+        ptrType = ctypes.POINTER(arrType)
+        nbytes = ctypes.sizeof(arrType)
+
         # vertex buffer in hardware
         self.gl_vb = GL.GLuint()
         GL.glGenBuffers(1, self.gl_vb)
         GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_vb)
-        GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-            vertices), ADT.voidDataPointer(vertices), GL.GL_STATIC_DRAW)
+        GL.glBufferData(
+            GL.GL_ARRAY_BUFFER,
+            vertices.size * nbytes,
+            vertices.ctypes.data_as(ptrType),
+            GL.GL_STATIC_DRAW)
 
-        # vertex buffer tdata in hardware
+        # vertex buffer texture data in hardware
         self.gl_tb = GL.GLuint()
         GL.glGenBuffers(1, self.gl_tb)
         GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_tb)
-        GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-            tcoords), ADT.voidDataPointer(tcoords), GL.GL_STATIC_DRAW)
+        GL.glBufferData(
+            GL.GL_ARRAY_BUFFER,
+            tcoords.size * nbytes,
+            tcoords.ctypes.data_as(ptrType),
+            GL.GL_STATIC_DRAW)
 
         # opacity buffer in hardware (only for warp files)
         if opacity is not None:
             self.gl_color = GL.GLuint()
             GL.glGenBuffers(1, self.gl_color)
             GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_color)
+
             # convert opacity to RGBA, one point for each corner of the quad
-            GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-                opacity), ADT.voidDataPointer(opacity), GL.GL_STATIC_DRAW)
+            GL.glBufferData(
+                GL.GL_ARRAY_BUFFER,
+                opacity.size * nbytes,
+                opacity.ctypes.data_as(ptrType),
+                GL.GL_STATIC_DRAW)
+
         else:
             self.gl_color = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     pillow
     glfw
     pygame
-    pyopengl
     pyo
     soundfile
     sounddevice


### PR DESCRIPTION
This commit removes the use of PyOpenGL in the window warper class, instead using `pyget.gl` exclusively. This should allow tests to pass on MacOS where PyOpenGL is presently broken.