### PR TITLE
ENH: If no JS file for local debug, make one

### DIFF
--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -783,13 +783,14 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         self.getPsychoJS()
 
         htmlPath = str(self.currentFile.parent / self.outputPath)
+        jsFile = self.currentFile.parent / (self.currentFile.stem + ".js")
         pythonExec = Path(sys.executable)
         command = [str(pythonExec), "-m", "http.server", str(port)]
 
-        if not os.path.exists(htmlPath):
-            print('##### HTML output path: "{}" does not exist. '
-                  'Try exporting your HTML, and try again #####\n'.format(self.outputPath))
-            return
+        if not os.path.exists(jsFile):
+            generateScript(experimentPath=str(jsFile),
+                           exp=self.loadExperiment(),
+                           target="PsychoJS")
 
         self.serverProcess = Popen(command,
                                    bufsize=1,


### PR DESCRIPTION
Seems silly that we ask the user to go export the file when Runner has access to the export function and all the info it needs to just go and do it