### PR TITLE
RF: Catch most exceptions from extension modules during import

### DIFF
--- a/psychopy/hardware/bbtk/__init__.py
+++ b/psychopy/hardware/bbtk/__init__.py
@@ -21,6 +21,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Black Box Toolkit hardware is not available this session. "
         "Please install `psychopy-bbtk` and restart the session to enable "
         "support.")
+except Exception as e:  # misc errors during module loading
+    logging.error(
+        "Error encountered while loading `psychopy-bbtk`. Check logs for more "
+        "information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/brainproducts.py
+++ b/psychopy/hardware/brainproducts.py
@@ -22,6 +22,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Brain Products GMBH hardware is not available this "
         "session. Please install `psychopy-brainproducts` and restart the "
         "session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-brainproducts`. Check logs "
+        "for more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/buttonbox/__init__.py
+++ b/psychopy/hardware/buttonbox/__init__.py
@@ -29,19 +29,19 @@ bboxInterfaces = {}
 # Cedrus
 try:
     from ..cedrus import RB730
-except (ModuleNotFoundError, ImportError):
+except Exception:
     RB730 = None
 
 # ioLabs
 try:
     from ..iolab import ButtonBox as ioLabsButtonBox
-except (ModuleNotFoundError, ImportError, NameError):  # NameError from dud pkg
+except Exception:  # NameError from dud pkg
     ioLabsButtonBox = None
 
 # Current Designs
 try:
     from ..forp import ButtonBox as curdesButtonBox
-except (ModuleNotFoundError, ImportError):
+except Exception:
     curdesButtonBox = None
 
 

--- a/psychopy/hardware/cedrus.py
+++ b/psychopy/hardware/cedrus.py
@@ -27,6 +27,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Cedrus Corporation hardware is not available this "
         "session. Please install `psychopy-cedrus` and restart the session "
         "to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-cedrus`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/crs/__init__.py
+++ b/psychopy/hardware/crs/__init__.py
@@ -22,7 +22,7 @@ try:
         DisplayPlusPlusTouch)
     from .optical import OptiCAL
     from .colorcal import ColorCAL
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "Support for Cambridge Research Systems hardware is not available this "
         "session. Please install `psychopy-crs` and restart the session to "

--- a/psychopy/hardware/crs/bits.py
+++ b/psychopy/hardware/crs/bits.py
@@ -25,6 +25,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Cambridge Research Systems Bits#, Bits++, Display++ and "
         "Display++ Touch hardware is not available this session. Please "
         "install `psychopy-crs` and restart the session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-crs`. Check logs for more "
+        "information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/crs/colorcal.py
+++ b/psychopy/hardware/crs/colorcal.py
@@ -9,11 +9,15 @@ import psychopy.logging as logging
 
 try:
     from psychopy_crs.colorcal import ColorCAL
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "Support for Cambridge Research Systems ColorCAL is not available this "
         "session. Please install `psychopy-crs` and restart the session to "
         "enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-crs`. Check logs for more "
+        "information.")
 else:
     # Monkey-patch our metadata into CRS class if missing required attributes
     if not hasattr(ColorCAL, "longName"):

--- a/psychopy/hardware/crs/optical.py
+++ b/psychopy/hardware/crs/optical.py
@@ -30,6 +30,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Cambridge Research Systems OptiCAL is not available this "
         "session. Please install `psychopy-crs` and restart the session to "
         "enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-crs`. Check logs for more "
+        "information.")
 else:
     # Monkey-patch our metadata into CRS class if missing required attributes
     if not hasattr(OptiCAL, "longName"):

--- a/psychopy/hardware/crs/shaders.py
+++ b/psychopy/hardware/crs/shaders.py
@@ -14,7 +14,7 @@
 
 try:
     from psychopy_crs.shaders import bitsMonoModeFrag, bitsColorModeFrag
-except (ModuleNotFoundError, ImportError):
+except Exception:
     pass
 
 if __name__ == "__main__":

--- a/psychopy/hardware/emotiv.py
+++ b/psychopy/hardware/emotiv.py
@@ -20,10 +20,14 @@ try:
         CortexApiException,
         CortexNoHeadsetException,
         CortexTimingException)
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "Support for Emotiv hardware is not available this session. Please "
         "install `psychopy-emotiv` and restart the session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-emotiv`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/emulator.py
