### PR TITLE
FF: More subprocess fixes

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -60,12 +60,97 @@ SIGINT = wx.SIGINT
 KILL_NOCHILDREN = wx.KILL_NOCHILDREN
 KILL_CHILDREN = wx.KILL_CHILDREN  # yeesh ...
 
-# Error values for `wx.Process.Kill`, check against using `is` not `==`
+# Error values for `wx.Process.Kill`
 KILL_OK = wx.KILL_OK
 KILL_BAD_SIGNAL = wx.KILL_BAD_SIGNAL
 KILL_ACCESS_DENIED = wx.KILL_ACCESS_DENIED
 KILL_NO_PROCESS = wx.KILL_NO_PROCESS
 KILL_ERROR = wx.KILL_ERROR
+
+
+class PipeReader(Thread):
+    """Thread for reading standard stream pipes. This is used by the `Job` class
+    to provide non-blocking reads of pipes.
+
+    Parameters
+    ----------
+    fdpipe : Any
+        File descriptor for the pipe, either `Popen.stdout` or `Popen.stderr`.
+    pollMillis : int or float
+        Number of milliseconds to wait between pipe reads.
+
+    """
+    def __init__(self, fdpipe):
+        # setup the `Thread` stuff
+        super(PipeReader, self).__init__()
+        self.daemon = True
+
+        self._fdpipe = fdpipe  # pipe file descriptor
+        # queue objects for passing bytes to the main thread
+        self._queue = Queue(maxsize=1)
+        # Overflow buffer if the queue is full, prevents data loss if the
+        # application isn't reading the pipe quick enough.
+        self._overflowBuffer = []
+        # used to signal to the thread that it's time to stop
+        self._stopSignal = Event()
+
+    @property
+    def isAvailable(self):
+        """Are there bytes available to be read (`bool`)?"""
+        return self._queue.full()
+
+    def read(self):
+        """Read all bytes enqueued by the thread coming off the pipe. This is
+        a non-blocking operation. The value `''` is returned if there is no
+        new data on the pipe since the last `read()` call.
+
+        Returns
+        -------
+        bytes
+            Most recent data passed from the subprocess since the last `read()`
+            call.
+
+        """
+        try:
+            return self._queue.get_nowait()
+        except Empty:
+            return ''
+
+    def run(self):
+        """Payload routine for the thread. This reads bytes from the pipe and
+        enqueues them.
+        """
+        # read bytes in chunks until EOF
+        for pipeBytes in iter(self._fdpipe.readline, ''):
+            # put bytes into the queue, handle overflows if the queue is full
+            if not self._queue.full():
+                # we have room, check if we have a backlog of bytes to send
+                if self._overflowBuffer:
+                    pipeBytes = "".join(self._overflowBuffer) + pipeBytes
+                    self._overflowBuffer = []  # clear the overflow buffer
+
+                # write bytes to the queue
+                self._queue.put(pipeBytes)
+            else:
+                # Put bytes into buffer if the queue hasn't been emptied quick
+                # enough. These bytes will be passed along once the queue has
+                # space.
+                self._overflowBuffer.append(pipeBytes)
+
+            # Put the thread to sleep for a bit, not sure if we need this since
+            # this loop will block execution of this thread if there is nothing
+            # to read.
+            time.sleep(0.1)
+
+            # exit the loop
+            if self._stopSignal.is_set():
+                break
+
+        self._fdpipe.close()  # close the pipe if stopped
+
+    def stop(self):
+        """Call this to signal the thread to stop reading bytes."""
+        self._stopSignal.set()
 
 
 class Job:
@@ -75,7 +160,7 @@ class Job:
 
     Parameters
     ----------
-    command : str, list or tuple
+    command : list or tuple
         Command to execute when the job is started. Similar to who you would
         specify the command to `Popen`.
     flags : int
@@ -129,8 +214,18 @@ class Job:
         self.terminateCallback = terminateCallback
         self.pollMillis = pollMillis
 
