### PR TITLE
FF: `MovieStim` fixes and performance improvements

### DIFF
--- a/psychopy/demos/coder/stimuli/MovieStim.py
+++ b/psychopy/demos/coder/stimuli/MovieStim.py
@@ -4,7 +4,7 @@
 """
 Demo of MovieStim
 
-MovieStim opens a video file and displays it.
+MovieStim opens a video file and displays it on a window.
 
 """
 from psychopy import visual, core, event, constants
@@ -13,24 +13,35 @@ from psychopy import visual, core, event, constants
 win = visual.Window((800, 600), fullscr=False)
 
 # create a new movie stimulus instance
-mov = visual.MovieStim(win, 'default.mp4', size=(256, 256), flipVert=False,
-                       flipHoriz=False, loop=False)
+mov = visual.MovieStim(
+    win,
+    'default.mp4',    # path to video file
+    size=(256, 256),
+    flipVert=False,
+    flipHoriz=False,
+    loop=True,
+    noAudio=False,
+    volume=0.1,
+    autoStart=False)
 
 # print some information about the movie
 print('orig movie size={}'.format(mov.frameSize))
+print('orig movie duration={}'.format(mov.duration))
 
 # instructions
 instrText = "`s` Start/Resume\n`p` Pause\n`r` Restart\n`q` Stop and Close"
 instr = visual.TextStim(win, instrText, pos=(0.0, -0.75))
 
-# start playback
-mov.pause()  # start paused
-
 # main loop
 while mov.status != constants.FINISHED:
+    # draw the movie
     mov.draw()
+    # draw the instruction text
     instr.draw()
+    # flip buffers so they appear on the window
     win.flip()
+
+    # process keyboard input
     if event.getKeys('q'):   # quit
         break
     elif event.getKeys('s'):  # play/start
@@ -39,8 +50,14 @@ while mov.status != constants.FINISHED:
         mov.pause()
     elif event.getKeys('r'):  # restart/replay
         mov.replay()
+    elif event.getKeys('m'):  # volume up 5%
+        mov.volumeUp()
+    elif event.getKeys('n'):  # volume down 5%
+        mov.volumeDown()
 
+# stop the movie, this frees resources too
 mov.stop()
+
 # clean up and exit
 win.close()
 core.quit()


### PR DESCRIPTION
This PR makes: 
* `autoPlay`, `loop`, `volume` and `noAudio` work with the new player. 
* Greatly improves performance within the decoder thread which reduces 'juddering' that was visible with some movies. * Commands are passed to the thread using a queue rather than events which is more flexible. 
* Video looping also works now with a loop counter attribute too keep track of loops. 
* The `replay` command reloads the video and passes the correct parameters back to FFMPEG. 
* Attributes like `fps`, `pts`, `getPercentageComplete()`, etc. all work now.

