### PR TITLE
BF: Fix crash in Builder/Runner when using Camera within an experiment

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -249,7 +249,8 @@ class Job:
                 cwd=cwd,
                 env=None,
                 universal_newlines=True,  # gives us back a string instead of bytes
-                creationflags=0
+                creationflags=0,
+                text=True
             )
         except FileNotFoundError:
             return -1  # negative PID means failure

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -2387,7 +2387,7 @@ def renderVideo(outputFile, videoFile, audioFile=None):
         videoClip.audio = CompositeAudioClip([audioClip])
 
     # transcode with the format the user wants
-    videoClip.write_videofile(outputFile, verbose=False)
+    videoClip.write_videofile(outputFile, verbose=False, logging=None)
 
     return os.path.getsize(outputFile)
 

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -2387,7 +2387,7 @@ def renderVideo(outputFile, videoFile, audioFile=None):
         videoClip.audio = CompositeAudioClip([audioClip])
 
     # transcode with the format the user wants
-    videoClip.write_videofile(outputFile, verbose=False, logging=None)
+    videoClip.write_videofile(outputFile, verbose=False, logger=None)
 
     return os.path.getsize(outputFile)
 


### PR DESCRIPTION
Fixes an issue where the video encoder (MoviePy) stdout/sterr output causes a crash of the parent process.