### PR TITLE
BF: numpy 1.24.0 fully deprecates np.float so make sure removed

### DIFF
--- a/docs/source/recipes/showImages.py
+++ b/docs/source/recipes/showImages.py
@@ -53,7 +53,7 @@ image_np = np.array(
     pil_image, order="C"
 )  # convert to numpy array with shape width, height, channels
 image_np = (
-    image_np.astype(np.float) / 255.0
+    image_np.astype(float) / 255.0
 )  # convert to float in 0--1 range, assuming image is 8-bit uint.
 
 # Note this float conversion is "quick and dirty" and will not

--- a/psychopy/voicekey/vk_tools.py
+++ b/psychopy/voicekey/vk_tools.py
@@ -98,7 +98,7 @@ def rms(data):
     Identical to `std` when the mean is zero; faster to compute just rms.
     """
     if data.dtype == np.int16:
-        md2 = data.astype(np.float) ** 2  # int16 wrap around --> negative
+        md2 = data.astype(float) ** 2  # int16 wrap around --> negative
     else:
         md2 = data ** 2
     return np.sqrt(np.mean(md2))

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
 install_requires =
     requests[security]
     cryptography
-    numpy
+    numpy < 1.24.0
     scipy
     matplotlib
     pandas


### PR DESCRIPTION
For using psychopyVersions which will not include this fix, we should fix version to numpy<1.24 for now

# Conflicts:
#	setup.cfg