### PR TITLE
FF: Remove redundant calls to `_createTexture` during `GratingStim` init

### DIFF
--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -153,13 +153,15 @@ class GratingStim(BaseVisualStim, TextureMixin, ColorMixin, ContainerMixin):
         self.depth = depth
         self.anchor = anchor
 
-        self.tex = tex
+        # Removed the following line since setting this attribute will call
+        # `_createTexture` again.
+        # self.tex = tex
         self.mask = mask
         self.contrast = float(contrast)
         self.opacity = opacity
         self.autoLog = autoLog
         self.autoDraw = autoDraw
-        self.blendmode=blendmode
+        self.blendmode = blendmode
 
         # fix scaling to window coords
         self._calcCyclesPerStim()


### PR DESCRIPTION
Keeps `_createTexture` from being called multiple times to no real effect during `GratingStim` initialization. Removes the attribute setter since `_needsUpdate` is set as `True` at the end of the init routine, which will cause the update to happen anyways later on rendering the `self.tex = tex` call pointless. 