### PR TITLE
BF: Fixes to 3D rendering

### DIFF
--- a/psychopy/CHANGELOG.txt
+++ b/psychopy/CHANGELOG.txt
@@ -52,6 +52,7 @@ PsychoPy 2022.2
   (they were always correct in the log file)
 - Python: Better timing in non-slip Routines. Previously the non-slip timer corrected for overshoots but
   not undershoots. This is now fixed.
+- Python: 3D rendering should be working again.
 
 **Also:**
 

--- a/psychopy/demos/coder/stimuli/stim3d.py
+++ b/psychopy/demos/coder/stimuli/stim3d.py
@@ -12,7 +12,7 @@ from psychopy.tools.gltools import createTexImage2dFromFile
 from psychopy import event
 
 # open a window to render the shape
-win = visual.Window((600, 600), allowGUI=False, monitor='testMonitor')
+win = visual.Window((600, 600), monitor='testMonitor')
 
 # setup scene lights
 redLight = LightSource(win, pos=(0, 1, 0), diffuseColor=(.5, 0, 0),

--- a/psychopy/demos/coder/stimuli/stim3d.py
+++ b/psychopy/demos/coder/stimuli/stim3d.py
@@ -7,23 +7,12 @@ This demonstrates how to render 3D stimuli, set lighting and adjust materials.
 """
 from psychopy import core
 import psychopy.visual as visual
-from psychopy.visual import LightSource, BlinnPhongMaterial, BoxStim
+from psychopy.visual import LightSource, BlinnPhongMaterial, BoxStim, SphereStim
 from psychopy.tools.gltools import createTexImage2dFromFile
 from psychopy import event
 
 # open a window to render the shape
 win = visual.Window((600, 600), monitor='testMonitor')
-
-# setup scene lights
-redLight = LightSource(win, pos=(0, 1, 0), diffuseColor=(.5, 0, 0),
-                       specularColor=(.5, .5, .5), lightType='directional')
-blueLight = LightSource(win, pos=(5, -3, 0), diffuseColor=(0, 0, .5),
-                        specularColor=(.5, .5, .5), lightType='point')
-greenLight = LightSource(win, pos=(-5, -3, 0), diffuseColor=(0, .5, 0),
-                         specularColor=(.5, .5, .5), lightType='point')
-
-# assign the lights to the scene
-win.lights = [redLight, blueLight, greenLight]
 
 # create the stimulus object, try other classes like SphereStim and PlaneStim
 boxStim = BoxStim(win, size=(.2, .2, .2))
@@ -32,21 +21,58 @@ boxStim = BoxStim(win, size=(.2, .2, .2))
 boxStim.thePose.pos = (0, 0, -3)
 
 # create a white material and assign it
-boxStim.material = BlinnPhongMaterial(win, diffuseColor=(1, 1, 1),
-                                      specularColor=(0, 0, 0), shininess=125.0)
+boxStim.material = BlinnPhongMaterial(
+    win, diffuseColor=(1, 1, 1), specularColor=(0, 0, 0), shininess=125.0)
 
 # load a diffuse texture
 boxStim.material.diffuseTexture = createTexImage2dFromFile('face.jpg')
 
-# set the box 3 meters away from the observer by editing the stimuli's rigid
+# set the box 3 units away from the observer by editing the stimuli's rigid
 # body class
-boxStim.thePose.pos = (0, 0, -3)
+boxStim.thePose.pos = (0, 0, -1)
+
+# setup scene lights
+redLight = LightSource(
+    win,
+    pos=(0, 0.5, -1),
+    diffuseColor='red',
+    specularColor='red',
+    lightType='point')
+greenLight = LightSource(
+    win,
+    pos=(-0.5, -0.5, -1),
+    diffuseColor='lightgreen',
+    specularColor='lightgreen',
+    lightType='point')
+blueLight = LightSource(
+    win,
+    pos=(0.5, -0.5, -1),
+    diffuseColor='blue',
+    specularColor='blue',
+    lightType='point')
+
+# assign the lights to the scene
+win.lights = [redLight, greenLight, blueLight]
+
+# Draw spheres at the positions of the light sources to show them. Note that the
+# spheres themselves are not emitting light, just made to appear so.
+redSphere = SphereStim(win, radius=0.1)
+redSphere.thePose.pos = redLight.pos
+redSphere.material = BlinnPhongMaterial(win, emissionColor='red')
+
+greenSphere = SphereStim(win, radius=0.1)
+greenSphere.thePose.pos = greenLight.pos
+greenSphere.material = BlinnPhongMaterial(win, emissionColor='green')
+
+blueSphere = SphereStim(win, radius=0.1)
+blueSphere.thePose.pos = blueLight.pos
+blueSphere.material = BlinnPhongMaterial(win, emissionColor='blue')
 
 # text to overlay
 message = visual.TextStim(
     win, text='Any key to quit', pos=(0, -0.8), units='norm')
 
-angle = 0.0
+angle = 0.0  # box angle
 
 while not event.getKeys():
     win.setPerspectiveView()  # set the projection, must be done every frame
@@ -59,9 +85,18 @@ while not event.getKeys():
     # draw the stimulus
     boxStim.draw()
 
-    win.resetEyeTransform()  # reset the transformation to draw 2D stimuli
-    # disable lights for 2D stimuli, or else colors will be modulated
+    # Disable lights for 2D stimuli and light source shapes, or else colors will
+    # be modulated.
     win.useLights = False
+
+    # Disabling lighting will cause these not to appear shaded by other light
+    # sources in the scene.
+    redSphere.draw()
+    greenSphere.draw()
+    blueSphere.draw()
+
+    win.resetEyeTransform()  # reset the transformation to draw 2D stimuli
+
     message.draw()
 
     win.flip()

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -96,10 +96,15 @@ import pyglet.gl as GL  # using Pyglet for now
 from contextlib import contextmanager
 from PIL import Image
 import numpy as np
-import os, sys
+import os
+import sys
+import platform
 import warnings
 import psychopy.tools.mathtools as mt
 from psychopy.visual.helpers import setColor
+
+
+_thisPlatform = platform.system()
 
 # create a query counter to get absolute GPU time
 
@@ -2280,8 +2285,13 @@ def createVAO(attribBuffers, indexBuffer=None, attribDivisors=None, legacy=False
 
     # create a vertex buffer ID
     vaoId = GL.GLuint()
-    GL.glGenVertexArrays(1, ctypes.byref(vaoId))
-    GL.glBindVertexArray(vaoId)
+
+    if _thisPlatform != 'Darwin':
+        GL.glGenVertexArrays(1, ctypes.byref(vaoId))
+        GL.glBindVertexArray(vaoId)
+    else:
+        GL.glGenVertexArraysAPPLE(1, ctypes.byref(vaoId))
+        GL.glBindVertexArrayAPPLE(vaoId)
 
     # add attribute pointers
     activeAttribs = {}
@@ -2344,7 +2354,10 @@ def createVAO(attribBuffers, indexBuffer=None, attribDivisors=None, legacy=False
         for key, val in attribDivisors.items():
             GL.glVertexAttribDivisor(key, val)
 
-    GL.glBindVertexArray(0)
+    if _thisPlatform != 'Darwin':
+        GL.glBindVertexArray(0)
+    else:
+        GL.glBindVertexArrayAPPLE(0)
 
     return VertexArrayInfo(vaoId.value,
                            count,
@@ -2387,7 +2400,11 @@ def drawVAO(vao, mode=GL.GL_TRIANGLES, start=0, count=None, instanceCount=None,
 
     """
     # draw the array
-    GL.glBindVertexArray(vao.name)
+    if _thisPlatform != 'Darwin':
+        GL.glBindVertexArray(vao.name)
+    else:
+        GL.glBindVertexArrayAPPLE(vao.name)
+
     if count is None:
         count = vao.count
     else:
@@ -2412,7 +2429,10 @@ def drawVAO(vao, mode=GL.GL_TRIANGLES, start=0, count=None, instanceCount=None,
         GL.glFlush()
 
     # reset
-    GL.glBindVertexArray(0)
+    if _thisPlatform != 'Darwin':
+        GL.glBindVertexArray(0)
+    else:
+        GL.glBindVertexArrayAPPLE(0)
 
 
 def deleteVAO(vao):

--- a/psychopy/visual/shaders.py
+++ b/psychopy/visual/shaders.py
@@ -396,17 +396,18 @@ void main (void)
         // realism
         vec4 emission = clamp(gl_FrontMaterial.emission, 0.0, 1.0);
         
-        finalColor += ambient + emission + attenuation * (diffuse + specular);
+        finalColor += (ambient + emission) + attenuation * (diffuse + specular);
     }
     gl_FragColor = finalColor;  // use texture alpha
 #else
-    // no lights, only track ambient component, frontColor modulates ambient
+    // no lights, only track ambient and emission component
+    vec4 emission = clamp(gl_FrontMaterial.emission, 0.0, 1.0);
     vec4 ambient = gl_FrontLightProduct[0].ambient * gl_LightModel.ambient; 
     ambient = clamp(ambient, 0.0, 1.0); 
 #ifdef DIFFUSE_TEXTURE
-    gl_FragColor = ambient * texture2D(diffTexture, gl_TexCoord[0].st);
+    gl_FragColor = (ambient + emission) * texture2D(diffTexture, gl_TexCoord[0].st);
 #else
-    gl_FragColor = ambient;
+    gl_FragColor = ambient + emission;
 #endif
 #endif
 }

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -45,7 +45,7 @@ class LightSource:
                  diffuseColor=(1., 1., 1.),
                  specularColor=(1., 1., 1.),
                  ambientColor=(0., 0., 0.),
