### PR TITLE
RF: import linebreak only for "aux14"

### DIFF
--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -29,8 +29,6 @@ from .. import shaders
 from ..rect import Rect
 from ... import core, alerts, layout
 
-from psychopy.tools.linebreak import get_breakable_points, break_units
-
 allFonts = FontManager()
 
 # compile global shader programs later (when we're certain a GL context exists)
@@ -790,6 +788,8 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             self._lineLenChars.append(charsThisLine)
 
         elif self._lineBreaking == 'uax14':
+            # not needed for regular line breaks but slows down debugging
+            from psychopy.tools.linebreak import get_breakable_points, break_units
 
             # get a list of line-breakable points according to UAX#14
             breakable_points = list(get_breakable_points(self._text))


### PR DESCRIPTION
**Problem**: psychopy/tools/linebreak_class.py used in linebreak.py
Current implementation stores all linebreak codes in a massive dictionary (300K+ lines). This works for normal running (~0.6 s on my setup) but slows initialization (imports) dramatically when debugging (~60 s). The slow start up times when debugging are general issue replicated both on Windows and Macs.

**Solution:** as suggested by @peircej, import inside the method only if line breaking is "aux14". Solves problem for everyone who uses "default" line breaks. 