### PR TITLE
NF: Add dialog box for editing Routine info

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1657,7 +1657,7 @@ class RoutinePage(wx.Panel, ThemeMixin):
             element=self.routine,
             experiment=self.routine.exp, editing=True
         )
-        if dlg.ShowModal() == wx.ID_OK:
+        if dlg.OK:
             # Do safe rename, as the component panel will have set name directly (skipping important steps)
             (oldName, newName) = self.routine.rename(self.routine.name)
             # Add change to undo stack

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -3680,7 +3680,11 @@ class FlowPanel(wx.ScrolledWindow):
             font.SetPointSize(1000 / self.dpi - fontSizeDelta)
 
         maxTime, nonSlip = routine.getMaxTime()
-        if nonSlip:
+        if routine.disabled:
+            rtFill = cs['rt_comp_disabled']
+            rtEdge = cs['rt_comp_disabled']
+            rtText = cs['fl_routine_fg']
+        elif nonSlip:
             rtFill = cs['fl_routine_bg_nonslip']
             rtEdge = cs['fl_routine_bg_nonslip']
             rtText = cs['fl_routine_fg']

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2941,11 +2941,10 @@ class FlowPanel(wx.ScrolledWindow):
         # the component (loop or routine)
         self.componentFromID = {}
         self.contextMenuLabels = {
-            'open': _translate('Open'),
             'edit': _translate('Edit info'),
             'remove': _translate('Remove')
         }
-        self.contextMenuItems = ['open', 'edit', 'remove']
+        self.contextMenuItems = ['edit', 'remove']
         self.contextItemFromID = {}
         self.contextIDFromItem = {}
         for item in self.contextMenuItems:

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1638,6 +1638,7 @@ class RoutinePage(wx.Panel, ThemeMixin):
         # Make info controls
         self.infoCtrls = wx.Button(self, label="✏️", size=(36, 36), style=wx.BORDER_NONE)
         self.infoCtrls.Bind(wx.EVT_BUTTON, self.editInfo)
+        self.infoCtrls.SetToolTip(_translate("Edit routine info"))
         self.sizer.Add(self.infoCtrls, border=6, flag=wx.ALL | wx.ALIGN_BOTTOM)
 
     def _applyAppTheme(self, target=None):

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -645,47 +645,53 @@ class Experiment:
                     modifiedNames.append(routineNode.get('name'))
                 self.namespace.user.append(routineGoodName)
                 routine = Routine(name=routineGoodName, exp=self)
-                # self._getXMLparam(params=routine.params, paramNode=routineNode)
                 self.routines[routineNode.get('name')] = routine
-                for componentNode in routineNode:
-
-                    componentType = componentNode.tag
-                    if componentType in allCompons:
-                        # create an actual component of that type
-                        component = allCompons[componentType](
-                            name=componentNode.get('name'),
-                            parentName=routineNode.get('name'), exp=self)
+                # Populate routine
+                for childNode in routineNode:
+                    if childNode.tag == "Param":
+                        # Apply params
+                        self._getXMLparam(params=routine.params,
+                                          paramNode=childNode,
+                                          componentNode=routineNode)
                     else:
