### PR TITLE
BF: Set markerPos AFTER rating when resetting slider

### DIFF
--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -407,8 +407,8 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         """Resets the slider to its starting state (so that it can be restarted
         on each trial with a new stimulus)
         """
-        self.markerPos = self.startValue
         self.rating = None  # this is reset to None, whatever the startValue
+        self.markerPos = self.startValue
         self.history = []
         self.rt = None
         self.responseClock.reset()


### PR DESCRIPTION
Otherwise Slider resets with no value regardless of startVal