### PR TITLE
BF: Fix stall when running test suite due to multiple instantiations of the app

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -248,9 +248,6 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
 
     def onInit(self, showSplash=True, testMode=False):
         """This is launched immediately *after* the app initialises with wx
-        :Parameters:
-
-          testMode: bool
         """
         self.SetAppName('PsychoPy3')
 
@@ -269,85 +266,88 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
 
         # Create the memory-mapped file if not present, this is handled
         # differently between Windows and UNIX-likes.
-        if wx.Platform == '__WXMSW__':
-            tfile = tempfile.TemporaryFile(prefix="ag", suffix="tmp")
-            fno = tfile.fileno()
-            self._sharedMemory = mmap.mmap(fno, self.mmap_sz, "shared_memory")
-        else:
-            tfile = open(
-                os.path.join(
-                    tempfile.gettempdir(),
-                    tempfile.gettempprefix() + self.GetAppName() + '-' +
-                    wx.GetUserId() + "AGSharedMemory"),
-                'w+b')
-
-            # insert markers into the buffer
-            tfile.write(b"*")
-            tfile.seek(self.mmap_sz)
-            tfile.write(b" ")
-            tfile.flush()
-            fno = tfile.fileno()
-            self._sharedMemory = mmap.mmap(fno, self.mmap_sz)
-
-        # use wx to determine if another instance is running
-        self._singleInstanceChecker = wx.SingleInstanceChecker(
-            self.GetAppName() + '-' + wx.GetUserId(),
-            tempfile.gettempdir())
-
-        # If another instance is running, message our args to it by writing the
-        # path the the buffer.
-        if self._singleInstanceChecker.IsAnotherRunning():
-            # Message the extant running instance the arguments we want to
-            # process.
-            args = sys.argv[1:]
-
-            # if there are no args, tell the user another instance is running
-            if not args:
-                errMsg = "Another instance of PsychoPy is already running."
-                errDlg = wx.MessageDialog(
-                    None, errMsg, caption="PsychoPy Error",
-                    style=wx.OK | wx.ICON_ERROR, pos=wx.DefaultPosition)
-                errDlg.ShowModal()
-                errDlg.Destroy()
-
-                self.quit(None)
-
-            # serialize the data
-            data = pickle.dumps(args)
-
-            # Keep alive until the buffer is free for writing, this allows
-            # multiple files to be opened in succession. Times out after 5
-            # seconds.
-            attempts = 0
-            while attempts < 5:
-                # try to write to the buffer
-                self._sharedMemory.seek(0)
-                marker = self._sharedMemory.read(1)
-                if marker == b'\0' or marker == b'*':
-                    self._sharedMemory.seek(0)
-                    self._sharedMemory.write(b'-')
-                    self._sharedMemory.write(data)
-                    self._sharedMemory.seek(0)
-                    self._sharedMemory.write(b'+')
-                    self._sharedMemory.flush()
-                    break
-                else:
-                    # wait a bit for the buffer to become free
-                    time.sleep(1)
-                    attempts += 1
+        if not self.testMode:
+            if wx.Platform == '__WXMSW__':
+                tfile = tempfile.TemporaryFile(prefix="ag", suffix="tmp")
+                fno = tfile.fileno()
+                self._sharedMemory = mmap.mmap(
+                    fno, self.mmap_sz, "shared_memory")
             else:
-                if not self.testMode:
-                    # error that we could not access the memory-mapped file
-                    errMsg = \
-                        "Cannot communicate with running PsychoPy instance!"
+                tfile = open(
+                    os.path.join(
+                        tempfile.gettempdir(),
+                        tempfile.gettempprefix() + self.GetAppName() + '-' +
+                        wx.GetUserId() + "AGSharedMemory"),
+                    'w+b')
+
+                # insert markers into the buffer
+                tfile.write(b"*")
+                tfile.seek(self.mmap_sz)
+                tfile.write(b" ")
+                tfile.flush()
+                fno = tfile.fileno()
+                self._sharedMemory = mmap.mmap(fno, self.mmap_sz)
+
+            # use wx to determine if another instance is running
+            self._singleInstanceChecker = wx.SingleInstanceChecker(
+                self.GetAppName() + '-' + wx.GetUserId(),
+                tempfile.gettempdir())
+
+            # If another instance is running, message our args to it by writing
+            # the path the buffer.
+            if self._singleInstanceChecker.IsAnotherRunning():
+                # Message the extant running instance the arguments we want to
+                # process.
+                args = sys.argv[1:]
+
+                # if there are no args, tell the user another instance is
+                # running
+                if not args:
+                    errMsg = "Another instance of PsychoPy is already running."
                     errDlg = wx.MessageDialog(
                         None, errMsg, caption="PsychoPy Error",
                         style=wx.OK | wx.ICON_ERROR, pos=wx.DefaultPosition)
                     errDlg.ShowModal()
                     errDlg.Destroy()
 
-            # since were not the main instance, exit ...
-            self.quit(None)
+                    self.quit(None)
+
+                # serialize the data
+                data = pickle.dumps(args)
+
+                # Keep alive until the buffer is free for writing, this allows
+                # multiple files to be opened in succession. Times out after 5
+                # seconds.
+                attempts = 0
+                while attempts < 5:
+                    # try to write to the buffer
+                    self._sharedMemory.seek(0)
+                    marker = self._sharedMemory.read(1)
+                    if marker == b'\0' or marker == b'*':
+                        self._sharedMemory.seek(0)
+                        self._sharedMemory.write(b'-')
+                        self._sharedMemory.write(data)
+                        self._sharedMemory.seek(0)
+                        self._sharedMemory.write(b'+')
+                        self._sharedMemory.flush()
+                        break
+                    else:
+                        # wait a bit for the buffer to become free
+                        time.sleep(1)
+                        attempts += 1
+                else:
+                    if not self.testMode:
+                        # error that we could not access the memory-mapped file
+                        errMsg = \
+                            "Cannot communicate with running PsychoPy instance!"
+                        errDlg = wx.MessageDialog(
+                            None, errMsg, caption="PsychoPy Error",
+                            style=wx.OK | wx.ICON_ERROR, pos=wx.DefaultPosition)
+                        errDlg.ShowModal()
+                        errDlg.Destroy()
+
+                # since were not the main instance, exit ...
+                self.quit(None)
 
         # ----
 


### PR DESCRIPTION
Multi instance checking fails in the test suite since it hooks onto the app's idle event which is never invoked. This disables the check and allows the tests to run through. 