### PR TITLE
ENH: Update defaults

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -126,7 +126,7 @@ class Experiment:
         # What libs are needed (make sound come first)
         self.requiredImports = []
         libs = ('sound', 'gui', 'visual', 'core', 'data', 'event',
-                'logging', 'clock', 'colors')
+                'logging', 'clock', 'colors', 'layout')
         self.requirePsychopyLibs(libs=libs)
         self.requireImport(importName='keyboard',
                            importFrom='psychopy.hardware')

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -36,7 +36,7 @@ class FormComponent(BaseVisualComponent):
     def __init__(self, exp, parentName,
                  name='form',
                  items='.csv',
-                 textHeight=.03,
+                 textHeight=0.03,
                  font="Open Sans",
                  randomize=False,
                  fillColor='',

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -34,7 +34,7 @@ class TextComponent(BaseVisualComponent):
                  text=_translate('Any text\n\nincluding line breaks'),
                  font='Open Sans', units='from exp settings',
                  color='white', colorSpace='rgb',
-                 pos=(0, 0), letterHeight=0.1, ori=0,
+                 pos=(0, 0), letterHeight=0.05, ori=0,
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  flip='None', startEstim='', durationEstim='', wrapWidth='',

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -47,7 +47,7 @@ class TextboxComponent(BaseVisualComponent):
                  font='Open Sans', units='from exp settings', bold=False, italic=False,
                  color='white', colorSpace='rgb', opacity="",
                  pos=(0, 0), size=(None, None), letterHeight=0.05, ori=0,
-                 anchor='center', alignment='top-left',
+                 anchor='center', alignment='center',
                  lineSpacing=1.0, padding=0,  # gap between box and text
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -58,7 +58,8 @@ debug = False
 # If text is ". " we don't want to start next line with single space?
 
 class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
-    def __init__(self, win, text, font,
+    def __init__(self, win, text,
+                 font="Open Sans",
                  pos=(0, 0), units=None, letterHeight=None,
                  size=None,
                  color=(1.0, 1.0, 1.0), colorSpace='rgb',


### PR DESCRIPTION
- Builder experiments should import `psychopy.layout` so users can set sizes/positions with it if they want
- TextBox alignment should default to center in Builder rather than top-left
- TextStim should be 0.05h rather than 0.1h
- Now that we have fonts pre-loaded, font no longer needs to be compulsory for TextBox Python objects; make it optional with Open Sans as default