### PR TITLE
ENH: Implementing pre-release feedback from Science team

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -787,6 +787,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             # actually save
             self.fileSave(event=None, filename=newPath)
             self.filename = newPath
+            self.project = pavlovia.getProject(filename)
             returnVal = 1
         dlg.Destroy()
 

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -502,7 +502,7 @@ class CodeSnippetValidator(BaseValidator):
         # Validate as code
         if codeWanted or isCodeField:
             # get var names from val, check against namespace:
-            code = experiment.getCodeFromParamStr(val)
+            code = experiment.getCodeFromParamStr(val, target="PsychoPy")
             try:
                 names = list(stringtools.getVariables(code))
                 parent.warnings.clearWarning(control)

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -450,17 +450,17 @@ class DetailsPanel(wx.Panel):
             self.syncLbl.Show(bool(project.localRoot) or (not project.editable))
             self.syncLbl.Enable(project.editable)
             # Local root
-            self.localRoot.SetValue(project.localRoot or "")#project.info['path'])
-            self.localRootLabel.Enable(project.editable)  # bool(project.info['path']))
-            self.localRoot.Enable(project.editable)#bool(project.info['path']) and project.editable)
+            self.localRoot.SetValue(project.localRoot or "")
+            self.localRootLabel.Enable(project.editable)
+            self.localRoot.Enable(project.editable)
             # Description
             self.description.SetValue(project['description'])
             self.description.Enable(project.editable)
             # Visibility
-            self.visibility.SetStringSelection(project.info['visibility'])
+            self.visibility.SetStringSelection(project['visibility'])
             self.visibility.Enable(project.editable)
             # Status
-            self.status.SetStringSelection(project.info['status'])
+            self.status.SetStringSelection(str(project['status2']).title())
             self.status.Enable(project.editable)
             # Tags
             self.tags.items = project['keywords']

--- a/psychopy/app/pavlovia_ui/project.py
+++ b/psychopy/app/pavlovia_ui/project.py
@@ -339,6 +339,8 @@ class DetailsPanel(wx.Panel):
         self.tags.Bind(wx.EVT_LIST_DELETE_ITEM, self.updateProject)
         self.tagSizer.Add(self.tags, proportion=1, border=6, flag=wx.EXPAND | wx.ALL)
         # Populate
+        if project is not None:
+            project.refresh()
         self.project = project
 
     @property

--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -69,7 +69,7 @@ class ResourceManagerComponent(BaseComponent):
               "true": "hide",  # what to do with param if condition is True
               "false": "show",  # permitted: hide, show, enable, disable
               }
-         )
+        )
         self.depends.append(
              {"dependsOn": "actionType",  # must be param name
               "condition": "=='Check Only'",  # val to check for
@@ -77,7 +77,10 @@ class ResourceManagerComponent(BaseComponent):
               "true": "hide",  # what to do with param if condition is True
               "false": "show",  # permitted: hide, show, enable, disable
               }
-         )
+        )
+
+        del self.params['syncScreenRefresh']
+        del self.params['saveStartStop']
 
     def writeInitCodeJS(self, buff):
         # Get initial values

--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -78,14 +78,6 @@ class ResourceManagerComponent(BaseComponent):
               "false": "show",  # permitted: hide, show, enable, disable
               }
          )
-        self.depends.append(
-             {"dependsOn": "checkAll",  # must be param name
-              "condition": "==True",  # val to check for
-              "param": "resources",  # param property to alter
-              "true": "disable",  # what to do with param if condition is True
-              "false": "enable",  # permitted: hide, show, enable, disable
-              }
-         )
 
     def writeInitCodeJS(self, buff):
         # Get initial values

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -359,15 +359,19 @@ class Param():
     __nonzero__ = __bool__  # for python2 compatibility
 
 
-def getCodeFromParamStr(val):
+def getCodeFromParamStr(val, target=None):
     """Convert a Param.val string to its intended python code
     (as triggered by special char $)
     """
-    tmp = re.sub(r"^(\$)+", '', val)  # remove leading $, if any
+    # Substitute target
+    if target is None:
+        target = utils.scriptTarget
+    # remove leading $, if any
+    tmp = re.sub(r"^(\$)+", '', val)
     # remove all nonescaped $, squash $$$$$
     tmp2 = re.sub(r"([^\\])(\$)+", r"\1", tmp)
     out = re.sub(r"[\\]\$", '$', tmp2)  # remove \ from all \$
-    if utils.scriptTarget=='PsychoJS':
+    if target == 'PsychoJS':
         out = py2js.expression2js(out)
     return out if out else ''
 

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -562,6 +562,8 @@ class PavloviaProject(dict):
         except KeyError:
             if key in self.project.attributes:
                 value = self.project.attributes[key]
+            elif hasattr(self, "_info") and key in self._info:
+                return self._info[key]
             else:
                 value = None
         # Transform datetimes

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -236,7 +236,7 @@ class PavloviaSession:
     def currentProject(self, value):
         self._currentProject = PavloviaProject(value)
 
-    def createProject(self, name, description="", tags=(), visibility='public',
+    def createProject(self, name, description="", tags=(), visibility='private',
                       localRoot='', namespace=''):
         """Returns a PavloviaProject object (derived from a gitlab.project)
 

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -597,7 +597,8 @@ class PavloviaProject(dict):
         self._info = None
         # for a new project it may take time for Pavlovia to register the new ID so try for a while
         while self._info is None and (time.time() - start) < 30:
-            requestVal = requests.get("https://pavlovia.org/api/v2/experiments/" + str(self.id)).json()
+            requestVal = requests.get(f"https://pavlovia.org/api/v2/experiments/{self.project.id}",
+                                      headers={'OauthToken': self.session.getToken()}).json()
             self._info = requestVal['experiment']
         if self._info is None:
             raise ValueError(f"Could not find project with id `{self.id}` on Pavlovia: {requestVal}")


### PR DESCRIPTION
- Checking "check all" in Resource Manager no longer disables "resources" field
- Removed the "sync with screen refresh" param from Resource Manager
- Send oauth token with info request in PavloviaProject.refresh()
- Visibility and status weren't being retrieved properly (visibility wasn't capitalised for the control, status is called status2 on Pavlovia API)
- Project default visibility is now Private