### PR TITLE
FF: Don't compute stdev on frame intervals if degrees of freedom is invalid

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -3156,8 +3156,7 @@ class Window():
             self.flip()
             recentFrames = self.frameIntervals[-nIdentical:]
             nIntervals = len(self.frameIntervals)
-            recentFramesStd = numpy.std(recentFrames)  # compute variability
-            if nIntervals >= nIdentical and recentFramesStd < threshSecs:
+            if nIntervals >= nIdentical and numpy.std(recentFrames) < threshSecs:
                 # average duration of recent frames
                 period = numpy.mean(recentFrames)  # log this too?
                 rate = 1.0 / period  # compute frame rate in Hz


### PR DESCRIPTION
Fixes an issue where the variability calculation for frame intervals is being computed with inadequate degrees of freedom.