### PR TITLE
BF: Refresh HoverButton on setting theme

### DIFF
--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -291,7 +291,8 @@ class HoverButton(wx.Button, HoverMixin, handlers.ThemeMixin):
         self.ForegroundColourHover = colors.app['txtbutton_fg_hover']
         self.BackgroundColourNoHover = colors.app['frame_bg']
         self.BackgroundColourHover = colors.app['txtbutton_bg_hover']
-        self.Update()
+        # Refresh
+        self.OnHover(evt=None)
 
 
 class ButtonArray(wx.Window):


### PR DESCRIPTION
Previously: When you change theme, the add routine/loop buttons would stay the colour of the old theme until hovered over.