### PR TITLE
BF: Added addTime() to class CountdownTimer

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -241,7 +241,7 @@ class CountdownTimer(Clock):
             while countdownTimer.getTime() > 0:
                 # do something
         """
-        
+
         self._timeAtLastReset += t
 
     def reset(self, t=None):
@@ -468,12 +468,3 @@ def getAbsTime():
 
     """
     return int(time.mktime(time.localtime()))
-
-
-if __name__ == "__main__":
-    clock = Clock()
-    countdowntimer = CountdownTimer()
-
-    clock.addTime(1)
-    countdowntimer.addTime(1)
-    print(clock.getTime(), countdowntimer.getTime())

--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -183,8 +183,8 @@ class Clock(MonotonicClock):
         e.g.::
 
             timer = core.Clock()
-            timer.add(5)
-            while timer.getTime()<0:
+            timer.addTime(5)
+            while timer.getTime() > 0:
                 # do something
         """
         self._timeAtLastReset -= t
@@ -230,6 +230,19 @@ class CountdownTimer(Clock):
         precision (`float`).
         """
         return self._timeAtLastReset - getTime()
+
+    def addTime(self, t):
+        """Add more time to the CountdownTimer
+        
+        e.g.:
+            countdownTimer = core.CountdownTimer()
+            countdownTimer.addTime(1)
+
+            while countdownTimer.getTime() > 0:
+                # do something
+        """
+        
+        self._timeAtLastReset += t
 
     def reset(self, t=None):
         """Reset the time on the clock.
@@ -455,3 +468,12 @@ def getAbsTime():
 
     """
     return int(time.mktime(time.localtime()))
+
+
+if __name__ == "__main__":
+    clock = Clock()
+    countdowntimer = CountdownTimer()
+
+    clock.addTime(1)
+    countdowntimer.addTime(1)
+    print(clock.getTime(), countdowntimer.getTime())


### PR DESCRIPTION
Current behavior of `CountdownTimer.addTime()` subtracts time from the timer because it inherits from `Clock.addTime()`, which has its time counting up.  This pull request adds an `addTime()` specific to `CountdownTimer` which increases the time to match the behavior expected from the example in the docs (contrast [this](https://discourse.psychopy.org/t/countdowntimer-addtime-seems-to-be-subtracting-time-instead/31250) behavior, and the example usage [here](https://psychopy.org/api/core.html#psychopy.core.CountdownTimer)).

This is my first pull request for both psychopy and in general.  Please let me know if I'm just misunderstanding the purpose of `addTime()`, or, if I'm not, if there is a better way to fix this.

(also fixed a typo in `Clock.addTime()`'s example usage)
