### PR TITLE
FF: Improved subprocess execution 

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -60,97 +60,12 @@ SIGINT = wx.SIGINT
 KILL_NOCHILDREN = wx.KILL_NOCHILDREN
 KILL_CHILDREN = wx.KILL_CHILDREN  # yeesh ...
 
-# Error values for `wx.Process.Kill`
+# Error values for `wx.Process.Kill`, check against using `is` not `==`
 KILL_OK = wx.KILL_OK
 KILL_BAD_SIGNAL = wx.KILL_BAD_SIGNAL
 KILL_ACCESS_DENIED = wx.KILL_ACCESS_DENIED
 KILL_NO_PROCESS = wx.KILL_NO_PROCESS
 KILL_ERROR = wx.KILL_ERROR
-
-
-class PipeReader(Thread):
-    """Thread for reading standard stream pipes. This is used by the `Job` class
-    to provide non-blocking reads of pipes. Threads are kept alive even after
-    the pipe has closed, only until all data has been read.
-
-    Parameters
-    ----------
-    fdpipe : Any
-        File descriptor for the pipe, either `Popen.stdout` or `Popen.stderr`.
-
-    """
-    def __init__(self, fdpipe):
-        # setup the `Thread` stuff
-        super(PipeReader, self).__init__()
-        self.daemon = True
-
-        self._fdpipe = fdpipe  # pipe file descriptor
-        # queue objects for passing bytes to the main thread
-        self._queue = Queue(maxsize=1)
-        # Overflow buffer if the queue is full, prevents data loss if the
-        # application isn't reading the pipe quick enough.
-        self._overflowBuffer = []
-        # used to signal to the thread that it's time to stop
-        self._stopSignal = Event()
-
-    @property
-    def isAvailable(self):
-        """Are there bytes available to be read (`bool`)?"""
-        return self._queue.full()
-
-    def read(self):
-        """Read all bytes enqueued by the thread coming off the pipe. This is
-        a non-blocking operation. The value `''` is returned if there is no
-        new data on the pipe since the last `read()` call.
-        Returns
-        -------
-        bytes
-            Most recent data passed from the subprocess since the last `read()`
-            call.
-        """
-        try:
-            return self._queue.get_nowait()
-        except Empty:
-            return ''
-
-    def run(self):
-        """Payload routine for the thread. This reads bytes from the pipe and
-        enqueues them.
-        """
-        # read bytes in chunks until EOF
-        for pipeBytes in iter(self._fdpipe.readline, ''):
-            # put bytes into the queue, handle overflows if the queue is full
-            if not self._queue.full():
-                # we have room, check if we have a backlog of bytes to send
-                if self._overflowBuffer:
-                    pipeBytes = "".join(self._overflowBuffer) + pipeBytes
-                    self._overflowBuffer = []  # clear the overflow buffer
-
-                # write bytes to the queue
-                self._queue.put(pipeBytes)
-            else:
-                # Put bytes into buffer if the queue hasn't been emptied quick
-                # enough. These bytes will be passed along once the queue has
-                # space.
-                self._overflowBuffer.append(pipeBytes)
-
-            # exit the loop
-            if self._stopSignal.is_set():
-                break
-
-            # Put the thread to sleep for a bit, not sure if we need this since
-            # this loop will block execution of this thread if there is nothing
-            # to read.
-            time.sleep(0.05)
-
-        # NB - Normally we would flush here and read the remaining bytes in the
-        # thread, but since the process terminates itself
-        # self._fdpipe.flush()  # make sure we get everything
-        self._fdpipe.close()  # close the pipe if stopped
-
-    def stop(self):
-        """Call this to signal the thread to stop reading bytes."""
-        self._stopSignal.set()
 
 
 class Job:
@@ -160,7 +75,7 @@ class Job:
 
     Parameters
     ----------
-    command : list or tuple
+    command : str, list or tuple
         Command to execute when the job is started. Similar to who you would
         specify the command to `Popen`.
     flags : int
@@ -214,10 +129,6 @@ class Job:
         self.terminateCallback = terminateCallback
         self.pollMillis = pollMillis
 
-        # non-blocking pipe reading threads and FIFOs
-        self._stdoutReader = None
-        self._stderrReader = None
-
     def start(self, cwd=None):
         """Start the subprocess.
 
@@ -233,42 +144,22 @@ class Job:
             Process ID assigned by the operating system.
 
         """
