### PR TITLE
BF: Add placeholder corr value for JoyButtons like Keyboard has

### DIFF
--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -89,6 +89,15 @@ class JoyButtonsComponent(BaseComponent):
             hint=msg,
             label=_localized['storeCorrect'])
 
+        self.depends += [  # allows params to turn each other off/on
+            {"dependsOn": "storeCorrect",  # must be param name
+             "condition": "== True",  # val to check for
+             "param": "correctAns",  # param property to alter
+             "true": "enable",  # what to do with param if condition is True
+             "false": "disable",  # permitted: hide, show, enable, disable
+             }
+        ]
+
         msg = _translate(
             "What is the 'correct' key? Might be helpful to add a "
             "correctAns column and use $correctAns to compare to the key "

--- a/psychopy/experiment/components/joyButtons/virtualJoyButtons.py
+++ b/psychopy/experiment/components/joyButtons/virtualJoyButtons.py
@@ -19,6 +19,8 @@ class VirtualJoyButtons:
         self.modifierKeys=['ctrl','alt']
         self.mouse = event.Mouse()
         event.Mouse(visible=False)
+        # Create .corr property with placeholder value
+        self.corr = False
 
     def getNumButtons(self):
         return len(self.numberKeys)


### PR DESCRIPTION
Addresses the issue this user was having:
https://discourse.psychopy.org/t/error-message-when-syncing-experiments-from-psychopy-builder-to-pavlovia/21558/19

Also noticed that `correctAns` doesn't use the same depends for JotButtons as for Keyboard so added that behaviour for clarity