### PR TITLE
BF: Builder code validator was interpreting non-assignment values as assignments

### DIFF
--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -82,7 +82,8 @@ def getVariables(code):
         if hasattr(line, "targets") and hasattr(line, "value"):
             # Append targets and values this line to arguments dict
             for target in line.targets:
-                vars[target.id] = _actualizeAstValue(line.value)
+                if hasattr(target, "id"):
+                    vars[target.id] = _actualizeAstValue(line.value)
 
     return vars
 


### PR DESCRIPTION
Builder's code validator converts code to an AST tree and looks for variables being defined, this is fine when parsing the fields of a code component but if the code snippet is just a value (i.e. in most other component parameters) then there will be instances where the AST node doesn't have an id, in which case these need to be skipped by the validator.