### PR TITLE
BF: Fix to Updates  dialog box border display issue

### DIFF
--- a/psychopy/app/connections/updates.py
+++ b/psychopy/app/connections/updates.py
@@ -314,7 +314,7 @@ class InstallUpdateDialog(wx.Dialog):
             btns = [self.cancelBtn, self.installBtn]
         btnSizer.Add(btns[0], 0, flag=wx.LEFT, border=5)
         btnSizer.Add(btns[1], 0, flag=wx.LEFT, border=5)
-        mainSizer.Add(btnSizer, flag=wx.ALL | wx.EXPAND, border=5)
+        mainSizer.Add(btnSizer, flag=wx.ALL | wx.EXPAND, border=15)
 
         self.SetSizerAndFit(mainSizer)
         self.SetAutoLayout(True)


### PR DESCRIPTION
Fixed https://github.com/psychopy/psychopy/issues/4726 and tested it

Before:
![Snipaste_2022-03-27_10-55-49](https://user-images.githubusercontent.com/10348402/160266588-16727c23-382d-4498-ad2d-94a696162489.png)

After this PR:
![Snipaste_2022-03-27_11-56-42](https://user-images.githubusercontent.com/10348402/160266600-3ea56b2b-b07d-4c76-877a-0f5c421fbba3.png)

