### PR TITLE
BF: ensure we get (correct) timestamps at end of Routine

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -14,22 +14,6 @@ from .utils import checkValidFilePath
 from .base import _ComparisonMixin
 
 
-class DataEntry(dict):
-    """A helper class to represent one Entry (row/trial) in an ExperimentHandler.
-
-    This very simply extends dictionaries with an addData method.
-
-    This is only really needed because of stimuli needing to store their
-    stop time, which may only be known after that trial has technically
-    finished"""
-
-    def addData(self, name, value, overwriteExisting=True):
-        """Add `value` to the column called `name`"""
-        if not overwriteExisting and name in self:
-            return
-        self[name] = value
-
-
 class ExperimentHandler(_ComparisonMixin):
     """A container class for keeping track of multiple loops/handlers
 
@@ -101,7 +85,7 @@ class ExperimentHandler(_ComparisonMixin):
         self.savePickle = savePickle
         self.saveWideText = saveWideText
         self.dataFileName = dataFileName
-        self.thisEntry = DataEntry({})
+        self.thisEntry = {}
         self.entries = []  # chronological list of entries
         self._paramNamesSoFar = []
         self.dataNames = []  # names of all the data (eg. resp.keys)
@@ -245,9 +229,24 @@ class ExperimentHandler(_ComparisonMixin):
         self.thisEntry[name] = value
 
     def timestampOnFlip(self, win, name):
-        """Add a timestamp (in the future) to the current row"""
+        """Add a timestamp (in the future) to the current row
+
+        Parameters
+        ----------
+
+        win : psychopy.visual.Window
+
+            The window object that we'll base the timestamp flip on
+
+        name : str
+
+            The name of the column in the datafile being written,
+            such as 'myStim.stopped'
+        """
+        # make sure the name is used when writing the datafile
         if name not in self.dataNames:
             self.dataNames.append(name)
+        #
         win.timeOnFlip(self.thisEntry, name)
 
     def nextEntry(self):
@@ -265,7 +264,7 @@ class ExperimentHandler(_ComparisonMixin):
         if type(self.extraInfo) == dict:
             this.update(self.extraInfo)
         self.entries.append(this)
-        self.thisEntry = DataEntry({})
+        self.thisEntry = {}
 
     def getAllEntries(self):
         """Fetches a copy of all the entries including a final (orphan) entry

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -293,14 +293,14 @@ class BaseComponent:
         if self.type != "Sound":
             # for sounds, don't update to actual frame time because it will start
             # on the *expected* time of the flip
-            code += (f"win.timeOnFlip({params['name']}, 'started')"
+            code += (f"win.timeOnFlip({params['name']}, 'tStartRefresh')"
                      f"  # time at next scr refresh\n")
         if self.params['saveStartStop']:
             code += f"# add timestamp to datafile\n"
-            if self.type=='Sound' and self.params['syncToScreen']:
+            if self.type=='Sound' and self.params['syncScreenRefresh']:
                 # use the time we *expect* the flip
                 code += f"thisExp.addData('{params['name']}.started', tThisFlipGlobal)\n"
-            elif 'syncToScreen' in self.params and self.params['syncToScreen']:
+            elif 'syncScreenRefresh' in self.params and self.params['syncScreenRefresh']:
                 # use the time we *detect* the flip (in the future)
                 code += f"thisExp.timestampOnFlip(win, '{params['name']}.started')\n"
             else:
@@ -376,7 +376,7 @@ class BaseComponent:
                 )
         if self.params['saveStartStop']:
             code += f"# add timestamp to datafile\n"
-            if 'syncToScreen' in self.params and self.params['syncToScreen']:
+            if 'syncScreenRefresh' in self.params and self.params['syncScreenRefresh']:
                 # use the time we *detect* the flip (in the future)
                 code += f"thisExp.timestampOnFlip(win, '{params['name']}.stopped')\n"
             else:

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -289,11 +289,23 @@ class BaseComponent:
                 f"{params['name']}.frameNStart = frameN  # exact frame index\n"
                 f"{params['name']}.tStart = t  # local t and not account for scr refresh\n"
                 f"{params['name']}.tStartRefresh = tThisFlipGlobal  # on global time\n"
-                f"thisExp.timestampOnFlip(win, '{params['name']}.tStartRefresh')  # add timestamp in datafile\n"
                 )
