### PR TITLE
Display the eyelink setup options menu after calibration.

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/eyeLinkCoreGraphicsIOHubPsychopy.py
@@ -538,8 +538,10 @@ class EyeLinkCoreGraphicsIOHubPsychopy(pylink.EyeLinkCustomDisplay):
         self.window.flip()
 
     def exit_cal_display(self):
-        """Exits calibration display."""
-        self.clear_cal_display()
+        """Exits calibration display and return to initial menu with
+        instructions."""
+        self.setup_cal_display()
+
 
     def clear_cal_display(self):
         """Clears the calibration display."""


### PR DESCRIPTION
Display the eyelink setup options menu after calibration, currently a blank screen is shown.