### PR TITLE
updates to keyboard.Keyboard & iohub keymap usage 

### DIFF
--- a/psychopy/demos/coder/input/keyNameFinder.py
+++ b/psychopy/demos/coder/input/keyNameFinder.py
@@ -15,12 +15,11 @@ output = visual.TextBox2(win,
     font="Open Sans", letterHeight=0.1,
     pos=(0, -0.2))
 
-# Make keyboard object
-# Set backend to 'iohub', 'ptb', 'event', or ''.
+# Make keyboard object. Optionally add backend kwarg, using 'iohub', 'ptb', 'event', or ''.
 # If using '', best available backend will be selected.
-keyboard.Keyboard.backend = 'iohub'
+#kb = keyboard.Keyboard(backend='iohub')
 kb = keyboard.Keyboard()
-print("KB backend: ", kb.backend)
+print("KB backend: ", kb.getBackend())
 
 # Listen for keypresses until escape is pressed
 keys = kb.getKeys()

--- a/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
+++ b/psychopy/demos/coder/iohub/eyetracking/gcCursor/run.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
         # start trial instuctions have been displayed.
         #
         io_hub.clearEvents('all')
-        kb.waitForPresses(keys=['space', ])
+        kb.waitForPresses(keys=[' ', ])
 
         # Space Key has been pressed, start the trial.
         # Set the current session and trial id values to be saved
@@ -272,7 +272,7 @@ if __name__ == "__main__":
             # Check any new keyboard press events by a space key.
             # If one is found, set the trial end variable and break.
             # from the loop
-            if kb.getPresses(keys=['space', ]):
+            if kb.getPresses(keys=[' ', ]):
                 run_trial = False
                 break
 

--- a/psychopy/demos/coder/iohub/eyetracking/simple.py
+++ b/psychopy/demos/coder/iohub/eyetracking/simple.py
@@ -118,7 +118,7 @@ while t < TRIAL_COUNT:
         # Check any new keyboard char events for a space key.
         # If one is found, set the trial end variable.
         #
-        if keyboard.getPresses(keys='space'):
+        if keyboard.getPresses(keys=' '):
             run_trial = False
         elif core.getTime()-tstart_time > T_MAX:
             run_trial = False

--- a/psychopy/demos/coder/iohub/eyetracking/validation.py
+++ b/psychopy/demos/coder/iohub/eyetracking/validation.py
@@ -235,7 +235,7 @@ while t < TRIAL_COUNT:
         # Check any new keyboard char events for a space key.
         # If one is found, set the trial end variable.
         #
-        if keyboard.getPresses(keys='space'):
+        if keyboard.getPresses(keys=' '):
             run_trial = False
         elif core.getTime()-tstart_time > T_MAX:
             run_trial = False

--- a/psychopy/demos/coder/iohub/keyboard.py
+++ b/psychopy/demos/coder/iohub/keyboard.py
@@ -21,10 +21,11 @@ win = visual.Window(WINDOW_SIZE, units=unit_type,
     color=[128, 128, 128], colorSpace='rgb255')
 
 # Create a Keyboard class with ptb as the backend
+ptb_keyboard.Keyboard.backend = 'ptb'
 ptb_keyboard = ptb_keyboard.Keyboard()
 
 # Start iohub process. The iohub process can be accessed using `io`.
-io = launchHubServer(window=win)
+io = launchHubServer(window=win, Keyboard=dict(use_keymap='psychopy'))
 
 # A `keyboard` variable is used to access the iohub Keyboard device.
 keyboard = io.devices.keyboard

--- a/psychopy/demos/coder/iohub/keyboard.py
+++ b/psychopy/demos/coder/iohub/keyboard.py
@@ -21,8 +21,7 @@ win = visual.Window(WINDOW_SIZE, units=unit_type,
     color=[128, 128, 128], colorSpace='rgb255')
 
 # Create a Keyboard class with ptb as the backend
-ptb_keyboard.Keyboard.backend = 'ptb'
-ptb_keyboard = ptb_keyboard.Keyboard()
+ptb_keyboard = ptb_keyboard.Keyboard(backend='ptb')
 
 # Start iohub process. The iohub process can be accessed using `io`.
 io = launchHubServer(window=win, Keyboard=dict(use_keymap='psychopy'))

