### PR TITLE
NF: Set focus on output console when experiment ends

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2636,7 +2636,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
         self.app.runner.Raise()
         if event:
             if event.Id in [self.cdrBtnRun.Id, self.IDs.cdrRun]:
-                self.app.runner.panel.runLocal(event)
+                self.app.runner.panel.runLocal(event, focusOnExit='coder')
                 self.Raise()
             else:
                 self.app.showRunner()

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -683,7 +683,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
         if self.currentSelection:
             self.runBtn.Enable()
 
-    def runLocal(self, evt):
+    def runLocal(self, evt, focusOnExit='runner'):
         """Run experiment from new process using inherited ScriptProcess class methods."""
         if self.currentSelection is None:
             return
@@ -692,7 +692,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
         if self.currentFile.suffix == '.psyexp':
             generateScript(experimentPath=currentFile.replace('.psyexp', '_lastrun.py'),
                            exp=self.loadExperiment())
-        self.runFile(fileName=currentFile)
+        self.runFile(fileName=currentFile, focusOnExit=focusOnExit)
 
         # Enable/Disable btns
         self.runBtn.Disable()

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -36,6 +36,24 @@ class ScriptProcess:
         self.app = app  # reference to the app
         self.scriptProcess = None  # reference to the `Job` object
         self._processEndTime = None  # time the process ends
+        self._focusOnExit = 'runner'
+
+    @property
+    def focusOnExit(self):
+        """Which output to focus on when the script exits (`str`)?
+        """
+        return self._focusOnExit
+
+    @focusOnExit.setter
+    def focusOnExit(self, value):
+        if not isinstance(value, str):
+            raise TypeError('Property `focusOnExit` must be string.')
+        elif value not in ('runner', 'coder'):
+            raise ValueError(
+                'Property `focusOnExit` must have value either "runner" or '
+                '"coder"')
+
+        self._focusOnExit = value
 
     @property
     def running(self):
@@ -47,7 +65,7 @@ class ScriptProcess:
 
         return self.scriptProcess.isRunning
 
-    def runFile(self, event=None, fileName=None):
+    def runFile(self, event=None, fileName=None, focusOnExit='runner'):
         """Begin new process to run experiment.
 
         Parameters
@@ -57,6 +75,9 @@ class ScriptProcess:
             callback. Set as `None` if calling directly.
         fileName : str
             Path to the file to run.
+        focusOnExit : str
+            Which output window to focus on when the application exits. Can be
+            either 'coder' or 'runner'. Default is 'runner'.
 
         """
         # full path to the script
@@ -107,6 +128,7 @@ class ScriptProcess:
 
         # start the subprocess
         self.scriptProcess.start()
+        self.focusOnExit = focusOnExit
 
     def stopFile(self, event=None):
         """Stop the script process.
@@ -231,6 +253,24 @@ class ScriptProcess:
             if itemIdx >= 0:
                 self.expCtrl.Select(itemIdx)
                 self.runBtn.Enable()
+
+        def _focusOnOutput(win):
+            """Subroutine to focus on a given output window."""
+            win.Show()
+            win.Raise()
+            win.Iconize(False)
+
+        # set focus to output window
+        if self.app is not None:
+            if self.focusOnExit == 'coder' and hasattr(self.app, 'coder'):
+                if self.app.coder is not None:
+                    _focusOnOutput(self.app.coder)
+                    self.app.coder.shelf.SetSelection(1)  # page for the console output
+                    self.app.coder.shell.SetFocus()
+            elif self.focusOnExit == 'runner' and hasattr(self.app, 'runner'):
+                if self.app.runner is not None:
+                    _focusOnOutput(self.app.runner)
+                    self.app.runner.stdOut.SetFocus()
 
         EndBusyCursor()
 

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -267,6 +267,14 @@ class ScriptProcess:
                     _focusOnOutput(self.app.coder)
                     self.app.coder.shelf.SetSelection(1)  # page for the console output
                     self.app.coder.shell.SetFocus()
+                else:  # coder is closed, open runner and show output instead
+                    if hasattr(self.app, 'runner') and \
+                            hasattr(self.app, 'showRunner'):
+                        # show runner if available
+                        if self.app.runner is None:
+                            self.app.showRunner()
+                        _focusOnOutput(self.app.runner)
+                        self.app.runner.stdOut.SetFocus()
             elif self.focusOnExit == 'runner' and hasattr(self.app, 'runner'):
                 if self.app.runner is not None:
                     _focusOnOutput(self.app.runner)


### PR DESCRIPTION
This PR automatically sets focus to an output window when the experiment ends. Uses the following rules to determine which window to use.

1. If the experiment was launched from runner, the runner window is focused.
2. If the experiment was lunched from coder, the coder output view gets focus.
3. If no output window is present, or coder was closed at some point while the experiment is running, open a runner window and focus on the dialog.

~Rule #3 could be changed to open/raise a runner window then set focus.~