-                 colorSpace='rgb1',
+                 colorSpace='rgb',
                  contrast=1.0,
                  lightType='point',
                  attenuation=(1, 0, 0)):
@@ -219,8 +219,7 @@ class LightSource:
         """Diffuse color for the light source (`psychopy.color.Color`,
         `ArrayLike` or None).
         """
-        if hasattr(self, '_diffuseColor'):
-            return self._diffuseColor.render(self.colorSpace)
+        return self._diffuseColor.render(self.colorSpace)
 
     @diffuseColor.setter
     def diffuseColor(self, value):
@@ -662,7 +661,7 @@ class BlinnPhongMaterial:
     """
     def __init__(self,
                  win=None,
-                 diffuseColor=(.5, .5, .5),
+                 diffuseColor=(-1., -1., -1.),
                  specularColor=(-1., -1., -1.),
                  ambientColor=(-1., -1., -1.),
                  emissionColor=(-1., -1., -1.),
@@ -694,15 +693,15 @@ class BlinnPhongMaterial:
         self._ptrAmbient = None
         self._ptrEmission = None
 
-        self.colorSpace = colorSpace
-        self.opacity = opacity
-        self.contrast = contrast
-        self.face = face
-
         self.diffuseColor = diffuseColor
         self.specularColor = specularColor
         self.ambientColor = ambientColor
         self.emissionColor = emissionColor
+
+        self.colorSpace = colorSpace
+        self.opacity = opacity
+        self.contrast = contrast
+        self.face = face
 
         self._diffuseTexture = diffuseTexture
         self._normalTexture = None
@@ -1082,8 +1081,9 @@ class BlinnPhongMaterial:
         GL.glDisable(GL.GL_COLOR_MATERIAL)  # disable color tracking
         face = self._face
 
-        # number of scene lights
-        nLights = len(self.win.lights)
+        # check if lighting is enabled, otherwise don't render lights
+        nLights = len(self.win.lights) if self.win.useLights else 0
+
         useTextures = useTextures and self.diffuseTexture is not None
         shaderKey = (nLights, useTextures)
         gt.useProgram(self.win._shaders['stim3d_phong'][shaderKey])


### PR DESCRIPTION
Some fixes for 3D stimuli since they have been broken for a while apparently. The `stim3d.py` demo should work fine now. Fixes include:

* Use `glBindVertexArrayAPPLE` and `glGenVertexArrayAPPLE` when the platform is `Darwin`. This fixes issues with rendering people experienced on that platform (also helps that I have a Mac now).
* Fixed material and lighting classes to use `psychopy.colors.Color` to specify their properties.