### PR TITLE
ENH: Make Runner panels resizable

### DIFF
--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -488,6 +488,8 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
             ==========
             parent : wx.Window
                 Window to use as parent when creating this panel
+            runner : RunnerPanel
+                Runner panel containing all the necessary methods to bind button functions to
             """
             wx.Panel.__init__(self, parent)
             # Setup sizer

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -488,78 +488,79 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
             ==========
             parent : wx.Window
                 Window to use as parent when creating this panel
-            runner : RunnerPanel
-                Runner panel containing all the necessary methods to bind button functions to
             """
             wx.Panel.__init__(self, parent)
             # Setup sizer
             self.sizer = wx.BoxSizer(wx.VERTICAL)
             self.SetSizer(self.sizer)
 
+            # Button storage
+            self.buttons = {}
+
             # Plus
-            btn = runner.plusBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['plusBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['plusBtn'].SetToolTip(
                 _translate("Add experiment to list")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.addTask)
-            btn.stem = "addExp"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['plusBtn'].Bind(wx.EVT_BUTTON, runner.addTask)
+            self.buttons['plusBtn'].stem = "addExp"
+            self.sizer.Add(self.buttons['plusBtn'], border=5, flag=wx.ALL)
             # Minus
-            btn = runner.negBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['negBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['negBtn'].SetToolTip(
                 _translate("Remove experiment from list")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.removeTask)
-            btn.stem = "removeExp"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['negBtn'].Bind(wx.EVT_BUTTON, runner.removeTask)
+            self.buttons['negBtn'].stem = "removeExp"
+            self.sizer.Add(self.buttons['negBtn'], border=5, flag=wx.ALL)
             # Save
-            btn = runner.saveBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['saveBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['saveBtn'].SetToolTip(
                 _translate("Save task list to a file")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.parent.saveTaskList)
-            btn.stem = "filesaveas"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['saveBtn'].Bind(wx.EVT_BUTTON, runner.parent.saveTaskList)
+            self.buttons['saveBtn'].stem = "filesaveas"
+            self.sizer.Add(self.buttons['saveBtn'], border=5, flag=wx.ALL)
             # Load
-            btn = runner.loadBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['loadBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['loadBtn'].SetToolTip(
                 _translate("Load tasks from a file")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.parent.loadTaskList)
-            btn.stem = "fileopen"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['loadBtn'].Bind(wx.EVT_BUTTON, runner.parent.loadTaskList)
+            self.buttons['loadBtn'].stem = "fileopen"
+            self.sizer.Add(self.buttons['loadBtn'], border=5, flag=wx.ALL)
             # Run
-            btn = runner.runBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['runBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['runBtn'].SetToolTip(
                 _translate("Run the current script in Python")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.runLocal)
-            btn.stem = "run"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['runBtn'].Bind(wx.EVT_BUTTON, runner.runLocal)
+            self.buttons['runBtn'].stem = "run"
+            self.sizer.Add(self.buttons['runBtn'], border=5, flag=wx.ALL)
             # Stop
-            btn = runner.stopBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['stopBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['stopBtn'].SetToolTip(
                 _translate("Stop task")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.stopTask)
-            btn.stem = "stop"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['stopBtn'].Bind(wx.EVT_BUTTON, runner.stopTask)
+            self.buttons['stopBtn'].stem = "stop"
+            self.sizer.Add(self.buttons['stopBtn'], border=5, flag=wx.ALL)
             # Run online
-            btn = runner.onlineBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['onlineBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['onlineBtn'].SetToolTip(
                 _translate("Run PsychoJS task from Pavlovia")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.runOnline)
-            btn.stem = "globe_run"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['onlineBtn'].Bind(wx.EVT_BUTTON, runner.runOnline)
+            self.buttons['onlineBtn'].stem = "globe_run"
+            self.sizer.Add(self.buttons['onlineBtn'], border=5, flag=wx.ALL)
             # Debug online
