### PR TITLE
BF: Fixed transformation of mouse coordinates on Retina displays

### DIFF
--- a/psychopy/visual/backends/_base.py
+++ b/psychopy/visual/backends/_base.py
@@ -278,8 +278,9 @@ class BaseBackend(ABC):
             Position `(x, y)` in PsychoPy pixel coordinates.
 
         """
+        invScaleFactor = 1.0 / self.win.getContentScaleFactor()
         return np.asarray(self._windowToBufferCoords(pos) - self.win.size / 2.0,
-                          dtype=np.float32)
+                          dtype=np.float32) * invScaleFactor
 
     def _pixToWindowCoords(self, pos):
         """Convert PsychoPy 'pix' to the window coordinate system. This is the
@@ -296,8 +297,10 @@ class BaseBackend(ABC):
             Position `(x, y)` in window coordinates.
 
         """
+        scaleFactor = self.win.getContentScaleFactor()
         return self._bufferToWindowCoords(
-            np.asarray(pos, dtype=np.float32) + self.win.size / 2.0)
+            np.asarray(pos, dtype=np.float32) +
+            self.win.size / 2.0) * scaleFactor
 
     # --------------------------------------------------------------------------
     # Mouse related methods (e.g., event handlers)

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -679,8 +679,8 @@ class PygletBackend(BaseBackend):
         """
         # We override `_winToBufferCoords` here since Pyglet uses the OpenGL
         # window coordinate convention by default.
-        scaleFactor = self.win.getContentScaleFactor()
-        return np.asarray(pos, dtype=np.float32) * scaleFactor
+        invScaleFactor = 1.0 / self.win.getContentScaleFactor()
+        return np.asarray(pos, dtype=np.float32) * invScaleFactor
 
     def _bufferToWindowCoords(self, pos):
         """OpenGL buffer coordinates to window coordinates.
@@ -698,8 +698,8 @@ class PygletBackend(BaseBackend):
             Position `(x, y)` in buffer coordinates.
 
         """
-        invScaleFactor = 1.0 / self.win.getContentScaleFactor()
-        return np.asarray(pos, dtype=np.float32) * invScaleFactor
+        scaleFactor = self.win.getContentScaleFactor()
+        return np.asarray(pos, dtype=np.float32) * scaleFactor
 
     # --------------------------------------------------------------------------
     # Mouse event handlers and utilities


### PR DESCRIPTION
Not sure if something changed but mouse coordinates are off when using Retina displays. This patch should fix the issue, but needs testing on a Retina monitor. Works fine on Macs hooked up to a regular display, so nothing should break on those hardware setups and Windows/Linux.