### PR TITLE
NF: Param/attribute to give a textbox a tail (like a speech bubble)

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -308,7 +308,7 @@ def getInitVals(params, target="PsychoPy"):
         elif name == 'vertices':
             inits[name].val = "[[-0.5,-0.5], [-0.5, 0.5], [0.5, 0.5], [0.5, -0.5]]"
             inits[name].valType = 'code'
-        elif name in ('movie', 'latitude', 'longitude', 'altitude', 'azimuth'):
+        elif name in ('movie', 'latitude', 'longitude', 'altitude', 'azimuth', 'tailPoint'):
             inits[name].val = 'None'
             inits[name].valType = 'code'
         else:

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -48,6 +48,7 @@ class TextboxComponent(BaseVisualComponent):
                  font='Open Sans', units='from exp settings', bold=False, italic=False,
                  color='white', colorSpace='rgb', opacity="",
                  pos=(0, 0), size=(None, None), letterHeight=0.05, ori=0,
+                 hasTail=False, tailPoint="",
                  anchor='center', alignment='center',
                  lineSpacing=1.0, padding=0,  # gap between box and text
                  startType='time (s)', startVal=0.0,
@@ -190,6 +191,27 @@ class TextboxComponent(BaseVisualComponent):
             updates='constant',
             hint=_translate("If the text is bigger than the textbox, how should it behave?"),
             label=_translate('Overflow'))
+        self.params['hasTail'] = Param(
+            hasTail, valType='bool', inputType="bool", categ='Appearance',
+            updates='constant', direct=False,
+            hint=_translate("Should this textbox have a tail like a speech bubble?"),
+            label=_translate("Speech bubble")
+        )
+        self.depends.append(
+            {
+                "dependsOn": "hasTail",  # if...
+                "condition": "==True",  # meets...
+                "param": "tailPoint",  # then...
+                "true": "show",  # should...
+                "false": "hide",  # otherwise...
+            }
+        )
+        self.params['tailPoint'] = Param(
+            tailPoint, valType='list', inputType="single", categ='Appearance',
+            updates='constant', allowedUpdates=_allow3[:], direct=False,
+            hint=_translate("Position of the tail's point."),
+            label=_translate("Tail position [x,y]")
+        )
         self.params['borderWidth'] = Param(
             borderWidth, valType='num', inputType="single", allowedTypes=[], categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:],
@@ -216,6 +238,9 @@ class TextboxComponent(BaseVisualComponent):
         # do writing of init
         # replaces variable params with sensible defaults
         inits = getInitVals(self.params, 'PsychoPy')
