### PR TITLE
FF/NF: Seeking support for `MovieStim`

### DIFF
--- a/psychopy/demos/coder/stimuli/MovieStim.py
+++ b/psychopy/demos/coder/stimuli/MovieStim.py
@@ -19,17 +19,18 @@ mov = visual.MovieStim(
     size=(256, 256),
     flipVert=False,
     flipHoriz=False,
-    loop=True,
+    loop=False,
     noAudio=False,
     volume=0.1,
-    autoStart=False)
+    autoStart=False,
+    replayOnStop=True)
 
 # print some information about the movie
 print('orig movie size={}'.format(mov.frameSize))
 print('orig movie duration={}'.format(mov.duration))
 
 # instructions
-instrText = "`s` Start/Resume\n`p` Pause\n`r` Restart\n`q` Stop and Close"
+instrText = "`z` Start/Resume\n`x` Pause\n`b` Restart\n`q` Stop and Close"
 instr = visual.TextStim(win, instrText, pos=(0.0, -0.75))
 
 # main loop
@@ -44,19 +45,23 @@ while mov.status != constants.FINISHED:
     # process keyboard input
     if event.getKeys('q'):   # quit
         break
-    elif event.getKeys('s'):  # play/start
+    elif event.getKeys('z'):  # play/start
         mov.play()
-    elif event.getKeys('p'):  # pause
+    elif event.getKeys('x'):  # pause
         mov.pause()
-    elif event.getKeys('r'):  # restart/replay
+    elif event.getKeys('b'):  # replay
         mov.replay()
-    elif event.getKeys('m'):  # volume up 5%
+    elif event.getKeys('n'):  # rewind 1 second
+        mov.rewind(1)
+    elif event.getKeys('m'):  # forward 1 second
+        mov.fastForward(1)
+    elif event.getKeys('a'):  # volume up 5%
         mov.volumeUp()
-    elif event.getKeys('n'):  # volume down 5%
+    elif event.getKeys('s'):  # volume down 5%
         mov.volumeDown()
 
 # stop the movie, this frees resources too
-mov.stop()
+mov.unload()  # unloads when `mov.status == constants.FINISHED`
 
 # clean up and exit
 win.close()

--- a/psychopy/demos/coder/stimuli/MovieStim.py
+++ b/psychopy/demos/coder/stimuli/MovieStim.py
@@ -30,10 +30,10 @@ print('orig movie size={}'.format(mov.frameSize))
 print('orig movie duration={}'.format(mov.duration))
 
 # instructions
-instrText = "`z` Start/Resume\n`x` Pause\n`b` Restart\n`q` Stop and Close"
+instrText = "`r` Play/Resume\n`p` Pause\n`s` Stop\n`q` Stop and Close"
 instr = visual.TextStim(win, instrText, pos=(0.0, -0.75))
 
-# main loop
+# main loop, exit when the status is finished
 while mov.status != constants.FINISHED:
     # draw the movie
     mov.draw()
@@ -45,20 +45,12 @@ while mov.status != constants.FINISHED:
     # process keyboard input
     if event.getKeys('q'):   # quit
         break
-    elif event.getKeys('z'):  # play/start
+    elif event.getKeys('r'):  # play/start
         mov.play()
-    elif event.getKeys('x'):  # pause
+    elif event.getKeys('p'):  # pause
         mov.pause()
-    elif event.getKeys('b'):  # replay
-        mov.replay()
-    elif event.getKeys('n'):  # rewind 1 second
-        mov.rewind(1)
-    elif event.getKeys('m'):  # forward 1 second
-        mov.fastForward(1)
-    elif event.getKeys('a'):  # volume up 5%
-        mov.volumeUp()
-    elif event.getKeys('s'):  # volume down 5%
-        mov.volumeDown()
+    elif event.getKeys('s'):  # stop the movie
+        mov.stop()
 
 # stop the movie, this frees resources too
 mov.unload()  # unloads when `mov.status == constants.FINISHED`

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -75,10 +75,6 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         the movie is done. Default is `False`.
     autoStart : bool
         Automatically begin playback of the video when `flip()` is called.
-    replayOnStop : bool
-        Seek to the beginning of the video when `stop()` is called instead of
-        unloading the video. If `True`, the video will still be unloaded if
-        `stop()` is called when `status==FINISHED`.
 
     """
     def __init__(self,
@@ -103,8 +99,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
                  depth=0.0,
                  noAudio=False,
                  interpolate=True,
-                 autoStart=True,
-                 replayOnStop=False):
+                 autoStart=True):
 
         # # check if we have the VLC lib
         # if not haveFFPyPlayer:
@@ -138,7 +133,6 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.loop = loop
         self._recentFrame = None
         self._autoStart = autoStart
-        self._replayOnStop = replayOnStop
 
         # OpenGL data
         self.interpolate = True

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -257,7 +257,9 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         """
         # get the current movie frame for the video time
-        self._recentFrame = self._player.getMovieFrame()
+        newFrameFromPlayer = self._player.getMovieFrame()
+        if newFrameFromPlayer is not None:
+            self._recentFrame = newFrameFromPlayer
 
         # only do a pixel transfer on valid frames
         if self._recentFrame is not None:

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -365,11 +365,8 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
     def stop(self, log=True):
         """Stop the current point in the movie (sound will stop, current frame
-        will not advance). Once stopped the movie cannot be restarted - it must
-        be loaded again.
-
-        If `replayOnStop==True` or `status!=FINISHED` calling stop will not
-        unload the movie, rather restart it.
+        will not advance and remain on-screen). Once stopped the movie can be
+        restarted from the beginning by calling `play()`.
 
         Parameters
         ----------
@@ -377,11 +374,10 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
             Log this event.
 
         """
-        if self._replayOnStop and self.status != FINISHED:
-            self.replay(log=log)
-        else:
-            self.status = FINISHED
-            self.unload(log=log)
+        # stop should reset the video to the start and pause
+        self._player.pause()
+        self._player.seek(0.0)
+        self.status = NOT_STARTED
 
     def seek(self, timestamp, log=True):
         """Seek to a particular timestamp in the movie.
@@ -440,6 +436,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         """
         self._player.replay(log=log)
+        self.status = NOT_STARTED
 
     # --------------------------------------------------------------------------
     # Audio stream control methods


### PR DESCRIPTION
This PR adds basic seeking support to `MovieStim`. This allows us to call `stop()` to soft-restart the video instead of doing a costly load/unload cycle. I also made sure that status flags are the ones actually used by builder and not the internal state ones.