### PR TITLE
BF in Py-JS transpiler: f string formatting now uses toFixed instead of toPrecision

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -179,7 +179,7 @@ class pythonTransformer(ast.NodeTransformer):
             precisionCall = ast.Call(
                 func=ast.Attribute(
                     value=conversionFunc,
-                    attr='toPrecision',
+                    attr='toFixed',
                     ctx=ast.Load()
                 ),
                 args=[ast.Constant(value=precision, kind=None)],


### PR DESCRIPTION
toPrecision will sometimes return strings in the format XXe+X, which is not what we wish for.