### PR TITLE
FF: Improved handling of subprocess pipes

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -67,6 +67,8 @@ KILL_ACCESS_DENIED = wx.KILL_ACCESS_DENIED
 KILL_NO_PROCESS = wx.KILL_NO_PROCESS
 KILL_ERROR = wx.KILL_ERROR
 
+PIPE_READER_POLL_INTERVAL = 0.025  # seconds
+
 
 class PipeReader(Thread):
     """Thread for reading standard stream pipes. This is used by the `Job` class
@@ -140,7 +142,7 @@ class PipeReader(Thread):
             # Put the thread to sleep for a bit, not sure if we need this since
             # this loop will block execution of this thread if there is nothing
             # to read.
-            time.sleep(0.05)
+            time.sleep(PIPE_READER_POLL_INTERVAL)
 
             # exit the loop
             if self._stopSignal.is_set():

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -140,13 +140,15 @@ class PipeReader(Thread):
             # Put the thread to sleep for a bit, not sure if we need this since
             # this loop will block execution of this thread if there is nothing
             # to read.
-            time.sleep(0.1)
+            time.sleep(0.05)
 
             # exit the loop
             if self._stopSignal.is_set():
                 break
 
-        self._fdpipe.close()  # close the pipe if stopped
+            self._fdpipe.flush()
+
+        #self._fdpipe.close()  # close the pipe if stopped
 
     def stop(self):
         """Call this to signal the thread to stop reading bytes."""
@@ -198,8 +200,8 @@ class Job:
         self._pid = None
         self._flags = flags
         self._process = None
-        self._pollMillis = None
-        self._pollTimer = wx.Timer()
+        # self._pollMillis = None
+        # self._pollTimer = wx.Timer()
 
         # user defined callbacks
         self._inputCallback = None
@@ -287,6 +289,8 @@ class Job:
         if not self.isRunning:
             return False  # nop
 
+        self.parent.Unbind(wx.EVT_IDLE)
+
         # isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
         #self._pollTimer.Stop()
         self._process.terminate()  # kill the process
@@ -299,16 +303,9 @@ class Job:
             processStillRunning = self._process.poll() is None
             time.sleep(0.1)  # sleep a bit to avoid CPU over-utilization
 
-        # stop the pipe reader threads now
-        self._stdoutReader.stop()
-        self._stderrReader.stop()
-
         # get the return code of the subprocess
         retcode = self._process.returncode
         self.onTerminate(retcode)
-
-        self._process = self._pid = None  # reset
-        self._flags = 0
 
         return retcode is None
 
@@ -557,6 +554,8 @@ class Job:
 
         # poll the subprocess
         retCode = self._process.poll()
+        if retCode is not None:  # process has exited?
+            wx.CallAfter(self.onTerminate, retCode)
 
         # get data from pipes
         if self.isInputAvailable:
@@ -568,9 +567,6 @@ class Job:
             stderrText = self.getErrorData()
             if self._errorCallback is not None:
                 wx.CallAfter(self._errorCallback, stderrText)
-
-        if retCode is not None:  # process has exited?
-            wx.CallAfter(self.onTerminate, retCode)
 
     def onTerminate(self, exitCode):
         """Called when the process exits.
@@ -584,17 +580,22 @@ class Job:
         called.
 
         """
-        if self._pollTimer.IsRunning():
-            self._pollTimer.Stop()
+        # if self._pollTimer.IsRunning():
+        #     self._pollTimer.Stop()
 
+        # unbind the idle loop used to poll the subprocess
         self.parent.Bind(wx.EVT_IDLE, None)
 
-        # flush remaining data from pipes, process it
-        # self.poll()
+        # stop the pipe reader threads now
+        self._stdoutReader.stop()
+        self._stderrReader.stop()
 
         # if callback is provided, else nop
         if self._terminateCallback is not None:
             wx.CallAfter(self._terminateCallback, self._pid, exitCode)
+
+        self._process = self._pid = None  # reset
+        self._flags = 0
 
     # def onNotify(self):
     #     """Called when the polling timer elapses.

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -17,6 +17,7 @@ __all__ = ['ScriptProcess']
 import sys
 import psychopy.app.jobs as jobs
 from wx import BeginBusyCursor, EndBusyCursor
+from psychopy.app.console import StdStreamDispatcher
 
 
 class ScriptProcess:
@@ -90,7 +91,7 @@ class ScriptProcess:
 
         # if we have a runner frame, write to the output text box
         if hasattr(self.app, 'runner'):
-            stdOut = self.app.runner.stdOut
+            stdOut = StdStreamDispatcher.getInstance()
             stdOut.lenLastRun = len(self.app.runner.stdOut.getText())
         else:
             # if not, just write to the standard output pipe
@@ -116,7 +117,7 @@ class ScriptProcess:
 
         # create a new job with the user script
         self.scriptProcess = jobs.Job(
-            self.app,
+            self,
             command=command,
             flags=execFlags,
             inputCallback=self._onInputCallback,  # both treated the same
@@ -172,7 +173,11 @@ class ScriptProcess:
         # not available we just write to `sys.stdout`.
         if hasattr(self.app, 'runner'):
             # get any remaining data on the pipes
-            stdOut = self.app.runner.stdOut
+            stdOut = StdStreamDispatcher.getInstance()
+            # backup if we don't have an instance for some reason
+            if stdOut is None:
+                stdOut = self.app.runner.stdOut
+
             self.app.runner.Show()
         else:
             stdOut = sys.stdout
@@ -237,8 +242,9 @@ class ScriptProcess:
         """
         # write a close message, shows the exit code
         closeMsg = \
-            "##### Experiment ended with exit code {} [pid:{}] #####\n".format(
+            " Experiment ended with exit code {} [pid:{}] ".format(
                 exitCode, pid)
+        closeMsg = closeMsg.center(80, '#') + '\n'
         self._writeOutput(closeMsg)
 
         self.scriptProcess = None  # reset


### PR DESCRIPTION
This PR makes the following changes:

1. Some data was still being cut-off after applying changes to subprocess communication. We're now much more aggressive at getting bytes from the pipes. Works fine in testing so far.
2. Ensure that the `EVT_IDLE` event is bound to the Runner window and not the main application instance. Fixes some issues where that event wasn't being unbound when it should.
3. Restore stream redirection code which has output showing up in runner which is immediately mirrored in coder. 