### PR TITLE
BF: Regular polygon code wasn't written when nVertices not a number

### DIFF
--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -185,7 +185,7 @@ class PolygonComponent(BaseVisualComponent):
             code = ("%s = visual.ShapeStim(\n" % inits['name'] +
                     "    win=win, name='%s', vertices='cross',%s\n" % (inits['name'], unitsStr) +
                     "    size=%(size)s,\n" % inits)
-        elif isinstance(vertices, (int, float, str)):
+        elif self.params['shape'] == 'regular polygon...':
             code = ("%s = visual.Polygon(\n" % inits['name'] +
                     "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +
                     "    edges=%s," % str(inits['nVertices'].val) +


### PR DESCRIPTION
e.g. when nVertices is a variable name

Not causing problems as ShapeStim can interpret a numeric value as a regular polygon, but it's better that the case is always hit for the sake of readability