### PR TITLE
Remove pyopengl dependency that was needlessly breaking tests on Py3.6 MacOS

### DIFF
--- a/psychopy/tests/test_Installation.py
+++ b/psychopy/tests/test_Installation.py
@@ -8,9 +8,9 @@ def test_essential_imports():
     import matplotlib
     #import pygame  # soft dependency only
     import pyglet
-    import OpenGL
     import openpyxl
     import pandas
+
 
 def test_extra_imports():
     # only Jon needs to run this, so test first if you are him!

--- a/psychopy/visual/windowwarp.py
+++ b/psychopy/visual/windowwarp.py
@@ -18,9 +18,9 @@ from __future__ import absolute_import, division, print_function
 from builtins import map
 from builtins import range
 from builtins import object
+import ctypes
 import numpy as np
 from psychopy import logging
-from OpenGL.arrays import ArrayDatatype as ADT
 import pyglet
 GL = pyglet.gl
 
@@ -416,28 +416,44 @@ class Warper(object):
 
         GL.glEnableClientState(GL.GL_VERTEX_ARRAY)
 
+        # type and size for arrays
+        arrType = ctypes.c_float
+        ptrType = ctypes.POINTER(arrType)
+        nbytes = ctypes.sizeof(arrType)
+
         # vertex buffer in hardware
         self.gl_vb = GL.GLuint()
         GL.glGenBuffers(1, self.gl_vb)
         GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_vb)
-        GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-            vertices), ADT.voidDataPointer(vertices), GL.GL_STATIC_DRAW)
+        GL.glBufferData(
+            GL.GL_ARRAY_BUFFER,
+            vertices.size * nbytes,
+            vertices.ctypes.data_as(ptrType),
+            GL.GL_STATIC_DRAW)
 
-        # vertex buffer tdata in hardware
+        # vertex buffer texture data in hardware
         self.gl_tb = GL.GLuint()
         GL.glGenBuffers(1, self.gl_tb)
         GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_tb)
-        GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-            tcoords), ADT.voidDataPointer(tcoords), GL.GL_STATIC_DRAW)
+        GL.glBufferData(
+            GL.GL_ARRAY_BUFFER,
+            tcoords.size * nbytes,
+            tcoords.ctypes.data_as(ptrType),
+            GL.GL_STATIC_DRAW)
 
         # opacity buffer in hardware (only for warp files)
         if opacity is not None:
             self.gl_color = GL.GLuint()
             GL.glGenBuffers(1, self.gl_color)
             GL.glBindBuffer(GL.GL_ARRAY_BUFFER, self.gl_color)
+
             # convert opacity to RGBA, one point for each corner of the quad
-            GL.glBufferData(GL.GL_ARRAY_BUFFER, ADT.arrayByteCount(
-                opacity), ADT.voidDataPointer(opacity), GL.GL_STATIC_DRAW)
+            GL.glBufferData(
+                GL.GL_ARRAY_BUFFER,
+                opacity.size * nbytes,
+                opacity.ctypes.data_as(ptrType),
+                GL.GL_STATIC_DRAW)
+
         else:
             self.gl_color = None
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ install_requires =
     pillow
     glfw
     pygame
-    pyopengl
     pyo
     soundfile
     sounddevice


### PR DESCRIPTION
PyOpenGL no longer supports Py3.6 on MacOS and that was breaking the test suite on that platform

Matthew had worked out on dev branch how to remove the need for pyopengl by replacing it with
pyglet/ctypes in windowwarp (everywhere else in the lib was already on pyglet)