### PR TITLE
BF: Alias None and Default with 0 for Camera device

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -509,7 +509,7 @@ class BaseComponent:
                 if stopVal in ['', None, -1, 'None']:
                     stopVal = '-1'
                 buff.writeIndented(f"{compName}.setSound({params['sound']}, secs={stopVal}){endStr}\n")
-            elif paramName == 'movie':
+            elif paramName == 'movie' and params['backend'].val in ('moviepy', 'avbin', 'vlc'):
                 # we're going to do this for now ...
                 if params['units'].val == 'from exp settings':
                     unitsStr = "units=''"
@@ -530,7 +530,7 @@ class BaseComponent:
                             "    win=win, name='%s', %s,\n" % (
                                 params['name'], unitsStr))
                 else:
-                    code = ("%s = visual.MovieStim2(\n" % params['name'] +
+                    code = ("%s = visual.MovieStim(\n" % params['name'] +
                             "    win=win, name='%s', %s,\n" % (
                                 params['name'], unitsStr) +
                             "    noAudio=%(No audio)s,\n" % params)

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -645,6 +645,9 @@ class Camera:
              '_codecOpts': None,
              '_libOpts': None})
 
+        # alias device None or Default as being device 0
+        if device in (None, "None", "none", "Default", "default"):
+            device = 0
         # resolve getting the camera identifier
         if isinstance(device, int):  # get camera if integer
             try:

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -194,6 +194,9 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         # If given `default.mp4`, sub in full path
         if filename == "default.mp4":
             filename = Path(prefs.paths['resources']) / "default.mp4"
+        # If given a recording component, use its last clip
+        if hasattr(filename, "lastClip"):
+            filename = filename.lastClip
 
         self._filename = filename
         self._player.load(self._filename)

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -159,6 +159,9 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
     def filename(self, value):
         self.loadMovie(value)
 
+    def setMovie(self, value):
+        self.loadMovie(value)
+
     @property
     def autoStart(self):
         """Start playback when `.draw()` is called (`bool`)."""


### PR DESCRIPTION
Required for Camera to work with Builder, as the boilerplate supplies "Default" for device