### PR TITLE
FF: Set default sample rate for microphone to 48kHz, atexit for threads

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -50,7 +50,7 @@ class MicrophoneComponent(BaseComponent):
                  stopType='duration (s)', stopVal=2.0,
                  startEstim='', durationEstim='',
                  channels='auto', device="default",
-                 sampleRate='Voice (16kHz)', maxSize=24000,
+                 sampleRate='DVD Audio (48kHz)', maxSize=24000,
                  outputType='default', speakTimes=True, trimSilent=False,
                  transcribe=True, transcribeBackend="Google", transcribeLang="en-US", transcribeWords="",
                  #legacy

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -9,6 +9,10 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import time
+import atexit
+from pathlib import Path
+
+from psychopy import prefs
 import math
 import numpy as np
 import threading
@@ -221,6 +225,12 @@ class MovieStreamThreadFFPyPlayer(threading.Thread):
         self._warmUpLock = threading.Lock()
         self._warmUpLock.acquire(blocking=False)
         # TODO - shutdown thread lock to prevent segfaulting
+
+        # call this on exit to shutdown the thread
+        def close_on_exit():
+            self.shutdown()
+
+        atexit.register(close_on_exit)
 
     def run(self):
         """Main sub-routine for this thread.


### PR DESCRIPTION
@RebeccaHirst  suggested that many users cannot use a sample rate other than 48kHz, so we'll set that as a default with this PR.