### PR TITLE
BUGFIX: Add imports back to into crs/shaders.py

### DIFF
--- a/psychopy/hardware/crs/shaders.py
+++ b/psychopy/hardware/crs/shaders.py
@@ -12,6 +12,9 @@
 #    (Mario Kleiner) but does not use that code directly
 #    It is, for example, Mario's idea to add the 0.01 to avoid rounding issues
 
+from __future__ import absolute_import, print_function
+from psychopy.visual.shaders import compileProgram, vertSimple
+
 bitsMonoModeFrag = """
 /* Mono++ output formatter
  *


### PR DESCRIPTION
The current version of PsychoPy fails to initialise CRS hardware because the shaders cannot be complied. This is due to missing imports that were in older versions and when they are added back in the initialisation works.