### PR TITLE
BF: Fix Project dialog loading

### DIFF
--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -460,7 +460,7 @@ class DetailsPanel(wx.Panel):
             self.status.SetStringSelection(project.info['status'])
             self.status.Enable(project.editable)
             # Tags
-            self.tags.items = self.project.info['keywords']
+            self.tags.items = project.info['keywords']
             self.tags.Enable(project.editable)
 
         # Layout
@@ -585,7 +585,7 @@ class DetailsPanel(wx.Panel):
             self.project.save()
         if obj == self.status and self.project.editable:
             requests.put(f"https://pavlovia.org/api/v2/experiments/{self.project.id}",
-                         data={"keywords": self.status.GetStringSelection()},
+                         data={"status": self.status.GetStringSelection()},
                          headers={'OauthToken': self.session.getToken()})
         if obj == self.tags and self.project.editable:
             requests.put(f"https://pavlovia.org/api/v2/experiments/{self.project.id}",

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -402,6 +402,8 @@ class DetailsPanel(wx.Panel):
             self.tags.clear()
             self.tags.Disable()
         else:
+            # Refresh project to make sure it has info
+            project.refresh()
             # Icon
             if 'avatarUrl' in project.info:
                 try:
@@ -460,7 +462,7 @@ class DetailsPanel(wx.Panel):
             self.status.SetStringSelection(project.info['status'])
             self.status.Enable(project.editable)
             # Tags
-            self.tags.items = project.info['keywords']
+            self.tags.items = project['keywords']
             self.tags.Enable(project.editable)
 
         # Layout

--- a/psychopy/app/pavlovia_ui/toolbar.py
+++ b/psychopy/app/pavlovia_ui/toolbar.py
@@ -83,7 +83,7 @@ class PavloviaButtons:
         searchDlg.Show()
 
     def onPavloviaProject(self, evt=None):
-        if self.frame.project:
+        if self.frame.project is not None:
             dlg = ProjectFrame(app=self.frame.app,
                                project=self.frame.project)
         else:

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -556,7 +556,10 @@ class PavloviaProject(dict):
         try:
             value = dict.__getitem__(self, key)
         except KeyError:
-            value = self.project.attributes[key]
+            if key in self.project.attributes:
+                value = self.project.attributes[key]
+            else:
+                value = None
         # Transform datetimes
         dtRegex = re.compile("\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?\w?")
         if dtRegex.match(str(value)):


### PR DESCRIPTION
Because a `PavloviaProject` extends `dict`, when it didn't have items yet (because `.refresh()` is yet to be called, as info is retreived on access not on init) it was treated as None.