### PR TITLE
FF: Remove unecessary error when GratingStim size is None

### DIFF
--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -227,9 +227,6 @@ class GratingStim(BaseVisualStim, TextureMixin, ColorMixin, ContainerMixin):
         self.phase = val2array(phase, False)
         self._origSize = None  # updated if an image texture is loaded
 
-        if size is None:
-            raise ValueError("`GratingStim` requires `size != None`.")
-
         self._requestedSize = size
         self.size = size
         self.sf = val2array(sf)


### PR DESCRIPTION
I swear we already did this, but this line is back somehow