### PR TITLE
BF: Fix polygon vertices each frame/repeat setting

### DIFF
--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -75,7 +75,7 @@ class PolygonComponent(BaseVisualComponent):
         self.params['nVertices'] = Param(
             nVertices, valType='int', inputType="single", categ='Basic',
             updates='constant',
-            allowedUpdates=['constant'],
+            allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_localized['nVertices'])
 
@@ -156,11 +156,11 @@ class PolygonComponent(BaseVisualComponent):
             inits['size'].val = '[1.0, 1.0]'
 
         if self.params['shape'] == 'regular polygon...':
-            vertices = self.params['nVertices']
+            vertices = inits['nVertices']
         elif self.params['shape'] == 'custom polygon...':
-            vertices = self.params['vertices']
+            vertices = inits['vertices']
         else:
-            vertices = self.params['shape']
+            vertices = inits['shape']
         if vertices in ['line', '2']:
             code = ("%s = visual.Line(\n" % inits['name'] +
                     "    win=win, name='%s',%s\n" % (inits['name'], unitsStr) +

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -239,6 +239,24 @@ class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.setLineColor(color, colorSpace, operation, log)
         self.setFillColor(color, colorSpace, operation, log)
 
+    @property
+    def vertices(self):
+        return BaseVisualStim.vertices.fget(self)
+
+    @vertices.setter
+    def vertices(self, value):
+        # check if this is a name of one of our known shapes
+        if isinstance(value, str) and value in knownShapes:
+            value = knownShapes[value]
+        if value == "circle":
+            # If circle is requested, calculate how many points are needed for the gap between line rects to be < 1px
+            value = self._calculateMinEdges(self.lineWidth, threshold=5)
+        if isinstance(value, int):
+            value = self._calcEquilateralVertices(value)
+        # Check shape
+        WindowMixin.vertices.fset(self, value)
+        self._needVertexUpdate = True
+
     def setVertices(self, value=None, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,
         but use this method if you need to suppress the log message


### PR DESCRIPTION
Because the init values were coming from self.params rather than inits, if a name like `t` or the header of a table was used it would crash.