### PR TITLE
PKG: unify `python-vlc` dependency definition

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ install_requires =
     google-cloud-speech
     googleapis-common-protos
     # Platform-specific dependencies.
-    python-vlc <= 3.0.11115; platform_system == "Windows"
+    python-vlc == 3.0.11115; platform_system == "Windows"
     python-vlc >= 3.0.12118; platform_system != "Windows"
     javascripthon; python_version >= "3.5"
     pyglet >= 1.5; platform_system == "Darwin"
@@ -88,8 +88,6 @@ install_requires =
     pyqmix >= 2018.12.13; platform_system == "Windows"
     pyqt5; python_version >= "3"
     wxPython != 4.0.2, != 4.0.3; platform_system != "Linux"
-    python-vlc >= 3.0.12118; platform_system != "Windows"
-    python-vlc == 3.0.11115; platform_system == "Windows"
     pypiwin32; platform_system == "Windows"
     pyobjc-core < 8.0; platform_system == "Darwin"
     pyobjc-framework-Quartz < 8.0; platform_system == "Darwin"


### PR DESCRIPTION
The dependency on `python-vlc` is (somewhat) duplicated in `setup.cfg`.
This causes the Poetry package manager to bail out when adding PsychoPy
as a dependency (likely due to a bug in Poetry, see
python-poetry/poetry#5378).

This commit simplifies/unifies the `python-vlc` dependency definitions,
retaining the semantics of the original ones.

See: https://github.com/python-poetry/poetry/issues/5378
See: 8692b9c6dfc8fc0a573b7bd5fe40f8815873023e
See: https://github.com/psychopy/psychopy/pull/4613
See: d5c366e4c92064ba199d26d002246999e44526ef
See: https://github.com/psychopy/psychopy/pull/4059