--- a/psychopy/demos/coder/iohub/mouse.py
+++ b/psychopy/demos/coder/iohub/mouse.py
@@ -90,9 +90,8 @@ while not kb_events:
     displayIdMsg.draw()
     flip_time = win.flip()  # redraw the buffer
 
-    # Check for keyboard orand mouse events.
-    # If 15 seconds passes without receiving any kb or mouse event,
-    # then exit the demo
+    # Check for keyboard and mouse events.
+    # If 15 seconds passes without receiving any mouse events, then exit the demo
     kb_events = keyboard.getEvents()
     mouse_events = mouse.getEvents()
     if mouse_events:

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1099,6 +1099,15 @@ class SettingsComponent:
             )
             buff.writeIndentedLines(code % inits)
 
+        # Add keyboard to ioConfig
+        if self.params['keyboardBackend'] == 'ioHub':
+            code = (
+                "\n"
+                "# Setup iohub keyboard\n"
+                "ioConfig['Keyboard'] = dict(use_keymap='psychopy')\n\n"
+            )
+            buff.writeIndentedLines(code % inits)
+
         # Start ioHub server
         if self.needIoHub:
             # Specify session

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1153,8 +1153,7 @@ class SettingsComponent:
         code = (
             "\n"
             "# create a default keyboard (e.g. to check for escape)\n"
-            "keyboard.Keyboard.backend = %(keyboardBackend)s\n"
-            "defaultKeyboard = keyboard.Keyboard()\n"
+            "defaultKeyboard = keyboard.Keyboard(backend=%(keyboardBackend)s)\n"
         )
         buff.writeIndentedLines(code % inits)
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -172,8 +172,9 @@ class Keyboard:
             from psychopy.iohub.devices import Computer
             if not ioHubConnection.getActiveConnection() and Keyboard.backend == 'iohub':
                 # iohub backend was explicitly requested, but iohub is not running, so start it up
+                # setting keyboard to use standard psychopy key mappings
                 from psychopy.iohub import launchHubServer
-                launchHubServer()
+                launchHubServer(Keyboard=dict(use_keymap='psychopy'))
 
             if ioHubConnection.getActiveConnection() and Keyboard._iohubKeyboard is None:
                 Keyboard._iohubKeyboard = ioHubConnection.getActiveConnection().getDevice('keyboard')

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -244,8 +244,8 @@ class Keyboard:
                                                                                                         'event', '']))
 
         else:
-            logging.warning("keyboard.Keyboard.setBackend already using '%s' backend. Can not switch to '%s'" % (self._backend,
-                                                                                                      backend))
+            logging.warning("keyboard.Keyboard.setBackend already using '%s' backend. "
+                            "Can not switch to '%s'" % (self._backend, backend))
 
         return self._backend
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -126,13 +126,11 @@ class Keyboard:
     systems.
 
     """
+    _backend = None
     _iohubKeyboard = None
     _iohubOffset = 0.0
-    # Before creating an instance of Keyboard, set backend to one of 'ptb', 'iohub', or 'event'.
-    # If '' is used, best available backend will be selected.
-    backend = ''
 
-    def __init__(self, device=-1, bufferSize=10000, waitForStart=False, clock=None):
+    def __init__(self, device=-1, bufferSize=10000, waitForStart=False, clock=None, backend=None):
         """Create the device (default keyboard or select one)
 
         Parameters
