### PR TITLE
ENH: When drawing a circle, work out how many edges are needed for a smooth circle

### DIFF
--- a/psychopy/visual/circle.py
+++ b/psychopy/visual/circle.py
@@ -107,7 +107,7 @@ class Circle(Polygon):
     def __init__(self,
                  win,
                  radius=.5,
-                 edges=32,
+                 edges="circle",
                  units='',
                  lineWidth=1.5,
                  lineColor=None,

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -135,6 +135,7 @@ class Polygon(BaseShapeStim):
 
         self.autoLog = False  # but will be changed if needed at end of init
         self.__dict__['edges'] = edges
+        self.__dict__['lineWidth'] = lineWidth
         self.radius = np.asarray(radius)
         self._calcVertices()
 
@@ -165,7 +166,12 @@ class Polygon(BaseShapeStim):
             colorSpace=colorSpace)
 
     def _calcVertices(self):
-        self.vertices = self._calcEquilateralVertices(self.edges, self.radius)
+        if self.edges == "circle":
+            # If circle is requested, calculate min edges needed for it to appear smooth
+            edges = self._calculateMinEdges(self.__dict__['lineWidth'], threshold=1)
+        else:
+            edges = self.edges
+        self.vertices = self._calcEquilateralVertices(edges, self.radius)
 
     @attributeSetter
     def edges(self, edges):

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -48,7 +48,7 @@ knownShapes = {
         [ .5, -.5],  # Bottom left
         [-.5, -.5],  # Bottom right
     ],
-    "circle": 100,  # Make 100 point equilateral
+    "circle": "circle",  # Placeholder, value calculated on set based on line width
     "cross": [
         (-0.1, +0.5),  # up
         (+0.1, +0.5),
@@ -265,6 +265,31 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
             [numpy.asarray((numpy.sin(e * d), numpy.cos(e * d))) * radius
              for e in range(int(round(edges)))])
         return vertices
+
+    @staticmethod
+    def _calculateMinEdges(lineWidth, threshold=180):
+        """
+        Calculate how many points are needed in an equilateral polygon for the gap between line rects to be < 1px and
+        for corner angles to exceed a threshold.
+
+        In other words, how many edges does a polygon need to have to appear smooth?
+
+        lineWidth : int, float, np.ndarray
+            Width of the line in pixels
+
+        threshold : int
+            Maximum angle (degrees) for corners of the polygon, useful for drawing a circle. Supply 180 for no maximum
+            angle.
+        """
+        # sin(theta) = opp / hyp, we want opp to be 1/4 (meaning gap between rects is 1/2px)
+        opp = 1/4
+        hyp = lineWidth / 2
+        thetaR = numpy.arcsin(opp / hyp)
+        theta = numpy.degrees(thetaR)
+        # If theta is below threshold, use threshold instead
+        theta = min(theta, threshold / 2)
+        # Angles in a shape add up to 360, so theta is 360/2n, solve for n
+        return int((360 / theta) / 2)
 
     def draw(self, win=None, keepMatrix=False):
         """Draw the stimulus in its relevant window.
@@ -560,6 +585,9 @@ class ShapeStim(BaseShapeStim):
         # check if this is a name of one of our known shapes
         if isinstance(value, str) and value in knownShapes:
             value = knownShapes[value]
+        if value == "circle":
+            # If circle is requested, calculate how many points are needed for the gap between line rects to be < 1px
+            value = self._calculateMinEdges(self.lineWidth, threshold=5)
         if isinstance(value, int):
             value = self._calcEquilateralVertices(value)
         # Check shape


### PR DESCRIPTION
Ensures that the corners between line rects in the rendered circle are always <1/2px, meaning it appears smooth with thicker line widths. Addresses "notches" appearing in test suite.