+        # if not using a tail, make tailPoint None
+        if not self.params['hasTail']:
+            inits['tailPoint'].val = None
         code = (
             "%(name)s = visual.TextBox2(\n"
             "     win, text=%(text)s, placeholder=%(placeholder)s, font=%(font)s,\n"
@@ -225,7 +250,7 @@ class TextboxComponent(BaseVisualComponent):
             "     color=%(color)s, colorSpace=%(colorSpace)s,\n"
             "     opacity=%(opacity)s,\n"
             "     bold=%(bold)s, italic=%(italic)s,\n"
-            "     lineSpacing=%(lineSpacing)s,\n"
+            "     lineSpacing=%(lineSpacing)s, tailPoint=%(tailPoint)s,\n"
             "     padding=%(padding)s, alignment=%(alignment)s,\n"
             "     anchor=%(anchor)s, overflow=%(overflow)s,\n"
             "     fillColor=%(fillColor)s, borderColor=%(borderColor)s,\n"

--- a/psychopy/layout.py
+++ b/psychopy/layout.py
@@ -760,12 +760,16 @@ class Vertices:
         if hasattr(self, "_anchorX") and hasattr(self, "_anchorY"):
             # If set, return set values
             return self._anchorX, self._anchorY
+        if hasattr(self.obj, "anchor"):
+            return self.obj.anchor
 
         # Otherwise, assume center
         return "center", "center"
 
     @anchor.setter
     def anchor(self, anchor):
+        if anchor is None and hasattr(self.obj, "anchor"):
+            anchor = self.obj.anchor
         # Set defaults
         self._anchorY = None
         self._anchorX = None
@@ -826,6 +830,8 @@ class Vertices:
         value /= getattr(self.size, units)
         # Account for flip
         value *= self._flip
+        # Account for anchor
+        value -= self.anchorAdjust * getattr(self.size, units)
         # Account for pos
         if self.pos is None:
             raise ValueError(

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -794,6 +794,32 @@ def angleTo(v, point, degrees=True, out=None, dtype=None):
     return np.degrees(angle) if degrees else angle
 
 
+def sortClockwise(verts):
+    """
+    Sort vertices clockwise from 12 O'Clock (aka vertex (0, 1)).
+
+    Parameters
+    ==========
+    verts : array
+        Array of vertices to sort
+    """
+    # Blank array of angles
+    angles = []
+    # Calculate angle of each vertex
+    for vert in verts:
+        # Get angle
+        ang = angleTo(v=[0, 1], point=vert)
+        # Flip angle if we're past 6 O'clock
+        if vert[0] < 0:
+            ang = 360 - ang
+        # Append to angles array
+        angles.append(ang)
+    # Sort vertices by angles array values
+    verts = [x for _, x in sorted(zip(angles, verts), key=lambda pair: pair[0])]
+
+    return verts
+
+
 def surfaceNormal(tri, norm=True, out=None, dtype=None):
     """Compute the surface normal of a given triangle.
 

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -544,6 +544,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         ]
         # Sort clockwise so tail point moves to correct place in vertices order
         verts = mt.sortClockwise(verts)
+        verts.reverse()
         # Assign vertices
         self.box.vertices = verts
 

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -117,12 +117,9 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         lineSpacing
         padding
         tailPoint : list, tuple, np.ndarray or None
-            Location of the end of a speech bubble tail on the textbox, relative to textbox
-            size. For example, (-0.6, 0.6) would be 10% of the textbox's width away from the
-            left edge and 10% of the textbox's height away from the top edge. If the point
-            sits within the textbox, the tail will be inverted.
-
-            Use `None` for no tail.
+            Location of the end of a speech bubble tail on the textbox, in the same
+            units as this textbox. If the point sits within the textbox, the tail
+            will be inverted. Use `None` for no tail.
         anchor
         alignment
         fillColor
@@ -508,6 +505,10 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             ]
             return
 
+        # Normalize point to vertex units
+        point = np.asarray(value)
+        point -= self.pos
+        point /= self.size
         # Square with snap points and tail point
         verts = [
             # Top right -> Bottom right
@@ -535,7 +536,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             [0.1, 0.5],
             [0.3, 0.5],
             # Tail
-            value
+            point
         ]
         # Sort clockwise so tail point moves to correct place in vertices order
         verts = mt.sortClockwise(verts)
@@ -1725,6 +1726,7 @@ class Style:
         self.b[i:i] = style.b
         self.c[i:i] = style.c
         self.len += len(style)
+
 
 class PlaceholderText(TextBox2):
     """

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -494,6 +494,8 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
     @attributeSetter
     def tailPoint(self, value):
         self.__dict__['tailPoint'] = value
+        # Match box size to own size
+        self.box.size = self.size
 
         # No tail if value is None
         if value is None:
@@ -506,11 +508,11 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             return
 
         # Normalize point to vertex units
-        point = np.asarray([value])
-        point -= self.box.pos
-        point /= self.box._vertices._flip
-        point -= self.box._vertices.anchorAdjust * self.box.size
-        point /= self.box.size
+        _point = layout.Vertices(
+            [[1, 1]], obj=self
+        )
+        _point.setas([value], self.units)
+        point = _point.base[0]
         # Square with snap points and tail point
         verts = [
             # Top right -> Bottom right
@@ -538,7 +540,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             [0.1, 0.5],
             [0.3, 0.5],
             # Tail
-            point[0]
+            point
         ]
         # Sort clockwise so tail point moves to correct place in vertices order
         verts = mt.sortClockwise(verts)

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -548,6 +548,9 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
         # Assign vertices
         self.box.vertices = verts
 
+    def setTailPoint(self, value, log=None):
+        setAttribute(self, 'tailPoint', value, log)
+
     @property
     def padding(self):
         if hasattr(self, "_padding"):

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -562,50 +562,20 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
                     points[line] = point
         # Construct new vertices array
         verts = [list(coord) for coord in self.box.vertices]
-        # Map sides to coords of last corner in vertices array
-        coords = {
-            "top": [0.5, 0.5],
-            "bottom": [-0.5, -0.5],
-            "left": [-0.5, 0.5],
-            "right": [0.5, -0.5],
-        }
         for line, point in enumerate(points):
-            # Work out what side the point is on
-            ax = list(np.abs(point)).index(0.5)
-            if ax == 0:
-                # If axis is 0, then we're either left or right
-                if point[ax] == 0.5:
-                    side = "right"
-                else:
-                    side = "left"
-            else:
-                # If axis is 1, then we're either top or bottom
-                if point[ax] == 0.5:
-                    side = "top"
-                else:
-                    side = "bottom"
-            # Insert point at correct point for its side
-            i = verts.index(coords[side])
-            verts.insert(i, point)
-
-        # Add tail point
+            verts.append(point)
+        # Sort vertices clockwise from top right corner
+        verts = mt.sortClockwise(verts)
+        # Get point indices
         i0 = verts.index(points[0])
         i1 = verts.index(points[1])
-        # If both connections are on the same side, append the tail point between them
-        if abs(i0 - i1) == 1:
-            verts.insert(max(i0, i1), p0)
-        elif abs(i0 - i1) == 2:
-            # If connections are either side of a corner, replace the corner with the tail point
-            verts[max(i0, i1) - 1] = p0
-        elif verts[-1] not in (i0, i1):
-            # If connections are on the final corner, replace it with the tail point
-            verts[-1] = p0
-        elif verts[0] not in (i0, i1):
-            # If connections are on the first corner, replace it with the tail point
-            verts[0] = p0
-        else:
-            # If none of these are true it's probably directly on the start/end so just append it
-            verts.append(p0)
+        # Remove any corners trapped in a tail
+        if abs(i0 - i1) == 2:
+            del verts[max(i0, i1) - 1]
+        # Add tail point
+        verts.append(p0)
+        # Sort vertices clockwise from top right corner
+        verts = mt.sortClockwise(verts)
 
         # Assign vertices
         self.box.vertices = verts

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -506,9 +506,11 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             return
 
         # Normalize point to vertex units
-        point = np.asarray(value)
-        point -= self.pos
-        point /= self.size
+        point = np.asarray([value])
+        point -= self.box.pos
+        point /= self.box._vertices._flip
+        point -= self.box._vertices.anchorAdjust * self.box.size
+        point /= self.box.size
         # Square with snap points and tail point
         verts = [
             # Top right -> Bottom right
@@ -536,7 +538,7 @@ class TextBox2(BaseVisualStim, ContainerMixin, ColorMixin):
             [0.1, 0.5],
             [0.3, 0.5],
             # Tail
-            point
+            point[0]
         ]
         # Sort clockwise so tail point moves to correct place in vertices order
         verts = mt.sortClockwise(verts)


### PR DESCRIPTION
Decisions pending:
- Should we call it a tail? Or "speech point", or something else?
- Should it have a Builder param at all? Is it better to just tell users to set it in a code component?
- Should it be two params (one that's on/off and one that's point position) or just one (point position, None or blank to have no point)?

Improvements pending:
- There's some weird stuff going on with vertices ( can be seen in below video ), despite being in correct order (as shown by numbers here) they don't seem to attach to the next closest vertex. Investigating on a different branch as this could be affecting anything with vertices.
https://user-images.githubusercontent.com/25686106/203536629-ff222d6d-4c8f-4fcc-b76d-3bf540a51675.mp4
- I notice that `mathtools.angleTo` doesn't specify direction - this is fine when comparing to 12 O'Clock as I do here as you know whether it's 90* or 270* based on the polarity of the x coordinate, but if I wanted to sort clockwise from a different start point it would be a bit harder. Would be handy to have an optional input like "directional=False` which, if `True`, returns the angle as negative if the direction is counter clockwise. @mdcutone is this something relatively simple to add? I'm not familiar enough with the geometry involved to know how difficult it would be.
