### PR TITLE
FF: fix eyelink calibration gfx runtime exception

### DIFF
--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -82,6 +82,22 @@ def displayEventTableSelectionDialog(title, list_label, list_values, default=u'S
     return list(dlg_info.values())[0]
 
 
+def getEyeSampleTypesInFile(hdf5FilePath):
+    """
+    Return the eye sample type(s) saved in the hdf5 file located in hdf5FilePath.
+    If no eye samples have been saved to the file return []. Possible return list values are defined in
+    psychopy.iohub.constants.EYE_SAMPLE_TYPES.
+
+    :param returnType: (type)
+    :return: (list)
+    """
+    dpath, dfile = os.path.split(hdf5FilePath)
+    datafile = ExperimentDataAccessUtility(dpath, dfile)
+    result = datafile.getAvailableEyeSampleTypes()
+    datafile.close()
+    return result
+
+
 def saveEventReport(hdf5FilePath="", eventType="", eventFields=[], trialStartMessage=None, trialStopMessage=None,
                     timeMargins=(0.0, 0.0)):
     """

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
@@ -32,15 +32,15 @@ class FixationTarget():
             inner_line_color = psychopy_eyelink_graphics.getCalibSetting(['target_attributes', 'inner_line_color'])
 
         self.calibrationPoint = visual.TargetStim(
-            self.window, name="CP", style="circles",
-            radius=self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0,
+            win, name="CP", style="circles",
+            radius=psychopy_eyelink_graphics.getCalibSetting(['target_attributes', 'outer_diameter']) / 2.0,
             fillColor=outer_fill_color,
             borderColor=outer_line_color,
-            lineWidth=self.getCalibSetting(['target_attributes', 'outer_stroke_width']),
-            innerRadius=self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0,
+            lineWidth=psychopy_eyelink_graphics.getCalibSetting(['target_attributes', 'outer_stroke_width']),
+            innerRadius=psychopy_eyelink_graphics.getCalibSetting(['target_attributes', 'inner_diameter']) / 2.0,
             innerFillColor=inner_fill_color,
             innerBorderColor=inner_line_color,
-            innerLineWidth=self.getCalibSetting(['target_attributes', 'inner_stroke_width']),
+            innerLineWidth=psychopy_eyelink_graphics.getCalibSetting(['target_attributes', 'inner_stroke_width']),
             pos=(0, 0),
             units=unit_type,
             colorSpace=color_type,


### PR DESCRIPTION
FF: fixes eyelink calibration gfx runtime exception, still not drawing as before though (inner target circle is not visible). 
ENH: added getEyeSampleTypesInFile function to iohub datastore util