### PR TITLE
Better timestamps for getDateStr() using ISO 8601 based format

### DIFF
--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -15,6 +15,24 @@ to run on the same PsychoPy version even where a different version is installed 
 That setting often even allows PsychoPy to run experiments from versions that have not yet
 been installed! If the dependencies haven't changed it will run.
 
+PsychoPy 2022.2
+---------------
+
+*Highlights:*
+
+- Template Routines
+- Improvements to VLC Movie backend
+- QUEST staircases now supported via multi-staircase in Loops
+- dynamic loading of stimuli now possible in online experiments rather
+  than loading all stimuli during the Exp Info dialog. Can now alter
+  the stimuli downloaded per-participant
+
+*Compatibility Changes:*
+
+- Filename timestamps now have a different default format (based on ISO 8601):
+  2022-01-14_14h39.36.092 for 2:39pm and 36s, 92ms
+  See :func:`psychopy.utils.getDateStr` for details on the new functionality
+
 PsychoPy 2021.2
 ---------------
 

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -422,7 +422,7 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (
-                "tag: %(filename)s + Date.now(),\n"
+                "tag: %(filename)s + util.MonotonicClock.getDateStr(),\n"
                 "flush: false\n"
         )
         buff.writeIndentedLines(code % inits)

--- a/psychopy/tests/test_data/test_utils.py
+++ b/psychopy/tests/test_data/test_utils.py
@@ -128,7 +128,14 @@ class Test_utilsClass:
 
     def test_getDateStr(self):
         import time
-        assert utils.getDateStr() == time.strftime("%Y_%b_%d_%H%M", time.localtime())
+        millisecs_dateStr = utils.getDateStr()
+        microsecs_dateStr = utils.getDateStr(fractionalSecondDigits=6)
+        assert len(millisecs_dateStr) == len(microsecs_dateStr[:-3])  # ms=3dp not 6
+        shortFormat = "%Y_%b_%d_%H%M"
+        customDateStr = utils.getDateStr(shortFormat)
+        # getDateStr() uses datetime.now().strftime(format) but should match
+        # format for time.strftime (the latter doesn't support milli/microsecs)
+        assert customDateStr == time.strftime(shortFormat, time.localtime())
 
     def test_import_blankColumns(self):
         fileName_blanks = join(fixturesPath, 'trialsBlankCols.xlsx')


### PR DESCRIPTION
- psychopy.utils.getDateStr now uses the format `2022-01-14_18h35.05.386` which is similar to ISO 8601 but without commas or colons because these don't work in filenames
- also set PsychoJS auido clip tag to use this instead of simply using Date.now() because this is more readable and is copmatible with our existing filenames