### PR TITLE
BF: fixed getTime function for Apple Silicon

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -96,9 +96,12 @@ elif sys.platform == "darwin":
     _libc.mach_timebase_info(ctypes.byref(_timebase))
     _ticks_per_second = _timebase.numer / _timebase.denom * 1.0e9
 
+    # scaling factor so that timing works correctly on Intal and Apple Silicon
+    _scaling_factor = _timebase.numer / _timebase.denom
+
     # then define getTime func
     def getTime():
-        return _mach_absolute_time() / _ticks_per_second
+        return (_mach_absolute_time() * _scaling_factor) / 1.0e9
 
 else:
     import timeit


### PR DESCRIPTION
getTime uses now scaling factor to take into account internal clock differences
between Intel and Apple Silicon Macs

More info
https://eclecticlight.co/2020/11/27/inside-m1-macs-time-and-logs/

fixes GH-4269