### PR TITLE
DOCS: Cleanup psychopy > online index

### DIFF
--- a/docs/source/online/index.rst
+++ b/docs/source/online/index.rst
@@ -5,17 +5,25 @@
 Running and sharing studies online
 =======================================
 
-Online studies are realized via PsychoJS; the online counterpart of |PsychoPy|. To run your study online, these are the basic steps:
+Online studies are realized via `PsychoJS <https://github.com/psychopy/psychojs>`_; the online counterpart of |PsychoPy|. To run your study online, these are the basic steps:
 
-.. toctree::
-  :maxdepth: 1
+* Check the :ref:`features supported by PsychoJS <onlineStatus>` to ensure the components you need will work online.
+* Make your experiment in :ref:`Builder <builder>`.
+* :ref:`Configure the online settings <configureOnline>` of your experiment.
+* :ref:`Launch your study on Pavlovia.org <usingPavlovia>`.
 
-  Check whether the features you need are supported by PsychoJS <status>
-  Configure the online settings of your experiment <configureOnline>
-  Using resources in online studies <resources>
-  Launch your study on Pavlovia.org <usingPavlovia>
 
-Besides the basics, we've got the following tutorials:
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/oYhcBDK2O10" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+When making an experiment to run online, there are a few important considerations to make and we **highly** recommend reading through the considerations below, as they could save a lot of time in the long run!
+
+* Using :ref:`resources <handlingOnlineResources>` in online studies.
+* :ref:`Caveats and cautions <onlineCaveats>` (timing accuracy and web-browser support).
+
+Related links
+--------------
 
 .. toctree::
   :maxdepth: 1
@@ -24,7 +32,6 @@ Besides the basics, we've got the following tutorials:
   How to search for experiments of other researchers and share your own experiment <sharingExperiments>
   How to recruit participants and connect with online services <onlineParticipants>
   How to counterbalance participants across conditions <counterbalancingOnline>
-  Caveats and cautions (timing accuracy and web-browser support) <cautions>
   How does it work? <tech>
   Manually coding PsychoJS studies <psychojsCode>
 

--- a/docs/source/online/usingPavlovia.rst
+++ b/docs/source/online/usingPavlovia.rst
@@ -3,7 +3,7 @@
 .. _usingPavlovia:
 
 Launch your study on Pavlovia.org
------------------------------------
+========================================
 
 `Pavlovia.org <https://pavlovia.org/>`_ is a site created by the PsychoPy team to make it easy to:
 


### PR DESCRIPTION
The online landing page of psychopy docs was a bit messy and needed a clearer links to existing resources (YouTube) reformatting to make it easier to slot in the shelf docs.  