### PR TITLE
Fix typos found by codespell in actual code

### DIFF
--- a/psychopy/iohub/client/wintab.py
+++ b/psychopy/iohub/client/wintab.py
@@ -68,7 +68,7 @@ class PenSampleEvent(ioEvent):
             if efvalue >= 0:
                 setattr(self, '_' + efname, ioe_array[efvalue])
         self._velocity = 0.0
-        self._accelleration = 0.0
+        self._acceleration = 0.0
 
     @property
     def x(self):
@@ -140,14 +140,18 @@ class PenSampleEvent(ioEvent):
         return self._velocity
 
     @property
-    def accelleration(self):
+    def acceleration(self):
         """Returns the calculated x, y, and xy acceleration for the current
         sample.
 
         :return: (float, float, float)
 
         """
-        return self._accelleration
+        return self._acceleration
+
+    @property
+    def accelleration(self):  # deprecated, use acceleration instead
+        return self._acceleration
 
     @velocity.setter
     def velocity(self, v):
@@ -158,15 +162,19 @@ class PenSampleEvent(ioEvent):
         """
         self._velocity = v
 
-    @accelleration.setter
-    def accelleration(self, a):
+    @acceleration.setter
+    def acceleration(self, a):
         """Returns the calculated x, y, and xy acceleration for the current
         sample.
 
         :return: (float, float, float)
 
         """
-        self._accelleration = a
+        self._acceleration = a
+
+    @accelleration.setter
+    def accelleration(self, a):  # deprecated, use acceleration instead
+        self._acceleration = a
 
     def __str__(self):
         sargs = [ioEvent.__str__(self), self.x, self.y, self.z, self.pressure,
@@ -250,7 +258,7 @@ class Wintab(ioHubDeviceView):
                         'Warning: dt == 0: {}, {}, {}'.format(
                             dt, curr_samp.time, prev_samp.time))
                     curr_samp.velocity = (0, 0, 0)
-                    curr_samp.accelleration = (0, 0, 0)
+                    curr_samp.acceleration = (0, 0, 0)
                 else:
                     cvx = dx / dt
                     cvy = dy / dt
@@ -263,24 +271,24 @@ class Wintab(ioHubDeviceView):
                         cax = dx / dt
                         cay = dy / dt
                         cayx = np.sqrt(dx * dx + dy * dy) / dt
-                        curr_samp.accelleration = cax, cay, cayx
+                        curr_samp.acceleration = cax, cay, cayx
                     else:
-                        curr_samp.accelleration = (0, 0, 0)
+                        curr_samp.acceleration = (0, 0, 0)
             except ZeroDivisionError:
                 print("ERROR: wintab._calculateVelAccel ZeroDivisionError "
                       "occurred. prevId: %d, currentId: %d" % (curr_samp.id,
                                                                prev_samp.id))
                 curr_samp.velocity = (0, 0, 0)
-                curr_samp.accelleration = (0, 0, 0)
+                curr_samp.acceleration = (0, 0, 0)
             except Exception as e: #pylint: disable=broad-except
                 print("ERROR: wintab._calculateVelAccel error [%s] occurred."
                       "prevId: %d, currentId: %d" % (str(e), curr_samp.id,
                                                      prev_samp.id))
                 curr_samp.velocity = (0, 0, 0)
-                curr_samp.accelleration = (0, 0, 0)
+                curr_samp.acceleration = (0, 0, 0)
         else:
             curr_samp.velocity = (0, 0, 0)
-            curr_samp.accelleration = (0, 0, 0)
+            curr_samp.acceleration = (0, 0, 0)
         self._prev_sample = curr_samp
         return curr_samp
 

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -249,10 +249,10 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         if editable is True:
             if self.win:
                 self.win.addEditable(self)
-        
+
     @property
-    def pallette(self):
-        self._pallette = {
+    def palette(self):
+        self._palette = {
             False: {
                 'lineColor': self._borderColor,
                 'lineWidth': self.borderWidth,
@@ -264,11 +264,34 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
                 'fillColor': self._fillColor+0.1
             }
         }
-        return self._pallette[self.hasFocus]
+        return self._palette[self.hasFocus]
+
+    @property
+    def pallette(self):  # deprecated, use palette instead
+        self._palette = {
+            False: {
+                'lineColor': self._borderColor,
+                'lineWidth': self.borderWidth,
+                'fillColor': self._fillColor
+            },
+            True: {
+                'lineColor': self._borderColor-0.1,
+                'lineWidth': self.borderWidth+1,
+                'fillColor': self._fillColor+0.1
+            }
+        }
+        return self._palette[self.hasFocus]
+
+    @palette.setter
+    def pallette(self, value):
+        self._palette = {
+            False: value,
+            True: value
+        }
 
     @pallette.setter
-    def pallette(self, value):
-        self._pallette = {
+    def pallette(self, value):  # deprecated, use palette instead
+        self._palette = {
             False: value,
             True: value
         }
@@ -769,13 +792,13 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
     def draw(self):
         """Draw the text to the back buffer"""
         # Border width
-        self.box.setLineWidth(self.pallette['lineWidth']) # Use 1 as base if border width is none
+        self.box.setLineWidth(self.palette['lineWidth']) # Use 1 as base if border width is none
         #self.borderWidth = self.box.lineWidth
         # Border colour
-        self.box.setLineColor(self.pallette['lineColor'], colorSpace='rgb')
+        self.box.setLineColor(self.palette['lineColor'], colorSpace='rgb')
         #self.borderColor = self.box.lineColor
         # Background
-        self.box.setFillColor(self.pallette['fillColor'], colorSpace='rgb')
+        self.box.setFillColor(self.palette['fillColor'], colorSpace='rgb')
         #self.fillColor = self.box.fillColor
 
         if self._needVertexUpdate:


### PR DESCRIPTION
1. Fix private variables:
   - `_accelleration` → `_acceleration`
   - `_pallette` → `_palette`
2. Modify API:
   - Keep existing properties, with typos, but deprecate them.
   - Create new properties, without typos.
   - Modify code/examples to use new properties.

Could add [deprecation](https://deprecation.readthedocs.io/) as a dependency: better and standard way to deprecate the function.
