### PR TITLE
BF: `allowedLabels` wasn't used for ChoiceCtrls

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -136,7 +136,8 @@ class ParamCtrls():
             #                                     limits=param.allowedVals)
         elif param.inputType == 'choice':
             self.valueCtrl = paramCtrls.ChoiceCtrl(parent,
-                                                   val=str(param.val), valType=param.valType, choices=param.allowedVals,
+                                                   val=str(param.val), valType=param.valType,
+                                                   choices=param.allowedVals, labels=param.allowedLabels,
                                                    fieldName=fieldName, size=wx.Size(self.valueWidth, 24))
         elif param.inputType == 'multiChoice':
             self.valueCtrl = paramCtrls.MultiChoiceCtrl(parent, valType=param.valType,
@@ -257,11 +258,6 @@ class ParamCtrls():
             return val
         elif hasattr(ctrl, 'GetCheckedStrings'):
             return ctrl.GetCheckedStrings()
-        elif hasattr(ctrl, 'GetSelection'):  # for wx.Choice
-            # _choices is defined during __init__ for all wx.Choice() ctrls
-            # NOTE: add untranslated value to _choices if
-            # _choices[ctrl.GetSelection()] fails.
-            return ctrl._choices[ctrl.GetSelection()]
         elif hasattr(ctrl, 'GetLabel'):  # for wx.StaticText
             return ctrl.GetLabel()
         else:

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -270,29 +270,33 @@ BoolCtrl = wx.CheckBox
 
 class ChoiceCtrl(wx.Choice, _ValidatorMixin, _HideMixin):
     def __init__(self, parent, valType,
-                 val="", choices=[], fieldName="",
+                 val="", choices=[], labels=[], fieldName="",
                  size=wx.Size(-1, 24)):
-        # translate add each label to the dropdown
-        choiceLabels = []
-        for item in choices:
-            try:
-                choiceLabels.append(_localized[item])
-            except KeyError:
-                choiceLabels.append(item)
-
+        # If not given any labels, alias values
+        if not labels:
+            labels = choices
+        # Map labels to values
+        self._choices = {}
+        for i, value in enumerate(choices):
+            if i < len(labels):
+                self._choices[labels[i]] = value
+            else:
+                self._choices[value] = value
+        # Create choice ctrl from labels
         wx.Choice.__init__(self)
-        self.Create(parent, -1, size=size, choices=choiceLabels, name=fieldName)
-        self._choices = choices
+        self.Create(parent, -1, size=size, choices=list(self._choices), name=fieldName)
         self.valType = valType
         self.SetStringSelection(val)
 
     def SetStringSelection(self, string):
         if string not in self._choices:
-            self._choices.append(string)
-            self.SetItems(self._choices)
-        # Don't use wx.Choice.SetStringSelection here
-        # because label string is localized.
-        wx.Choice.SetSelection(self, self._choices.index(string))
+            self._choices[string] = string
+            self.SetItems(list(self._choices))
+        wx.Choice.SetStringSelection(self, string)
+
+    def GetValue(self):
+        lbl = self.GetStringSelection()
+        return self._choices[lbl]
 
 
 class MultiChoiceCtrl(wx.CheckListBox, _ValidatorMixin, _HideMixin):


### PR DESCRIPTION
This is why e.g. audio latency options were listed as numbers without labels. Can pull into dev instead if the urgency doesn't warrant a (albeit minor) refactor in release.