+++ b/psychopy/hardware/emulator.py
@@ -28,6 +28,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for software fMRI emulation is not available this session. "
         "Please install `psychopy-mri-emulator` and restart the session to "
         "enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-mri-emulator`. Check logs "
+        "for more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/forp.py
+++ b/psychopy/hardware/forp.py
@@ -33,6 +33,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Current Designs Inc. hardware is not available this "
         "session. Please install `psychopy-curdes` and restart the session "
         "to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-curdes`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/gammasci.py
+++ b/psychopy/hardware/gammasci.py
@@ -23,6 +23,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Gamma-Scientific Inc. hardware is not available this "
         "session. Please install `psychopy-gammasci` and restart the session "
         "to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-gammasci`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/iolab.py
+++ b/psychopy/hardware/iolab.py
@@ -21,6 +21,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for ioLab Systems hardware is not available this session. "
         "Please install `psychopy-iolabs` and restart the session to enable "
         "support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-iolabs`. Check logs for "
+        "more information.")
 finally:
     logging.warning(
         "Support for ioLabs Systems hardware has been discontinued and will "

--- a/psychopy/hardware/labhackers.py
+++ b/psychopy/hardware/labhackers.py
@@ -17,7 +17,7 @@ import psychopy.logging as logging
 try:
     from psychopy_labhackers import (
         getDevices, getSerialPorts, getUSB2TTL8s, USB2TTL8)
-except (ModuleNotFoundError, ImportError):
+except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "Support for LabHackers hardware is not available this session. "
         "Please install `psychopy-labhackers` and restart the session to "

--- a/psychopy/hardware/labjacks.py
+++ b/psychopy/hardware/labjacks.py
@@ -21,6 +21,10 @@ except (ModuleNotFoundError, ImportError):
     logging.error(
         "Support for LabJack hardware is not available this session. Please "
         "install `psychopy-labjack` and restart the session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-labjack`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/minolta.py
+++ b/psychopy/hardware/minolta.py
@@ -21,6 +21,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Konica Minolta hardware is not available this session. "
         "Please install `psychopy-minolta` and restart the session to enable "
         "support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-minolta`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/photometer/__init__.py
+++ b/psychopy/hardware/photometer/__init__.py
@@ -26,25 +26,25 @@ import sys
 # photometer type to do that, but for now we're doing it like this.
 try:
     from ..crs import ColorCAL, OptiCAL
-except (ModuleNotFoundError, ImportError):
+except Exception:
     ColorCAL = OptiCAL = None
 
 # Photo Resaerch Inc. spectroradiometers
 try:
     from ..pr import PR655, PR650
-except (ModuleNotFoundError, ImportError):
+except Exception:
     PR655 = PR650 = None
 
 # Konica Minolta light-measuring devices
 try:
     from ..minolta import LS100, CS100A
-except (ModuleNotFoundError, ImportError):
+except Exception:
     LS100 = CS100A = None
 
 # Gamma scientific devices
 try:
     from ..gammasci import S470
-except (ModuleNotFoundError, ImportError):
+except Exception:
     S470 = None
 
 # photometer interfaces will be stored here after being registered

--- a/psychopy/hardware/pr.py
+++ b/psychopy/hardware/pr.py
@@ -21,6 +21,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for Photo Research Inc. hardware is not available this "
         "session. Please install `psychopy-photoresearch` and restart the "
         "session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-photoresearch`. Check logs "
+        "for more information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/qmix.py
+++ b/psychopy/hardware/qmix.py
@@ -32,6 +32,10 @@ except (ModuleNotFoundError, ImportError):
         "Support for the Cetoni neMESYS syringe pump system is not available "
         "this session. Please install `psychopy-qmix` and restart the session "
         "to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-qmix`. Check logs for more "
+        "information.")
 
 if __name__ == "__main__":
     pass

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -20,6 +20,10 @@ except (ModuleNotFoundError, ImportError):
     logging.error(
         "Support serial ports is not available this session. Please install "
         "`psychopy-connect` and restart the session to enable support.")
+except Exception as e:
+    logging.error(
+        "Error encountered while loading `psychopy-connect`. Check logs for "
+        "more information.")
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
This makes importing extension modules more robust by catching all errors that can arise, warning the user support is not available if an error occurs. This is mostly silent unless the user attempts to use objects that were suppose to appear in the namespace but failed to load.