### PR TITLE
BF: Add win argument to Camera JS and allow Python to accept it

### DIFF
--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -154,6 +154,7 @@ class CameraComponent(BaseComponent):
         code = (
             "%(name)s = new hardware.Camera({\n"
             "    name:'%(name)s',\n"
+            "    win:win,\n"
             "});\n"
             "// Get permission from participant to access their camera\n"
             "%(name)s.authorize()\n"

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -500,7 +500,7 @@ class Camera:
 
     """
     def __init__(self, device=0, mic=None, mode='video',
-                 cameraLib=u'ffpyplayer', codecOpts=None, libOpts=None):
+                 cameraLib=u'ffpyplayer', codecOpts=None, libOpts=None, win=None):
 
         # add attributes for setters
         self.__dict__.update(
@@ -567,6 +567,9 @@ class Camera:
         self._streamTime = 0.0
         self._isMonotonic = False
         self._outFile = ''
+
+        # store win (unused but needs to be set/got safely for parity with JS)
+        self.win = win
 
         # thread for reading a writing streams
         self._tStream = None


### PR DESCRIPTION
On Python end, win does nothing, but allowing the object to accept win as an input/return it on request means one less thing for designers to change when converting between JS and Py code