### PR TITLE
FF: Raise exceptions when a script subprocess exits abnormally

### DIFF
--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -68,11 +68,11 @@ def generateScript(experimentPath, exp, target="PsychoPy"):
         sys.stdout.write(stdout)
         sys.stderr.write(stderr)
 
-        # we got a non-zero error code
+        # we got a non-zero error code, raise an error
         if output.returncode != 0:
             raise ChildProcessError(
-                "Failed to compile `{}`. Check output for more "
-                "information.".format(exp.filename))
+                'Error: process exited with code {}, check log for '
+                'output.'.format(output.returncode))
 
     else:
         compileScript(infile=exp, version=None, outfile=filename)

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -67,6 +67,13 @@ def generateScript(experimentPath, exp, target="PsychoPy"):
         stdout, stderr = output.communicate()
         sys.stdout.write(stdout)
         sys.stderr.write(stderr)
+
+        # we got a non-zero error code
+        if output.returncode != 0:
+            raise ChildProcessError(
+                "Failed to compile `{}`. Check output for more "
+                "information.".format(exp.filename))
+
     else:
         compileScript(infile=exp, version=None, outfile=filename)
 

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -351,9 +351,23 @@ def _checkout(requestedVersion):
         # Grab new tags
         msg = _translate("Couldn't find version {} locally. Trying github...")
         logging.info(msg.format(requestedVersion))
-        subprocess.check_output('git fetch github --tags'.split(),
-                                cwd=VERSIONSDIR,
-                                env=constants.ENVIRON).decode('UTF-8')
+
+        out = subprocess.Popen(
+            'git fetch github --tags'.split(),
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            cwd=VERSIONSDIR,
+            env=constants.ENVIRON)
+        stdout, stderr = out.communicate()
+        logging.debug(stdout)
+
+        # check error code
+        if out.returncode != 0:
+            logging.error(stderr)
+            raise ChildProcessError(
+                'Error: process exited with code {}, check log for '
+                'output.'.format(out.returncode))
+
         # is requested here now? forceCheck to refresh cache
         if requestedVersion not in _localVersions(forceCheck=True):
             msg = _translate("{} is not currently available.")
@@ -362,12 +376,24 @@ def _checkout(requestedVersion):
 
     # Checkout the requested tag
     cmd = ['git', 'checkout', requestedVersion]
-    out = subprocess.check_output(cmd,
-                                  stderr=subprocess.STDOUT,
-                                  cwd=VERSIONSDIR,
-                                  env=constants.ENVIRON).decode('UTF-8')
-    logging.debug(out)
+    out = subprocess.Popen(
+        cmd,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        cwd=VERSIONSDIR,
+        env=constants.ENVIRON)
+    stdout, stderr = out.communicate()
+    logging.debug(stdout)
+
+    # check error code
+    if out.returncode != 0:
+        logging.error(stderr)
+        raise ChildProcessError(
+            'Error: process exited with code {}, check log for '
+            'output.'.format(out.returncode))
+
     logging.exp('Success:  ' + ' '.join(cmd))
+
     return requestedVersion
 
 


### PR DESCRIPTION
This PR adds code which catches errors from subprocesses which deal with git and compiling. This should make issues with those scripts more visible during testing. 