@@ -155,6 +153,17 @@ class Keyboard:
 
         """
         global havePTB
+
+        if self._backend is None and backend in ['iohub', 'ptb', 'event', '']:
+            Keyboard._backend = backend
+
+        if self._backend is None:
+            Keyboard._backend = ''
+
+        if backend and self._backend != backend:
+            logging.warning("keyboard.Keyboard already using '%s' backend. Can not switch to '%s'" % (self._backend,
+                                                                                                      backend))
+
         self.status = NOT_STARTED
         # Initiate containers for storing responses
         self.keys = []  # the key(s) pressed
@@ -167,10 +176,10 @@ class Keyboard:
         else:
             self.clock = psychopy.clock.Clock()
 
-        if Keyboard.backend in ['', 'iohub']:
+        if Keyboard._backend in ['', 'iohub']:
             from psychopy.iohub.client import ioHubConnection
             from psychopy.iohub.devices import Computer
-            if not ioHubConnection.getActiveConnection() and Keyboard.backend == 'iohub':
+            if not ioHubConnection.getActiveConnection() and Keyboard._backend == 'iohub':
                 # iohub backend was explicitly requested, but iohub is not running, so start it up
                 # setting keyboard to use standard psychopy key mappings
                 from psychopy.iohub import launchHubServer
@@ -179,10 +188,10 @@ class Keyboard:
             if ioHubConnection.getActiveConnection() and Keyboard._iohubKeyboard is None:
                 Keyboard._iohubKeyboard = ioHubConnection.getActiveConnection().getDevice('keyboard')
                 Keyboard._iohubOffset = Computer.global_clock.getLastResetTime()
-                Keyboard.backend = 'iohub'
+                Keyboard._backend = 'iohub'
 
-        if Keyboard.backend in ['', 'ptb'] and havePTB:
-            Keyboard.backend = 'ptb'
+        if Keyboard._backend in ['', 'ptb'] and havePTB:
+            Keyboard._backend = 'ptb'
             # get the necessary keyboard buffer(s)
             if sys.platform == 'win32':
                 self._ids = [-1]  # no indexing possible so get the combo keyboard
@@ -208,20 +217,47 @@ class Keyboard:
             if not waitForStart:
                 self.start()
 
-        if Keyboard.backend in ['', 'event']:
-            Keyboard.backend = 'event'
+        if Keyboard._backend in ['', 'event']:
+            Keyboard._backend = 'event'
 
-        logging.info('keyboard.Keyboard is using %s backend.' % Keyboard.backend)
+        logging.info('keyboard.Keyboard is using %s backend.' % Keyboard._backend)
+
+    @classmethod
+    def getBackend(self):
+        """Return backend being used."""
+        return self._backend
+
+    @classmethod
+    def setBackend(self, backend):
+        """
+        Set backend event handler. Returns currently active handler.
+
+        :param backend: 'iohub', 'ptb', 'event', or ''
+        :return: str
+        """
+        if self._backend is None:
+            if backend in ['iohub', 'ptb', 'event', '']:
+                Keyboard._backend = backend
+            else:
+                logging.warning("keyboard.Keyboard.setBackend failed. backend must be one of %s" % str(['iohub',
+                                                                                                        'ptb',
+                                                                                                        'event', '']))
+
+        else:
+            logging.warning("keyboard.Keyboard.setBackend already using '%s' backend. Can not switch to '%s'" % (self._backend,
+                                                                                                      backend))
+
+        return self._backend
 
     def start(self):
         """Start recording from this keyboard """
-        if Keyboard.backend == 'ptb':
+        if Keyboard._backend == 'ptb':
             for buffer in self._buffers.values():
                 buffer.start()
 
     def stop(self):
         """Start recording from this keyboard"""
-        if Keyboard.backend == 'ptb':
+        if Keyboard._backend == 'ptb':
             logging.warning("Stopping key buffers but this could be dangerous if"
                             "other keyboards rely on the same.")
             for buffer in self._buffers.values():
@@ -255,14 +291,14 @@ class Keyboard:
 
         """
         keys = []
-        if Keyboard.backend == 'ptb':
+        if Keyboard._backend == 'ptb':
             for buffer in self._buffers.values():
                 for origKey in buffer.getKeys(keyList, waitRelease, clear):
                     # calculate rt from time and self.timer
                     thisKey = copy.copy(origKey)  # don't alter the original
                     thisKey.rt = thisKey.tDown - self.clock.getLastResetTime()
                     keys.append(thisKey)
-        elif Keyboard.backend == 'iohub':
+        elif Keyboard._backend == 'iohub':
             watchForKeys = keyList
             if waitRelease:
                 key_events = Keyboard._iohubKeyboard.getReleases(keys=watchForKeys, clear=clear)
@@ -335,13 +371,13 @@ class Keyboard:
 
     def clearEvents(self, eventType=None):
         """"""
-        if Keyboard.backend == 'ptb':
+        if Keyboard._backend == 'ptb':
             for buffer in self._buffers.values():
                 buffer.flush()  # flush the device events to the soft buffer
                 buffer._evts.clear()
                 buffer._keys.clear()
                 buffer._keysStillDown.clear()
