### PR TITLE
BF: Refresh project only if there's no info

### DIFF
--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -402,6 +402,9 @@ class DetailsPanel(wx.Panel):
             self.tags.clear()
             self.tags.Disable()
         else:
+            # Refresh project to make sure it has info
+            if not hasattr(project, "_info"):
+                project.refresh()
             # Icon
             if 'avatarUrl' in project.info:
                 try:


### PR DESCRIPTION
After #4571, there are some use cases in which there genuinely isn't an `_info` and we do need to refresh