### PR TITLE
BF: slider.startValue should not be setting the slider.rating during reset

### DIFF
--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -408,6 +408,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         on each trial with a new stimulus)
         """
         self.markerPos = self.startValue
+        self.rating = None  # this is reset to None, whatever the startValue
         self.history = []
         self.rt = None
         self.responseClock.reset()

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -407,7 +407,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         """Resets the slider to its starting state (so that it can be restarted
         on each trial with a new stimulus)
         """
-        self.markerPos = self.rating = self.startValue
+        self.markerPos = self.startValue
         self.history = []
         self.rt = None
         self.responseClock.reset()


### PR DESCRIPTION
Only the markerPos should be controlled by the startValue, not the
rating. If a Rating exists it implies a response has been made which it
hasn't, at the time of resetting