-        # NB - keep these lines since we will use them once the bug in
-        # `wx.Execute` is fixed.
-        #
-        # create a new process object, this handles streams and stuff
-        # self._process = wx.Process(None, -1)
-        # self._process.Redirect()  # redirect streams from subprocess
-
-        # start the sub-process
+        # build the command, prepend the change directory command to get the
+        # process started in the correct directory
         command = self._command
+        if cwd is not None:
+            command = "cd " + cwd + "; " + command
 
-        self._process = Popen(
-            args=command,
-            bufsize=1,
-            executable=None,
-            stdin=None,
-            stdout=PIPE,
-            stderr=PIPE,
-            preexec_fn=None,
-            shell=False,
-            cwd=cwd,
-            env=None,
-            universal_newlines=True,  # gives us back a string instead of bytes
-            creationflags=0
-        )
-
-        # get the PID
-        self._pid = self._process.pid
+        # create a new process object, this handles streams and stuff
+        self._process = wx.Process(None, -1)
+        self._process.Redirect()  # redirect streams from subprocess
+        self._pid = wx.Execute(
+            command,
+            flags=wx.EXEC_ASYNC,
+            callback=self._process)
 
         # bind the event called when the process ends
-        # self._process.Bind(wx.EVT_END_PROCESS, self.onTerminate)
-
-        # setup asynchronous readers of the subprocess pipes
-        self._stdoutReader = PipeReader(self._process.stdout)
-        self._stderrReader = PipeReader(self._process.stderr)
-        self._stdoutReader.start()
-        self._stderrReader.start()
+        self._process.Bind(wx.EVT_END_PROCESS, self.onTerminate)
 
         # start polling for data from the subprocesses
         if self._pollMillis is not None:
@@ -277,8 +168,12 @@ class Job:
 
         return self._pid
 
-    def terminate(self):
+    def terminate(self, flags=SIGTERM):
         """Terminate the subprocess associated with this object.
+
+        Parameters
+        ----------
+        flags : int
 
         Return
         ------
@@ -293,28 +188,7 @@ class Job:
 
         # isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
         self._pollTimer.Stop()
-        self._process.terminate()  # kill the process
-
-        # Wait for the process to exit completely, return code will be incorrect
-        # if we don't.
-        processStillRunning = True
-        while processStillRunning:
-            wx.Yield()  # yield to the GUI main loop
-            processStillRunning = self._process.poll() is None
-            time.sleep(0.1)  # sleep a bit to avoid CPU over-utilization
-
-        # get the return code of the subprocess
-        retcode = self._process.returncode
-        self.onTerminate(retcode)
-
-        # stop the pipe reader threads now
-        self._stdoutReader.stop()
-        self._stderrReader.stop()
-
-        self._process = self._pid = None  # reset
-        self._flags = 0
-
-        return retcode is None
+        self._process.Kill(wx.SIGTERM)  # kill the process
 
     @property
     def command(self):
@@ -372,22 +246,22 @@ class Job:
         """
         return self._pid
 
-    # def setPriority(self, priority):
-    #     """Set the subprocess priority. Has no effect if the process has not
-    #     been started.
-    #
-    #     Parameters
-    #     ----------
-    #     priority : int
-    #         Process priority from 0 to 100, where 100 is the highest. Values
-    #         will be clipped between 0 and 100.
-    #
-    #     """
-    #     if self._process is None:
-    #         return
-    #
-    #     priority = max(min(int(priority), 100), 0)  # clip range
-    #     self._process.SetPriority(priority)  # set it
+    def setPriority(self, priority):
+        """Set the subprocess priority. Has no effect if the process has not
+        been started.
+
+        Parameters
+        ----------
+        priority : int
+            Process priority from 0 to 100, where 100 is the highest. Values
+            will be clipped between 0 and 100.
+
+        """
+        if self._process is None:
+            return
+
+        priority = max(min(int(priority), 100), 0)  # clip range
+        self._process.SetPriority(priority)  # set it
 
     @property
     def inputCallback(self):
@@ -452,28 +326,28 @@ class Job:
     #   this stuff with threads which greatly simplifies this class.
     #   ~~~
     #
