### PR TITLE
BF: pip install error for conda envs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if 'CONDA_PREFIX' in os.environ:
 # `pyqt` package should be installed via conda instead
 # cf. https://github.com/ContinuumIO/anaconda-issues/issues/1554
 if 'CONDA_PREFIX' in os.environ:
-    required.remove('pyqt5; python_version >= "3"')
+    required.remove('pyqt5')
 
 # compress psychojs to a zip file for packaging
 # only takes 0.5s but could skip if you prefer


### PR DESCRIPTION
`setup.cfg` was changed to remove redundant version constraints ( #4968 ), but `setup.py` still contains reference to old name for pyqt5 package during check for conda environments. This results in an error when attempting to pip install in a conda environment. Updating the name in `setup.py` seems to fix the issue.