### PR TITLE
DOCS: Update resource landing docs

### DIFF
--- a/docs/source/builder/components/resource_manager.rst
+++ b/docs/source/builder/components/resource_manager.rst
@@ -3,7 +3,7 @@
 Resource Manager Component
 -------------------------------
 
-(added version 2022.1)
+(added version 2022.1.0)
 
 Pre-load resources into memory so that components using them can start without having to load first.
 

--- a/docs/source/online/resources.rst
+++ b/docs/source/online/resources.rst
@@ -47,6 +47,7 @@ You can manually specify what resources your experiment will need when you :ref:
 
 Specify the files to download at the start
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(added version 2022.1.0)
 
 **Example use case:** fetch a whole set of movies, possibly a custom list, for the participant *while they read your instructions* (i.e. within the experiment rather than at the start). You can start them loading before the first instructions screen and then make sure they have all downloaded before the trials actually begin. You could even load yor files in two sets - download a few files during instructions and then fetch the rest during practice trials!
 
@@ -60,6 +61,7 @@ While the automatic method is easy, it suffers if you have lots of resources (th
 
 Specify the files to download each trial
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(added version 2022.1.0)
 
 **Example use case:** Fetch the image file during the fixation period on each trial.
 

--- a/docs/source/online/resources.rst
+++ b/docs/source/online/resources.rst
@@ -9,9 +9,9 @@ The loading of resources (images, sounds, movies etc.) in online experiments is 
 
 In a locally-executed experiment all the files that might be required by the study are already available on the computer. With an online experiment the HTML/JavaScript code needs to know what files in your project should be fetched from the server and sent to the participant ready for them to run the study. 
 
-PsychoPy/JS now provides multiple options for how to do this:
+PsychoPy/JS will try by default to :ref:`autoDetectOnlineResources`, but sometimes you might still bump into an "Unknown Resource" error, and it's good to know why these occur and how to approach them. PsychoPy/PsychoJS now provides multiple options for how to control what resources are loaded in your experiment and when:
 
-#. :ref:`autoDetectOnlineResources` (fine for not-too-many resources)
+#. :ref:`additionalResourcesOnlineResources` (fine for not-too-many resources)
 #. :ref:`specifyOnlineResources` (e.g. fetch during instructions slides)
 #. :ref:`specifyResourcesEachTrial` (e.g. fetch a single image during fixation)
 
@@ -24,20 +24,31 @@ Also, take note of the advice below on choosing and converting to :ref:`appropri
 .. _autoDetectOnlineResources:
 
 Auto-detect files and download at the start
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Example use case:** if you don't have a huge number of possible resources in your project then you could use this approach. The files will all download during the initial dialog, where participants input their details.
 
-This is the only method that has been made easily available to users of PsychoPy prior to PsychoPy version 2022.1. PsychoPy tries to work out what files you need in advance and codes these in to be fetched during the initial dialog box. To manage auto-detection, PsychoPy scans all your Components (e.g. Image Components, Sound Copmonents etc, and your conditions files) for signs of filenames that are being used and then adds those to a list of required resources for the study.
+This is method requires no manual intervention, it is performed automatically. PsychoPy tries to work out what files you need in advance and codes these in to be fetched during the initial dialog box. To manage auto-detection, PsychoPy scans all your Components (e.g. Image Components, Sound Copmonents etc, and your conditions files) for signs of filenames that are being used and then adds those to a list of required resources for the study.
 
 At times, PsychoPy won't be able to detect that you need a particular image or other resource, because you've specified the filename using code. For instance you may list the image name as being `"stim{N}.png".format(thisNumber)` but PsychoPy could never know what range of values `thisNumber` may take so it can't know what filenames to look for. In these cases you can manually extend the list of files that will be fetched using the `Extra Files` setting in the `Online` tab of the `Experiment Settings`.
+
+.. _additionalResourcesOnlineResources:
+
+Specifying "Additional Resources"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Example use case:** You don't have that many resources (e.g. <200 pictures), but some of your resources might be specified through code or are conditional base on experimental group. The files will all download during the initial dialog, where participants input their details.
+
+This is the only method of manually controlling resource loading that has been made easily available to users of PsychoPy prior to PsychoPy version 2022.1. If you don't have that many resources (e.g. <200 pictures), but you encounter an "Unknown Resource" error, this is probably the easiest fix (but we recommend you consider Methods 2 and 3 below). The reason the "Unknown Resource" error occurs is probably because you have a resource specified through code somewhere in your experiment (take for example the `"stim{N}.png".format(thisNumber)` case).
+
+You can manually specify what resources your experiment will need when you :ref:`configureOnline`. However, if you have a large number of files, we recommend you either :ref:`specifyOnlineResources` using the :ref:`resourceManager` or :ref:`specifyResourcesEachTrial` using :ref:`static`.
 
 .. _specifyOnlineResources:
 
 Specify the files to download at the start
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Example use case:** fetch a whole set of movies, possibly a custom list, for the participant while they read your instructions. You can start them loading before the first instructions screen and then make sure they have all downloaded before the trials actually begin. You could even load yor files in two sets - download a few files during instructions and then fetch the rest during practice trials!
+**Example use case:** fetch a whole set of movies, possibly a custom list, for the participant *while they read your instructions* (i.e. within the experiment rather than at the start). You can start them loading before the first instructions screen and then make sure they have all downloaded before the trials actually begin. You could even load yor files in two sets - download a few files during instructions and then fetch the rest during practice trials!
 
 While the automatic method is easy, it suffers if you have lots of resources (the participant sits waiting on that dialog box while the resources are fetched) or if each participant uses only a subset of resources. PsychoPy has a new Component called the :ref:`resourceManager` that allows you to specify the files you need and the time you want them to start and/or confirm downloading.
 
@@ -54,7 +65,7 @@ Specify the files to download each trial
 
 If each resource can be retrieved relatively quickly (e.g. an imagefile over a broadband connection) then you might want to fetch the stimulus on each trial. This has the advantage that you don't need to prespecify anything and you could even choose the stimulus to download dynamically, based on the previous response!
 
-The other nice thing about this method is that it can be used either using a Resource Manager Component, or by simply setting the stmulus to update using a :ref:`Static Component` where that Static Component lasts during your fixation period.
+The other nice thing about this method is that it can be used either using a :ref:`resourceManager` Component, or by simply setting the stmulus to update using a :ref:`static` where that Static Component lasts during your fixation period.
 
 .. warning::
 


### PR DESCRIPTION
Make clearer the difference between "automatic" detection and manually specifying resources using the experiment settings (both of these were available pre 2022 (but I don't think it was immediately clear why one might be needed sometimes)