### PR TITLE
BF: when working out psychojs version ignore additional suffixes

### DIFF
--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -59,7 +59,7 @@ def getPsychoJSVersionStr(currentVersion, preferredVersion=''):
         # e.g. 2021.1.0 not 2021.1.0.dev3
         useVerStr = '.'.join(useVerStr.split('.')[:3])
     # PsychoJS doesn't have additional rc1 or dev1 releases
-    for versionSuffix in ["rc", "dev"]:
+    for versionSuffix in ["rc", "dev", "a", "b"]:
         if versionSuffix in useVerStr:
             useVerStr = useVerStr.split(versionSuffix)[0]
 


### PR DESCRIPTION
Previously we ignored dev and rc suffixes but should also ignore a and b