### PR TITLE
BF: Fix references to pavlovia buttons

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -144,7 +144,6 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.filename = fileName
         self.htmlPath = None
         self.session = pavlovia.getCurrentSession()
-        self.btnHandles = {}  # stores toolbar buttons so they can be altered
         self.scriptProcess = None
         self.stdoutBuffer = None
         self.readmeFrame = None
@@ -199,6 +198,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.componentButtons = ComponentsPanel(self)
         # menus and toolbars
         self.toolbar = BuilderToolbar(frame=self)
+        self.btnHandles = self.toolbar.buttons  # stores toolbar buttons so they can be altered
         self.SetToolBar(self.toolbar)
         self.toolbar.Realize()
         self.makeMenus()
@@ -3867,31 +3867,31 @@ class BuilderToolbar(BasePsychopyToolbar):
         self.AddSeparator()
 
         # Pavlovia run
-        self.buttons['pavRun'] = self.makeTool(
+        self.buttons['pavloviaRun'] = self.makeTool(
             name='globe_run',
             label=_translate("Run online"),
             tooltip=_translate("Run the study online (with pavlovia.org)"),
             func=self.frame.onPavloviaRun)
         # Pavlovia sync
-        self.buttons['pavSync'] = self.makeTool(
+        self.buttons['pavloviaSync'] = self.makeTool(
             name='globe_greensync',
             label=_translate("Sync online"),
             tooltip=_translate("Sync with web project (at pavlovia.org)"),
             func=self.frame.onPavloviaSync)
         # Pavlovia search
-        self.buttons['pavSearch'] = self.makeTool(
+        self.buttons['pavloviaSearch'] = self.makeTool(
             name='globe_magnifier',
             label=_translate("Search Pavlovia.org"),
             tooltip=_translate("Find existing studies online (at pavlovia.org)"),
             func=self.onPavloviaSearch)
         # Pavlovia user
-        self.buttons['pavUser'] = self.makeTool(
+        self.buttons['pavloviaUser'] = self.makeTool(
             name='globe_user',
             label=_translate("Current Pavlovia user"),
             tooltip=_translate("Log in/out of Pavlovia.org, view your user profile."),
             func=self.onPavloviaUser)
         # Pavlovia user
-        self.buttons['pavProject'] = self.makeTool(
+        self.buttons['pavloviaProject'] = self.makeTool(
             name='globe_info',
             label=_translate("View project"),
             tooltip=_translate("View details of this project"),

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -198,7 +198,6 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.componentButtons = ComponentsPanel(self)
         # menus and toolbars
         self.toolbar = BuilderToolbar(frame=self)
-        self.btnHandles = self.toolbar.buttons  # stores toolbar buttons so they can be altered
         self.SetToolBar(self.toolbar)
         self.toolbar.Realize()
         self.makeMenus()
@@ -3900,6 +3899,8 @@ class BuilderToolbar(BasePsychopyToolbar):
         # Disable compile buttons until an experiment is present
         self.EnableTool(self.buttons['compile_py'].GetId(), Path(str(self.frame.filename)).is_file())
         self.EnableTool(self.buttons['compile_js'].GetId(), Path(str(self.frame.filename)).is_file())
+
+        self.frame.btnHandles = self.buttons
 
     def onPavloviaSearch(self, evt=None):
         searchDlg = SearchFrame(

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1219,7 +1219,6 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
 
         # Create toolbar
         self.toolbar = CoderToolbar(self)
-        self.btnHandles = self.toolbar.buttons  # stores toolbar buttons so they can be altered
         self.SetToolBar(self.toolbar)
         self.toolbar.Realize()
         # Create menus and status bar
@@ -2999,6 +2998,8 @@ class CoderToolbar(BasePsychopyToolbar):
             label=_translate("Current Pavlovia user"),
             tooltip=_translate("Log in/out of Pavlovia.org, view your user profile."),
             func=self.onPavloviaUser)
+
+        self.frame.btnHandles = self.buttons
 
     def onPavloviaSearch(self, evt=None):
         searchDlg = SearchFrame(

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1161,7 +1161,6 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.fileStatusLastChecked = time.time()
         self.fileStatusCheckInterval = 5 * 60  # sec
         self.showingReloadDialog = False
-        self.btnHandles = {}  # stores toolbar buttons so they can be altered
 
         # default window title string
         self.winTitle = "PsychoPy Coder (v{})".format(self.app.version)
@@ -1220,6 +1219,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
 
         # Create toolbar
         self.toolbar = CoderToolbar(self)
+        self.btnHandles = self.toolbar.buttons  # stores toolbar buttons so they can be altered
         self.SetToolBar(self.toolbar)
         self.toolbar.Realize()
         # Create menus and status bar
@@ -2982,19 +2982,19 @@ class CoderToolbar(BasePsychopyToolbar):
         self.AddSeparator()
 
         # Pavlovia sync
-        self.buttons['pavSync'] = self.makeTool(
+        self.buttons['pavloviaSync'] = self.makeTool(
             name='globe_greensync',
             label=_translate("Sync online"),
             tooltip=_translate("Sync with web project (at pavlovia.org)"),
             func=self.frame.onPavloviaSync)
         # Pavlovia search
-        self.buttons['pavSearch'] = self.makeTool(
+        self.buttons['pavloviaSearch'] = self.makeTool(
             name='globe_magnifier',
             label=_translate("Search Pavlovia.org"),
             tooltip=_translate("Find existing studies online (at pavlovia.org)"),
             func=self.onPavloviaSearch)
         # Pavlovia user
-        self.buttons['pavUser'] = self.makeTool(
+        self.buttons['pavloviaUser'] = self.makeTool(
             name='globe_user',
             label=_translate("Current Pavlovia user"),
             tooltip=_translate("Log in/out of Pavlovia.org, view your user profile."),


### PR DESCRIPTION
Had to do some digging to figure out where I'd gone wrong with this; essentially, I moved the methods for enabling/disabling pavlovia buttons to the Builder/Coder frames during the theme rework, as the pavlovia buttons being in their own class rather than a part of the toolbar was one of the things causing _applyAppTheme to repeat itself; because the PavloviaButtons object was a child of the frame, and a new one was created each time the theme was applied to the toolbar. While the Builder/Coder frames have a `btnHandles` attribute, it wasn't updated with button handles, causing a key error when Builder attempts to enable/disable the sync button.

This fix ensures that `btnHandles` matches the dict of buttons in the toolbar, and corrects the key names to match those expected in the sync function.