### PR TITLE
BF: minor numpy division warning that's breaking tests

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -3156,6 +3156,8 @@ class Window():
             self.flip()
             recentFrames = self.frameIntervals[-nIdentical:]
             nIntervals = len(self.frameIntervals)
+            if len(recentFrames) < 3:
+                continue  # no need to check variance yet
             recentFramesStd = numpy.std(recentFrames)  # compute variability
             if nIntervals >= nIdentical and recentFramesStd < threshSecs:
                 # average duration of recent frames


### PR DESCRIPTION
Caused by checking numpy.std() on an empty list. That used to return 0.0
but now gives a warning