### PR TITLE
ENH: Save on click as Mouse default

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -33,7 +33,7 @@ class MouseComponent(BaseComponent):
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
                  startEstim='', durationEstim='',
-                 save='final', forceEndRoutineOnPress="any click",
+                 save='on click', forceEndRoutineOnPress="any click",
                  timeRelativeTo='mouse onset'):
         super(MouseComponent, self).__init__(
             exp, parentName, name=name,


### PR DESCRIPTION
Default value for when to save mouse state should be "on click" rather than "final" (as per ClickUp request)