### PR TITLE
NF/RF: `BaseAuiFrame` class

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -148,6 +148,9 @@ class BuilderFrame(BaseAuiFrame, ThemeMixin):
         self.readmeFrame = None
         self.generateScript = generateScript
 
+        # default window title
+        self.winTitle = 'PsychoPy Builder (v{})'.format(self.app.version)
+
         if fileName in self.appData['frames']:
             self.frameData = self.appData['frames'][fileName]
         else:  # work out a new frame size/location
@@ -1013,8 +1016,7 @@ class BuilderFrame(BaseAuiFrame, ThemeMixin):
         """
         if newTitle is None:
             shortName = os.path.split(self.filename)[-1]
-            newTitle = '%s - PsychoPy Builder (v%s)' % (shortName, self.app.version)
-        self.SetTitle(newTitle)
+            self.setTitle(title=self.winTitle, document=shortName)
 
     def setIsModified(self, newVal=None):
         """Sets current modified status and updates save icon accordingly.

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -177,9 +177,6 @@ class BuilderFrame(BaseAuiFrame, ThemeMixin):
                                     int(self.frameData['winH'])),
                               style=style)
 
-        self.Bind(wx.EVT_CLOSE, self.closeFrame)
-        #self.panel = wx.Panel(self)
-
         # detect retina displays (then don't use double-buffering)
         self.isRetina = \
             self.GetContentScaleFactor() != 1 and wx.Platform == '__WXMAC__'

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -48,6 +48,7 @@ from ... import experiment, prefs
 from .. import dialogs
 from ..themes import ThemeMixin
 from ..themes._themes import PsychopyDockArt, PsychopyTabArt, ThemeSwitcher
