### PR TITLE
ENH: Add copy methods to params, components and routines

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -135,6 +135,18 @@ class BaseComponent:
 
         return element
 
+    def copy(self):
+        """
+        Create a copy of this component, such that changes to the copy won't affect the original.
+        """
+        return self.__deepcopy__()
+
+    def __deepcopy__(self, memo=None):
+        newComp = type(self)(exp=self.exp, parentName=self.parentName)
+        for name, param in self.params.items():
+            newComp.params[name] = param.copy()
+        return newComp
+
     def integrityCheck(self):
         """
         Run component integrity checks for non-visual components

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -316,6 +316,22 @@ class Param():
 
         return element
 
+    def copy(self):
+        """
+        Create a copy of this parameter, such that changes to the copy won't affect the original.
+        """
+        return self.__deepcopy__()
+
+    def __deepcopy__(self, memo=None):
+        return type(self)(
+            val=self.val, updates=self.updates, categ=self.categ,
+            valType=self.valType, inputType=self.inputType,
+            hint=self.hint, label=self.label,
+            allowedVals=self.allowedVals, allowedTypes=self.allowedTypes,
+            allowedUpdates=self.allowedUpdates, allowedLabels=self.allowedLabels,
+            direct=self.direct, canBePath=self.canBePath
+        )
+
     def dollarSyntax(self):
         """
         Interpret string according to dollar syntax, return:

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -102,6 +102,18 @@ class BaseStandaloneRoutine:
 
         return element
 
+    def copy(self):
+        """
+        Create a copy of this standalone routine, such that changes to the copy won't affect the original.
+        """
+        return self.__deepcopy__()
+
+    def __deepcopy__(self, memo=None):
+        newRT = type(self)(exp=self.exp)
+        for name, param in self.params.items():
+            newRT.params[name] = param.copy()
+        return newRT
+
     def writePreCode(self, buff):
         return
 
@@ -221,6 +233,16 @@ class Routine(list):
     def __repr__(self):
         _rep = "psychopy.experiment.Routine(name='%s', exp=%s, components=%s)"
         return _rep % (self.name, self.exp, str(list(self)))
+
+    def copy(self):
+        """
+        Create a copy of this routine, such that changes to the copy won't affect the original.
+        """
+        return self.__deepcopy__()
+
+    def __deepcopy__(self, memo=None):
+        components = [comp.copy() for comp in self]
+        return type(self)(name=self.name, exp=self.exp, components=components)
 
     @property
     def _xml(self):

--- a/psychopy/tests/test_experiment/test_base_components.py
+++ b/psychopy/tests/test_experiment/test_base_components.py
@@ -1,0 +1,77 @@
+import pytest
+import inspect
+import warnings
+import copy
+
+from psychopy import experiment
+
+
+class _TestCopyMixin:
+    compClass = experiment.components.BaseComponent
+
+    def test_name_congruence(self):
+        """
+        Test that params have the same names as the init value required to initiate them, which is not essential but
+        is preferable.
+        """
+        # Make an experiment and routine to put everything in
+        exp = experiment.Experiment()
+        # Make a component with all the default params
+        comp = self.compClass(parentName="testroutine", exp=exp)
+        # Get inits for this component
+        inits = inspect.getfullargspec(self.compClass.__init__).args
+        # Make sure all params from obj are represented in inits
+        for param in comp.params:
+            if param not in inits:
+                warnings.warn(
+                    f"Parameter {param} is not represented in the init arguments of {self.compClass.__name__}: {inits}"
+                )
+        # Make sure all params from xml are represented in inits
+        for node in comp._xml.getchildren():
+            param = node.get('name')
+            if param not in inits:
+                warnings.warn(
+                    f"XML parameter {param} is not represented in the init arguments of {self.compClass.__name__}: {inits}"
+                )
+
+    def test_copy_methods(self):
+        """
+        Test that components copy without error and that copies are *not* linked to the original
+        """
+        # Make an experiment and routine to put everything in
+        exp = experiment.Experiment()
+        # Make a component with all the default params
+        comp = self.compClass(parentName="testroutine", exp=exp)
+        # Try to copy using class method
+        copy1 = comp.copy()
+        # Try to copy using protected method
+        copy2 = copy.deepcopy(comp)
+        # Make sure that changing the original doesn't change the copy
+        comp.params['name'].val = "original"
+        assert copy1.params['name'] != "original", (
+            f"When copying a {self.compClass.__name__} object using `.copy()`, changes to the original still affect "
+            f"the copy."
+        )
+        assert copy2.params['name'] != "original", (
+            f"When copying a {self.compClass.__name__} object using `copy.deepcopy()`, changes to the original still "
+            f"affect the copy."
+        )
+        # Make sure changing the copy doesn't change the original
+        copy1.params['name'].val = "copy1"
+        assert comp.params['name'] != "copy1", (
+            f"When copying a {self.compClass.__name__} object using `.copy()`, changes to the copy still affect "
+            f"the original."
+        )
+        copy2.params['name'].val = "copy2"
+        assert comp.params['name'] != "copy2", (
+            f"When copying a {self.compClass.__name__} object using `copy.deepcopy()`, changes to the copy still "
+            f"affect the original."
+        )
+
+
+class TestBaseComponent(_TestCopyMixin):
+    compClass = experiment.components.BaseComponent
+
+
+class TestBaseVisualComponent(_TestCopyMixin):
+    compClass = experiment.components.BaseVisualComponent


### PR DESCRIPTION
ensures that when they're copied, a genuinely new object is created, copying all params, components, etc. too, so that changing the original won't affect the copy and vice versa.