### PR TITLE
BF: Fixed test suite stalling on single instance error

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -336,13 +336,15 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
                     time.sleep(1)
                     attempts += 1
             else:
-                # error that we could not access the memory-mapped file
-                errMsg = "Cannot communicate with running PsychoPy instance!"
-                errDlg = wx.MessageDialog(
-                    None, errMsg, caption="PsychoPy Error",
-                    style=wx.OK | wx.ICON_ERROR, pos=wx.DefaultPosition)
-                errDlg.ShowModal()
-                errDlg.Destroy()
+                if not self.testMode:
+                    # error that we could not access the memory-mapped file
+                    errMsg = \
+                        "Cannot communicate with running PsychoPy instance!"
+                    errDlg = wx.MessageDialog(
+                        None, errMsg, caption="PsychoPy Error",
+                        style=wx.OK | wx.ICON_ERROR, pos=wx.DefaultPosition)
+                    errDlg.ShowModal()
+                    errDlg.Destroy()
 
             # since were not the main instance, exit ...
             self.quit(None)


### PR DESCRIPTION
Test suite doesn't allow for multiple instance checking since the mechanism relies on the application checking for other processes when idle.