### PR TITLE
BF: default for mic should be transcription=False

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -52,7 +52,7 @@ class MicrophoneComponent(BaseComponent):
                  channels='auto', device="default",
                  sampleRate='DVD Audio (48kHz)', maxSize=24000,
                  outputType='default', speakTimes=True, trimSilent=False,
-                 transcribe=True, transcribeBackend="Google", transcribeLang="en-US", transcribeWords="",
+                 transcribe=False, transcribeBackend="Google", transcribeLang="en-US", transcribeWords="",
                  #legacy
                  stereo=None, channel=None):
         super(MicrophoneComponent, self).__init__(


### PR DESCRIPTION
Most users don't have google API, so most users are getting an error
when they try to run the study with a mic in the default settings