### PR TITLE
FF: Fixed `MovieStim` stalling on `stop()` when `status != FINISHED`

### DIFF
--- a/psychopy/demos/coder/stimuli/MovieStim.py
+++ b/psychopy/demos/coder/stimuli/MovieStim.py
@@ -10,25 +10,35 @@ MovieStim opens a video file and displays it.
 from psychopy import visual, core, event, constants
 
 # window to present the video
-win = visual.Window((800, 600))
+win = visual.Window((800, 600), fullscr=False)
 
 # create a new movie stimulus instance
-mov = visual.MovieStim(win, 'default.mp4', size=(800, 600), flipVert=False,
+mov = visual.MovieStim(win, 'default.mp4', size=(256, 256), flipVert=False,
                        flipHoriz=False, loop=False)
-mov.play()
-# print('orig movie size=%s' % mov.size)
-# print('duration=%.2fs' % mov.duration)
+
+# print some information about the movie
+print('orig movie size={}'.format(mov.frameSize))
+
+# instructions
+instrText = "`s` Start/Resume\n`p` Pause\n`r` Restart\n`q` Stop and Close"
+instr = visual.TextStim(win, instrText, pos=(0.0, -0.75))
+
+# start playback
+mov.pause()  # start paused
 
 # main loop
 while mov.status != constants.FINISHED:
     mov.draw()
+    instr.draw()
     win.flip()
-    if event.getKeys('q'):
+    if event.getKeys('q'):   # quit
         break
-    if event.getKeys('m'):
+    elif event.getKeys('s'):  # play/start
         mov.play()
-    if event.getKeys('n'):
+    elif event.getKeys('p'):  # pause
         mov.pause()
+    elif event.getKeys('r'):  # restart/replay
+        mov.replay()
 
 mov.stop()
 # clean up and exit

--- a/psychopy/visual/movie.py
+++ b/psychopy/visual/movie.py
@@ -7,5 +7,6 @@
 # Part of the PsychoPy library
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
+
 from psychopy.visual.movies import MovieStim
 

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -195,6 +195,19 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self._autoStart = bool(value)
 
     @property
+    def frameSize(self):
+        """Movie frame size/resolution (w, h) in pixels (`tuple`). Only valid
+        after calling `load()`.
+        """
+        return self._player.metadata.size
+
+    @property
+    def frameRate(self):
+        """Frame rate of the movie in Hertz (`float`).
+        """
+        return self._player.metadata.frameRate
+
+    @property
     def _hasPlayer(self):
         """`True` if a media player instance is started.
         """

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -218,6 +218,9 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self._filename = filename
         self._player.load(self._filename)
 
+        self._freeBuffers()  # free buffers (if any) before creating a new one
+        self._setupTextureBuffers()
+
     @property
     def frameTexture(self):
         """Texture ID for the current video frame (`GLuint`). You can use this
@@ -244,7 +247,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # only do a pixel transfer on valid frames
         if self._recentFrame is not NULL_MOVIE_FRAME_INFO:
-            self._setupTextureBuffers()
+
             self._pixelTransfer()
 
         return self._recentFrame
@@ -356,6 +359,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         """
         self._player.stop(log=log)
+        self._freeBuffers()  # free buffer before creating a new one
 
     def seek(self, timestamp, log=True):
         """Seek to a particular timestamp in the movie.
@@ -564,8 +568,6 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         `_freeBuffers` first.
 
         """
-        self._freeBuffers()  # free buffer before creating a new one
-
         # get the size of the movie frame and compute the buffer size
         vidWidth, vidHeight = self._player.getMetadata().size
         nBufferBytes = vidWidth * vidHeight * 3
@@ -694,10 +696,13 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         GL.glDisable(GL.GL_TEXTURE_2D)
 
     def _drawRectangle(self):
-        """Draw the video frame to the window. This is called by the `draw()`
-        method.
+        """Draw the video frame to the window.
+
+        This is called by the `draw()` method to blit the video to the display
+        window.
+
         """
-        # make sure that textures are on and GL_TEXTURE0 is activ
+        # make sure that textures are on and GL_TEXTURE0 is active
         GL.glEnable(GL.GL_TEXTURE_2D)
         GL.glActiveTexture(GL.GL_TEXTURE0)
 

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -505,11 +505,11 @@ class FFPyPlayer(BaseMoviePlayer):
         # handle to `ffpyplayer`
         self._handle = None
         self._queuedFrame = NULL_MOVIE_FRAME_INFO
-        self._frameIndex = -1
         self._lastFrame = NULL_MOVIE_FRAME_INFO
+        self._frameIndex = -1
 
-        # flag when random access has been invoked
-        self._needsNewFrame = False
+        # metadata from the stream
+        self._metadata = None
 
         # status flags
         self._status = NOT_STARTED
@@ -540,6 +540,9 @@ class FFPyPlayer(BaseMoviePlayer):
         # hand off the player interface to the thread
         self._tStream = MovieStreamThreadFFPY(self._handle)
         self._tStream.begin()
+
+        # make sure we have metadata
+        self.update()
 
     def load(self, pathToMovie):
         """Load a movie file from disk.
@@ -612,7 +615,7 @@ class FFPyPlayer(BaseMoviePlayer):
         """
         self._assertMediaPlayer()
 
-        metadata = self._handle.get_metadata()
+        metadata = self._metadata
 
         # write metadata to the fields of a `MovieMetadata` object
         toReturn = MovieMetadata(
@@ -1088,7 +1091,7 @@ class FFPyPlayer(BaseMoviePlayer):
             return False
 
         # unpack the data we got back
-        metadata = enqueuedFrame.metadata
+        self._metadata = enqueuedFrame.metadata
         frameImage = enqueuedFrame.frameImage
         streamStatus = enqueuedFrame.streamStatus
         self.parent.status = self._status = streamStatus.status
@@ -1109,7 +1112,7 @@ class FFPyPlayer(BaseMoviePlayer):
             colorData=videoFrameArray,
             audioChannels=0,
             audioSamples=None,
-            metadata=metadata,
+            metadata=self.metadata,
             movieLib=u'ffpyplayer',
             userData=None)
 

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -641,6 +641,8 @@ class FFPyPlayer(BaseMoviePlayer):
 
     @property
     def status(self):
+        """Player status flag (`int`).
+        """
         return self._status
 
     @property
@@ -753,11 +755,8 @@ class FFPyPlayer(BaseMoviePlayer):
             Log the seek event.
 
         """
-        self._assertMediaPlayer()
-        self._handle.seek(timestamp, relative=False)
-        self._queuedFrame = NULL_MOVIE_FRAME_INFO
-
-        return self._handle.get_pts()
+        raise NotImplementedError(
+            "This feature is not available for the current backend.")
 
     def rewind(self, seconds=5, log=False):
         """Rewind the video.
@@ -776,13 +775,8 @@ class FFPyPlayer(BaseMoviePlayer):
             Timestamp after rewinding the video.
 
         """
-        self._assertMediaPlayer()
-
-        timestamp = self.pts - seconds
-        self.seek(timestamp)
-
-        # after seeking
-        return self._handle.get_pts()
+        raise NotImplementedError(
+            "This feature is not available for the current backend.")
 
     def fastForward(self, seconds=5, log=False):
         """Fast-forward the video.
@@ -801,12 +795,8 @@ class FFPyPlayer(BaseMoviePlayer):
             Timestamp at new position after fast forwarding the video.
 
         """
-        self._assertMediaPlayer()
-
-        timestamp = self.pts + seconds
-        self.seek(timestamp)
-
-        return self._handle.get_pts()
+        raise NotImplementedError(
+            "This feature is not available for the current backend.")
 
     def replay(self, autoStart=True, log=False):
         """Replay the movie from the beginning.

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -383,6 +383,16 @@ class MovieStreamThreadFFPY(threading.Thread):
             if self._player.get_pause() != pauseReq:
                 self._player.set_pause(pauseReq)
 
+            # Don't get another frame until we need one, keeps video and audio
+            # synced.
+            movieTimeNow = self._player.get_pts()
+            nextFrameTime = lastTimestamp + frameInterval
+            if movieTimeNow < nextFrameTime:
+                # wait a bit until we need another frame
+                sleepTime = nextFrameTime - movieTimeNow
+                time.sleep(sleepTime)
+                continue
+
             # grab the most recent frame
             frameData, val = self._player.get_frame(show=True)
 


### PR DESCRIPTION
Fixes an issues where the decoder thread doesn't exit and prevents the script from exiting. Also added fixes to make video texture creation more efficient and a bunch of `NotImplementedError` exceptions for unsupported player functions.