### PR TITLE
BF: Handle `ImportError` too for pocketsphinx

### DIFF
--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -59,7 +59,7 @@ try:
     sphinxLangs = [folder.stem for folder
                    in Path(pocketsphinx.get_model_path()).glob('??-??')]
     haveSphinx = True
-except ModuleNotFoundError:
+except (ImportError, ModuleNotFoundError):
     haveSphinx = False
     sphinxLangs = None
 


### PR DESCRIPTION
Catches all errors when trying to import pocketsphinx and disables its features.