### PR TITLE
http:// → https://

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -631,8 +631,8 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    {one line to give the program's name and a brief idea of what it does.}
-    Copyright (C) {year}  {name of author}
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -645,14 +645,14 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    {project}  Copyright (C) {year}  {fullname}
+    <program>  Copyright (C) <year>  <name of author>
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/docs/source/about/credits.rst
+++ b/docs/source/about/credits.rst
@@ -32,7 +32,7 @@ Support and training providers
 
 Software projects aren't just about code. A great deal of work is done by the community in terms of supporting each other.
 
-You can see the most `active posters on the user forum <https://discourse.psychopy.org/u?period=all>`_ and those `answering PsychoPy questions on StackOverflow here <http://stackoverflow.com/tags/psychopy/info>`_ but notable examples that have done a fantastic job of supporting users:
+You can see the most `active posters on the user forum <https://discourse.psychopy.org/u?period=all>`_ and those `answering PsychoPy questions on StackOverflow here <https://stackoverflow.com/tags/psychopy/info>`_ but notable examples that have done a fantastic job of supporting users:
 
 - Mike MacAskill (New Zealand)
 - Jonas Lindeløv (Denmark)

--- a/docs/source/about/overview.rst
+++ b/docs/source/about/overview.rst
@@ -40,4 +40,4 @@ System requirements
 ----------------------
 Although PsychoPy runs on a wide variety of hardware, and on Windows, macOS or Linux, it really does benefit from a decent graphics card. Get an ATI or nVidia card that supports OpenGL 2.0. *Avoid built-in Intel graphics chips (e.g. GMA 950)*
 
-.. _Python: http://www.python.org
+.. _Python: https://www.python.org

--- a/docs/source/api/encryption.rst
+++ b/docs/source/api/encryption.rst
@@ -8,6 +8,6 @@ python package, pyFileSec, which grew out of PsychoPy. pyFileSec is distributed
 with the StandAlone versions of PsychoPy, or can be installed using pip or easy_install
 via https://pypi.python.org/pypi/PyFileSec/
 
-Some elaboration of pyFileSec usage and security strategy can be found here: http://pythonhosted.org/PyFileSec
+Some elaboration of pyFileSec usage and security strategy can be found here: https://pythonhosted.org/PyFileSec
 
 Basic usage is illustrated in the Coder demo > misc > encrypt_data.py

--- a/docs/source/api/serial.rst
+++ b/docs/source/api/serial.rst
@@ -1,7 +1,7 @@
 :mod:`psychopy.serial` - functions for interacting with the serial port
 =================================================================================
 
-PsychoPy is compatible with Chris Liechti's `pyserial <http://pyserial.sourceforge.net>`_ package. You can use it like this::
+PsychoPy is compatible with Chris Liechti's `pyserial <https://github.com/pyserial/pyserial>`_ package. You can use it like this::
     
     import serial
     ser = serial.Serial(0, 19200, timeout=1)  # open first serial port
@@ -10,8 +10,6 @@ PsychoPy is compatible with Chris Liechti's `pyserial <http://pyserial.sourcefor
     line = ser.readline()   # read a '\n' terminated line
     ser.close()
     
-Ports are fully configurable with all the options you would expect of RS232 communications. See http://pyserial.sourceforge.net  for further details and documentation.
+Ports are fully configurable with all the options you would expect of RS232 communications. See https://pyserial.readthedocs.io for further details and documentation.
 
 pyserial is packaged in the Standalone (Windows and Mac distributions), for manual installations you should install this yourself.
-
-    

--- a/docs/source/developers/demoStyleGuide.rst
+++ b/docs/source/developers/demoStyleGuide.rst
@@ -21,7 +21,7 @@ The idea is to have clean code that looks and works the same way across demos, w
     """Demo name, purpose, description (1-2 sentences, although some demos need more explanation).
     """
 
-For the comment / description, it's a good idea to read and be informed by the relevant parts of the API (see http://psychopy.org/api/api.html), but there's no need to duplicate that text in your comment. If you are unsure, please post to the dev list psychopy-dev@googlegroups.com.
+For the comment / description, it's a good idea to read and be informed by the relevant parts of the API (see https://psychopy.org/api/api.html), but there's no need to duplicate that text in your comment. If you are unsure, please post to the dev list psychopy-dev@googlegroups.com.
 
 - Follow PEP-8 mostly, some exceptions:
 

--- a/docs/source/developers/repository.rst
+++ b/docs/source/developers/repository.rst
@@ -83,7 +83,7 @@ When you first start using the repo there are a few additional steps that you wo
 Create your own fork of the central repository
 ________________________________________________
 
-Go to `github <http://www.github.com>`_, create an account and make a fork of the `psychopy repository <https://github.com/psychopy/psychopy>`_
+Go to `github <https://www.github.com>`_, create an account and make a fork of the `psychopy repository <https://github.com/psychopy/psychopy>`_
 You can change your fork in any way you choose without it affecting the central project. You can also share your fork with others, including the central project.
 
 .. _fetchLocalCopy:
@@ -91,7 +91,7 @@ You can change your fork in any way you choose without it affecting the central 
 Fetch a local copy
 ________________________________________________
 
-`Install git on your computer <http://book.git-scm.com/2_installing_git.html>`_.
+`Install git on your computer <https://book.git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_.
 Create and upload an ssh key to your github account - this is necessary for you to push changes back to your fork of the project at github.
 
 Then, in a folder of your choosing fetch your fork::

--- a/docs/source/general/colours.rst
+++ b/docs/source/general/colours.rst
@@ -33,7 +33,7 @@ These are not case sensitive, but should not include any spaces.
 
 Colors by hex value
 --------------------
-This is really just another way of specifying the r,g,b values of a color, where each gun's value is given by two hexadecimal characters. For some examples see `this chart <http://html-color-codes.com/>`_. To use these in PsychoPy they should be formatted as a string, beginning with `#` and with no spaces. (NB on a British Mac keyboard the # key is hidden - you need to press Alt-3)
+This is really just another way of specifying the r,g,b values of a color, where each gun's value is given by two hexadecimal characters. For some examples see `this chart <https://html-color-codes.com/>`_. To use these in PsychoPy they should be formatted as a string, beginning with `#` and with no spaces. (NB on a British Mac keyboard the # key is hidden - you need to press Alt-3)
 
 .. _RGB:
 
@@ -60,7 +60,7 @@ Note that PsychoPy will use your monitor calibration to linearize this for each 
 HSV color space
 ------------------
 
-Another way to specify colors is in terms of their Hue, Saturation and 'Value' (HSV). For a description of the color space see the `Wikipedia HSV entry <http://en.wikipedia.org/wiki/HSL_and_HSV>`_. The Hue in this case is specified in degrees, the saturation ranging 0:1 and the 'value' also ranging 0:1.
+Another way to specify colors is in terms of their Hue, Saturation and 'Value' (HSV). For a description of the color space see the `Wikipedia HSV entry <https://en.wikipedia.org/wiki/HSL_and_HSV>`_. The Hue in this case is specified in degrees, the saturation ranging 0:1 and the 'value' also ranging 0:1.
 
 Examples:
 
@@ -85,7 +85,7 @@ In the Derrington, Krauskopf and Lennie [#dkl1984]_ color space (based on the Ma
 
 In PsychoPy these values are specified in units of degrees for elevation and azimuth and as a float (ranging -1:1) for the contrast.
 
-Note that not all colors that can be specified in DKL color space can be reproduced on a monitor. `Here <http://youtu.be/xwoVrGoBaWg>`_ is a movie plotting in DKL space (showing `cartesian` coordinates, not spherical coordinates) the gamut of colors available on an example CRT monitor.
+Note that not all colors that can be specified in DKL color space can be reproduced on a monitor. `Here <https://youtu.be/xwoVrGoBaWg>`_ is a movie plotting in DKL space (showing `cartesian` coordinates, not spherical coordinates) the gamut of colors available on an example CRT monitor.
 
 Examples:
 

--- a/docs/source/general/timing/millisecondPrecision.rst
+++ b/docs/source/general/timing/millisecondPrecision.rst
@@ -2,7 +2,7 @@
 Can PsychoPy deliver millisecond precision?
 ---------------------------------------------
 
-.. _Labhackers Millikey: http://labhackers.com/millikey.html
+.. _Labhackers Millikey: https://labhackers.com/millikey.html
 
 The simple answer is 'yes'. PsychoPy's timing is as good as (or in most cases better than) any package out there. 
 

--- a/docs/source/general/timing/reducingFrameDrops.rst
+++ b/docs/source/general/timing/reducingFrameDrops.rst
@@ -35,5 +35,5 @@ Possible good ideas
 It isn't clear that these actually make a difference, but they might).
 
    #. disconnect the internet cable (to prevent programs performing auto-updates?)
-   #. on Macs you can actually shut down the Finder. It might help. See Alex Holcombe's page `here <http://openwetware.org/wiki/Holcombe:VerifyTiming>`_
+   #. on Macs you can actually shut down the Finder. It might help. See Alex Holcombe's page `here <https://openwetware.org/wiki/Holcombe:VerifyTiming>`_
    #. use a single screen rather than two (probably there is some graphics card overhead in managing double the number of pixels?)

--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -2385,7 +2385,7 @@ Released: Feb 2010
 * FIXED bug in the new win.clearBuffer() method
 * CHANGED builder component variables so that the user inputs are interpreted as literal text unless preceded by $, in which case they are treated as variables/python code
 * CHANGED builder handling of keyboard 'allowedKeys' parameter. Instead of `['1','2','q']` you can now simply use `12q` to indicate those three keys. If you want a key like `'right'` and `'left'` you now have to use `$['right','left']`
-* TWITTER follow on http://twitter.com/psychopy
+* TWITTER follow on https://twitter.com/psychopy
 * FIXED? win32 version now compatible with Vista/7? Still compatible with XP?
 
 PsychoPy 1.60.00

--- a/psychopy/LICENSE.txt
+++ b/psychopy/LICENSE.txt
@@ -2,7 +2,7 @@ Copyright (c) 2002-2021, J. W. Peirce.
 All rights reserved.
 
 As of version 1.5 PsychoPy is licensed under the GNU General Public License (version 3). For the complete text of that license see
-http://www.gnu.org/copyleft/gpl.html
+https://www.gnu.org/licenses/gpl-3.0.html
 
 In basic terms, this allows you to use, redistribute, add to, modify, or even sell, PsychoPy or any of its components. If you do release any such 'derivative works' however, you must make this source code available with the distribution and must also license your product under the GNU GPL.
 

--- a/psychopy/LICENSES.txt
+++ b/psychopy/LICENSES.txt
@@ -2,7 +2,7 @@ From version 1.5 onwards PsychoPy is distributed under the GNU GPLv3
 
 The PsychoPy *library* includes the following:
 
-    - pyparallel (http://pyserial.sourceforge.net/pyparallel.html). License: Python Software Foundation
+    - pyparallel (https://github.com/pyserial/pyparallel). License: Python Software Foundation
     - quest (http://www.visionegg.org/Quest). License: BSD
     - psychopy/app/Resources/DejaVuSerif.ttf. License: BSD-like (see below for full list of terms)
     
@@ -53,4 +53,3 @@ License:
     Inc., respectively. For further information, contact: fonts at gnome dot
     org. 
 ~
-

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -169,7 +169,7 @@ class PsychopyPyShell(wx.py.shell.Shell, ThemeMixin):
 class Printer(HtmlEasyPrinting):
     """bare-bones printing, no control over anything
 
-    from http://wiki.wxpython.org/Printing
+    from https://wiki.wxpython.org/Printing
     """
 
     def __init__(self):

--- a/psychopy/app/connections/news.py
+++ b/psychopy/app/connections/news.py
@@ -10,7 +10,7 @@ from psychopy import logging, prefs
 import wx
 from datetime import datetime
 
-newsURL = "http://news.psychopy.org/"
+newsURL = "https://news.psychopy.org/"
 
 CRITICAL = 40
 ANNOUNCE = 30

--- a/psychopy/app/connections/sendusage.py
+++ b/psychopy/app/connections/sendusage.py
@@ -48,7 +48,7 @@ def sendUsageStats(app=None):
         systemInfo = "win32_v" + platform.version()
     else:
         systemInfo = platform.system() + platform.release()
-    u = "http://usage.psychopy.org/submit.php?date=%s&sys=%s&version=%s&misc=%s"
+    u = "https://usage.psychopy.org/submit.php?date=%s&sys=%s&version=%s&misc=%s"
     URL = u % (dateNow, systemInfo, v, miscInfo)
     try:
         req = web.urllib.request.Request(URL)

--- a/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
+++ b/psychopy/demos/coder/stimuli/MovieStim2TimingTest.py
@@ -336,7 +336,7 @@ def formattedDictStr(d, indent=1, rstr=''):
     return rstr
 
 def bytes2human(n):
-    # http://code.activestate.com/recipes/578019
+    # https://code.activestate.com/recipes/578019/
     # >>  > bytes2human(10000)
     # '9.8K'
     # >>  > bytes2human(100001221)

--- a/psychopy/demos/coder/stimuli/VlcMovieStim.py
+++ b/psychopy/demos/coder/stimuli/VlcMovieStim.py
@@ -8,7 +8,7 @@ This requires:
 
 1. VLC. Just install the standard VLC of the same bitness as Python for your OS.
 
-    http://www.videolan.org/vlc/index.html
+    https://www.videolan.org/vlc/index.html
 
 2. pip install python-vlc
 

--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -522,7 +522,7 @@ def fileSaveDlg(initFilePath="", initFileName="",
         allowed: string
             a string to specify file filters.
             e.g. "Text files (\\*.txt) ;; Image files (\\*.bmp \\*.gif)"
-            See http://pyqt.sourceforge.net/Docs/PyQt4/qfiledialog.html
+            See https://www.riverbankcomputing.com/static/Docs/PyQt4/qfiledialog.html
             #getSaveFileName
             for further details
 
@@ -569,7 +569,7 @@ def fileOpenDlg(tryFilePath="",
         allowed: string (available since v1.62.01)
             a string to specify file filters.
             e.g. "Text files (\\*.txt) ;; Image files (\\*.bmp \\*.gif)"
-            See http://pyqt.sourceforge.net/Docs/PyQt4/qfiledialog.html
+            See https://www.riverbankcomputing.com/static/Docs/PyQt4/qfiledialog.html
             #getOpenFileNames
             for further details
 

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -353,7 +353,7 @@ def fileSaveDlg(initFilePath="", initFileName="",
         allowed: string
             A string to specify file filters.
             e.g. "BMP files (*.bmp)|*.bmp|GIF files (*.gif)|*.gif"
-            See http://www.wxpython.org/docs/api/wx.FileDialog-class.html
+            See https://docs.wxpython.org/wx.FileDialog.html
             for further details
 
     If initFilePath or initFileName are empty or invalid then
@@ -398,7 +398,7 @@ def fileOpenDlg(tryFilePath="",
         allowed: string (available since v1.62.01)
             a string to specify file filters.
             e.g. "BMP files (*.bmp)|*.bmp|GIF files (*.gif)|*.gif"
-            See http://www.wxpython.org/docs/api/wx.FileDialog-class.html
+            See https://docs.wxpython.org/wx.FileDialog.html
             for further details
 
     If tryFilePath or tryFileName are empty or invalid then

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -863,7 +863,7 @@ def makeXYZ2RGB(red_xy,
     display's phosphor 'guns' are usually measured with a spectrophotometer.
 
     The routines here are based on methods found at:
-    http://www.ryanjuckett.com/programming/rgb-color-space-conversion/
+    https://www.ryanjuckett.com/rgb-color-space-conversion/
 
     Parameters
     ----------

--- a/psychopy/parallel/_dlportio.py
+++ b/psychopy/parallel/_dlportio.py
@@ -53,7 +53,7 @@ class PParallelDLPortIO(object):
     An alternative on other versions of Windows might be to use inpout32.
 
     .  _winioport: http://www.dinceraydin.com/python/indexeng.html
-    .. _PortIO driver: http://www.winfordeng.com/support/download.php
+    .. _PortIO driver: https://www.winford.com/support/download.php
     """
 
     def __init__(self, address=0x0378):

--- a/psychopy/platform_specific/darwin.py
+++ b/psychopy/platform_specific/darwin.py
@@ -169,7 +169,7 @@ def getThreadPolicy(getDefault, flavour):
            .constrain
            .preemptible
 
-    See http://docs.huihoo.com/darwin/kernel-programming-guide/scheduler/chapter_8_section_4.html
+    See https://docs.huihoo.com/darwin/kernel-programming-guide/scheduler/chapter_8_section_4.html
     """
     if importCtypesFailed:
         return False

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -176,7 +176,7 @@ def rec709TF(rgb, **kwargs):
     """Apply the Rec 709 transfer function (or gamma) to linear RGB values.
 
     This transfer function is defined in the ITU-R BT.709 (2015) recommendation
-    document (http://www.itu.int/rec/R-REC-BT.709-6-201506-I/en) and is
+    document (https://www.itu.int/rec/R-REC-BT.709-6-201506-I/en) and is
     commonly used with HDTV televisions.
 
     Parameters
@@ -575,7 +575,7 @@ def hsv2rgb(hsv_Nx3):
     PsychoPy functions.
     """
     # based on method in
-    # http://en.wikipedia.org/wiki/HSL_and_HSV#Converting_to_RGB
+    # https://en.wikipedia.org/wiki/HSL_and_HSV#Converting_to_RGB
 
     hsv_Nx3 = numpy.asarray(hsv_Nx3, dtype=float)
     # we expect a 2D array so convert there if needed

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -3990,7 +3990,7 @@ def createUVSphere(radius=0.5, sectors=16, stacks=16, flipFaces=False):
         normals = mt.applyMatrix(r, normals)
 
     """
-    # based of the code found here http://www.songho.ca/opengl/gl_sphere.html
+    # based of the code found here https://www.songho.ca/opengl/gl_sphere.html
     sectorStep = 2.0 * np.pi / sectors
     stackStep = np.pi / stacks
     lengthInv = 1.0 / radius

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -1368,7 +1368,7 @@ def intersectRaySphere(rayOrig, rayDir, sphereOrig=(0., 0., 0.), sphereRadius=1.
         units from `orig`. Returns `None` if there is no intersection.
 
     """
-    # based off example from http://antongerdelan.net/opengl/raycasting.html
+    # based off example from https://antongerdelan.net/opengl/raycasting.html
     dtype = np.float64 if dtype is None else np.dtype(dtype).type
 
     rayOrig = np.asarray(rayOrig, dtype=dtype)
@@ -1534,7 +1534,7 @@ def intersectRayOBB(rayOrig, rayDir, modelMatrix, boundsExtents, dtype=None):
 
     """
     # based off algorithm:
-    # http://www.opengl-tutorial.org/miscellaneous/clicking-on-objects/
+    # https://www.opengl-tutorial.org/miscellaneous/clicking-on-objects/
     # picking-with-custom-ray-obb-function/
     dtype = np.float64 if dtype is None else np.dtype(dtype).type
 
@@ -3171,7 +3171,7 @@ def matrixFromEulerAngles(rx, ry, rz, degrees=True, out=None, dtype=None):
     matrices.
 
     """
-    # from http://www.j3d.org/matrix_faq/matrfaq_latest.html
+    # from https://www.j3d.org/matrix_faq/matrfaq_latest.html
     if out is None:
         dtype = np.float64 if dtype is None else np.dtype(dtype).type
         toReturn = np.zeros((4, 4,), dtype=dtype)

--- a/psychopy/tools/wizard.py
+++ b/psychopy/tools/wizard.py
@@ -224,7 +224,7 @@ class BaseWizard(object):
         nDropped = sum(intervalsMS > (1.5 * median))
         if nDropped:
             msg = _translate(
-                'Warning: could not keep up during <a href="http://'
+                'Warning: could not keep up during <a href="https://'
                 'www.psychopy.org/api/visual/dotstim.html">DotStim</a>'
                 ' with 100 random dots.')
             warn = True
@@ -541,10 +541,10 @@ class ConfigWizard(BaseWizard):
                 <li> On Windows, don't use the windows option to check for updates
                   - it can report that there are no updates available.
                 <li> If your card is made by NVIDIA, go to
-                  <a href="http://www.nvidia.com/Drivers">the NVIDIA website</a>
+                  <a href="https://www.nvidia.com/download/index.aspx">the NVIDIA website</a>
                   and use the 'auto detect' option. Try here for
-                  <a href="http://support.amd.com/">ATI / Radeon drivers</a>. Or try
-                  <a href="http://www.google.com/search?q=download+drivers+%(card2)s">
+                  <a href="https://www.amd.com/fr/support">ATI / Radeon drivers</a>. Or try
+                  <a href="https://www.google.com/search?q=download+drivers+%(card2)s">
                   this google search</a> [google.com].
                 <li> Download and install the driver.
                 <li> Reboot the computer.

--- a/travis/00_set_up_packaging_system.sh
+++ b/travis/00_set_up_packaging_system.sh
@@ -10,7 +10,7 @@ travis_retry sudo apt-get update -qq
 travis_retry sudo apt-get install -qq lsb-release
 source /etc/lsb-release
 echo ${DISTRIB_CODENAME}
-wget -O- http://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
-wget -q -O- http://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
+wget -O- https://neuro.debian.net/lists/${DISTRIB_CODENAME}.us-nh.full | sudo tee /etc/apt/sources.list.d/neurodebian.sources.list
+wget -q -O- https://neuro.debian.net/_static/neuro.debian.net.asc | sudo apt-key add -
 travis_retry sudo apt-get update -qq
 sudo apt-cache policy  # What is actually available?


### PR DESCRIPTION
Update some links from `http` to `https`. Sometimes update the whole URL.

The `LICENSE` file itself has been updated to the latest [GPLv3 from FSF](https://www.gnu.org/licenses/gpl-3.0.txt), with similar updates from http to https of the FSF links.