-    def start(self):
+        # non-blocking pipe reading threads and FIFOs
+        self._stdoutReader = None
+        self._stderrReader = None
+
+    def start(self, cwd=None):
         """Start the subprocess.
+
+        Parameters
+        ----------
+        cwd : str or None
+            Working directory for the subprocess. Leave `None` to use the same
+            as the application.
 
         Returns
         -------
@@ -138,37 +233,52 @@ class Job:
             Process ID assigned by the operating system.
 
         """
-        # build the command, prepend the change directory command to get the
-        # process started in the correct directory
+        # NB - keep these lines since we will use them once the bug in
+        # `wx.Execute` is fixed.
+        #
+        # create a new process object, this handles streams and stuff
+        # self._process = wx.Process(None, -1)
+        # self._process.Redirect()  # redirect streams from subprocess
+
+        # start the sub-process
         command = self._command
 
-        # create a new process object, this handles streams and stuff
-        self._process = wx.Process(None, -1)
-        self._process.Redirect()  # redirect streams from subprocess
-        self._pid = wx.Execute(
-            command,
-            flags=wx.EXEC_ASYNC,
-            callback=self._process)
+        self._process = Popen(
+            args=command,
+            bufsize=1,
+            executable=None,
+            stdin=None,
+            stdout=PIPE,
+            stderr=PIPE,
+            preexec_fn=None,
+            shell=False,
+            cwd=cwd,
+            env=None,
+            universal_newlines=True,  # gives us back a string instead of bytes
+            creationflags=0
+        )
+
+        # get the PID
+        self._pid = self._process.pid
 
         # bind the event called when the process ends
-        self._process.Bind(wx.EVT_END_PROCESS, self.onTerminate)
+        # self._process.Bind(wx.EVT_END_PROCESS, self.onTerminate)
+
+        # setup asynchronous readers of the subprocess pipes
+        self._stdoutReader = PipeReader(self._process.stdout)
+        self._stderrReader = PipeReader(self._process.stderr)
+        self._stdoutReader.start()
+        self._stderrReader.start()
 
         # start polling for data from the subprocesses
         if self._pollMillis is not None:
             self._pollTimer.Notify = self.onNotify  # override
             self._pollTimer.Start(self._pollMillis, oneShot=wx.TIMER_CONTINUOUS)
 
-        if sys.platform == 'win32':
-            self._process.Activate()  # raise the GUI if available
-
         return self._pid
 
-    def terminate(self, flags=SIGTERM):
+    def terminate(self):
         """Terminate the subprocess associated with this object.
-
-        Parameters
-        ----------
-        flags : int
 
         Return
         ------
@@ -183,7 +293,28 @@ class Job:
 
         # isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
         self._pollTimer.Stop()
-        self._process.Kill(wx.SIGTERM)  # kill the process
+        self._process.terminate()  # kill the process
+
+        # Wait for the process to exit completely, return code will be incorrect
+        # if we don't.
+        processStillRunning = True
+        while processStillRunning:
+            wx.Yield()  # yield to the GUI main loop
+            processStillRunning = self._process.poll() is None
+            time.sleep(0.1)  # sleep a bit to avoid CPU over-utilization
+
+        # stop the pipe reader threads now
+        self._stdoutReader.stop()
+        self._stderrReader.stop()
+
+        # get the return code of the subprocess
+        retcode = self._process.returncode
+        self.onTerminate(retcode)
+
+        self._process = self._pid = None  # reset
+        self._flags = 0
+
+        return retcode is None
 
     @property
     def command(self):
@@ -241,22 +372,22 @@ class Job:
         """
         return self._pid
 
-    def setPriority(self, priority):
-        """Set the subprocess priority. Has no effect if the process has not
-        been started.
-
-        Parameters
-        ----------
-        priority : int
-            Process priority from 0 to 100, where 100 is the highest. Values
-            will be clipped between 0 and 100.
-
-        """
-        if self._process is None:
-            return
-
-        priority = max(min(int(priority), 100), 0)  # clip range
-        self._process.SetPriority(priority)  # set it
+    # def setPriority(self, priority):
+    #     """Set the subprocess priority. Has no effect if the process has not
+    #     been started.
+    #
+    #     Parameters
+    #     ----------
+    #     priority : int
+    #         Process priority from 0 to 100, where 100 is the highest. Values
+    #         will be clipped between 0 and 100.
+    #
+    #     """
+    #     if self._process is None:
+    #         return
+    #
+    #     priority = max(min(int(priority), 100), 0)  # clip range
+    #     self._process.SetPriority(priority)  # set it
 
     @property
     def inputCallback(self):
