### PR TITLE
RF: Use getDateStr to tag mic clips

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -359,6 +359,7 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         if inits['transcribeBackend'].val:
             code = (
+                "tag = data.utils.getDateStr()\n"
                 "%(name)sClip, %(name)sScript = %(name)s.bank(\n"
             )
         else:
@@ -368,7 +369,7 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (
-            "tag='%(loop)s', transcribe='%(transcribeBackend)s',\n"
+            "tag=tag, transcribe='%(transcribeBackend)s',\n"
         )
         buff.writeIndentedLines(code % inits)
         if transcribe:
@@ -383,7 +384,7 @@ class MicrophoneComponent(BaseComponent):
         buff.setIndentLevel(-1, relative=True)
         code = (
             ")\n"
-            "%(loop)s.addData('%(name)s.clip', os.path.join(%(name)sRecFolder, %(filename)s))\n"
+            "%(loop)s.addData('%(name)s.clip', os.path.join(%(name)sRecFolder, 'recording_%(name)s_%%s.%(outputType)s' %% tag))\n"
         )
         buff.writeIndentedLines(code % inits)
         if transcribe:
@@ -482,7 +483,22 @@ class MicrophoneComponent(BaseComponent):
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)
         code = (
-                    "clip.save(os.path.join(%(name)sRecFolder, 'recording_%(name)s_%%s_%%s.%(outputType)s' %% (tag, i)))\n"
+                    "clipFilename = 'recording_%(name)s_%%s.%(outputType)s' %% tag\n"
+        )
+        buff.writeIndentedLines(code % inits)
+        code = (
+                    "# if there's more than 1 clip with this tag, append a counter for all beyond the first\n"
+                    "if i > 0:\n"
+        )
+        buff.writeIndentedLines(code % inits)
+        buff.setIndentLevel(1, relative=True)
+        code = (
+                        "clipFilename += '_%%s' %% i"
+        )
+        buff.writeIndentedLines(code % inits)
+        buff.setIndentLevel(-1, relative=True)
+        code = (
+                    "clip.save(os.path.join(%(name)sRecFolder, clipFilename))\n"
         )
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(-2, relative=True)


### PR DESCRIPTION
Previously, filenames were:
```
recording_{component name}_{loop name or 'thisExp'}_{trialN}.wav
```
Now they're:
```
recording_{component name}_{timestamp}.wav
```
(with a "_1", "_2", etc. added after the timestamp if there's more than one with the exact same timestamp, which should be never, but better safe than sorry)

Adding the science team but you don't need to go over the code, just approve/request changes based on whether the change described above seems reasonable :)