### PR TITLE
ENH: `reset` function for Form

### DIFF
--- a/psychopy/tests/test_visual/test_form.py
+++ b/psychopy/tests/test_visual/test_form.py
@@ -22,6 +22,9 @@ class Test_Form(_TestColorMixin):
     """Test suite for Form component"""
 
     def setup_class(self):
+        # Store different response types
+        self.respTypes = ['heading', 'description', 'rating', 'slider', 'free text', 'choice', 'radio']
+
         # Create temp files for storing items
         self.temp_dir = mkdtemp()
         self.fileName_xlsx = os.path.join(self.temp_dir, 'items.xlsx')
@@ -112,7 +115,6 @@ class Test_Form(_TestColorMixin):
         """
         Test that question options interact well
         """
-        types = ['heading', 'description', 'rating', 'slider', 'free text', 'choice', 'radio']
         # Define sets of each option
         exemplars = {
             'bigResp': [  # Resp is bigger than item
@@ -228,7 +230,7 @@ class Test_Form(_TestColorMixin):
         self.win.flip()
         for name, case in cases.items():
             # Test it for each type
-            for thisType in types:
+            for thisType in self.respTypes:
                 # Set type
                 for i, q in enumerate(case):
                     case[i]['type'] = thisType
@@ -241,6 +243,30 @@ class Test_Form(_TestColorMixin):
                 #self.win.getMovieFrame(buffer='back').save(Path(utils.TESTS_DATA_PATH) / filename)
                 utils.compareScreenshot(Path(utils.TESTS_DATA_PATH) / filename, self.win, crit=20)
                 self.win.flip()
+
+    def test_reset(self):
+        """
+        Test that the reset function can reset all types of form item
+        """
+        items = []
+        # Add an item of each type
+        for thisType in self.respTypes:
+            items.append({
+                'type': thisType,
+                'itemText': "A PsychoPy zealot knows a smidge of wx but JavaScript is the question",
+                'options': [1, "a", "multiple word"],
+                'ticks': [1, 2, 3],
+                'layout': 'vert',
+                'itemColor': 'darkslateblue',
+                'itemWidth': 0.7,
+                'responseColor': 'darkred',
+                'responseWidth': 0.3,
+                'font': 'Open Sans',
+            })
+        # Create form
+        survey = Form(self.win, units="height", size=(1, 1), fillColor="white", items=items)
+        # Reset form to check it doesn't error
+        survey.reset()
 
     def test_scrolling(self):
         # Define basic question to test with

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -914,6 +914,22 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self._complete = (nIncomplete == 0)
         return copy.copy(self.items)  # don't want users changing orig
 
+    def reset(self):
+        """
+        Clear all responses and set all items to their initial values.
+        """
+        # Iterate through all items
+        for item in self.items:
+            # If item doesn't have a response ctrl, skip it
+            if "responseCtrl" not in item:
+                continue
+            # If response ctrl is a slider, set its rating to None
+            if isinstance(item['responseCtrl'], psychopy.visual.Slider):
+                item['responseCtrl'].rating = None
+            # If response ctrl is a textbox, set its text to blank
+            elif isinstance(item['responseCtrl'], psychopy.visual.TextBox2):
+                item['responseCtrl'].text = ""
+
     def addDataToExp(self, exp, itemsAs='rows'):
         """Gets the current Form data and inserts into an
         :class:`~psychopy.experiment.ExperimentHandler` object either as rows


### PR DESCRIPTION
As this user experienced:
https://discourse.psychopy.org/t/forms-and-loops-can-i-use-the-same-survey-at-multiple-times-with-a-loop/16147

resetting all the values in a Form is a bit wordy, but the code is always the same so I thought it may as well be in a method of Form.

Requesting review from Matthew to generally check my code and Jon to check whether it's too early for the dev branch to begin deviating from release and, if so, whether this is small enough to sneak into release...