### PR TITLE
BF: `eyetracker` still needs defining when ioHub isn't used

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1253,7 +1253,7 @@ class SettingsComponent:
                 buff.writeIndentedLines(code % inits)
         else:
             code = (
-                "ioSession = ioServer = None"
+                "ioSession = ioServer = eyetracker = None"
             )
             buff.writeIndentedLines(code % inits)
 


### PR DESCRIPTION
Fixes #4659 