### PR TITLE
ENH: the Py->JS transpiler now accepts both tuples and lists for % formatted strings

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -105,11 +105,15 @@ class pythonTransformer(ast.NodeTransformer):
         node.left = pythonTransformer().visit(node.left)
         node.right = pythonTransformer().visit(node.right)
 
-        # formatted strings with %:
+        # formatted strings with %
+        # note: we have extended the pythong syntax slightly, to accommodate both tuples and lists
+        # so both '%_%' % (1,2) and '%_%' % [1,2] are successfully transpiled
         if isinstance(node.op, ast.Mod) and isinstance(node.left, ast.Str):
             # transform the node into an f-string node:
             stringFormat = node.left.value
-            stringTuple = node.right.elts if isinstance(node.right, ast.Tuple) else [node.right]
+            stringTuple = node.right.elts if (
+              isinstance(node.right, ast.Tuple) or isinstance(node.right, ast.List))\
+                else [node.right]
 
             values = []
             tupleIndex = 0


### PR DESCRIPTION
This syntax extension makes it possible to transpile both
'%s_%s' % (1,2)
and
'%s_%s' % [1,2]
even though the latter is not syntactically correct python code

This simplifies the job of the Builder when dealing with % formatted strings.
