### PR TITLE
DOC:fix link at "https://psychopy.github.io/psychojs/Shelf.html"

### DIFF
--- a/docs/source/online/shelf.rst
+++ b/docs/source/online/shelf.rst
@@ -40,7 +40,7 @@ Interacting with Integer Records
 
 Imagine the simple case of wanting to count how many participants have completed your task. You would make an Integer Record, which starts at 0 and assign the scope of the Record to the experiment of interest.
 
-From within your experiment you can use several methods to interact with Integers including (though not limited to; see all methods `here <https://psychopy.github.io/psychojs/module-data.Shelf.html>`_):
+From within your experiment you can use several methods to interact with Integers including (though not limited to; see all methods `here <https://psychopy.github.io/psychojs/Shelf.html>`_):
 
 * :code:`psychoJS.shelf.getIntegerValue()`
 * :code:`psychoJS.shelf.setIntegerValue()`


### PR DESCRIPTION
Thanks for great repository!
This PR  closes  #5160. 
I went back through the commits and found a place where "module-data.Shelf.html" was renamed to "Shelf.html".

the commit is here:
https://github.com/psychopy/psychojs/pull/524/files#diff-87376320a40115444a4223b30fddce9970be55f0421ab6e6bf956efd2f37abd5