### PR TITLE
BF: for local debug we need better checks for the correct JS version

### DIFF
--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -30,6 +30,7 @@ from psychopy.app.stdOutRich import StdOutRich
 from psychopy.projects.pavlovia import getProject
 from psychopy.scripts.psyexpCompile import generateScript
 from psychopy.app.runner.scriptProcess import ScriptProcess
+import psychopy.tools.versionchooser as versions
 
 folderColumn = 1
 filenameColumn = 0
@@ -755,14 +756,14 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
     def onURL(self, evt):
         self.parent.onURL(evt)
 
-    def getPsychoJS(self):
+    def getPsychoJS(self, useVersion=''):
         """
         Download and save the current version of the PsychoJS library.
 
         Useful for debugging, amending scripts.
         """
         libPath = self.currentFile.parent / self.outputPath / 'lib'
-        ver = '.'.join(self.app.version.split('.')[:3])
+        ver = versions.getPsychoJSVersionStr(self.app.version, useVersion)
         libFileExtensions = ['css', 'iife.js', 'iife.js.map', 'js', 'js.LEGAL.txt', 'js.map']
 
         try:  # ask-for-forgiveness rather than query-then-make

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -739,24 +739,9 @@ class SettingsComponent:
             self.prepareResourcesJS()
         jsFilename = os.path.basename(os.path.splitext(self.exp.filename)[0])
 
-        # decide if we need anchored useVersion or leave plain
+        # configure the PsychoJS version number from current/requested versions
         useVer = self.params['Use version'].val
-        if useVer == '':
-            useVer = version
-        elif useVer == 'latest':
-            useVer = versions.latestVersion()
-        else:
-            useVer = versions.fullVersion(useVer)
-
-        # do we shorten minor versions ('3.4.2' to '3.4')?
-        # only from 3.2 onwards
-        if (parse_version('3.2')) <= parse_version(useVer) < parse_version('2021') \
-                and len(useVer.split('.')) > 2:
-            # e.g. 2020.2 not 2021.2.5
-            useVer = '.'.join(useVer.split('.')[:2])
-        elif len(useVer.split('.')) > 3:
-            # e.g. 2021.1.0 not 2021.1.0.dev3
-            useVer = '.'.join(useVer.split('.')[:3])
+        useVer = versions.getPsychoJSVersionStr(version, useVer)
 
         # html header
         if self.exp.expPath:

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -36,6 +36,36 @@ def _translate(string):
     return string
 
 
+def getPsychoJSVersionStr(currentVersion, preferredVersion=''):
+    """Get the PsychoJS version string for a given PsychoPy version
+    taking into account:
+    - the current/requested version
+    - the fact that early PsychoJS versions did not include minor version
+    - PsychoJS versions do not use rc1 or dev1 suffixes"""
+    if preferredVersion == '':
+        useVerStr = currentVersion
+    elif preferredVersion == 'latest':
+        useVerStr = latestVersion()
+    else:
+        useVerStr = fullVersion(preferredVersion)
+
+    # do we shorten minor versions ('3.4.2' to '3.4')?
+    # only from 3.2 onwards
+    if (parse_version('3.2')) <= parse_version(useVerStr) < parse_version('2021') \
+            and len(useVerStr.split('.')) > 2:
+        # e.g. 2020.2 not 2021.2.5
+        useVerStr = '.'.join(useVerStr.split('.')[:2])
+    elif len(useVerStr.split('.')) > 3:
+        # e.g. 2021.1.0 not 2021.1.0.dev3
+        useVerStr = '.'.join(useVerStr.split('.')[:3])
+    # PsychoJS doesn't have additional rc1 or dev1 releases
+    for versionSuffix in ["rc", "dev"]:
+        if versionSuffix in useVerStr:
+            useVerStr = useVerStr.split(versionSuffix)[0]
+
+    return useVerStr
+
+
 def useVersion(requestedVersion):
     """Manage paths and checkout psychopy libraries for requested versions
     of PsychoPy.


### PR DESCRIPTION
This adds a function to work out the right version, excluding suffixes (like
rc1, dev1...) and use the correct verion length (no minor version in early
versions)