-                        # create UnknownComponent instead
-                        component = allCompons['UnknownComponent'](
-                            name=componentNode.get('name'),
-                            parentName=routineNode.get('name'), exp=self)
-                    # check for components that were absent in older versions of
-                    # the builder and change the default behavior
-                    # (currently only the new behavior of choices for RatingScale,
-                    # HS, November 2012)
-                    # HS's modification superseded Jan 2014, removing several
-                    # RatingScale options
-                    if componentType == 'RatingScaleComponent':
-                        if (componentNode.get('choiceLabelsAboveLine') or
-                                componentNode.get('lowAnchorText') or
-                                componentNode.get('highAnchorText')):
-                            pass
-                        # if not componentNode.get('choiceLabelsAboveLine'):
-                        #    # this rating scale was created using older version
-                        #    component.params['choiceLabelsAboveLine'].val=True
-                    # populate the component with its various params
-                    for paramNode in componentNode:
-                        self._getXMLparam(params=component.params,
-                                          paramNode=paramNode,
-                                          componentNode=componentNode)
-                    compGoodName = self.namespace.makeValid(
-                        componentNode.get('name'))
-                    if compGoodName != componentNode.get('name'):
-                        modifiedNames.append(componentNode.get('name'))
-                    self.namespace.add(compGoodName)
-                    component.params['name'].val = compGoodName
-                    routine.append(component)
+                        # Apply components
+                        componentType = childNode.tag
+                        if componentType in allCompons:
+                            # create an actual component of that type
+                            component = allCompons[componentType](
+                                name=childNode.get('name'),
+                                parentName=routineNode.get('name'), exp=self)
+                        else:
+                            # create UnknownComponent instead
+                            component = allCompons['UnknownComponent'](
+                                name=childNode.get('name'),
+                                parentName=routineNode.get('name'), exp=self)
+                        # check for components that were absent in older versions of
+                        # the builder and change the default behavior
+                        # (currently only the new behavior of choices for RatingScale,
+                        # HS, November 2012)
+                        # HS's modification superseded Jan 2014, removing several
+                        # RatingScale options
+                        if componentType == 'RatingScaleComponent':
+                            if (childNode.get('choiceLabelsAboveLine') or
+                                    childNode.get('lowAnchorText') or
+                                    childNode.get('highAnchorText')):
+                                pass
+                            # if not componentNode.get('choiceLabelsAboveLine'):
+                            #    # this rating scale was created using older version
+                            #    component.params['choiceLabelsAboveLine'].val=True
+                        # populate the component with its various params
+                        for paramNode in childNode:
+                            self._getXMLparam(params=component.params,
+                                              paramNode=paramNode,
+                                              componentNode=childNode)
+                        compGoodName = self.namespace.makeValid(
+                            childNode.get('name'))
+                        if compGoodName != childNode.get('name'):
+                            modifiedNames.append(childNode.get('name'))
+                        self.namespace.add(compGoodName)
+                        component.params['name'].val = compGoodName
+                        routine.append(component)
             else:
                 if routineNode.tag in allRoutines:
                     # If not a routine, may be a standalone routine

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -234,7 +234,7 @@ class Experiment:
         # Remove disabled components, but leave original experiment unchanged.
         self_copy = deepcopy(self)
         for key, routine in list(self_copy.routines.items()):  # PY2/3 compat
-            if isinstance(routine, BaseStandaloneRoutine):
+            if isinstance(routine, (BaseStandaloneRoutine, Routine)):
                 # Remove disabled / unimplemented standalone routines
                 if routine.disabled or target not in routine.targets:
                     for node in self_copy.flow:

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -255,6 +255,13 @@ class Routine(list):
         # Make root element
         element = Element("Routine")
         element.set("name", self.name)
+        # Add an element for each parameter
+        for key, param in sorted(self.params.items()):
+            # Create node
+            paramNode = param._xml
+            paramNode.set("name", key)
+            # Add node
+            element.append(paramNode)
         # Add each component's element
         for comp in self:
             element.append(comp._xml)
@@ -289,6 +296,14 @@ class Routine(list):
             comp.parentName = newName
 
         return oldName, newName
+
+    @property
+    def disabled(self):
+        return self.params['disabled'].val
+
+    @disabled.setter
+    def disabled(self, value):
+        self.params['disabled'].val = value
 
     def integrityCheck(self):
         """Run tests on self and on all the Components inside"""

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -223,12 +223,13 @@ class Routine(list):
             name,
             valType='code', inputType="single", categ='Basic',
             hint=_translate("Name of this routine"),
-            label=_translate('name')
+            label=_translate('Name')
         )
         self.params['description'] = Param(
             description,
             hint=_translate("Disable this routine"), allowedTypes=[], direct=False,
             valType='str', inputType="multi", categ='Basic',
+            label=_translate("Description")
         )
         self.params['disabled'] = Param(
             disabled,


### PR DESCRIPTION
- `+` Routines can now have a description, useful for template routines
- `+` Routines can now be disabled
- `+` Routines having params, in general, opens the door for more Routine functionality in future
- `-` Older versions of PsychoPy will interpret Routine params as UnknownComponent, which ends up looking like this:
![image](https://user-images.githubusercontent.com/25686106/158374892-2c58237a-c6d1-4cf2-a15c-9933b8c9b092.png)

To do:

- [x] Add Edit Info button to Routine Panel as well as Flow Panel context menu
