### PR TITLE
FF: Only use generic themer if child ISN'T from ThemeMixin

### DIFF
--- a/psychopy/app/themes/handlers.py
+++ b/psychopy/app/themes/handlers.py
@@ -218,7 +218,7 @@ class ThemeMixin:
             if isinstance(child, ThemeMixin):
                 # If child is a ThemeMixin subclass, we can just set theme
                 child.theme = self.theme
-            if hasattr(child, "_applyAppTheme"):
+            elif hasattr(child, "_applyAppTheme"):
                 # If it's manually been given an _applyAppTheme function, use it
                 child._applyAppTheme()
             else:


### PR DESCRIPTION
Otherwise things like the Routine Canvas or StdOut, which have a different background colour than their base classes would, end up using the generic method if theme is set by their parent rather than themself