### PR TITLE
ENH: Use Pavlovia API for me mode

### DIFF
--- a/psychopy/app/pavlovia_ui/search.py
+++ b/psychopy/app/pavlovia_ui/search.py
@@ -274,6 +274,12 @@ class SearchPanel(wx.Panel):
             self.mineBtn.Value = evt
         # Apply "mine" filter
         self._mine = self.mineBtn.Value
+        # Clear and disable filters & search todo: This is a stop gap, remove once the Pavlovia API can accept searches and filters WITHIN a designer
+        self.filterBtn.Enable(not self._mine)
+        self.searchCtrl.Enable(not self._mine)
+        if self._mine:
+            self.filterOptions = {key: [] for key in self.filterOptions}
+            self.searchCtrl.Value = ""
         # Update
         self.filterLbl.update()
         self.search()

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -487,7 +487,7 @@ class PavloviaSearch(pandas.DataFrame):
             elif term or filterBy:
                 data = requests.get(
                     f"https://pavlovia.org/api/v2/experiments?search={term}{filterBy}",
-                    timeout=2
+                    timeout=5
                 ).json()
             else:
                 # Display demos for blank search


### PR DESCRIPTION
Not to be pulled in until the Pavlovia API can receive search terms and filters alongside a user filter, e.g.
```
https://pavlovia.org/api/v2/designers/5/experiments?search="healthbar"
```
returns only the healthbar demo, rather than all demos