### PR TITLE
ENH: Add new ParamCtrl for multiline code (as in ButtonStim callback)

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -118,10 +118,16 @@ class ParamCtrls():
                                                        val=str(param.val), valType=param.valType,
                                                        fieldName=fieldName, size=wx.Size(self.valueWidth, 24))
         elif param.inputType == 'multi':
-            # Create multiline string control
-            self.valueCtrl = paramCtrls.MultiLineCtrl(parent,
-                                                      val=str(param.val), valType=param.valType,
-                                                      fieldName=fieldName, size=wx.Size(self.valueWidth, 144))
+            if param.valType == "extendedCode":
+                # Create multiline code control
+                self.valueCtrl = paramCtrls.CodeCtrl(parent,
+                                                     val=str(param.val), valType=param.valType,
+                                                     fieldName=fieldName, size=wx.Size(self.valueWidth, 144))
+            else:
+                # Create multiline string control
+                self.valueCtrl = paramCtrls.MultiLineCtrl(parent,
+                                                          val=str(param.val), valType=param.valType,
+                                                          fieldName=fieldName, size=wx.Size(self.valueWidth, 144))
             # Set focus if field is text of a Textbox or Text component
             if fieldName == 'text':
                 self.valueCtrl.SetFocus()

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 
 import wx
+import wx.stc
 
 from psychopy.app.colorpicker import PsychoColorPicker
 from psychopy.app.dialogs import ListWidget
@@ -19,8 +20,10 @@ from psychopy import data, prefs, experiment
 import re
 from pathlib import Path
 
+from . import CodeBox
 from ..localizedStrings import _localizedDialogs as _localized
-from ...themes import icons
+from ...coder import BaseCodeEditor
+from ...themes import icons, handlers
 
 
 class _ValidatorMixin:
@@ -181,6 +184,29 @@ class MultiLineCtrl(SingleLineCtrl, _ValidatorMixin, _HideMixin):
         SingleLineCtrl.__init__(self, parent, valType,
                                 val=val, fieldName=fieldName,
                                 size=size, style=wx.TE_MULTILINE)
+
+
+class CodeCtrl(BaseCodeEditor, handlers.ThemeMixin, _ValidatorMixin):
+    def __init__(self, parent, valType,
+                 val="", fieldName="",
+                 size=wx.Size(-1, 144)):
+        BaseCodeEditor.__init__(self, parent,
+                                ID=wx.ID_ANY, pos=wx.DefaultPosition, size=size,
+                                style=0)
+        self.valType = valType
+        self.val = val
+        self.fieldName = fieldName
+        self.params = fieldName
+        # Setup lexer to style text
+        self.SetLexer(wx.stc.STC_LEX_PYTHON)
+        self._applyAppTheme()
+        # Hide margin
+        self.SetMarginWidth(0, 0)
+        # Setup auto indent behaviour as in Code component
+        self.Bind(wx.EVT_KEY_DOWN, self.onKey)
+
+    def onKey(self, evt=None):
+        CodeBox.OnKeyPressed(self, evt)
 
 
 class InvalidCtrl(SingleLineCtrl, _ValidatorMixin, _HideMixin):


### PR DESCRIPTION
Means that writing a callback in a ButtonStim has all the same code styling, auto indent, etc. as a Code component