@@ -293,8 +424,7 @@ class Job:
 
     @property
     def pollMillis(self):
-        """Polling interval for input and error pipes in seconds (`int` or
-        `None`). Setting to `None` will disable automatic periodic polling.
+        """Polling interval for input and error pipes (`int` or `None`).
         """
         return self._pollMillis
 
@@ -321,28 +451,28 @@ class Job:
     #   this stuff with threads which greatly simplifies this class.
     #   ~~~
     #
-    @property
-    def isOutputAvailable(self):
-        """`True` if the output pipe to the subprocess is opened (therefore
-        writeable). If not, you cannot write any bytes to 'outputStream'. Some
-        subprocesses may signal to the parent process that its done processing
-        data by closing its input.
-        """
-        if self._process is None:
-            return False
-
-        return self._process.IsInputOpened()
-
-    @property
-    def outputStream(self):
-        """Handle to the file-like object handling the standard output stream
-        (`wx.OutputStream`). This is used to write bytes which will show up in
-        the 'stdin' pipe of the subprocess.
-        """
-        if not self.isRunning:
-            return None
-
-        return self._process.OutputStream
+    # @property
+    # def isOutputAvailable(self):
+    #     """`True` if the output pipe to the subprocess is opened (therefore
+    #     writeable). If not, you cannot write any bytes to 'outputStream'. Some
+    #     subprocesses may signal to the parent process that its done processing
+    #     data by closing its input.
+    #     """
+    #     if self._process is None:
+    #         return False
+    #
+    #     return self._process.IsInputOpened()
+    #
+    # @property
+    # def outputStream(self):
+    #     """Handle to the file-like object handling the standard output stream
+    #     (`ww.OutputStream`). This is used to write bytes which will show up in
+    #     the 'stdin' pipe of the subprocess.
+    #     """
+    #     if not self.isRunning:
+    #         return None
+    #
+    #     return self._process.OutputStream
 
     @property
     def isInputAvailable(self):
@@ -352,7 +482,7 @@ class Job:
         if self._process is None:
             return False
 
-        return self._process.IsInputAvailable()
+        return self._stdoutReader.isAvailable
 
     def getInputData(self):
         """Get any new data which has shown up on the input pipe (stdout of the
@@ -367,21 +497,21 @@ class Job:
         if self._process is None:
             return
 
-        if self._process.IsInputAvailable():
-            return self._process.InputStream.read()
+        if self._stdoutReader.isAvailable:
+            return self._stdoutReader.read()
 
         return ''
 
-    @property
-    def inputStream(self):
-        """Handle to the file-like object handling the standard input stream
-        (`wx.InputStream`). This is used to read bytes which the subprocess is
-        writing to 'stdout'.
-        """
-        if not self.isRunning:
-            return None
-
-        return self._process.InputStream
+    # @property
+    # def inputStream(self):
+    #     """Handle to the file-like object handling the standard input stream
+    #     (`wx.InputStream`). This is used to read bytes which the subprocess is
+    #     writing to 'stdout'.
+    #     """
+    #     if not self.isRunning:
+    #         return None
+    #
+    #     return self._process.InputStream
 
     @property
     def isErrorAvailable(self):
@@ -391,7 +521,7 @@ class Job:
         if self._process is None:
             return False
 
-        return self._process.IsErrorAvailable()
+        return self._stderrReader.isAvailable
 
     def getErrorData(self):
         """Get any new data which has shown up on the error pipe (stderr of the
@@ -406,21 +536,21 @@ class Job:
         if self._process is None:
             return
 
-        if self._process.IsErrorAvailable():
-            return self._process.ErrorStream.read()
+        if self._stderrReader.isAvailable:
+            return self._stderrReader.read()
 
         return ''
 
-    @property
-    def errorStream(self):
-        """Handle to the file-like object handling the standard error stream
-        (`wx.InputStream`). This is used to read bytes which the subprocess is
-        writing to 'stderr'.
-        """
-        if not self.isRunning:
-            return None
-
-        return self._process.ErrorStream
+    # @property
+    # def errorStream(self):
+    #     """Handle to the file-like object handling the standard error stream
+    #     (`wx.InputStream`). This is used to read bytes which the subprocess is
+    #     writing to 'stderr'.
+    #     """
+    #     if not self.isRunning:
+    #         return None
+    #
+    #     return self._process.ErrorStream
 
     def poll(self):
         """Poll input and error streams for data, pass them to callbacks if
@@ -428,6 +558,9 @@ class Job:
         """
         if self._process is None:  # do nothing if there is no process
             return
+
+        # poll the subprocess
+        retCode = self._process.poll()
 
         # get data from pipes
         if self.isInputAvailable:
@@ -440,7 +573,10 @@ class Job:
             if self._errorCallback is not None:
                 wx.CallAfter(self._errorCallback, stderrText)
 
-    def onTerminate(self, event):
+        if retCode is not None:  # process has exited?
+            wx.CallAfter(self.onTerminate, retCode)
+
+    def onTerminate(self, exitCode):
         """Called when the process exits.
 
         Override for custom functionality. Right now we're just stopping the
@@ -456,19 +592,11 @@ class Job:
             self._pollTimer.Stop()
 
         # flush remaining data from pipes, process it
-        self._process.InputStream.flush()
-        self._process.ErrorStream.flush()
-        self.poll()
-
-        pid = event.GetPid()
-        exitcode = event.GetExitCode()
+        # self.poll()
 
         # if callback is provided, else nop
         if self._terminateCallback is not None:
-            wx.CallAfter(self._terminateCallback, pid, exitcode)
-
-        self._process = self._pid = None  # reset
-        self._flags = 0
+            wx.CallAfter(self._terminateCallback, self._pid, exitCode)
 
     def onNotify(self):
         """Called when the polling timer elapses.

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -176,11 +176,6 @@ class Job:
         Callback function called when `poll` is invoked and the error pipe has
         data. Data is passed to the first argument of the callable object. You
         may set `inputCallback` and `errorCallback` using the same function.
-    pollMillis : int or None
-        Time in milliseconds between polling intervals. When interval specified
-        by `pollMillis` elapses, the input and error streams will be read and
-        callback functions will be called. If `None`, then the timer will be
-        disabled and the `poll()` method will need to be invoked.
 
     Examples
     --------
@@ -195,7 +190,7 @@ class Job:
 
     """
     def __init__(self, parent, command='', flags=EXEC_ASYNC, terminateCallback=None,
-                 inputCallback=None, errorCallback=None, pollMillis=None):
+                 inputCallback=None, errorCallback=None):
 
         # command to be called, cannot be changed after spawning the process
         self.parent = parent
@@ -213,7 +208,6 @@ class Job:
         self.inputCallback = inputCallback
         self.errorCallback = errorCallback
         self.terminateCallback = terminateCallback
-        self.pollMillis = pollMillis
 
         # non-blocking pipe reading threads and FIFOs
         self._stdoutReader = None
@@ -602,13 +596,13 @@ class Job:
         if self._terminateCallback is not None:
             wx.CallAfter(self._terminateCallback, self._pid, exitCode)
 
-    def onNotify(self):
-        """Called when the polling timer elapses.
-
-        Default action is to read input and error streams and broadcast any data
-        to user defined callbacks (if `poll()` has not been overwritten).
-        """
-        self.poll()
+    # def onNotify(self):
+    #     """Called when the polling timer elapses.
+    #
+    #     Default action is to read input and error streams and broadcast any data
+    #     to user defined callbacks (if `poll()` has not been overwritten).
+    #     """
+    #     self.poll()
 
     def __del__(self):
         """Called when the object is garbage collected or deleted."""

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -158,6 +158,9 @@ class Job:
             self._pollTimer.Notify = self.onNotify  # override
             self._pollTimer.Start(self._pollMillis, oneShot=wx.TIMER_CONTINUOUS)
 
+        if sys.platform == 'win32':
+            self._process.Activate()  # raise the GUI if available
+
         return self._pid
 
     def terminate(self, flags=SIGTERM):

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -121,8 +121,7 @@ class ScriptProcess:
             flags=execFlags,
             inputCallback=self._onInputCallback,  # both treated the same
             errorCallback=self._onErrorCallback,
-            terminateCallback=self._onTerminateCallback,
-            pollMillis=120  # check input/error pipes every 120 ms
+            terminateCallback=self._onTerminateCallback
         )
 
         BeginBusyCursor()  # visual feedback

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -14,14 +14,9 @@ compiled from Builder.
 
 __all__ = ['ScriptProcess']
 
