### PR TITLE
BF: State visibility explicitly when sending query to Pavlovia API

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -463,6 +463,10 @@ class PavloviaSearch(pandas.DataFrame):
         def __str__(self):
             # Start off with blank str
             terms = ""
+            # Synonymise visibility unspecified with visibility all ticked (compensate for back-end being
+            # exploration focussed)
+            if "Visibility" not in self or not self['Visibility']:
+                self['Visibility'] = ["owned", "private", "public"]
             # Iterate through values
             for key, value in self.items():
                 # Ensure value is iterable and mutable


### PR DESCRIPTION
This isn't needed for other filters as these don't affect whether or not authentication needs to be done, so the server can afford to assume blank = no filter for these, but visibility needs to be treated as a special case as showing private projects means authenticating, which is a more significant undertaking, computationally.