-        if self.type != "Sound":  # for sounds, don't update to actual frame time
-                code += (f"win.timeOnFlip({params['name']}, 'tStartRefresh')"
-                         f"  # time at next scr refresh\n")
+        if self.type != "Sound":
+            # for sounds, don't update to actual frame time because it will start
+            # on the *expected* time of the flip
+            code += (f"win.timeOnFlip({params['name']}, 'started')"
+                     f"  # time at next scr refresh\n")
+        if self.params['saveStartStop']:
+            code += f"# add timestamp to datafile\n"
+            if self.type=='Sound' and self.params['syncToScreen']:
+                # use the time we *expect* the flip
+                code += f"thisExp.addData('{params['name']}.started', tThisFlipGlobal)\n"
+            elif 'syncToScreen' in self.params and self.params['syncToScreen']:
+                # use the time we *detect* the flip (in the future)
+                code += f"thisExp.timestampOnFlip(win, '{params['name']}.started')\n"
+            else:
+                # use the time ignoring any flips
+                code += f"thisExp.addData('{params['name']}.started', t)\n"
         buff.writeIndentedLines(code)
 
     def writeStartTestCodeJS(self, buff):
@@ -361,8 +373,15 @@ class BaseComponent:
         code = (f"# keep track of stop time/frame for later\n"
                 f"{params['name']}.tStop = t  # not accounting for scr refresh\n"
                 f"{params['name']}.frameNStop = frameN  # exact frame index\n"
-                f"thisExp.timestampOnFlip(win, '{params['name']}.tStopped')  # timestamp in datafile\n"
                 )
+        if self.params['saveStartStop']:
+            code += f"# add timestamp to datafile\n"
+            if 'syncToScreen' in self.params and self.params['syncToScreen']:
+                # use the time we *detect* the flip (in the future)
+                code += f"thisExp.timestampOnFlip(win, '{params['name']}.stopped')\n"
+            else:
+                # use the time ignoring any flips
+                code += f"thisExp.addData('{params['name']}.stopped', t)\n"
         buff.writeIndentedLines(code)
 
     def writeStopTestCodeJS(self, buff):

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -242,18 +242,6 @@ class BaseComponent:
 
             loop = currLoop.params['name']
             name = self.params['name']
-            if self.params['syncScreenRefresh'].val:
-                code = (
-                    f"{loop}.{addDataFunc}('{name}.started', {name}.tStartRefresh)\n"
-                    f"{loop}.{addDataFunc}('{name}.stopped', {name}.tStopRefresh)\n"
-                )
-            else:
-                code = (
-                    f"{loop}.{addDataFunc}('{name}.started', {name}.tStart)\n"
-                    f"{loop}.{addDataFunc}('{name}.stopped', {name}.tStop)\n"
-                )
-
-            buff.writeIndentedLines(code)
 
     def writeRoutineEndCodeJS(self, buff):
         """Write the code that will be called at the end of
@@ -300,7 +288,9 @@ class BaseComponent:
         code = (f"# keep track of start time/frame for later\n"
                 f"{params['name']}.frameNStart = frameN  # exact frame index\n"
                 f"{params['name']}.tStart = t  # local t and not account for scr refresh\n"
-                f"{params['name']}.tStartRefresh = tThisFlipGlobal  # on global time\n")
+                f"{params['name']}.tStartRefresh = tThisFlipGlobal  # on global time\n"
+                f"thisExp.timestampOnFlip(win, '{params['name']}.tStartRefresh')  # add timestamp in datafile\n"
+                )
         if self.type != "Sound":  # for sounds, don't update to actual frame time
                 code += (f"win.timeOnFlip({params['name']}, 'tStartRefresh')"
                          f"  # time at next scr refresh\n")
@@ -371,8 +361,8 @@ class BaseComponent:
         code = (f"# keep track of stop time/frame for later\n"
                 f"{params['name']}.tStop = t  # not accounting for scr refresh\n"
                 f"{params['name']}.frameNStop = frameN  # exact frame index\n"
-                f"win.timeOnFlip({params['name']}, 'tStopRefresh')"
-                f"  # time at next scr refresh\n")
+                f"thisExp.timestampOnFlip(win, '{params['name']}.tStopped')  # timestamp in datafile\n"
+                )
         buff.writeIndentedLines(code)
 
     def writeStopTestCodeJS(self, buff):


### PR DESCRIPTION
Until now, visual stimuli that run until the end of a Routine typically either showed no .stopped time in the csv file, or showed an incorrect value from "before" the start time (the stop time of the previous trial). The issue was caused by the fact that the stimulus technically disappears from screen on the first screen refresh of the *next* trial but by that point the trial loop has advanced onto the next trial and can't save the data (or saves it to the wrong row.

The log file always showed the correct time, so data were always available

This fix provides a new method `ExperimentHandler.timestampOnFlip(win, dataName)` which uses the `ExperimentHandler.thisEntry` dictionary, combined with a call to `win.timeOnFlip()` and finally we can save data to the current trial from a "future" event and the stimulus.stopped timestamps will be correct! 🚀 