-import os.path
 import sys
 import psychopy.app.jobs as jobs
 from wx import BeginBusyCursor, EndBusyCursor
-from psychopy.app.console import StdStreamDispatcher
-
-# polling interval for pipes in milliseconds
-PIPE_POLL_INTERVAL_MS = 120
 
 
 class ScriptProcess:
@@ -87,7 +82,6 @@ class ScriptProcess:
         """
         # full path to the script
         fullPath = fileName.replace('.psyexp', '_lastrun.py')
-        workingDir = os.path.split(fullPath)[0]
 
         # provide a message that the script is running
         # format the output message
@@ -96,7 +90,7 @@ class ScriptProcess:
 
         # if we have a runner frame, write to the output text box
         if hasattr(self.app, 'runner'):
-            stdOut = StdStreamDispatcher.getInstance()
+            stdOut = self.app.runner.stdOut
             stdOut.lenLastRun = len(self.app.runner.stdOut.getText())
         else:
             # if not, just write to the standard output pipe
@@ -116,15 +110,9 @@ class ScriptProcess:
             execFlags |= jobs.EXEC_MAKE_GROUP_LEADER
 
         # build the shell command to run the script
-        execCmd = (
-            '"__file__={fileName}; '
-            'import os; os.chdir({cwd}); '
-            'exec(open({fullPath}, encoding=\'utf-8-sig\').read())"')
-        execCmd = execCmd.format(
-            fileName=repr(fileName),
-            cwd=repr(workingDir),
-            fullPath=repr(fullPath))
-        command = ' '.join([pyExec, '-c', execCmd])  # passed to the Job object
+        # pyExec = '"' + pyExec + '"'  # use quotes to prevent issues with spaces
+        # fullPath = '"' + fullPath + '"'
+        command = [pyExec, '-u', fullPath]  # passed to the Job object
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(
@@ -133,7 +121,7 @@ class ScriptProcess:
             inputCallback=self._onInputCallback,  # both treated the same
             errorCallback=self._onErrorCallback,
             terminateCallback=self._onTerminateCallback,
-            pollMillis=PIPE_POLL_INTERVAL_MS  # to check input/error pipes
+            pollMillis=120  # check input/error pipes every 120 ms
         )
 
         BeginBusyCursor()  # visual feedback
@@ -184,11 +172,7 @@ class ScriptProcess:
         # not available we just write to `sys.stdout`.
         if hasattr(self.app, 'runner'):
             # get any remaining data on the pipes
-            stdOut = StdStreamDispatcher.getInstance()
-            # backup if we don't have an instance for some reason
-            if stdOut is None:
-                stdOut = self.app.runner.stdOut
-
+            stdOut = self.app.runner.stdOut
             self.app.runner.Show()
         else:
             stdOut = sys.stdout
@@ -253,9 +237,8 @@ class ScriptProcess:
         """
         # write a close message, shows the exit code
         closeMsg = \
-            " Experiment ended with exit code {} [pid:{}] ".format(
+            "##### Experiment ended with exit code {} [pid:{}] #####\n".format(
                 exitCode, pid)
-        closeMsg = closeMsg.center(80, '#') + '\n'
         self._writeOutput(closeMsg)
 
         self.scriptProcess = None  # reset

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -116,6 +116,7 @@ class ScriptProcess:
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(
+            self.app,
             command=command,
             flags=execFlags,
             inputCallback=self._onInputCallback,  # both treated the same


### PR DESCRIPTION
Unfortunately, we encountered some bugs on Windows with the previous system. This will use the more "universal" subprocess module and hook onto `EVT_IDLE` when polling rather than a timer. Hopefully we found a nice spot where all the input is captured and we get scripts launching across correctly across multiple platforms.