### PR TITLE
BF: When slider is categorical, snap to nearest tick

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -322,7 +322,7 @@ class SliderComponent(BaseVisualComponent):
         if inits['style'] == "radio":
             # If style is radio, make sure the slider is marked as categorical
             initStr += (
-                "\n"
+                " ticks: [],\n"
                 "  granularity: 1, style: {styles},\n"
             )
         else:

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -105,6 +105,20 @@ class SliderComponent(BaseVisualComponent):
                 hint=_translate("Tick positions (numerical) on the scale, "
                                 "separated by commas"),
                 label=_localized['ticks'])
+        self.depends.append(
+            {
+                # if...
+                "dependsOn": "styles",
+                # meets...
+                "condition": "=='radio'",
+                # then...
+                "param": "ticks",
+                # should...
+                "true": "disable",
+                # otherwise...
+                "false": "enable",
+            }
+        )
         self.params['labels'] = Param(
                 labels, valType='list', inputType="single", allowedTypes=[], categ='Basic',
                 updates='constant',
@@ -231,13 +245,15 @@ class SliderComponent(BaseVisualComponent):
         initStr = (
             "{name} = visual.Slider(win=win, name='{name}',\n"
             "    startValue={initVal}, size={size}, pos={pos}, units={units},\n"
-            "    labels={labels}, ticks={ticks}, "
+            "    labels={labels},"
         )
         if inits['style'] == "radio":
             # If style is radio, granularity should always be 1
-            initStr += "granularity=1,\n"
+            initStr += "ticks=None, granularity=1,\n"
         else:
-           initStr += "granularity={granularity},\n"
+           initStr += (
+               " ticks={ticks}, granularity={granularity},\n"
+           )
         initStr += (
             "    style={styles}, styleTweaks={styleTweaks}, opacity={opacity},\n"
             "    labelColor={color}, markerColor={fillColor}, lineColor={borderColor}, colorSpace={colorSpace},\n"
@@ -301,13 +317,19 @@ class SliderComponent(BaseVisualComponent):
             "  win: psychoJS.window, name: '{name}',\n"
             "  startValue: {initVal},\n"
             "  size: {size}, pos: {pos}, ori: {ori}, units: {units},\n"
-            "  labels: {labels}, fontSize: {letterHeight}, ticks: {ticks},\n"
+            "  labels: {labels}, fontSize: {letterHeight},"
         )
         if inits['style'] == "radio":
-            # If style is radio, granularity should always be 1
-            initStr += "  granularity: 1, style: {styles},\n"
+            # If style is radio, make sure the slider is marked as categorical
+            initStr += (
+                "\n"
+                "  granularity: 1, style: {styles},\n"
+            )
         else:
-           initStr += "  granularity: {granularity}, style: {styles},\n"
+            initStr += (
+                " ticks: {ticks},\n"
+                "  granularity: {granularity}, style: {styles},\n"
+            )
         initStr += (
             "  color: new util.Color({color}), markerColor: new util.Color({fillColor}), lineColor: new util.Color({borderColor}), \n"
             "  opacity: {opacity}, fontFamily: {font}, bold: true, italic: false, depth: {depth}, \n"

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -263,7 +263,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
     @property
     def categorical(self):
         """(readonly) determines from labels and ticks whether the slider is categorical"""
-        return self.ticks is None
+        return self.ticks is None or self.style == "radio"
 
     @property
     def extent(self):
@@ -686,7 +686,12 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
     def _granularRating(self, rating):
         """Handle granularity for the rating"""
         if rating is not None:
-            if self.granularity > 0:
+            if self.categorical:
+                # If this is a categorical slider, snap to closest tick
+                deltas = np.absolute(np.asarray(self.ticks) - rating)
+                i = np.argmin(deltas)
+                rating = self.ticks[i]
+            elif self.granularity > 0:
                 rating = round(rating / self.granularity) * self.granularity
                 rating = round(rating, 8)  # or gives 1.9000000000000001
             rating = max(rating, self.ticks[0])
@@ -1001,8 +1006,6 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
             self.tickLines.elementMask = 'circle'
             self._tickSizeMultiplier = (1, 1)
             self._tickSizeAddition = (0, 0)
-            # Radio doesn't make sense with granularity 0
-            self.granularity = 1
 
         if style == 'scrollbar':
             # Semi-transparent rectangle for a line (+ extra area for marker)


### PR DESCRIPTION
Safer than setting granularity to 1 as designers do use radio sliders with custom ticks