### PR TITLE
BF: Still define mouse.x and mouse.y when "on valid click"

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -208,7 +208,7 @@ class MouseComponent(BaseComponent):
         """Write the code that will be called at the start of the routine"""
 
         code = ("// setup some python lists for storing info about the %(name)s\n")
-        if self.params['saveMouseState'].val in ['every frame', 'on click']:
+        if self.params['saveMouseState'].val in ['every frame', 'on click', 'on valid click']:
             code += ("// current position of the mouse:\n"
                      "%(name)s.x = [];\n"
                      "%(name)s.y = [];\n"


### PR DESCRIPTION
Unable to test all the way as the experiment I made to test it with gives "404 forbidden" when running for some reason - I'm guessing this isn't related to the boilerplate. Science team, if you could try it out with the experiment which initially showed the bug then we can pull in once it's confirmed working :)