### PR TITLE
BF: Use Path.glob to search for readme as glob.glob can't handle some valid chars

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -844,17 +844,16 @@ class BuilderFrame(wx.Frame, ThemeMixin):
             self.readmeFrame = ReadmeFrame(parent=self)
         # look for a readme file
         if self.filename and self.filename != 'untitled.psyexp':
-            dirname = os.path.dirname(self.filename)
-            possibles = glob.glob(os.path.join(dirname, 'readme*'))
+            dirname = Path(self.filename).parent
+            possibles = list(dirname.glob('readme*'))
             if len(possibles) == 0:
-                possibles = glob.glob(os.path.join(dirname, 'Readme*'))
-                possibles.extend(glob.glob(os.path.join(dirname, 'README*')))
+                possibles = list(dirname.glob('Readme*'))
+                possibles.extend(dirname.glob('README*'))
             # still haven't found a file so use default name
             if len(possibles) == 0:
-                self.readmeFilename = os.path.join(
-                    dirname, 'readme.md')  # use this as our default
+                self.readmeFilename = str(dirname / 'readme.md')  # use this as our default
             else:
-                self.readmeFilename = possibles[0]  # take the first one found
+                self.readmeFilename = str(possibles[0])  # take the first one found
         else:
             self.readmeFilename = None
         self.readmeFrame.setFile(self.readmeFilename)


### PR DESCRIPTION
Addresses issue found by this user:
https://discourse.psychopy.org/t/experiment-doesnt-launch-psychopy-encountered-an-unhandled-internal-error/28368