### PR TITLE
build(deps): removed redundant version constraints

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -75,17 +75,16 @@ install_requires =
     # Platform-specific dependencies.
     python-vlc == 3.0.11115; platform_system == "Windows"
     python-vlc >= 3.0.12118; platform_system != "Windows"
-    javascripthon; python_version >= "3.5"
+    javascripthon
     pyglet >= 1.5; platform_system == "Darwin"
     pyglet < 1.5; platform_system != "Darwin"
-    pathlib; python_version < "3.4"
     questplus >= 2019.3; python_version >= "3.6"
-    imageio >= 2.5; python_version >= "3"
-    imageio-ffmpeg; python_version >= "3"
+    imageio >= 2.5
+    imageio-ffmpeg
     pyparallel; platform_system == "Linux"
     pyWinhook; platform_system == "Windows"
     pyqmix >= 2018.12.13; platform_system == "Windows"
-    pyqt5; python_version >= "3"
+    pyqt5
     wxPython != 4.0.2, != 4.0.3; platform_system != "Linux"
     pypiwin32; platform_system == "Windows"
     pyobjc-core < 8.0; platform_system == "Darwin"
@@ -96,7 +95,7 @@ install_requires =
     websocket_client
     # Hardware specific dependencies
     tobii-research; python_version <= "3.8"
-    egi-pynetstation; python_version >= "3"
+    egi-pynetstation
     markdown-it-py
     ffpyplayer
 


### PR DESCRIPTION
Also removed not needed pathlib (needed for <3.4, but psychopy currently targets >3.6)

Found it as was looking into the crazy amount of time it to poetry to generate a lockfile for eeg-notebooks: https://github.com/NeuroTechX/eeg-notebooks/pull/22

No idea if it actually impacts the time taken for lockfile generation, though.