### PR TITLE
FF: filename for PsychoJS was not passed through the Param str formatter

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -886,7 +886,7 @@ class SettingsComponent:
         #     projID = 'undefined'
         code = template.format(
             params=self.params,
-            filename=self.params['Data filename'],
+            filename=str(self.params['Data filename']),
             name=self.params['expName'].val,
             loggingLevel=self.params['logging level'].val.upper(),
             setRedirectURL=setRedirectURL,


### PR DESCRIPTION
For some reason the filename being provided to the JS script boilerplate
was not being run through the __str__() method automatically