### PR TITLE
RF/BF: Always substitute PsychoJS names

### DIFF
--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -21,28 +21,6 @@ from io import StringIO
 from psychopy.experiment.py2js_transpiler import translatePythonToJavaScript
 
 
-class NamesJS(dict):
-    def __getitem__(self, name):
-        try:
-            return dict.__getitem__(self, name)
-        except:
-            return "{}".format(name)
-
-
-namesJS = NamesJS()
-namesJS['sin'] = 'Math.sin'
-namesJS['cos'] = 'Math.cos'
-namesJS['tan'] = 'Math.tan'
-namesJS['pi'] = 'Math.PI'
-namesJS['rand'] = 'Math.random'
-namesJS['random'] = 'Math.random'
-namesJS['sqrt'] = 'Math.sqrt'
-namesJS['abs'] = 'Math.abs'
-namesJS['randint'] = 'util.randint'
-namesJS['round'] = 'util.round'  # better than Math.round, supports n DPs arg
-namesJS['sum'] = 'util.sum'
-
-
 class TupleTransformer(ast.NodeTransformer):
     """ An ast subclass that walks the abstract syntax tree and
     allows modification of nodes.
@@ -53,6 +31,7 @@ class TupleTransformer(ast.NodeTransformer):
     """
     def visit_Tuple(self, node):
         return ast.List(node.elts, node.ctx)
+
 
 class Unparser(astunparse.Unparser):
     """astunparser had buried the future_imports option underneath its init()
@@ -101,7 +80,6 @@ def expression2js(expr):
         if isinstance(node, ast.Name):
             if node.id == 'undefined':
                 continue
-            node.id = namesJS[node.id]
     jsStr = unparse(syntaxTree).strip()
     if not any(ch in jsStr for ch in ("=",";","\n")):
         try:

--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -17,11 +17,28 @@ except ImportError:
 import astunparse
 
 
+namesJS = {
+    'sin': 'Math.sin',
+    'cos': 'Math.cos',
+    'tan': 'Math.tan',
+    'pi': 'Math.PI',
+    'rand': 'Math.random',
+    'random': 'Math.random',
+    'sqrt': 'Math.sqrt',
+    'abs': 'Math.abs',
+    'randint': 'util.randint',
+    'round': 'util.round',  # better than Math.round, supports n DPs arg
+    'sum': 'util.sum',
+}
+
+
 class psychoJSTransformer(ast.NodeTransformer):
     """PsychoJS-specific AST transformer
     """
 
     def visit_Name(self, node):
+        if node.id in namesJS:
+            node.id = namesJS[node.id]
         # status = STOPPED --> status = PsychoJS.Status.STOPPED
         if node.id in ['STARTED', 'FINISHED', 'STOPPED'] and isinstance(node.ctx, ast.Load):
             return ast.copy_location(


### PR DESCRIPTION
Moves the code to substitute PsychoJS names from the expression2js function (which is only called on single-line parameters, not e.g. Code components) to the base-level name node visitor, which is always called.

Also converted names dict to basic Python syntax for readability (i.e. so future contributors won't have the same reaction I had of "wait, we're always indexing this dict, even if the index isn't in its keys?!")