### PR TITLE
BF: Update component experiment refs on paste

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1246,6 +1246,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
         """
         newRoutine.name = self.exp.namespace.makeValid(routineName, prefix="routine")
         newRoutine.params['name'] = newRoutine.name
+        newRoutine.exp = self.exp
         self.exp.namespace.add(newRoutine.name)
         # add to the experiment
         self.exp.addRoutine(newRoutine.name, newRoutine)
@@ -1253,6 +1254,7 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             newName = self.exp.namespace.makeValid(newComp.params['name'])
             self.exp.namespace.add(newName)
             newComp.params['name'].val = newName
+            newComp.exp = self.exp
         # could do redrawRoutines but would be slower?
         self.routinePanel.addRoutinePage(newRoutine.name, newRoutine)
         self.routinePanel.setCurrentRoutine(newRoutine)


### PR DESCRIPTION
Otherwise, copying from one experiment to another causes an error on compile as the component still points to its original experiment