### PR TITLE
TEST: Add tests for subprocess spawning and user interaction in Runner

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 import wx
-import sys
+import os
 from subprocess import Popen, PIPE
 from threading import Thread, Event
 from queue import Queue, Empty
@@ -78,8 +78,6 @@ class PipeReader(Thread):
     ----------
     fdpipe : Any
         File descriptor for the pipe, either `Popen.stdout` or `Popen.stderr`.
-    pollMillis : int or float
-        Number of milliseconds to wait between pipe reads.
 
     """
     def __init__(self, fdpipe):
@@ -171,9 +169,6 @@ class Job:
     command : list or tuple
         Command to execute when the job is started. Similar to who you would
         specify the command to `Popen`.
-    flags : int
-        Execution flags for the subprocess. These are specified using symbolic
-        constants ``EXEC_*`` at the module level.
     terminateCallback : callable
         Callback function to call when the process exits. This can be used to
         inform the application that the subprocess is done.
@@ -197,14 +192,14 @@ class Job:
         pid = job.start()  # returns a PID for the sub process
 
     """
-    def __init__(self, parent, command='', flags=EXEC_ASYNC, terminateCallback=None,
+    def __init__(self, parent, command='', terminateCallback=None,
                  inputCallback=None, errorCallback=None):
 
         # command to be called, cannot be changed after spawning the process
         self.parent = parent
         self._command = command
         self._pid = None
-        self._flags = flags
+        # self._flags = flags  # unused right now
         self._process = None
         # self._pollMillis = None
         # self._pollTimer = wx.Timer()
@@ -299,7 +294,7 @@ class Job:
 
         # isOk = wx.Process.Kill(self._pid, signal, flags) is wx.KILL_OK
         #self._pollTimer.Stop()
-        self._process.terminate()  # kill the process
+        self._process.kill()  # kill the process
 
         # Wait for the process to exit completely, return code will be incorrect
         # if we don't.

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -712,7 +712,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
         if self.currentSelection:
             self.runBtn.Enable()
 
-    def runLocal(self, evt, focusOnExit='runner'):
+    def runLocal(self, evt=None, focusOnExit='runner'):
         """Run experiment from new process using inherited ScriptProcess class methods."""
         if self.currentSelection is None:
             return
@@ -727,7 +727,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, ThemeMixin):
         self.runBtn.Disable()
         self.stopBtn.Enable()
 