-    # @property
-    # def isOutputAvailable(self):
-    #     """`True` if the output pipe to the subprocess is opened (therefore
-    #     writeable). If not, you cannot write any bytes to 'outputStream'. Some
-    #     subprocesses may signal to the parent process that its done processing
-    #     data by closing its input.
-    #     """
-    #     if self._process is None:
-    #         return False
-    #
-    #     return self._process.IsInputOpened()
-    #
-    # @property
-    # def outputStream(self):
-    #     """Handle to the file-like object handling the standard output stream
-    #     (`ww.OutputStream`). This is used to write bytes which will show up in
-    #     the 'stdin' pipe of the subprocess.
-    #     """
-    #     if not self.isRunning:
-    #         return None
-    #
-    #     return self._process.OutputStream
+    @property
+    def isOutputAvailable(self):
+        """`True` if the output pipe to the subprocess is opened (therefore
+        writeable). If not, you cannot write any bytes to 'outputStream'. Some
+        subprocesses may signal to the parent process that its done processing
+        data by closing its input.
+        """
+        if self._process is None:
+            return False
+
+        return self._process.IsInputOpened()
+
+    @property
+    def outputStream(self):
+        """Handle to the file-like object handling the standard output stream
+        (`wx.OutputStream`). This is used to write bytes which will show up in
+        the 'stdin' pipe of the subprocess.
+        """
+        if not self.isRunning:
+            return None
+
+        return self._process.OutputStream
 
     @property
     def isInputAvailable(self):
@@ -483,7 +357,7 @@ class Job:
         if self._process is None:
             return False
 
-        return self._stdoutReader.isAvailable
+        return self._process.IsInputAvailable()
 
     def getInputData(self):
         """Get any new data which has shown up on the input pipe (stdout of the
@@ -498,21 +372,21 @@ class Job:
         if self._process is None:
             return
 
-        if self._stdoutReader.isAvailable:
-            return self._stdoutReader.read()
+        if self._process.IsInputAvailable():
+            return self._process.InputStream.read()
 
         return ''
 
-    # @property
-    # def inputStream(self):
-    #     """Handle to the file-like object handling the standard input stream
-    #     (`wx.InputStream`). This is used to read bytes which the subprocess is
-    #     writing to 'stdout'.
-    #     """
-    #     if not self.isRunning:
-    #         return None
-    #
-    #     return self._process.InputStream
+    @property
+    def inputStream(self):
+        """Handle to the file-like object handling the standard input stream
+        (`wx.InputStream`). This is used to read bytes which the subprocess is
+        writing to 'stdout'.
+        """
+        if not self.isRunning:
+            return None
+
+        return self._process.InputStream
 
     @property
     def isErrorAvailable(self):
@@ -522,7 +396,7 @@ class Job:
         if self._process is None:
             return False
 
-        return self._stderrReader.isAvailable
+        return self._process.IsErrorAvailable()
 
     def getErrorData(self):
         """Get any new data which has shown up on the error pipe (stderr of the
@@ -537,21 +411,21 @@ class Job:
         if self._process is None:
             return
 
-        if self._stderrReader.isAvailable:
-            return self._stderrReader.read()
+        if self._process.IsErrorAvailable():
+            return self._process.ErrorStream.read()
 
         return ''
 
-    # @property
-    # def errorStream(self):
-    #     """Handle to the file-like object handling the standard error stream
-    #     (`wx.InputStream`). This is used to read bytes which the subprocess is
-    #     writing to 'stderr'.
-    #     """
-    #     if not self.isRunning:
-    #         return None
-    #
-    #     return self._process.ErrorStream
+    @property
+    def errorStream(self):
+        """Handle to the file-like object handling the standard error stream
+        (`wx.InputStream`). This is used to read bytes which the subprocess is
+        writing to 'stderr'.
+        """
+        if not self.isRunning:
+            return None
+
+        return self._process.ErrorStream
 
     def poll(self):
         """Poll input and error streams for data, pass them to callbacks if
@@ -559,9 +433,6 @@ class Job:
         """
         if self._process is None:  # do nothing if there is no process
             return
-
-        # poll the subprocess
-        retCode = self._process.poll()
 
         # get data from pipes
         if self.isInputAvailable:
@@ -574,10 +445,7 @@ class Job:
             if self._errorCallback is not None:
                 wx.CallAfter(self._errorCallback, stderrText)
 
-        if retCode is not None:  # process has exited?
-            wx.CallAfter(self.onTerminate, retCode)
-
-    def onTerminate(self, exitCode):
+    def onTerminate(self, event):
         """Called when the process exits.
 
         Override for custom functionality. Right now we're just stopping the
@@ -593,11 +461,17 @@ class Job:
             self._pollTimer.Stop()
 
         # flush remaining data from pipes, process it
-        # self.poll()
+        self.poll()
+
+        pid = event.GetPid()
+        exitcode = event.GetExitCode()
 
         # if callback is provided, else nop
         if self._terminateCallback is not None:
-            wx.CallAfter(self._terminateCallback, self._pid, exitCode)
+            wx.CallAfter(self._terminateCallback, pid, exitcode)
+
+        self._process = self._pid = None  # reset
+        self._flags = 0
 
     def onNotify(self):
         """Called when the polling timer elapses.

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -129,14 +129,8 @@ class Job:
         self.terminateCallback = terminateCallback
         self.pollMillis = pollMillis
 