-            btn = runner.onlineDebugBtn = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
-            btn.SetToolTip(
+            self.buttons['onlineDebugBtn'] = wx.Button(self, size=(32, 32), style=wx.BORDER_NONE)
+            self.buttons['onlineDebugBtn'].SetToolTip(
                 _translate("Run PsychoJS task in local debug mode")
             )
-            btn.Bind(wx.EVT_BUTTON, runner.runOnlineDebug)
-            btn.stem = "globe_bug"
-            self.sizer.Add(btn, border=5, flag=wx.ALL)
+            self.buttons['onlineDebugBtn'].Bind(wx.EVT_BUTTON, runner.runOnlineDebug)
+            self.buttons['onlineDebugBtn'].stem = "globe_bug"
+            self.sizer.Add(self.buttons['onlineDebugBtn'], border=5, flag=wx.ALL)
 
         def _applyAppTheme(self):
             # Iterate through buttons
@@ -665,8 +666,8 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         self.SetSizerAndFit(self.mainSizer)
         self.SetMinSize(self.Size)
 
-        # disable the stop button on start
-        self.stopBtn.Disable()
+        # Set starting states on buttons
+        self.toolbar.buttons['stopBtn'].Disable()
 
         self.theme = parent.theme
 
@@ -718,9 +719,9 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         if self.scriptProcess is not None:
             self.stopFile(event)
 
-        self.stopBtn.Disable()
+        self.toolbar.buttons['stopBtn'].Disable()
         if self.currentSelection:
-            self.runBtn.Enable()
+            self.toolbar.buttons['runBtn'].Enable()
 
     def runLocal(self, evt=None, focusOnExit='runner'):
         """Run experiment from new process using inherited ScriptProcess class methods."""
@@ -737,8 +738,8 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
 
         # Enable/Disable btns
         if procStarted:
-            self.runBtn.Disable()
-            self.stopBtn.Enable()
+            self.toolbar.buttons['runBtn'].Disable()
+            self.toolbar.buttons['stopBtn'].Enable()
 
     def runOnline(self, evt=None):
         """Run PsychoJS task from https://pavlovia.org."""
@@ -901,13 +902,13 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         # thisItem = self.entries[self.currentFile]
 
         if not self.running:  # if we aren't already running we can enable run button
-            self.runBtn.Enable()
+            self.toolbar.buttons['runBtn'].Enable()
         if self.currentFile.suffix == '.psyexp':
-            self.onlineBtn.Enable()
-            self.onlineDebugBtn.Enable()
+            self.toolbar.buttons['onlineBtn'].Enable()
+            self.toolbar.buttons['onlineDebugBtn'].Enable()
         else:
-            self.onlineBtn.Disable()
-            self.onlineDebugBtn.Disable()
+            self.toolbar.buttons['onlineBtn'].Disable()
+            self.toolbar.buttons['onlineDebugBtn'].Disable()
         self.updateAlerts()
         self.app.updateWindowMenu()
 
@@ -918,9 +919,9 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         self.currentFile = None
         self.currentExperiment = None
         self.currentProject = None
-        self.runBtn.Disable()
-        self.onlineBtn.Disable()
-        self.onlineDebugBtn.Disable()
+        self.toolbar.buttons['runBtn'].Disable()
+        self.toolbar.buttons['onlineBtn'].Disable()
+        self.toolbar.buttons['onlineDebugBtn'].Disable()
         self.app.updateWindowMenu()
 
     def updateAlerts(self):

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -687,9 +687,16 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         bmp = icons.ButtonIcon("alerts", size=(16, 16)).bitmap
         self.alertsToggleBtn.SetBitmap(bmp)
         self.alertsToggleBtn.SetBitmapMargins(x=6, y=0)
-
-        self.stdoutToggleBtn._applyAppTheme()
-        self.alertsToggleBtn._applyAppTheme()
+        # Apply app theme on objects in non-theme-mixin panels
+        for obj in (
+                self.alertsCtrl, self.alertsToggleBtn,
+                self.stdoutCtrl, self.stdoutToggleBtn,
+                self.expCtrl, self.toolbar
+        ):
+            if hasattr(obj, "_applyAppTheme"):
+                obj._applyAppTheme()
+            else:
+                handlers.ThemeMixin._applyAppTheme(obj)
 
         self.Refresh()
 

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -668,6 +668,8 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
 
         # Set starting states on buttons
         self.toolbar.buttons['stopBtn'].Disable()
+        self.alertsToggleBtn.ToggleMenu(True)
+        self.stdoutToggleBtn.ToggleMenu(True)
 
         self.theme = parent.theme
 

--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -585,8 +585,6 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         # double buffered better rendering except if retina
         self.SetDoubleBuffered(parent.IsDoubleBuffered())
 
-        expCtrlSize = [500, 150]
-
         self.app = app
         self.prefs = self.app.prefs.coder
         self.paths = self.app.prefs.paths
@@ -615,8 +613,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         # ListCtrl for list of tasks
         self.expCtrl = wx.ListCtrl(self.topPanel,
                                    id=wx.ID_ANY,
-                                   style=wx.LC_REPORT | wx.BORDER_NONE |
-                                         wx.LC_NO_HEADER | wx.LC_SINGLE_SEL)
+                                   style=wx.LC_REPORT | wx.BORDER_NONE | wx.LC_NO_HEADER | wx.LC_SINGLE_SEL)
         self.expCtrl.SetMinSize((500, -1))
         self.expCtrl.Bind(wx.EVT_LIST_ITEM_SELECTED,
                           self.onItemSelected, self.expCtrl)
