### PR TITLE
NF: Add "live choice" ctrl and use it to control frame rate & resolution

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -262,6 +262,11 @@ class ParamCtrls():
             return None
         elif hasattr(ctrl, 'GetText'):
             return ctrl.GetText()
+        elif hasattr(ctrl, "getValue"):
+            val = ctrl.getValue()
+            if isinstance(self.valueCtrl, dialogs.ListWidget):
+                val = self.expInfoFromListWidget(val)
+            return val
         elif hasattr(ctrl, 'GetValue'):  # e.g. TextCtrl
             val = ctrl.GetValue()
             if isinstance(self.valueCtrl, dialogs.ListWidget):

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -140,6 +140,16 @@ class ParamCtrls():
                                                    val=str(param.val), valType=param.valType,
                                                    choices=param.allowedVals, labels=param.allowedLabels,
                                                    fieldName=fieldName, size=wx.Size(self.valueWidth, 24))
+        elif param.inputType == 'liveChoice':
+            comp = populator = None
+            if hasattr(param, "comp"):
+                comp = param.comp
+            if hasattr(param, "populator"):
+                populator = param.populator
+            self.valueCtrl = paramCtrls.LiveChoiceCtrl(parent, comp=comp,
+                                                       val=str(param.val), valType=param.valType,
+                                                       fieldName=fieldName, size=wx.Size(-1, 24),
+                                                       populator=populator)
         elif param.inputType == 'multiChoice':
             self.valueCtrl = paramCtrls.MultiChoiceCtrl(parent, valType=param.valType,
                                                         vals=param.val, choices=param.allowedVals, fieldName=fieldName,

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -146,7 +146,7 @@ class ParamCtrls():
                 comp = param.comp
             if hasattr(param, "populator"):
                 populator = param.populator
-            self.valueCtrl = paramCtrls.LiveChoiceCtrl(parent, comp=comp,
+            self.valueCtrl = paramCtrls.LiveChoiceCtrl(parent,
                                                        val=str(param.val), valType=param.valType,
                                                        fieldName=fieldName, size=wx.Size(-1, 24),
                                                        populator=populator)

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -296,6 +296,7 @@ class LiveChoiceCtrl(wx.ToggleButton, _ValidatorMixin, _HideMixin, _ParentMixin)
         # Store params
         self.fieldName = fieldName
         self.parent = parent
+        self.valType = valType
 
         # Assign populator function
         if populator is None:
@@ -374,10 +375,10 @@ class LiveChoiceCtrl(wx.ToggleButton, _ValidatorMixin, _HideMixin, _ParentMixin)
         if value in self.values:
             # If value is in list of expected, set button text to corresponding label
             i = self.values.index(value)
-            self.SetLabel(self.labels[i])
+            self.SetLabel(str(self.labels[i]))
         else:
             # Otherwise, set button text as value
-            self.SetLabel(value)
+            self.SetLabel(str(value))
 
     def getValue(self):
         return self.value

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -67,6 +67,19 @@ class _ValidatorMixin:
             self.SetFont(fontNormal)
 
 
+class _ParentMixin:
+    @property
+    def notebook(self):
+        # Start off with self
+        target = self
+        # Keep going up a generation until we hit a ParamNotebook or a dead end
+        while type(target).__name__ != "ParamNotebook" and hasattr(target, "GetParent"):
+            target = target.GetParent()
+        # If we have a Param Notebook, return it
+        if type(target).__name__ == "ParamNotebook":
+            return target
+
+
 class _FileMixin:
     @property
     def rootDir(self):
@@ -269,20 +282,20 @@ class IntCtrl(wx.SpinCtrl, _ValidatorMixin, _HideMixin):
 BoolCtrl = wx.CheckBox
 
 
-class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin):
+class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
     """
     Similar to a choice ctrl, but allowed values are updating each time the control is clicked - meaning they can
     change dynamically each time according to other values.
     """
-    def __init__(self, parent, comp,
-                 val=None, valType="code", fieldName="",
+    def __init__(self, parent,
+                 val=None, valType="str", fieldName="",
                  populator=None,
                  size=wx.Size(-1, 24)):
         # Make button
         wx.Button.__init__(self, parent, size=size, style=wx.NO_BORDER | wx.BU_LEFT)
         # Store params
         self.fieldName = fieldName
-        self.comp = comp
+        self.parent = parent
 
         # Assign populator function
         if populator is None:

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -330,7 +330,7 @@ class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin):
         self.menu.Bind(wx.EVT_MENU, self.setSelection)
         # Populate menu from populator function output
         for i in range(len(self.values)):
-            item = self.menu.Append(i, self.labels[i])
+            item = self.menu.Append(i, str(self.labels[i]))
             item.value = self.values[i]
         # Show menu
         self.PopupMenu(self.menu, (0, self.Size[1]))

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -282,7 +282,7 @@ class IntCtrl(wx.SpinCtrl, _ValidatorMixin, _HideMixin):
 BoolCtrl = wx.CheckBox
 
 
-class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
+class LiveChoiceCtrl(wx.ToggleButton, _ValidatorMixin, _HideMixin, _ParentMixin):
     """
     Similar to a choice ctrl, but allowed values are updating each time the control is clicked - meaning they can
     change dynamically each time according to other values.
@@ -292,7 +292,7 @@ class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
                  populator=None,
                  size=wx.Size(-1, 24)):
         # Make button
-        wx.Button.__init__(self, parent, size=size, style=wx.NO_BORDER | wx.BU_LEFT)
+        wx.ToggleButton.__init__(self, parent, size=size, style=wx.NO_BORDER | wx.BU_LEFT)
         # Store params
         self.fieldName = fieldName
         self.parent = parent
@@ -308,7 +308,7 @@ class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
 
         # Bind to menu show function
         self.menu = wx.Menu()
-        self.Bind(wx.EVT_BUTTON, self.onClick)
+        self.Bind(wx.EVT_TOGGLEBUTTON, self.onClick)
 
     def populate(self, evt=None):
         # Check how many arguments the populator function takes
@@ -333,7 +333,11 @@ class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
             f"Labels: {self.labels}\n"
         )
 
+    def onMenuDefocus(self, evt=None):
+        self.SetValue(False)
+
     def onClick(self, evt=None):
+        self.SetValue(True)
         self.populate(evt=evt)
 
         # Clear menu
@@ -341,6 +345,7 @@ class LiveChoiceCtrl(wx.Button, _ValidatorMixin, _HideMixin, _ParentMixin):
         self.menu = wx.Menu()
         # Rebind selection function
         self.menu.Bind(wx.EVT_MENU, self.setSelection)
+        self.menu.Bind(wx.EVT_MENU_CLOSE, self.onMenuDefocus)
         # Populate menu from populator function output
         for i in range(len(self.values)):
             item = self.menu.Append(i, str(self.labels[i]))

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -65,7 +65,7 @@ class CameraComponent(BaseComponent):
 
             return (
                 list(range(len(cams))),
-                list(cams)
+                cams
             )
 
 
@@ -101,26 +101,26 @@ class CameraComponent(BaseComponent):
                     [None],
                     ["highest"]
                 )
-            # Get list of camera specs
+            # Get list of cameras
             cams = getCameras()
 
             # Get selected camera
             camera = params['device'].val
             if camera not in cams:
-                camera = list(cams)[0]
-            # Filter for only chosen camera
-            camsList = cams[camera]
+                camera = cams[0]
+            # Get modes for chosen camera
+            modes = getCameraInfo(camera)
 
             # Get selected framerate
             fr = params['frameRate'].val
-            print(fr)
             if fr in (None, "None", "none", "default", "Default", "highest", "Highest"):
                 fr = None
             # Filter for only chosen frame rate
-            camsList = [cam for cam in camsList if str(cam.frameRate) == str(fr) or fr is None]
+            if fr is not None:
+                modes = [md for md in modes if int(md.frameRate[0] / md.frameRate[1]) == int(fr)]
 
             # Get values
-            values = [cam.frameSize for cam in camsList]
+            values = [md.frameSize for md in modes]
             values = list(set(values))
             # Sort values by screen area
             values.sort(key=lambda val: np.prod(val), reverse=True)
@@ -151,23 +151,23 @@ class CameraComponent(BaseComponent):
                     [None],
                     ["highest"]
                 )
-            # Get list of camera specs
+            # Get list of cameras
             cams = getCameras()
 
             # Get selected camera
             camera = params['device'].val
             if camera not in cams:
-                camera = list(cams)[0]
-            # Filter for only chosen camera
-            camsList = cams[camera]
+                camera = cams[0]
+            # Get modes for chosen camera
+            modes = getCameraInfo(camera)
 
             # Get values
-            values = [cam.frameRate for cam in camsList]
+            values = [int(md.frameRate[0] / md.frameRate[1]) for md in modes]
             values = list(set(values))
-            # Sort values by screen area
+            # Sort values by refresh rate
             values.sort(reverse=True)
             # Get labels
-            labels = [str(fr) for fr in values]
+            labels = values
 
             return (
                 values,
@@ -374,4 +374,17 @@ def getCameras():
         from psychopy.hardware.camera import getCameras
         return getCameras()
     except:
-        return {}
+        return []
+
+def getCameraInfo(camera):
+    """
+    Wrapper around psychopy.hardware.camera.getCameraInfo which tries to import the module locally and handles
+    failure cleanly.
+    """
+    try:
+        from psychopy.hardware.camera import getCameraInfo
+        return getCameraInfo(camera)
+    except:
+        return []
+
+

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -56,15 +56,26 @@ class CameraComponent(BaseComponent):
         self.exp.requireImport(importName="microphone", importFrom="psychopy.sound")
 
         # Basic
+        def _devicePopulator():
+            # Get list of camera specs
+            try:
+                from psychopy.hardware.camera import getCameras
+                cams = getCameras()
+            except:
+                cams = {}
+
+            return list(range(len(cams) + 1)), ["default"] + list(cams)
+
+
         msg = _translate("What device would you like to use to record video? This will only affect local "
                          "experiments - online experiments ask the participant which device to use.")
         self.params['device'] = Param(
-            device, valType='str', inputType="choice", categ="Basic",
-            allowedVals=list(devices),
-            allowedLabels=[d.title() for d in list(devices)],
+            device, valType='str', inputType="liveChoice", categ="Basic",
             hint=msg,
             label=_translate("Video Device")
         )
+        self.params['device'].comp = self
+        self.params['device'].populator = _devicePopulator
 
         msg = _translate("What device would you like to use to record audio? This will only affect local "
                          "experiments - online experiments ask the participant which device to use.")
@@ -77,7 +88,6 @@ class CameraComponent(BaseComponent):
         )
 
 
-        # Not implemented (yet!)
         # # Hardware
         # msg = _translate("Resolution (w x h) to record to, leave blank to use device default.")
         # self.params['resolution'] = Param(

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -92,18 +92,27 @@ class CameraComponent(BaseComponent):
 
         # Hardware
         def _resolutionPopulator(ctrl):
+            # Get params from dlg
+            try:
+                params = ctrl.notebook.getParams()
+            except KeyError:
+                # On first call, may get a KeyError as some components aren't made yet, in this case just skip
+                return (
+                    [None],
+                    ["default"]
+                )
             # Get list of camera specs
             cams = getCameras()
 
             # Get selected camera
-            camera = ctrl.comp.params['device'].val
+            camera = params['device'].val
             if camera not in cams:
                 camera = list(cams)[0]
             # Filter for only chosen camera
             camsList = cams[camera]
 
             # Get selected framerate
-            fr = ctrl.comp.params['frameRate'].val
+            fr = params['frameRate'].val
             print(fr)
             if fr in (None, "None", "none", "default", "Default", "highest", "Highest"):
                 fr = None
@@ -133,11 +142,20 @@ class CameraComponent(BaseComponent):
         self.params['resolution'].populator = _resolutionPopulator
 
         def _frameRatePopulator(ctrl):
+            # Get params from dlg
+            try:
+                params = ctrl.notebook.getParams()
+            except KeyError:
+                # On first call, may get a KeyError as some components aren't made yet, in this case just skip
+                return (
+                    [None],
+                    ["default"]
+                )
             # Get list of camera specs
             cams = getCameras()
 
             # Get selected camera
-            camera = ctrl.comp.params['device'].val
+            camera = params['device'].val
             if camera not in cams:
                 camera = list(cams)[0]
             # Filter for only chosen camera

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -30,7 +30,7 @@ class CameraComponent(BaseComponent):
             stopType='duration (s)', stopVal='', durationEstim='',
             device="Default", mic="Default",
             # Hardware
-            resolution="(960, 540)", frameRate="30",
+            resolution=None, frameRate=None,
             # Data
             saveFile=True,
             outputFileType="mp4", codec="h263",

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -242,6 +242,7 @@ class CameraComponent(BaseComponent):
         code = (
             "%(name)s = camera.Camera(\n"
             "    device=%(device)s, name='%(name)s', mic=microphone.Microphone(device=%(mic)s),\n"
+            "    frameRate=%(frameRate)s, size=%(resolution)s\n"
             ")\n"
             "# Switch on %(name)s\n"
             "%(name)s.open()\n"

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -30,7 +30,7 @@ class CameraComponent(BaseComponent):
             stopType='duration (s)', stopVal='', durationEstim='',
             device="Default", mic="Default",
             # Hardware
-            resolution="", frameRate="",
+            resolution="(960, 540)", frameRate="30",
             # Data
             saveFile=True,
             outputFileType="mp4", codec="h263",

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -99,7 +99,7 @@ class CameraComponent(BaseComponent):
                 # On first call, may get a KeyError as some components aren't made yet, in this case just skip
                 return (
                     [None],
-                    ["default"]
+                    ["highest"]
                 )
             # Get list of camera specs
             cams = getCameras()
@@ -149,7 +149,7 @@ class CameraComponent(BaseComponent):
                 # On first call, may get a KeyError as some components aren't made yet, in this case just skip
                 return (
                     [None],
-                    ["default"]
+                    ["highest"]
                 )
             # Get list of camera specs
             cams = getCameras()

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -12,7 +12,7 @@ experimenter to create movie stimuli or instructions.
 # Distributed under the terms of the GNU General Public License (GPL).
 
 __all__ = ['CameraNotFoundError', 'Camera', 'CameraInfo', 'StreamData',
-           'getCameras']
+           'getCameras', 'getCameraInfo']
 
 import glob
 import platform


### PR DESCRIPTION
LiveChoiceCtrl sets its values when clicked on, rather than when created, meaning that they can update live according to what's available given the values of other params. Essentially, rather than being passed a set of values & labels on init, it's passed a function that returns values & labels - it executes this function when the menu opens.

Used here to set resolution and frame rate but only show the options available to the current device.