### PR TITLE
BF: Fix order of dataFileName and addInfoFromUrl (#4831)

### DIFF
--- a/psychopy/experiment/components/settings/JS_setupExp.tmpl
+++ b/psychopy/experiment/components/settings/JS_setupExp.tmpl
@@ -7,7 +7,6 @@ async function updateInfo() {{
   expInfo['psychopyVersion'] = '{version}';
   expInfo['OS'] = window.navigator.platform;
 
-  psychoJS.experiment.dataFileName = (("." + "/") + {filename});
 
   // store frame rate of monitor if we can measure it successfully
   expInfo['frameRate'] = psychoJS.window.getActualFrameRate();
@@ -19,5 +18,10 @@ async function updateInfo() {{
   // add info from the URL:
   util.addInfoFromUrl(expInfo);
   {setRedirectURL}
+
+  
+  psychoJS.experiment.dataFileName = (("." + "/") + {filename});
+
+
   return Scheduler.Event.NEXT;
 }}


### PR DESCRIPTION
This fixes a bug where participant ids provided via URL parameters are not being added to the data filename of experiments run online (#4831). dataFileName assignment should come after addInfoFromUrl so that URL parameters (such as participant id) can be added to the filename.