### PR TITLE
BF: Fix form scrolling

### DIFF
--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -548,7 +548,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
             anchor="top-right",
             lineColor="red",
             fillColor=None,
-            units=self.units
+            units=self.units,
+            autoLog=False
         )
         # Get slider pos and size
         if item['layout'] == 'horiz':


### PR DESCRIPTION
Rather than calculating offset from last _currentVirtualY, work out virtual height on layout and use difference between virtual height & aperture height to work out offset. Can also use these two values to decide whether or not to hide the scrollbar (it's only needed if virtual height is bigger than aperture height)