### PR TITLE
RF: Update package information and python versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,15 +17,16 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*
-setup_requires = 
+python_requires = >=3.6
+setup_requires =
     distro; platform_system == "Linux"
 install_requires =
     requests[security]


### PR DESCRIPTION
This PR updates `setup.cfg` to include Python versions we support. Completely drops support for Python versions <3.6.