### PR TITLE
BF: Refresh project object to get info when known project is found

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -4029,6 +4029,7 @@ class BuilderToolbar(BasePsychopyToolbar):
             self.frame.project = pavlovia.getProject(self.frame.filename)
         # Get project
         if self.frame.project is not None:
+            self.frame.project.refresh()
             dlg = ProjectFrame(app=self.frame.app,
                                project=self.frame.project,
                                parent=self.frame)


### PR DESCRIPTION
Fixes problems where clicking Project Info showed a blank project when one should be linked