+from ..ui import BaseAuiFrame
 from psychopy import logging, data
 from psychopy.tools.filetools import mergeFolder
 from .dialogs import (DlgComponentProperties, DlgExperimentProperties,
@@ -117,7 +118,7 @@ class TemplateManager(dict):
                     self[categName][routineName] = copy.copy(thisExp.routines[routineName])
 
 
-class BuilderFrame(wx.Frame, ThemeMixin):
+class BuilderFrame(BaseAuiFrame, ThemeMixin):
     """Defines construction of the Psychopy Builder Frame"""
 
     routineTemplates = TemplateManager()
@@ -168,12 +169,14 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             self.frameData['winX'], self.frameData['winY'] = (0, 0)
         if self.frameData['winY'] < 20:
             self.frameData['winY'] = 20
-        wx.Frame.__init__(self, parent=parent, id=id, title=title,
-                          pos=(int(self.frameData['winX']), int(
-                              self.frameData['winY'])),
-                          size=(int(self.frameData['winW']), int(
-                              self.frameData['winH'])),
-                          style=style)
+
+        BaseAuiFrame.__init__(self, parent=parent, id_=id, title=title,
+                              pos=(int(self.frameData['winX']),
+                                   int(self.frameData['winY'])),
+                              size=(int(self.frameData['winW']),
+                                    int(self.frameData['winH'])),
+                              style=style)
+
         self.Bind(wx.EVT_CLOSE, self.closeFrame)
         #self.panel = wx.Panel(self)
 
@@ -214,9 +217,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
         self.updateReadme()  # check/create frame as needed
 
         # control the panes using aui manager
-        self._mgr = aui.AuiManager(
-            self,
-            aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT)
+        self._mgr = self.getAuiManager()
 
         #self._mgr.SetArtProvider(PsychopyDockArt())
         #self._art = self._mgr.GetArtProvider()

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -170,7 +170,7 @@ class BuilderFrame(BaseAuiFrame, ThemeMixin):
         if self.frameData['winY'] < 20:
             self.frameData['winY'] = 20
 
-        BaseAuiFrame.__init__(self, parent=parent, id_=id, title=title,
+        BaseAuiFrame.__init__(self, parent=parent, id=id, title=title,
                               pos=(int(self.frameData['winX']),
                                    int(self.frameData['winY'])),
                               size=(int(self.frameData['winW']),

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -33,6 +33,7 @@ from psychopy import logging, prefs
 from psychopy.alerts._alerts import alert
 from psychopy.localization import _translate
 from ..utils import FileDropTarget, PsychopyToolbar, FrameSwitcher, updateDemosMenu
+from ..ui import BaseAuiFrame
 from psychopy.projects import pavlovia
 import psychopy.app.pavlovia_ui.menu
 from psychopy.app.errorDlg import exceptionCallback
@@ -1138,7 +1139,7 @@ class CodeEditor(BaseCodeEditor, CodeEditorFoldingMixin, ThemeMixin):
             #     findDlg.Close()
 
 
-class CoderFrame(wx.Frame, ThemeMixin):
+class CoderFrame(BaseAuiFrame, ThemeMixin):
 
     def __init__(self, parent, ID, title, files=(), app=None):
         self.app = app  # type: psychopy.app.PsychoPyApp
@@ -1168,21 +1169,16 @@ class CoderFrame(wx.Frame, ThemeMixin):
         if self.appData['winX'] == -32000:
             self.appData['winX'], self.appData['winY'] = wx.DefaultPosition
             self.appData['winH'], self.appData['winW'] = wx.DefaultSize
-        wx.Frame.__init__(self, parent, ID, title,
-                          (self.appData['winX'], self.appData['winY']),
-                          size=(self.appData['winW'], self.appData['winH']))
+
+        BaseAuiFrame.__init__(
+            self, parent, ID, title,
+            (self.appData['winX'], self.appData['winY']),
+            (self.appData['winW'], self.appData['winH']))
 
         # detect retina displays (then don't use double-buffering)
         self.isRetina = \
             self.GetContentScaleFactor() != 1 and wx.Platform == '__WXMAC__'
 
-        # create a panel which the aui manager can hook onto
-        szr = wx.BoxSizer(wx.VERTICAL)
-        self.pnlMain = wx.Panel(self)
-        szr.Add(self.pnlMain, flag=wx.EXPAND | wx.ALL, proportion=1)
-        self.SetSizer(szr)
-
-        # self.panel = wx.Panel(self)
         self.Hide()  # ugly to see it all initialise
         # create icon
         if sys.platform == 'darwin':
@@ -1213,8 +1209,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
         self.SetAcceleratorTable(accelTable)
 
         # Setup pane and art managers
-        self.paneManager = aui.AuiManager(
-            self.pnlMain, aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT)
+        self.paneManager = self.getAuiManager()
 
         # Create toolbar
         self.toolbar = PsychopyToolbar(self)
@@ -1230,12 +1225,10 @@ class CoderFrame(wx.Frame, ThemeMixin):
         self.SetDropTarget(FileDropTarget(targetFrame=self))
 
         # Create editor notebook
-        #todo: Why is editor default background not same as usual frame backgrounds?
         self.notebook = aui.AuiNotebook(
-            self.pnlMain, -1, size=wx.Size(480, 480),
+            self, -1, size=wx.Size(480, 480),
             agwStyle=aui.AUI_NB_TAB_MOVE | aui.AUI_NB_CLOSE_ON_ACTIVE_TAB)
 
-        #self.notebook.SetArtProvider(PsychopyTabArt())
         # Add editor panel
         self.paneManager.AddPane(self.notebook, aui.AuiPaneInfo().
                                  Name("Editor").
@@ -1250,7 +1243,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
 
         # Create source assistant notebook
         self.sourceAsst = aui.AuiNotebook(
-            self.pnlMain,
+            self,
             wx.ID_ANY,
             size = wx.Size(500, 600),
             agwStyle=aui.AUI_NB_CLOSE_ON_ALL_TABS |
@@ -1301,7 +1294,7 @@ class CoderFrame(wx.Frame, ThemeMixin):
 
         # Create shelf notebook
         self.shelf = aui.AuiNotebook(
-            self.pnlMain, wx.ID_ANY, size=wx.Size(600, 600),
+            self, wx.ID_ANY, size=wx.Size(600, 600),
             agwStyle=aui.AUI_NB_CLOSE_ON_ALL_TABS)
         #self.shelf.SetArtProvider(PsychopyTabArt())
 

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1159,6 +1159,9 @@ class CoderFrame(BaseAuiFrame, ThemeMixin):
         self.showingReloadDialog = False
         self.btnHandles = {}  # stores toolbar buttons so they can be altered
 
+        # default window title string
+        self.winTitle = "PsychoPy Coder (v{})".format(self.app.version)
+
         # we didn't have the key or the win was minimized/invalid
         if self.appData['winH'] == 0 or self.appData['winW'] == 0:
             self.appData['winH'], self.appData['winW'] = wx.DefaultSize
@@ -2044,7 +2047,7 @@ class CoderFrame(BaseAuiFrame, ThemeMixin):
         self.currentDoc = self.notebook.GetPage(new)
         self.app.updateWindowMenu()
         self.setFileModified(self.currentDoc.UNSAVED)
-        self.SetLabel('%s - PsychoPy Coder' % self.currentDoc.filename)
+        self.setTitle(title=self.winTitle, document=self.currentDoc.filename)
 
         self.currentDoc.analyseScript()
 
@@ -2351,7 +2354,7 @@ class CoderFrame(BaseAuiFrame, ThemeMixin):
                 wx.stc.STC_WRAP_WORD if self.lineWrapChk.IsChecked() else wx.stc.STC_WRAP_NONE)
             self.statusBar.SetStatusText(fileType, 2)
         fname = Path(self.currentDoc.filename).name
-        self.SetLabel('%s - PsychoPy Coder (v%s)' % (fname, psychopy.__version__))
+        self.setTitle(title=self.winTitle, document=fname)
         #if len(self.getOpenFilenames()) > 0:
         self.currentDoc.analyseScript()
 
@@ -2540,7 +2543,8 @@ class CoderFrame(BaseAuiFrame, ThemeMixin):
             self.currentDoc.analyseScript()
             # Update status bar and title bar labels
             self.statusBar.SetStatusText(self.currentDoc.getFileType(), 2)
-            self.SetLabel(f'{self.currentDoc.filename} - PsychoPy Coder')
+
+            self.setTitle(title=self.winTitle, document=self.currentDoc.filename)
 
         dlg.Destroy()
 
@@ -2583,8 +2587,9 @@ class CoderFrame(BaseAuiFrame, ThemeMixin):
             self.statusBar.SetStatusText("", 1)  # clear line pos
             self.statusBar.SetStatusText("", 2)  # clear file type in status bar
             self.statusBar.SetStatusText("", 3)  # psyhcopy version
+            # set window title
+            self.setTitle(title=self.winTitle, document=self.currentDoc)
             # clear the source tree
-            self.SetLabel("PsychoPy v%s (Coder)" % self.app.version)
             self.structureWindow.srcTree.DeleteAllItems()
         else:
             self.currentDoc = self.notebook.GetPage(newPageID)

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Classes for graphical user interface elements for the main application.
+"""
+
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import wx
+import wx.lib.agw.aui as aui
+
+# default values
+DEFAULT_FRAME_SIZE = wx.Size(800, 600)
+DEFAULT_FRAME_TITLE = u"PsychoPy"
+# flags for AUI
+DEFAULT_AUI_STYLE_FLAGS = aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT
+
+
+class BaseAuiFrame(wx.Frame):
+    """Base class for AUI managed frames.
+
+    Takes the same same arguments as `wx.Frame`. This frame is AUI managed which
+    allows for sub-windows to be attached to it. No application logic should be
+    implemented in this class, only its sub-classes.
+
+    """
+    def __init__(self,
+                 parent,
+                 id_=wx.ID_ANY,
+                 title=DEFAULT_FRAME_TITLE,
+                 pos=wx.DefaultPosition,
+                 size=DEFAULT_FRAME_SIZE,
+                 style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL):
+        wx.Frame.__init__(self, parent, id=id_, title=title, pos=pos, size=size,
+                          style=style)
+
+        # defaults for window
+        self.SetSizeHints(wx.DefaultSize, wx.DefaultSize)
+
+        # create the AUI manager and attach it to this window
+        self.m_mgr = aui.AuiManager(self, agwFlags=DEFAULT_AUI_STYLE_FLAGS)
+        self.m_mgr.Update()
+
+        self.Centre(wx.BOTH)
+
+        # events associated with this window
+        self.Bind(aui.EVT_AUI_PANE_ACTIVATED, self.onAuiPaneActivate)
+        self.Bind(aui.EVT_AUI_PANE_BUTTON, self.onAuiPaneButton)
+        self.Bind(aui.EVT_AUI_PANE_CLOSE, self.onAuiPaneClose)
+        self.Bind(aui.EVT_AUI_PANE_MAXIMIZE, self.onAuiPaneMaximize)
+        self.Bind(aui.EVT_AUI_PANE_RESTORE, self.onAuiPaneRestore)
+        self.Bind(wx.EVT_CLOSE, self.onClose)
+        self.Bind(wx.EVT_IDLE, self.onIdle)
+
+    def __del__(self):
+        # called when tearing down the window
+        self.m_mgr.UnInit()
+
+    # --------------------------------------------------------------------------
+    # Class properties and methods
+    #
+
+    @property
+    def manager(self):
+        """Handle of the AUI manager for this frame (`wx.aui.AuiManager`).
+        """
+        return self.getAuiManager()
+
+    def getAuiManager(self):
+        """Get the AUI manager instance for this window.
+
+        Returns
+        -------
+        wx.aui.AuiManager
+            Handle for the AUI manager instance associated with this window.
+
+        """
+        return self.m_mgr
+
+    # --------------------------------------------------------------------------
+    # Events for the Coder Frame
+    #
+
+    def onAuiPaneActivate(self, event):
+        event.Skip()
+
+    def onAuiPaneButton(self, event):
+        event.Skip()
+
+    def onAuiPaneClose(self, event):
+        event.Skip()
+
+    def onAuiPaneMaximize(self, event):
+        event.Skip()
+
+    def onAuiPaneRestore(self, event):
+        event.Skip()
+
+    def onClose(self, event):
+        event.Skip()
+
+    def onIdle(self, event):
+        event.Skip()
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -80,7 +80,7 @@ class BaseAuiFrame(wx.Frame):
         return self.m_mgr
 
     # --------------------------------------------------------------------------
-    # Events for the Coder Frame
+    # Events for the AUI frame
     #
 
     def onAuiPaneActivate(self, event):

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -21,7 +21,7 @@ DEFAULT_AUI_STYLE_FLAGS = aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT
 class BaseAuiFrame(wx.Frame):
     """Base class for AUI managed frames.
 
-    Takes the same same arguments as `wx.Frame`. This frame is AUI managed which
+    Takes the same arguments as `wx.Frame`. This frame is AUI managed which
     allows for sub-windows to be attached to it. No application logic should be
     implemented in this class, only its sub-classes.
 

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -40,17 +40,17 @@ class BaseAuiFrame(wx.Frame):
         Initial sie of the window in desktop units.
     style : int
         Style flags for the window. Default is the combination of
-        wx.DEFAULT_FRAME_STYLE` and `wx.TAB_TRAVERSAL`.
+        `wx.DEFAULT_FRAME_STYLE` and `wx.TAB_TRAVERSAL`.
 
     """
     def __init__(self,
                  parent,
-                 id_=wx.ID_ANY,
+                 id=wx.ID_ANY,
                  title=DEFAULT_FRAME_TITLE,
                  pos=wx.DefaultPosition,
                  size=DEFAULT_FRAME_SIZE,
                  style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL):
-        wx.Frame.__init__(self, parent, id=id_, title=title, pos=pos, size=size,
+        wx.Frame.__init__(self, parent, id=id, title=title, pos=pos, size=size,
                           style=style)
 
         # defaults for window

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -14,8 +14,8 @@ import wx.lib.agw.aui as aui
 # default values
 DEFAULT_FRAME_SIZE = wx.Size(800, 600)
 DEFAULT_FRAME_TITLE = u"PsychoPy"
-# flags for AUI
-DEFAULT_AUI_STYLE_FLAGS = aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT
+DEFAULT_AUI_STYLE_FLAGS = (  # flags for AUI
+        aui.AUI_MGR_DEFAULT | aui.AUI_MGR_RECTANGLE_HINT)
 
 
 class BaseAuiFrame(wx.Frame):
@@ -50,6 +50,7 @@ class BaseAuiFrame(wx.Frame):
                  pos=wx.DefaultPosition,
                  size=DEFAULT_FRAME_SIZE,
                  style=wx.DEFAULT_FRAME_STYLE | wx.TAB_TRAVERSAL):
+        # subclass `wx.Frame`
         wx.Frame.__init__(self, parent, id=id, title=title, pos=pos, size=size,
                           style=style)
 
@@ -95,6 +96,44 @@ class BaseAuiFrame(wx.Frame):
 
         """
         return self.m_mgr
+
+    def setTitle(self, title=DEFAULT_FRAME_TITLE, document=None):
+        """Set the window title.
+
+        Use this method to set window titles to ensure that PsychoPy windows use
+        similar formatting for them.
+
+        Parameters
+        ----------
+        title : str
+            Window title to set. Default is `DEFAULT_FRAME_TITLE`.
+        document : str or None
+            Optional document file name or path. Will be appended to the title
+            bar with a `' - '` separator.
+
+        Examples
+        --------
+        Set the window title for the new document::
+
+            someFrame.setTitle(document='mycode.py')
+            # title set to: "PsychoPy - mycode.py"
+
+        """
+        if document is not None:
+            self.SetTitle(" - ".join([title, document]))
+        else:
+            self.SetTitle(title)
+
+    def getTitle(self):
+        """Get the window frame title.
+
+        Returns
+        -------
+        str
+            Current window frame title.
+
+        """
+        return self.GetTitle()
 
     # --------------------------------------------------------------------------
     # Events for the AUI frame

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -116,11 +116,11 @@ class BaseAuiFrame(wx.Frame):
         Set the window title for the new document::
 
             someFrame.setTitle(document='mycode.py')
-            # title set to: "PsychoPy - mycode.py"
+            # title set to: "mycode.py - PsychoPy"
 
         """
         if document is not None:
-            self.SetTitle(" - ".join([title, document]))
+            self.SetTitle(" - ".join([document, title]))
         else:
             self.SetTitle(title)
 

--- a/psychopy/app/ui/__init__.py
+++ b/psychopy/app/ui/__init__.py
@@ -25,6 +25,23 @@ class BaseAuiFrame(wx.Frame):
     allows for sub-windows to be attached to it. No application logic should be
     implemented in this class, only its sub-classes.
 
+    Parameter
+    ---------
+    parent : wx.Window or None
+        Parent window.
+    id : int
+        Unique ID for this window, default is `wx.ID_ANY`.
+    title : str
+        Window title to use. Can be set later.
+    pos : ArrayLike or `wx.Position`
+        Initial position of the window on the desktop. Default is
+        `wx.DefaultPosition`.
+    size : ArrayLike or `wx.Size`
+        Initial sie of the window in desktop units.
+    style : int
+        Style flags for the window. Default is the combination of
+        wx.DEFAULT_FRAME_STYLE` and `wx.TAB_TRAVERSAL`.
+
     """
     def __init__(self,
                  parent,
@@ -82,26 +99,45 @@ class BaseAuiFrame(wx.Frame):
     # --------------------------------------------------------------------------
     # Events for the AUI frame
     #
+    # AUI events can be used to monitor changes to the pane layout. These can
+    # then be used to update the appropriate menu item.
+    #
 
     def onAuiPaneActivate(self, event):
+        """Called when the pane gets focused or is activated.
+        """
         event.Skip()
 
     def onAuiPaneButton(self, event):
+        """Called when an AUI pane button is clicked.
+        """
         event.Skip()
 
     def onAuiPaneClose(self, event):
+        """Called when an AUI pane is closed.
+        """
         event.Skip()
 
     def onAuiPaneMaximize(self, event):
+        """Called when an AUI pane is maximized.
+        """
         event.Skip()
 
     def onAuiPaneRestore(self, event):
+        """Called when a AUI pane is restored.
+        """
         event.Skip()
 
     def onClose(self, event):
+        """Event handler for `EVT_CLOSE` events. This is usually called when the
+        user clicks the close button on the frame's title bar.
+        """
         event.Skip()
 
     def onIdle(self, event):
+        """Event handler for `EVT_IDLE` events. Called periodically when the
+        user is not interacting with the UI.
+        """
         event.Skip()
 
 


### PR DESCRIPTION
This PR introduces the `BaseAuiFrame` class, which is now the base class for `CoderFrame` and `BuilderFrame`. The purpose of this is to ensure consistency of AUI configurations between different parts of the application UI. Classes for AUI panes are going to be added at some point to simplify their creation and placement.

As PsychoPy grows, the UI will increase in complexity and these changes will help us leverage AUI better to meet those needs.

