### PR TITLE
BF: Fix microphone Builder boilerplate

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -364,6 +364,7 @@ class MicrophoneComponent(BaseComponent):
             )
         else:
             code = (
+                "tag = data.utils.getDateStr()\n"
                 "%(name)sClip = %(name)s.bank(\n"
             )
         buff.writeIndentedLines(code % inits)


### PR DESCRIPTION
Fixes error when using a microphone component when 'transcribe' is active.