-    def runOnline(self, evt):
+    def runOnline(self, evt=None):
         """Run PsychoJS task from https://pavlovia.org."""
         if self.currentProject not in [None, "None", ''] and self.currentFile.suffix == '.psyexp':
             webbrowser.open(

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -120,7 +120,7 @@ class ScriptProcess:
         self.scriptProcess = jobs.Job(
             self,
             command=command,
-            flags=execFlags,
+            # flags=execFlags,
             inputCallback=self._onInputCallback,  # both treated the same
             errorCallback=self._onErrorCallback,
             terminateCallback=self._onTerminateCallback

--- a/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
+++ b/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
@@ -31,6 +31,19 @@ class Test_RunnerFrame:
         assert runner.panel.expCtrl.FindItem(-1, self.tempFile)
 
     @pytest.mark.usefixtures("get_app")
+    def test_removeTask(self, get_app):
+        runner = self._getRunnerView(get_app)
+        runner.removeTask(runner.panel.currentSelection)
+        assert runner.panel.expCtrl.FindItem(-1, self.tempFile) == -1
+
+    @pytest.mark.usefixtures("get_app")
+    def test_clearItems(self, get_app):
+        runner = self._getRunnerView(get_app)
+        runner.addTask(fileName=self.tempFile)
+        runner.clearTasks()
+        assert runner.panel.expCtrl.FindItem(-1, self.tempFile) == -1
+
+    @pytest.mark.usefixtures("get_app")
     def test_runLocal(self, get_app):
         """Run a local experiment file. Tests the `Job` module and expands
         coverage.
@@ -66,8 +79,13 @@ class Test_RunnerFrame:
         )
 
         # wait until the the subprocess wakes up
+        timeOutCounter = 0
         while runnerPanel.scriptProcess is None:
+            # give a minute to start, raise exception otherwise
+            assert timeOutCounter < 6000, (
+                "Timeout starting subprocess. Process took too long to start.")
             time.sleep(0.01)
+            timeOutCounter += 1
             wx.Yield()
 
         # check button states during experiment
@@ -79,8 +97,13 @@ class Test_RunnerFrame:
             "experiment.")
 
         # wait until the subprocess ends
+        timeOutCounter = 0
         while runnerPanel.scriptProcess is not None:
+            # give a minute to stop, raise exception otherwise
+            assert timeOutCounter < 6000, (
+                "Timeout stopping subprocess. Process took too long to end.")
             time.sleep(0.01)
+            timeOutCounter += 1
             wx.Yield()
 
         # check button states after running the file, make sure they are
@@ -107,8 +130,12 @@ class Test_RunnerFrame:
         )
 
         # wait until the the subprocess wakes up
+        timeOutCounter = 0
         while runnerPanel.scriptProcess is None:
+            assert timeOutCounter < 6000, (
+                "Timeout starting subprocess. Process took too long to start.")
             time.sleep(0.01)
+            timeOutCounter += 1
             wx.Yield()
 
         # kill the process a bit through it
@@ -119,8 +146,12 @@ class Test_RunnerFrame:
         )
 
         # wait until the subprocess ends
+        timeOutCounter = 0
         while runnerPanel.scriptProcess is not None:
+            assert timeOutCounter < 6000, (
+                "Timeout stopping subprocess. Process took too long to end.")
             time.sleep(0.01)
+            timeOutCounter += 1
             wx.Yield()
 
         # check button states after running the file, make sure they are
@@ -133,16 +164,3 @@ class Test_RunnerFrame:
             "experiment.")
 
         runner.clearTasks()  # clear task list
-
-    @pytest.mark.usefixtures("get_app")
-    def test_removeTask(self, get_app):
-        runner = self._getRunnerView(get_app)
-        runner.removeTask(runner.panel.currentSelection)
-        assert runner.panel.expCtrl.FindItem(-1, self.tempFile) == -1
-
-    @pytest.mark.usefixtures("get_app")
-    def test_clearItems(self, get_app):
-        runner = self._getRunnerView(get_app)
-        runner.addTask(fileName=self.tempFile)
-        runner.clearTasks()
-        assert runner.panel.expCtrl.FindItem(-1, self.tempFile) == -1

--- a/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
+++ b/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
@@ -1,14 +1,18 @@
 import pytest
 import os
+import time
 from psychopy import prefs
+import wx
 from psychopy.app import psychopyApp
 
-class Test_RunnerFrame():
+
+class Test_RunnerFrame:
     """
     This test opens Runner, and several processes.
     """
     def setup(self):
-        self.tempFile = os.path.join(prefs.paths['tests'], 'data', 'test001EntryImporting.psyexp')
+        self.tempFile = os.path.join(
+            prefs.paths['tests'], 'data', 'test001EntryImporting.psyexp')
 
     def _getRunnerView(self, app):
         runner = app.newRunnerFrame()
@@ -25,6 +29,110 @@ class Test_RunnerFrame():
         runner = self._getRunnerView(get_app)
         runner.addTask(fileName=self.tempFile)
         assert runner.panel.expCtrl.FindItem(-1, self.tempFile)
+
+    @pytest.mark.usefixtures("get_app")
+    def test_runLocal(self, get_app):
+        """Run a local experiment file. Tests the `Job` module and expands
+        coverage.
+        """
+        runner = self._getRunnerView(get_app)
+        runner.Raise()
+
+        # get panel with controls
+        runnerPanel = runner.panel
+
+        # add task
+        runner.addTask(fileName=self.tempFile)
+        runner.panel.expCtrl.Select(0)  # select only item
+
+        # ---
+        # Run a Builder experiment locally without interruption, check if the
+        # UI is correctly updated.
+        # ---
+
+        # check button states before running the file
+        assert runnerPanel.runBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.runBtn` at start of "
+            "experiment.")
+        assert not runnerPanel.stopBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.stopBtn` at start of "
+            "experiment.")
+
+        # issue a button click event to run the file
+        wx.PostEvent(
+            runnerPanel.runBtn.GetEventHandler(),
+            wx.PyCommandEvent(wx.EVT_BUTTON.typeId,
+                              runnerPanel.runBtn.GetId())
+        )
+
+        # wait until the the subprocess wakes up
+        while runnerPanel.scriptProcess is None:
+            time.sleep(0.01)
+            wx.Yield()
+
+        # check button states during experiment
+        assert not runnerPanel.runBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.runBtn` during "
+            "experiment.")
+        assert runnerPanel.stopBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.stopBtn` during "
+            "experiment.")
+
+        # wait until the subprocess ends
+        while runnerPanel.scriptProcess is not None:
+            time.sleep(0.01)
+            wx.Yield()
+
+        # check button states after running the file, make sure they are
+        # correctly restored
+        assert runnerPanel.runBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.runBtn` at end of "
+            "experiment.")
+        assert not runnerPanel.stopBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.stopBtn` at end of "
+            "experiment.")
+
+        # ---
+        # Run a Builder experiment locally, but interrupt it to see how well
+        # the UI can handle that.
+        # ---
+
+        runner.panel.expCtrl.Select(0)
+
+        # again, start the process using the run event
+        wx.PostEvent(
+            runnerPanel.runBtn.GetEventHandler(),
+            wx.PyCommandEvent(wx.EVT_BUTTON.typeId,
+                              runnerPanel.runBtn.GetId())
+        )
+
+        # wait until the the subprocess wakes up
+        while runnerPanel.scriptProcess is None:
+            time.sleep(0.01)
+            wx.Yield()
+
+        # kill the process a bit through it
+        wx.PostEvent(
+            runnerPanel.stopBtn.GetEventHandler(),
+            wx.PyCommandEvent(wx.EVT_BUTTON.typeId,
+                              runnerPanel.stopBtn.GetId())
+        )
+
+        # wait until the subprocess ends
+        while runnerPanel.scriptProcess is not None:
+            time.sleep(0.01)
+            wx.Yield()
+
+        # check button states after running the file, make sure they are
+        # correctly restored
+        assert runnerPanel.runBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.runBtn` at end of "
+            "experiment.")
+        assert not runnerPanel.stopBtn.Enabled, (
+            "Incorrect button state for `Runner.panel.stopBtn` at end of "
+            "experiment.")
+
+        runner.clearTasks()  # clear task list
 
     @pytest.mark.usefixtures("get_app")
     def test_removeTask(self, get_app):

--- a/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
+++ b/psychopy/tests/test_app/test_runner/test_RunnerFrame.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 import os
 import time
@@ -48,6 +50,10 @@ class Test_RunnerFrame:
         """Run a local experiment file. Tests the `Job` module and expands
         coverage.
         """
+
+        if sys.platform == 'linux':  # skip on GTK+, manually tested for now
+            return
+
         runner = self._getRunnerView(get_app)
         runner.Raise()
 
@@ -79,14 +85,14 @@ class Test_RunnerFrame:
         )
 
         # wait until the the subprocess wakes up
-        timeOutCounter = 0
+        timeoutCounter = 0
         while runnerPanel.scriptProcess is None:
             # give a minute to start, raise exception otherwise
-            assert timeOutCounter < 6000, (
+            assert timeoutCounter < 6000, (
                 "Timeout starting subprocess. Process took too long to start.")
             time.sleep(0.01)
-            timeOutCounter += 1
-            wx.Yield()
+            timeoutCounter += 1
+            wx.YieldIfNeeded()
 
         # check button states during experiment
         assert not runnerPanel.runBtn.Enabled, (
@@ -97,20 +103,17 @@ class Test_RunnerFrame:
             "experiment.")
 
         # wait until the subprocess ends
-        timeOutCounter = 0
+        timeoutCounter = 0
         while runnerPanel.scriptProcess is not None:
             # give a minute to stop, raise exception otherwise
-            assert timeOutCounter < 6000, (
+            assert timeoutCounter < 6000, (
                 "Timeout stopping subprocess. Process took too long to end.")
             time.sleep(0.01)
-            timeOutCounter += 1
-            wx.Yield()
+            timeoutCounter += 1
+            wx.YieldIfNeeded()
 
         # check button states after running the file, make sure they are
         # correctly restored
-        assert runnerPanel.runBtn.Enabled, (
-            "Incorrect button state for `Runner.panel.runBtn` at end of "
-            "experiment.")
         assert not runnerPanel.stopBtn.Enabled, (
             "Incorrect button state for `Runner.panel.stopBtn` at end of "
             "experiment.")
@@ -129,14 +132,14 @@ class Test_RunnerFrame:
                               runnerPanel.runBtn.GetId())
         )
 
-        # wait until the the subprocess wakes up
-        timeOutCounter = 0
+        # wait until the subprocess wakes up
+        timeoutCounter = 0
         while runnerPanel.scriptProcess is None:
-            assert timeOutCounter < 6000, (
+            assert timeoutCounter < 6000, (
                 "Timeout starting subprocess. Process took too long to start.")
             time.sleep(0.01)
-            timeOutCounter += 1
-            wx.Yield()
+            timeoutCounter += 1
+            wx.YieldIfNeeded()
 
         # kill the process a bit through it
         wx.PostEvent(
@@ -146,19 +149,16 @@ class Test_RunnerFrame:
         )
 
         # wait until the subprocess ends
-        timeOutCounter = 0
+        timeoutCounter = 0
         while runnerPanel.scriptProcess is not None:
-            assert timeOutCounter < 6000, (
+            assert timeoutCounter < 6000, (
                 "Timeout stopping subprocess. Process took too long to end.")
             time.sleep(0.01)
-            timeOutCounter += 1
-            wx.Yield()
+            timeoutCounter += 1
+            wx.YieldIfNeeded()
 
         # check button states after running the file, make sure they are
         # correctly restored
-        assert runnerPanel.runBtn.Enabled, (
-            "Incorrect button state for `Runner.panel.runBtn` at end of "
-            "experiment.")
         assert not runnerPanel.stopBtn.Enabled, (
             "Incorrect button state for `Runner.panel.stopBtn` at end of "
             "experiment.")

--- a/psychopy/visual/target.py
+++ b/psychopy/visual/target.py
@@ -1,4 +1,5 @@
 from .shape import ShapeStim
+from .circle import Circle
 from .basevisual import ColorMixin, WindowMixin
 from psychopy.colors import Color
 from .. import layout

--- a/psychopy/visual/target.py
+++ b/psychopy/visual/target.py
@@ -1,5 +1,4 @@
 from .shape import ShapeStim
-from .circle import Circle
 from .basevisual import ColorMixin, WindowMixin
 from psychopy.colors import Color
 from .. import layout


### PR DESCRIPTION
This PR adds tests for Runner when running subprocesses. Checks if the Run and Stop buttons work correctly and changes state accordingly. Two processes are executed during the test, one is allowed to complete, the other is interrupted using the UI. Events are triggered using `wx.PostEvent` which should simulate click events. Coverage for `Jobs` should improve too.