### PR TITLE
BF: Fix loading movie stimuli during the static period

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -498,6 +498,47 @@ class BaseComponent:
                 if stopVal in ['', None, -1, 'None']:
                     stopVal = '-1'
                 buff.writeIndented(f"{compName}.setSound({params['sound']}, secs={stopVal}){endStr}\n")
+            elif paramName == 'movie':
+                # we're going to do this for now ...
+                if params['units'].val == 'from exp settings':
+                    unitsStr = "units=''"
+                else:
+                    unitsStr = "units=%(units)s" % params
+
+                if params['backend'].val == 'moviepy':
+                    code = ("%s = visual.MovieStim3(\n" % params['name'] +
+                            "    win=win, name='%s', %s,\n" % (
+                                params['name'], unitsStr) +
+                            "    noAudio = %(No audio)s,\n" % params)
+                elif params['backend'].val == 'avbin':
+                    code = ("%s = visual.MovieStim(\n" % params['name'] +
+                            "    win=win, name='%s', %s,\n" % (
+                                params['name'], unitsStr))
+                elif params['backend'].val == 'vlc':
+                    code = ("%s = visual.VlcMovieStim(\n" % params['name'] +
+                            "    win=win, name='%s', %s,\n" % (
+                                params['name'], unitsStr))
+                else:
+                    code = ("%s = visual.MovieStim2(\n" % params['name'] +
+                            "    win=win, name='%s', %s,\n" % (
+                                params['name'], unitsStr) +
+                            "    noAudio=%(No audio)s,\n" % params)
+
+                code += ("    filename=%(movie)s,\n"
+                         "    ori=%(ori)s, pos=%(pos)s, opacity=%(opacity)s,\n"
+                         "    loop=%(loop)s, anchor=%(anchor)s,\n"
+                         % params)
+
+                buff.writeIndentedLines(code)
+
+                if params['size'].val != '':
+                    buff.writeIndented("    size=%(size)s,\n" % params)
+
+                depth = -self.getPosInRoutine()
+                code = ("    depth=%.1f,\n"
+                        "    )\n")
+                buff.writeIndentedLines(code % depth)
+
             else:
                 buff.writeIndented(f"{compName}.set{paramCaps}({val}{loggingStr}){endStr}\n")
         elif target == 'PsychoJS':

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -227,7 +227,7 @@ class MovieComponent(BaseVisualComponent):
     def writeRoutineStartCode(self, buff):
         # If needed then use _writeCreationCode()
         # Movie could be created here or in writeInitCode()
-        if self.params['movie'].updates != 'constant':
+        if self.params['movie'].updates == 'set every repeat':
             # create the code using params, not vals
             self._writeCreationCode(buff, useInits=False)
 


### PR DESCRIPTION
Fixes crash when running a Builder experiment which loads a movie during a static period.