### PR TITLE
RF: Remove audio library from prefs, move to Experiment Settings

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -286,13 +286,12 @@ class SettingsComponent:
             hint=_translate("Force audio to stereo (2-channel) output"),
             label=_localized["Force stereo"])
         self.params['Audio lib'] = Param(
-            'use prefs', valType='str', inputType="choice",
-            allowedVals=['use prefs', 'ptb', 'pyo', 'sounddevice', 'pygame'],
+            'ptb', valType='str', inputType="choice",
+            allowedVals=['ptb', 'pyo', 'sounddevice', 'pygame'],
             hint=_translate("Which Python sound engine do you want to play your sounds?"),
             label=_translate("Audio library"), categ='Audio')
 
         audioLatencyLabels = [
-            _translate('use prefs'),
             '0: ' + _translate('Latency not important'),
             '1: ' + _translate('Share low-latency driver'),
             '2: ' + _translate('Exclusive low-latency'),
@@ -300,8 +299,8 @@ class SettingsComponent:
             '4: ' + _translate('Latency critical'),
         ]
         self.params['Audio latency priority'] = Param(
-            'use prefs', valType='str', inputType="choice",
-            allowedVals=['use prefs', '0', '1', '2', '3', '4'],
+            '3', valType='str', inputType="choice",
+            allowedVals=['0', '1', '2', '3', '4'],
             allowedLabels=audioLatencyLabels,
             hint=_translate("How important is audio latency for you? If essential then you may need to get all your sounds in correct formats."),
             label=_translate("Audio latency priority"), categ='Audio')

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -122,9 +122,9 @@
 
 # Settings for hardware
 [hardware]
-    # choice of audio library
+    # LEGACY: choice of audio library
     audioLib = list(default=list('sounddevice','PTB', 'pyo', 'pygame'))
-    # latency mode for PsychToolbox audio (3 is good for most applications. See
+    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
     audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -50,7 +50,9 @@ class Preferences:
 
     # Names of legacy parameters which are needed for use version
     legacy = [
-        "winType"
+        "winType",  # 2023.1.0
+        "audioLib",  # 2023.1.0
+        "audioLatencyMode",  # 2023.1.0
     ]
 
     def __init__(self):


### PR DESCRIPTION
Because the setting still exists in the prefs file (it's just marked as "legacy" so not shown in Builder), previous settings will be respected. Basically just means from here on in, users will set their audio library from Experiment Settings rather than Prefs