### PR TITLE
FF: a trialClock.reset() was accidentally removed from JS code instead of Py

### DIFF
--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -524,6 +524,7 @@ class Routine(list):
         code = ("TrialHandler.fromSnapshot(snapshot); // ensure that .thisN vals are up to date\n\n"
                 "//--- Prepare to start Routine '%(name)s' ---\n"
                 "t = 0;\n"
+                "%(name)sClock.reset(); // clock\n"
                 "frameN = -1;\n"
                 "continueRoutine = true; // until we're told otherwise\n"
                 % self.params)


### PR DESCRIPTION
In the refactoring of Python non-slip timing one of the calls to
trialClock.reset() in JS boilerplate was also accidentally removed