### PR TITLE
FF: for ResourceManager we don't want to "wait" resources just check

### DIFF
--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -162,7 +162,6 @@ class ResourceManagerComponent(BaseComponent):
             buff.setIndentLevel(1, relative=True)
             code = (
                         "console.log('resource specified in %(name)s took longer than expected to download');\n"
-                        "await waitForResources(resources = %(resources)s)"
             )
             buff.writeIndentedLines(code % inits)
             buff.setIndentLevel(-1, relative=True)


### PR DESCRIPTION
For StaticCompon we want to wait at the end (but the screen is static
anyway and this behaviour would be in keeping with PsychoPy behaviour,
whereas for ResourceManager we want to allow dynamic updating. In this
instance we should check but not freeze. User can see if this compon is
finished at any point