### PR TITLE
BF: Text validation was 1 character behind due to wx EVT_CHAR

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -163,7 +163,7 @@ class SingleLineCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin):
         # Add self to sizer
         self._szr.Add(self, proportion=1, border=5, flag=wx.EXPAND)
         # Bind to validation
-        self.Bind(wx.EVT_CHAR, self.validate)
+        self.Bind(wx.EVT_TEXT, self.validate)
         self.validate()
 
     def Show(self, value=True):


### PR DESCRIPTION
Further problem from this is that the validation actually affects the attributes of the ParamCtrl object, as `self.codeWanted` is set when dollar syntax is parsed. This is how we can end up in situations where the param should be type str and the value is just e.g. `abc`, but it's interpreted as code because codeWanted is True from the last character event when the value was `$abc`, which can lead to a situation where the code styling is flipped around so that it's only bold when there isn't a dollar. It's difficult to get to the point, but I *think* it is possible and I have hit it once or twice (obviously though I'm going in trying to break it).

I suspect this is linked to a bug where I've managed to get stuck in a dialog because the Okay is disabled despite the code being valid, as the valType is linked to whether the code is considered valid (plenty of values are perfectly valid for a str param but are incorrect Python syntax). Will put in a PR to dev which modularises the dollar syntax parsing to properly fix this, but for release I think just switching the event to bind to is enough as it means the value presented and the value validated are the same.