### PR TITLE
BF: ShapeStim was not setting opacity when opacity is 0

### DIFF
--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -169,7 +169,7 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
                             " Please use color and colorSpace args instead")
             self.setFillColor(fillRGB, colorSpace='rgb', log=None)
         self.contrast = contrast
-        if opacity:
+        if opacity is not None:
             self.opacity = opacity
 
         # Other stuff


### PR DESCRIPTION
Because `bool(0)` is `False`, when what we want really is to compare it against None