### PR TITLE
precise value setter for sound;

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -128,13 +128,7 @@ class SoundComponent(BaseComponent):
             stopVal = -1
 
         if self.params['sound'].updates == 'set every repeat':
-            buff.writeIndented("%s = new sound.Sound({\n"
-                               "    win: psychoJS.window,\n"
-                               "    value: %s,\n"
-                               "    secs: %s,\n"
-                               "    });\n" % (self.params['name'],
-                                              self.params['sound'],
-                                              stopVal))
+            buff.writeIndented("%(name)s.setValue(%(sound)s);\n" % self.params)
         if stopVal == -1:
             buff.writeIndentedLines("%(name)s.setVolume(%(volume)s);\n" % self.params)
         else:


### PR DESCRIPTION
When "set every repeat" is ticked JS version of experiment creates new instance of Sound in *routineBegin function. Combined with loops this causes continuous re-instantiation an eventually depletes resources.

Bug described here:
https://discourse.psychopy.org/t/repeated-sound-plays-inconsistently-after-a-few-minutes/30374/2

PsychoJS portion of the fix:
https://github.com/psychopy/psychojs/pull/527

cid: CU-3h645y3