### PR TITLE
BF: Add disabled attr to Routine, fixed as False for now

### DIFF
--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -220,6 +220,7 @@ class Routine(list):
         self.exp = exp
         self._clockName = None  # for scripts e.g. "t = trialClock.GetTime()"
         self.type = 'Routine'
+        self.disabled = False
         list.__init__(self, list(components))
 
     def __repr__(self):


### PR DESCRIPTION
Otherwise the new code to check for disabled routines fails (until we have editable params for routines, it's best that this is just fixed to False)