### PR TITLE
RF: Alias Textbox.startText with Textbox.placeholder for JS parity

### DIFF
--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -57,6 +57,7 @@ debug = False
 
 # If text is ". " we don't want to start next line with single space?
 
+
 class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
     def __init__(self, win, text,
                  font="Open Sans",
@@ -218,7 +219,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         # then layout the text (setting text triggers _layout())
         self.languageStyle = languageStyle
         self._text = ''
-        self.text = self.startText = text if text is not None else ""
+        self.text = self.placeholder = text if text is not None else ""
 
         # caret
         self.editable = editable
@@ -1407,3 +1408,18 @@ class Caret(ColorMixin):
             [x, bottom],
             [x, top]
         ])
+
+    # -------- legacy attributes --------
+
+    @property
+    def startText(self):
+        """
+        In v2022.1.4, `.startText` was replaced by `.placeholder` for consistency with PsychoJS. The two attributes
+        are fully interchangeable.
+        """
+        return self.placeholder
+
+    @startText.setter
+    def startText(self, value):
+        self.placeholder = value
+

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -1239,6 +1239,20 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         """
         setAttribute(self, 'font', font, log)
 
+    # -------- legacy attributes --------
+
+    @property
+    def startText(self):
+        """
+        In v2022.1.4, `.startText` was replaced by `.placeholder` for consistency with PsychoJS. The two attributes
+        are fully interchangeable.
+        """
+        return self.placeholder
+
+    @startText.setter
+    def startText(self, value):
+        self.placeholder = value
+
 
 class Caret(ColorMixin):
     """
@@ -1408,18 +1422,3 @@ class Caret(ColorMixin):
             [x, bottom],
             [x, top]
         ])
-
-    # -------- legacy attributes --------
-
-    @property
-    def startText(self):
-        """
-        In v2022.1.4, `.startText` was replaced by `.placeholder` for consistency with PsychoJS. The two attributes
-        are fully interchangeable.
-        """
-        return self.placeholder
-
-    @startText.setter
-    def startText(self, value):
-        self.placeholder = value
-


### PR DESCRIPTION
Could just as easily be pulled into dev if we want to be more cautious

Ideally, should be matched with an alias in PsychoJS to allow `startText` in place of `placeholder`