### PR TITLE
FF: Fix `GetValue` recursion limit error on GTK during component value validation

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -30,6 +30,9 @@ class _ValidatorMixin:
         """
         validate(self, self.valType)
 
+        if evt is not None:
+            evt.Skip()
+
     def showValid(self, valid):
         """Style input box according to valid"""
         if not hasattr(self, "SetForegroundColour"):
@@ -155,7 +158,7 @@ class SingleLineCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin):
         # Add self to sizer
         self._szr.Add(self, proportion=1, border=5, flag=wx.EXPAND)
         # Bind to validation
-        self.Bind(wx.EVT_TEXT, self.validate)
+        self.Bind(wx.EVT_CHAR, self.validate)
         self.validate()
 
     def Show(self, value=True):
@@ -516,7 +519,7 @@ class ColorCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin):
         self.pickerBtn.Bind(wx.EVT_BUTTON, self.colorPicker)
         self._szr.Add(self.pickerBtn)
         # Bind to validation
-        self.Bind(wx.EVT_TEXT, self.validate)
+        self.Bind(wx.EVT_CHAR, self.validate)
         self.validate()
 
     def colorPicker(self, evt):
@@ -527,7 +530,7 @@ class ColorCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin):
 
 def validate(obj, valType):
     val = str(obj.GetValue())
-    valid = True
+    valid = False
     if val.startswith("$"):
         # If indicated as code, treat as code
         valType = "code"
@@ -597,6 +600,7 @@ def validate(obj, valType):
             # If control has specified list of ext, does value end in correct ext?
             if val.suffix not in obj.validExt:
                 valid = False
+
     # If additional allowed values are defined, override validation
     if hasattr(obj, "allowedVals"):
         if val in obj.allowedVals:

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -473,7 +473,6 @@ class CodeSnippetValidator(BaseValidator):
         if not isinstance(val, str):
             return '', True
 
-        field = self.fieldName
         allowedUpdates = ['set every repeat', 'set every frame']
         # Set initials
         msg, OK = '', True  # until we find otherwise

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -33,7 +33,7 @@ VALIDATOR_WARNING_FONT_MISSING = 3
 VALIDATOR_WARNING_COUNT = 4  # increment when adding more
 
 
-class ValidatorWarning():
+class ValidatorWarning:
     """Class for validator warnings.
 
     These are used internally by the `WarningManager`, do not create instances
@@ -124,7 +124,8 @@ class ValidatorWarning():
         """`True` if this is a non-critical message which doesn't disable the OK button"""
         return self.kind in [VALIDATOR_WARNING_FONT_MISSING]
 
-class WarningManager():
+
+class WarningManager:
     """Manager for warnings produced by validators associated with controls
     within the component properties dialog. Assumes that the `parent` dialog
     uses a standardized convention for attribute names for all components.


### PR DESCRIPTION
For some reason we got recursion limit errors during validation of component field values on GTK/Linux. This PR switches to catching the `EVT_CHAR` event instead of `EVT_TEXT` which sidesteps the error. 

Might introduce other issues, so test accordingly on Window and Mac too.