### PR TITLE
BF: Fix readme frame logic

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -853,6 +853,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
             if len(possibles) == 0:
                 possibles = list(dirname.glob('Readme*'))
                 possibles.extend(dirname.glob('README*'))
+
             # still haven't found a file so use default name
             if len(possibles) == 0:
                 self.readmeFilename = str(dirname / 'readme.md')  # use this as our default
@@ -860,17 +861,16 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
                 self.readmeFilename = str(possibles[0])  # take the first one found
         else:
             self.readmeFilename = None
-        # don't try to open viewer if there's no file
-        if Path(self.readmeFilename).is_file():
-            filename = self.readmeFilename
-        else:
-            filename = None
-        # create the frame if we don't have one yet
-        if self.readmeFrame is None:
-            self.readmeFrame = ReadmeFrame(parent=self, filename=filename)
-        content = self.readmeFrame.ctrl.getValue()
-        if content and self.prefs['alwaysShowReadme']:
-            self.showReadme()
+
+        content = ''
+        if self.readmeFilename is not None:  # don't open viewer if no file
+            if Path(self.readmeFilename).is_file():
+                self.readmeFrame = ReadmeFrame(
+                    parent=self, filename=self.readmeFilename)
+                content = self.readmeFrame.ctrl.getValue()
+
+            if content and self.prefs['alwaysShowReadme']:  # make this or?
+                self.showReadme()
 
     def showReadme(self, evt=None, value=True):
         """Shows Readme file


### PR DESCRIPTION
App crashes on start since we're passing `None` to `Path(xxxx).is_file()` which is not valid. This fixes the issue and allows the app to start. The condition at the bottom of the method to show the readme frame is always `False` if no file is loaded (i.e. `content` is always empty with no file loaded), so no point in checking that condition outside the file unless we make it an `or`. 