-    def start(self, cwd=None):
+    def start(self):
         """Start the subprocess.
-
-        Parameters
-        ----------
-        cwd : str or None
-            Working directory for the subprocess. Leave `None` to use the same
-            as the application.
 
         Returns
         -------
@@ -147,8 +141,6 @@ class Job:
         # build the command, prepend the change directory command to get the
         # process started in the correct directory
         command = self._command
-        if cwd is not None:
-            command = "cd " + cwd + "; " + command
 
         # create a new process object, this handles streams and stuff
         self._process = wx.Process(None, -1)

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -453,6 +453,8 @@ class Job:
             self._pollTimer.Stop()
 
         # flush remaining data from pipes, process it
+        self._process.InputStream.flush()
+        self._process.ErrorStream.flush()
         self.poll()
 
         pid = event.GetPid()

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -14,6 +14,7 @@ compiled from Builder.
 
 __all__ = ['ScriptProcess']
 
+import os.path
 import sys
 import psychopy.app.jobs as jobs
 from wx import BeginBusyCursor, EndBusyCursor
@@ -86,6 +87,7 @@ class ScriptProcess:
         """
         # full path to the script
         fullPath = fileName.replace('.psyexp', '_lastrun.py')
+        workingDir = os.path.split(fullPath)[0]
 
         # provide a message that the script is running
         # format the output message
@@ -114,9 +116,9 @@ class ScriptProcess:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
 
         # build the shell command to run the script
-        # pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
-        # fullPath = '"' + fullPath + '"'
-        command = ' '.join([pyExec, '-u', fullPath])  # passed to the Job object
+        execCmd = '"import os; os.chdir({}); exec(open({}).read())"'
+        execCmd = execCmd.format(repr(workingDir), repr(fullPath))
+        command = ' '.join([pyExec, '-c', execCmd])  # passed to the Job object
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -116,8 +116,14 @@ class ScriptProcess:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
 
         # build the shell command to run the script
-        execCmd = '"import os; os.chdir({}); exec(open({}).read())"'
-        execCmd = execCmd.format(repr(workingDir), repr(fullPath))
+        execCmd = (
+            '"__file__={fileName}; '
+            'import os; os.chdir({cwd}); '
+            'exec(open({fullPath}, encoding=\'utf-8-sig\').read())"')
+        execCmd = execCmd.format(
+            fileName=repr(fileName),
+            cwd=repr(workingDir),
+            fullPath=repr(fullPath))
         command = ' '.join([pyExec, '-c', execCmd])  # passed to the Job object
 
         # create a new job with the user script

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -116,7 +116,7 @@ class ScriptProcess:
         # build the shell command to run the script
         # pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
         # fullPath = '"' + fullPath + '"'
-        command = [pyExec, '-u', fullPath]  # passed to the Job object
+        command = ' '.join([pyExec, '-u', fullPath])  # passed to the Job object
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(
@@ -243,12 +243,6 @@ class ScriptProcess:
             Program exit code.
 
         """
-        # get remaining data from pipes if available
-        if self.scriptProcess.isInputAvailable:
-            self._writeOutput(self.scriptProcess.getInputData())
-        if self.scriptProcess.isErrorAvailable:
-            self._writeOutput(self.scriptProcess.getErrorData())
-
         # write a close message, shows the exit code
         closeMsg = \
             " Experiment ended with exit code {} [pid:{}] ".format(


### PR DESCRIPTION
This PR refactors how PsychoPy executes subprocess, such as user scripts within runner. Reading of pipes in now left to wxPython's builtin `Process` library instead of `subprocess` which requires threading for non-blocking reads of pipes. The wxPython library also supports events which improves integration with the UI. All output should be captured at this point, unlike before where some would get cut off at the end.

I already went the `Process` route in the past, but reverted back to `subprocess` due to issues with how the `wx.Execute` function was wrapped. Where the function lacked support for setting the working directory for the subprocess environment. While the issue is getting fixed upsteam, I created an interim solution that allows us to use `wx.Execute` which sets the working directory by calling python commands to do so prior to running the user's script. This is done without modifying the output script in any way, so this change is not noticeable to the user.