### PR TITLE
BF: Fixed `pause` being undone by `draw()` command in `MovieStim`

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -295,7 +295,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self._selectWindow(self.win if win is None else win)
 
         # handle autoplay
-        if self._autoStart and not self._player.isPlaying:
+        if self._autoStart and self.status == NOT_STARTED:
             self.play()
 
         # update the video frame and draw it to a quad

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -136,7 +136,7 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self._autoStart = autoStart
 
         # OpenGL data
-        self.interpolate = True
+        self.interpolate = interpolate
         self._texFilterNeedsUpdate = True
         self._metadata = NULL_MOVIE_METADATA
         self._pixbuffId = GL.GLuint(0)


### PR DESCRIPTION
Fixes a bug where `draw()` being called unpauses the movie if `autoDraw` is `True`.