### PR TITLE
Fix builder-defined gaze confidence not being applied to Pupil Labs eye tracking

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1207,7 +1207,7 @@ class SettingsComponent:
                 code = (
                     "'pupillometry_only': %(plPupillometryOnly)s,\n"
                     "'surface_name': %(plSurfaceName)s,\n"
-                    "'gaze_confidence_threshold': %(plConfidenceThreshold)s,\n"
+                    "'confidence_threshold': %(plConfidenceThreshold)s,\n"
                 )
                 buff.writeIndentedLines(code % inits)
 


### PR DESCRIPTION
Changing the confidence value in the Pupil Labs eye-tracking builder settings did not have any effect.

Builder translated `plConfidenceThreshold` to `gaze_confidence_threshold` instead of `confidence_threshold`. [Only the latter field name is accessed by the Pupil Labs eye tracker class](https://github.com/psychopy/psychopy/blob/58c8d97bca642ea6e2d5f8c5471a2936ac2caf62/psychopy/iohub/devices/eyetracker/hw/pupil_labs/pupil_core/eyetracker.py#L97).

