### PR TITLE
BF: Preserve ref to experiment when copying a routine

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1215,7 +1215,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
         """copy the current routine from self.routinePanel
         to self.app.copiedRoutine.
         """
-        r = copy.deepcopy(self.routinePanel.getCurrentRoutine())
+        r = self.routinePanel.getCurrentRoutine().copy()
         if r is not None:
             self.app.copiedRoutine = r
 
@@ -1236,7 +1236,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             routineName = dlg.GetValue()
             if not routineName:
                 routineName = defaultName
-            newRoutine = copy.deepcopy(self.app.copiedRoutine)
+            newRoutine = self.app.copiedRoutine.copy()
             self.pasteRoutine(newRoutine, routineName)
         dlg.Destroy()
 

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -7,6 +7,7 @@
 
 """Describes the Flow of an experiment
 """
+import copy
 
 from psychopy.constants import FOREVER
 from xml.etree.ElementTree import Element
@@ -225,6 +226,20 @@ class Routine(list):
     def __repr__(self):
         _rep = "psychopy.experiment.Routine(name='%s', exp=%s, components=%s)"
         return _rep % (self.name, self.exp, str(list(self)))
+
+    def copy(self):
+        # Create a new routine with the same experiment and name as this one
+        dupe = type(self)(self.name, self.exp, components=())
+        # Iterate through components
+        for comp in self:
+            # Create a deep copy of each component...
+            newComp = copy.deepcopy(comp)
+            # ...but retain original exp reference
+            newComp.exp = self.exp
+            # Append to new routine
+            dupe.append(newComp)
+
+        return dupe
 
     @property
     def _xml(self):


### PR DESCRIPTION
Using `copy.deepcopy` means that the duplicate routine and its components all refer to an entirely new copy of the experiment, rather than to the original experiment. So if you create a routine with a Textbox in, copy it, paste it, then rename the pasted copy, you'd get an unhandled error when compiling to JS as Textbox refers to its parent routine in `writeInitCodeJS` and said parent routine doesn't exist within the copy of the experiment stored as `self.exp`.

Instead of using `copy.deepcopy`, I've used a custom `.copy()` method for base Routine which `deepcopy`s each component but retains the original `.exp` handle.