### PR TITLE
DOCS: update reference links in millisecond precision docs

### DIFF
--- a/docs/source/general/timing/millisecondPrecision.rst
+++ b/docs/source/general/timing/millisecondPrecision.rst
@@ -4,9 +4,9 @@ Can PsychoPy deliver millisecond precision?
 
 .. _Labhackers Millikey: https://labhackers.com/millikey.html
 
-The simple answer is 'yes'. PsychoPy's timing is as good as (or in most cases better than) any package out there. 
+The simple answer is 'yes'. PsychoPy's timing is as good as (or in most cases better than) any package out there. For detailed Studies of timing see `Bridges et al., 2020 <https://peerj.com/articles/9414/>`_
 
-The longer answer is that you should test the timing of your own experimental stimuli on your own hardware. Very often a computer is not optimally configured to produce good timing, and a poorly code experiment could also destroy your timing. Many software and hardware manufacturers will suggest that the key to this is using computer clocks with high precision (lots of decimal places) but that is not the answer at all. The sources of error in stimulus/response timing are almost never to do with the poor precision of the clock. The following issues are extremely common and **until you actually test your experiment you don't realise that your timing is being affected by them**:
+The longer answer is that you should test the timing of your own experimental stimuli on your own hardware. Very often a computer is not optimally configured to produce good timing, and a poorly coded experiment could also destroy your timing (which is one reason we now recommend even good coders use :ref:`builder`!). Many software and hardware manufacturers will suggest that the key to good timing is using computer clocks with high precision (lots of decimal places) but that is not the answer at all. The sources of error in stimulus/response timing are almost never to do with the poor precision of the clock. The following issues are extremely common and **until you actually test your experiment you don't realise that your timing is being affected by them**:
 
 - :ref:`monitorDelays`: e.g. the monitor taking additional time to process the image before presentation
 - :ref:`OSdelays`: Windows, Linux and Mac all perform further processing on the images, depending on settings and this can delay your visual stimulus delivery by a further frame interval or more
@@ -111,9 +111,9 @@ Common ways for this to happen are to forget the operations that are potentially
 
 For image stimuli where the image is constant the image should be loaded from disk at the beginning of the script (Builder-generate experiments will do so automatically for you). When an image stimulus has to *change on each trial*, it must be loaded from disk at some point. That typically takes several milliseconds (possibly hundreds of milliseconds for a large image) and while that is happening the screen will not be refreshing. You need to take your image-loading time into account and allow it to occur during a static period of the screen. 
 
-In Builder experiments if you set something to update "On every repeat" then it will update as that Routine begins so, if your trial Routine simply begins with 0.5s fixation period, all your stimuli can be loaded/updated in that period and you will have no further problems. Sometimes you want to load/update your stimulus explicitly at a different point in time and then you can insert a "Static Component" into your Builder experiment (a "Static Period" in the Python API) and then set your stimulus to update during that period (it will show up as an update option after you insert the Static Component).
+In B :ref:`builder` experiments if you set something to update "On every repeat" then it will update as that Routine begins so, if your trial Routine simply begins with 0.5s fixation period, all your stimuli can be loaded/updated in that period and you will have no further problems. Sometimes you want to load/update your stimulus explicitly at a different point in time and then you can insert a  :ref:`static` Component into your Builder experiment (a "Static Period" in the Python API) and then set your stimulus to update during that period (it will show up as an update option after you insert the Static Component).
 
-The good news is that a lot of the visual timing issues caused by coding problems **are** visible in the log files, unlike the problems with hardware and operating systems introducing lags.
+The good news is that a lot of the visual timing issues caused by coding problems **are** visible in the :ref:`Log Files <logFile>`, unlike the problems with hardware and operating systems introducing lags.
 
 .. _keyboardDelays:
 


### PR DESCRIPTION
add external links (bridges study) and internal links to components