### PR TITLE
TESTS: more complete fetching of xcb libs for ubuntu GitHub VMs

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -176,8 +176,8 @@ jobs:
         # sudo sh .github/workflows/prep_dummy_soundcard.sh  # couldn't find that file
 
         # for PyQt:
-        sudo apt-get install -y -qq libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1
-        sudo apt-get install -y -qq libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        sudo apt-get install -y -qq libdbus-1-3
+        sudo apt-get install -y -qq '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
         export LIBGL_ALWAYS_INDIRECT=0
         export QT_DEBUG_PLUGINS=1 # let us know about missing dependencies?
 


### PR DESCRIPTION
See the Xcb section on https://wiki.qt.io/Building_Qt_5_from_Git
It seems somethign has changed and more things are needed now to avoid
getting the error
```
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```