### PR TITLE
Fix setting color has no effect

### DIFF
--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -137,6 +137,10 @@ class Polygon(BaseShapeStim):
         self.__dict__['edges'] = edges
         self.radius = np.asarray(radius)
         self._calcVertices()
+        
+        # Set fillColor to False if color is used
+        if color is not None:
+            fillColor = False
 
         super(Polygon, self).__init__(
             win,


### PR DESCRIPTION
Only setting the color parameter which should set both the 'fillColor' and 'lineColor' has no effect since 'Polygon' parameter 'fillColor' is 'white'. BaseShapeStim then would draw the default white color instead of the color handed over to Polygon as argument.