### PR TITLE
ENH: Improve `Color.render` performance for the case when contrast is 1

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -376,6 +376,8 @@ class Color:
         """
         if space not in colorSpaces:
             raise ValueError(f"{space} is not a valid color space")
+        if self.contrast == 1:
+            return getattr(self, space)
         # Transform contrast to match rgb
         contrast = self.contrast
         contrast = np.reshape(contrast, (-1, 1))

--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -376,8 +376,8 @@ class Color:
         """
         if space not in colorSpaces:
             raise ValueError(f"{space} is not a valid color space")
-        if self.contrast == 1:
-            return getattr(self, space)
+        if np.all(self.contrast == 1):
+             return getattr(self, space)
         # Transform contrast to match rgb
         contrast = self.contrast
         contrast = np.reshape(contrast, (-1, 1))


### PR DESCRIPTION
This makes `draw()` faster, e.g. here are snakeviz profiles for 100x `Circle.draw()` calls:

Without this PR:

![image](https://user-images.githubusercontent.com/12845624/180171332-dc2229ee-37e4-4364-84f4-b27dd18b3ec6.png)

With this PR:

![image](https://user-images.githubusercontent.com/12845624/180171488-80e31647-f961-40fe-aed8-8a71e277f8f8.png)

Code used for above profiles:
```
from psychopy.visual.window import Window
from psychopy.visual.circle import Circle
import cProfile

window = Window(fullscr=True, units="height")
circle = Circle(window, radius=0.1, lineColor="black", fillColor="red")

with cProfile.Profile() as pr:
    for i in range(100):
        circle.draw()
        window.flip()
pr.dump_stats("profile.prof")
```