### PR TITLE
BF: Copy template on adding, don't add template

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1541,7 +1541,7 @@ class RoutinesNotebook(aui.AuiNotebook, ThemeMixin):
         routineName = None
         if dlg.ShowModal() == wx.ID_OK:
             routineName = dlg.nameCtrl.GetValue()
-            template = dlg.selectedTemplate
+            template = copy.deepcopy(dlg.selectedTemplate)
             self.frame.pasteRoutine(template, routineName)
             self.frame.addToUndoStack("NEW Routine `%s`" % routineName)
         dlg.Destroy()


### PR DESCRIPTION
Adding the template itself rather than a copy means that editing a new routine changes the template - and all routines from the same template (including blank)