### PR TITLE
DOCS: Improve Pupil Labs - Core documentation

### DIFF
--- a/docs/source/api/iohub/device/eyetracker_interface/PupilLabs_Core_Implementation_Notes.rst
+++ b/docs/source/api/iohub/device/eyetracker_interface/PupilLabs_Core_Implementation_Notes.rst
@@ -1,3 +1,5 @@
+.. _pupil_labs_core:
+
 #################
 Pupil Labs - Core
 #################
@@ -103,7 +105,7 @@ Setting Up PsychoPy
     :alt: Pupil Core eye tracking options, part of PsychoPy experiment settings
 
 Pupillometry + Gaze Mode
-======================
+========================
 
 To receive gaze, enable Pupil Capture's Surface Tracking
 plugin:

--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -31,7 +31,7 @@ PsychoPy 2022.1
 - Most visual stimuli now have an "anchor" parameter to control how it's laid out 
   relative to its position, and you can now set the alignment of text within a Textbox 
   (with a handy demo to illustrate the difference between anchor and alignment!)
-- Added support for Pupil labs eye trackers (thanks to Pupil Labs themselves) directly from 
+- Added support for :ref:`Pupil labs eye trackers <pupil_labs_core>` (thanks to Pupil Labs themselves) directly from 
   the Builder
 
 *Compatibility Changes:*


### PR DESCRIPTION
- Fixes sphinx warning due to incorrect number of `=` header chars
- Adds link to the Pupil Labs - Core documentation to the changelog