### PR TITLE
DOCS: fixes to pdf generation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -186,7 +186,7 @@ htmlhelp_basename = 'PsychoPydoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
-latex_engine = 'xelatex'  # or pdflatex
+latex_engine = 'pdflatex'  # xelatex or pdflatex
 # latex_elements = {
 #    'babel': '\\usepackage{babel}',
 #    'inputenc': '\\usepackage[utf8]{inputenc}'

--- a/docs/source/general/timing/millisecondPrecision.rst
+++ b/docs/source/general/timing/millisecondPrecision.rst
@@ -140,6 +140,6 @@ Most recently we added support for the Psychophysics Toolbox audio library (Psyc
 
 For further information please see the documentation about the :ref:`Sound library <soundAPI>`
 
-.. figure:: ../../images/audioScope_Win10_PTB_mode3.png
+.. figure:: /images/audioScope_Win10_PTB_mode3.png
 
     With the new PTB library you can achieve not only sub-millisecond precision, but roughly sub-millisecond lags!! You do need to know how to configure this though and testing it can only be done with hardware.

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -38,7 +38,7 @@ Start PsychoPy, and be sure to be in the Builder view.
 * If you have poked around a bit in the Builder already, be sure to start with a clean slate. To get a new Builder view, type `Ctrl-N` on Windows or Linux, or `Cmd-N` on Mac.
 * Click on a Text component and a Text Properties dialog will pop up.
 
-  .. image:: images/textdialog.png
+  .. image:: /images/textdialog.png
     :width: 80%
     :align: center
 
@@ -47,11 +47,11 @@ Start PsychoPy, and be sure to be in the Builder view.
 * Your text component now resides in a routine called `trial`. You can click on it to view or edit it. (Components, Routines, and other Builder concepts are explained in the :doc:`Builder documentation <builder/index>`.)
 * Back in the main Builder, type `Ctrl-R` (Windows, Linux) or `Cmd-R` (Mac), or use the mouse to click the `Run` icon.
 
-.. image:: images/run.png
+.. image:: /images/run.png
 
 Assuming you typed in "Hello world!", your screen should have looked like this (briefly):
 
-.. image:: images/helloworld.png
+.. image:: /images/helloworld.png
   :width: 80%
   :align: center
 
@@ -86,7 +86,7 @@ To get a better feel for what was happening "behind the scenes" in the Builder p
 * In the Builder, load or recreate your "hello world" program.
 * Instead of running the program, explicitly convert it into python: Type `F5`, or click the `Compile` icon:
 
-.. image:: images/compile_py.PNG
+.. image:: images/compile_py.png
 
 The view will automatically switch to the Coder, and display the python code. If you then save and run this code, it would look the same as running it directly from the Builder.
 

--- a/psychopy/hardware/qmix.py
+++ b/psychopy/hardware/qmix.py
@@ -10,7 +10,7 @@ Simple interface to the Cetoni neMESYS syringe pump system, based on the
 `pyqmix <https://github.com/psyfood/pyqmix/>`_ library. The syringe pump
 system is described in the following publication:
 
-    CA Andersen, L Alfine, K Ohla, & R Höchenberger (2018):
+    CA Andersen, L Alfine, K Ohla, & R Höchenberger (2018):
     "A new gustometer: Template for the construction of a portable and
      modular stimulator for taste and lingual touch."
     Behavior Research Methods. doi: 10.3758/s13428-018-1145-1


### PR DESCRIPTION
- Höchenberger had the wrong formulation of umlaut (looks the same but wrong char)
- wrong images folder for timing image
- .png not .PNG