### PR TITLE
BF: BaseComponent init shouldn't be given forceEndRoutine

### DIFF
--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -29,7 +29,6 @@ class ResourceManagerComponent(BaseComponent):
                                stopType=stopType, stopVal=stopVal,
                                startEstim=startEstim, durationEstim=durationEstim,
                                saveStartStop=saveStartStop, syncScreenRefresh=syncScreenRefresh,
-                               forceEndRoutine=forceEndRoutine,
                                disabled=disabled)
         self.type = 'ResourceManager'
         self.url = "https://www.psychopy.org/builder/components/resourcemanager"

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -279,7 +279,8 @@ class TextboxComponent(BaseVisualComponent):
                         inits[param].val = ""
 
             code = (
-                "%(name)s.setText(%(text)s);\n%(name)s.refresh();"
+                "%(name)s.setText(%(text)s);\n"
+                "%(name)s.refresh();\n"
             )
             buff.writeIndentedLines(code % inits)
         BaseVisualComponent.writeRoutineStartCodeJS(self, buff)


### PR DESCRIPTION
Also adds a newline to textbox boilerplate