### PR TITLE
BF: include ~/Library/Fonts for font searching in TextBox2

### DIFF
--- a/psychopy/visual/textbox2/fontmanager.py
+++ b/psychopy/visual/textbox2/fontmanager.py
@@ -43,6 +43,7 @@ _X11FontDirectories = [
 
 _OSXFontDirectories = [
     "/Library/Fonts/",
+    str(Path.home() / "Library" / "Fonts"),
     "/Network/Library/Fonts",
     "/System/Library/Fonts",
     # fonts installed via MacPorts


### PR DESCRIPTION
User-installed fonts are stored here. It's probably better to install them so
they're available to all users but macos uses User space by default (can
be changed in FontBook preferences)

Fixes #5002 #4978