### PR TITLE
BF: preferences.generateSpec was no longer operating correctly as a s…

### DIFF
--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -68,7 +68,7 @@
     # Show an error dialog when PsychoPy encounters an unhandled internal error.
     errorDialog = boolean(default='True')
     # Theme
-    theme = string(default='PsychopyDark')
+    theme = string(default='PsychopyLight')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -68,7 +68,7 @@
     # Show an error dialog when PsychoPy encounters an unhandled internal error.
     errorDialog = boolean(default='True')
     # Theme
-    theme = string(default='PsychopyDark')
+    theme = string(default='PsychopyLight')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -68,7 +68,7 @@
     # Show an error dialog when PsychoPy encounters an unhandled internal error.
     errorDialog = boolean(default='True')
     # Theme
-    theme = string(default='PsychopyDark')
+    theme = string(default='PsychopyLight')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -68,7 +68,7 @@
     # Show an error dialog when PsychoPy encounters an unhandled internal error.
     errorDialog = boolean(default='True')
     # Theme
-    theme = string(default='PsychopyDark')
+    theme = string(default='PsychopyLight')
 
 # Settings for the Coder window
 [coder]

--- a/psychopy/preferences/generateSpec.py
+++ b/psychopy/preferences/generateSpec.py
@@ -75,3 +75,6 @@ def generateSpec(baseSpec=None):
         f.write(winSpec)
 
     os.chdir(startPath)
+
+if __name__ == "__main__":
+    generateSpec()


### PR DESCRIPTION
…cript

It had been turned into a function for testing purposes by a408ec9ddf but
was no longer being used to generate the specs.

Also, the platforms had been manually changed to make PsychoPyDark their
default Theme. Dark is cool for the users that want to find it, but not
so good as a default, especially because doesn't quite apply to every
control (e.g. the status bar)