### PR TITLE
components/microphone: ensure getRecording tag prop is variable

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -422,7 +422,7 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (
-                "tag: %(filename)s,\n"
+                "tag: %(filename)s + Date.now(),\n"
                 "flush: false\n"
         )
         buff.writeIndentedLines(code % inits)


### PR DESCRIPTION
@TEParsons @apitiot Hoping this might work equally well as a counter suffix, closes #4446, [demo &rarr;](https://gitlab.pavlovia.org/support/onlinemicrophonetesting)