@@ -630,8 +627,6 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         # Toolbar
         self.toolbar = self.RunnerToolbar(self.topPanel, runner=self)
         self.topPanel.sizer.Add(self.toolbar, proportion=0, border=12, flag=wx.LEFT | wx.RIGHT | wx.EXPAND)
-
-        _style = platebtn.PB_STYLE_DROPARROW | platebtn.PB_STYLE_SQUARE
 
         # Setup panel for bottom half (alerts and stdout)
         self.bottomPanel = wx.Panel(self.splitter)
@@ -647,7 +642,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         self.alertsToggleBtn = self.SizerButton(self.bottomPanel, _translate("Alerts"), self.alertsCtrl)
         self.setAlertsVisible(True)
         self.bottomPanel.sizer.Add(self.alertsToggleBtn, 0, wx.TOP | wx.EXPAND, 10)
-        self.bottomPanel.sizer.Add(self.alertsCtrl, 1, wx.EXPAND | wx.ALL, 10)
+        self.bottomPanel.sizer.Add(self.alertsCtrl, proportion=1, border=10, flag=wx.EXPAND | wx.ALL)
 
         # StdOut
         self.stdoutCtrl = StdOutText(parent=self.bottomPanel,
@@ -656,8 +651,8 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         self.stdoutCtrl.SetMinSize((-1, 150))
         self.stdoutToggleBtn = self.SizerButton(self.bottomPanel, _translate("Stdout"), self.stdoutCtrl)
         self.setStdoutVisible(True)
-        self.bottomPanel.sizer.Add(self.stdoutToggleBtn, 0, wx.TOP | wx.EXPAND, 10)
-        self.bottomPanel.sizer.Add(self.stdoutCtrl, 1, wx.EXPAND | wx.ALL, 10)
+        self.bottomPanel.sizer.Add(self.stdoutToggleBtn, proportion=0, border=10, flag=wx.TOP | wx.EXPAND)
+        self.bottomPanel.sizer.Add(self.stdoutCtrl, proportion=1, border=10, flag=wx.EXPAND | wx.ALL)
 
         # Assign to splitter
         self.splitter.SplitHorizontally(


### PR DESCRIPTION
Adds a moveable "sash" between the top and bottom parts of the Runner window.

As `wx.SplitterWindow` has to be the parent of containing panels I had to refactor said panels to be more modular so they function the same regardless of which window is their parent.