-        elif Keyboard.backend == 'iohub':
+        elif Keyboard._backend == 'iohub':
             Keyboard._iohubKeyboard.clearEvents()
         else:
             event.clearEvents(eventType)
@@ -377,10 +413,10 @@ class KeyPress(object):
         self.tDown = tDown
         self.duration = None
         self.rt = None
-        if Keyboard.backend == 'event':  # we have event.getKeys()
+        if Keyboard._backend == 'event':  # we have event.getKeys()
             self.name = name
             self.rt = tDown
-        elif Keyboard.backend == 'ptb':
+        elif Keyboard._backend == 'ptb':
             if code not in keyNames:
                 self.name = 'n/a'
                 logging.warning("Got keycode {} but that code isn't yet known")
@@ -391,7 +427,7 @@ class KeyPress(object):
                 self.name = 'unknown'
             else:
                 self.name = keyNames[code]
-        elif Keyboard.backend == 'iohub':
+        elif Keyboard._backend == 'iohub':
             self.name = name
 
     def __eq__(self, other):

--- a/psychopy/iohub/client/eyetracker/validation/procedure.py
+++ b/psychopy/iohub/client/eyetracker/validation/procedure.py
@@ -324,7 +324,7 @@ class ValidationProcedure:
         if self.show_intro_screen:
             # Display Validation Intro Screen
             self.showIntroScreen()
-            if self.terminate_key and self.terminate_key in keyboard.waitForReleases(keys=[' ', self.terminate_key]):
+            if self.terminate_key and self.terminate_key in keyboard.waitForReleases(keys=[' ', 'space',self.terminate_key]):
                 print("Escape key pressed. Exiting validation")
                 self._validation_results = None
                 return
@@ -342,15 +342,15 @@ class ValidationProcedure:
 
         if self.show_results_screen:
             self.showResultsScreen()
-            kb_presses = keyboard.waitForPresses(keys=['space', self.terminate_key, self.targetsequence.gaze_cursor_key])
-            while 'space' not in kb_presses:
+            kb_presses = keyboard.waitForPresses(keys=['space',' ', self.terminate_key, self.targetsequence.gaze_cursor_key])
+            while 'space' not in kb_presses and ' ' not in kb_presses:
                 if self.targetsequence.gaze_cursor_key in kb_presses:
                     self.targetsequence.display_gaze = not self.targetsequence.display_gaze
                     self.showResultsScreen()
                 if self.terminate_key in kb_presses:
                     print("Escape key pressed. Exiting validation")
                     break
-                kb_presses = keyboard.waitForPresses(keys=['space',
+                kb_presses = keyboard.waitForPresses(keys=['space', ' ',
                                                            self.terminate_key,
                                                            self.targetsequence.gaze_cursor_key])
 
@@ -378,6 +378,7 @@ class ValidationProcedure:
                                                    wrapWidth=self.win.size[0] * .8)
 
         self.intro_text_stim.draw()
+        self.win.flip()
         return self.win.flip()
 
     @property

--- a/psychopy/iohub/devices/keyboard/default_keyboard.yaml
+++ b/psychopy/iohub/devices/keyboard/default_keyboard.yaml
@@ -42,7 +42,7 @@ Keyboard:
     # use_keymap: What key map set / heuristics should be used? Options:
     #   psychopy: Use key map that is the same as used by event.getKeys()
     #   legacy: Use original iohub key map
-    use_keymap: psychopy
+    use_keymap: legacy
 
     # save_events: *If* the ioHubDataStore is enabled for the experiment, then
     #   indicate if events for this device should be saved to the


### PR DESCRIPTION
ENH: Added 'backend' kwarg' to `keyboard.Keyboard`. Defaullt is '', which performs autoselect of backend, same as in 2021.2.x
ENH: Added `getBackend` and `setBackend` class methods to `keyboard.Keyboard` 
FF: switch iohub keyboard to use legacy keymap by default when using custom code. Switched to remove backwards incompatibility.
FF: When using Builder generated code or `keyboard.Keyboard()` with iohub backend set, iohub keyboard uses pyglet based keymap.
FF: revert iohub eyetracker coder demos to use ' ' keymapping instead of 'space'
FF: eye tracker validation now handles both ' ' and 'space' key mappings