### PR TITLE
BF: Use knownShapes for Aperture shape rather than trying to copy it manually

### DIFF
--- a/psychopy/tests/test_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_visual/test_all_stimuli.py
@@ -727,7 +727,7 @@ class _baseVisualTest():
         grating.draw()
         utils.compareScreenshot('aperture1_%s.png' %(self.contextName), win)
         #aperture should automatically disable on exit
-        for shape, nVert, pos in [(None, 120, (0,0)), ('circle', 17, (.2, -.7)),
+        for shape, nVert, pos in [(None, 4, (0,0)), ('circle', 72, (.2, -.7)),
                                   ('square', 4, (-.5,-.5)), ('triangle', 3, (1,1))]:
             aperture = visual.Aperture(win, pos=pos, shape=shape, nVert=nVert)
             assert len(aperture.vertices) == nVert  # true for BaseShapeStim; expect (nVert-2)*3 if tesselated

--- a/psychopy/visual/aperture.py
+++ b/psychopy/visual/aperture.py
@@ -26,7 +26,7 @@ import psychopy.event
 # (JWP has no idea why!)
 from psychopy.tools.monitorunittools import cm2pix, deg2pix, convertToPix
 from psychopy.tools.attributetools import attributeSetter, setAttribute
-from psychopy.visual.shape import BaseShapeStim
+from psychopy.visual.shape import BaseShapeStim, knownShapes
 from psychopy.visual.image import ImageStim
 from psychopy.visual.basevisual import MinimalStim, ContainerMixin, WindowMixin
 
@@ -92,33 +92,18 @@ class Aperture(MinimalStim, ContainerMixin):
         else:
             self.units = win.units
 
-        # set vertices using shape, or default to a circle with nVerts edges
-        if hasattr(shape, 'lower') and not os.path.isfile(shape):
-            shape = shape.lower()
-        if shape is None or shape == 'circle':
-            # NB: pentagon etc point upwards by setting x,y to be y,x
-            # (sin,cos):
-            vertices = [(0.5 * sin(radians(theta)), 0.5 * cos(radians(theta)))
-                        for theta in numpy.linspace(0, 360, nVert, False)]
-        elif isinstance(shape, int):
-            # if given a number, take it as a number of vertices and behave as if shape=='circle and nVerts==shape
-            vertices = [(0.5 * sin(radians(theta)), 0.5 * cos(radians(theta)))
-                        for theta in numpy.linspace(0, 360, shape, False)]
-        elif shape == 'square':
-            vertices = [[0.5, -0.5], [-0.5, -0.5], [-0.5, 0.5], [0.5, 0.5]]
-        elif shape == 'triangle':
-            vertices = [[0.5, -0.5], [0, 0.5], [-0.5, -0.5]]
-        elif type(shape) in [tuple, list, numpy.ndarray] and len(shape) > 2:
-            vertices = shape
-        elif isinstance(shape, str):
-            # is a string - see if it points to a file
-            if os.path.isfile(shape):
-                self.__dict__['filename'] = shape
-            else:
-                msg = ("Unrecognized shape for aperture. Expected 'circle',"
-                       " 'square', 'triangle', vertices, filename, or None;"
-                       " got %s")
-                logging.error(msg % repr(shape))
+        vertices = shape
+        if shape in knownShapes:
+            # if given a shape name, get vertices from known shapes
+            vertices = knownShapes[shape]
+        elif isinstance(shape, str) and os.path.isfile(shape):
+            # see if it points to a file
+            self.__dict__['filename'] = shape
+        else:
+            msg = ("Unrecognized shape for aperture. Expected 'circle',"
+                   " 'square', 'triangle', vertices, filename, or None;"
+                   " got %s")
+            logging.error(msg % repr(shape))
 
         if self.__dict__['filename']:
             self._shape = ImageStim(

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -89,6 +89,7 @@ knownShapes = {
         (0.5, 0.0)
     ],
 }
+knownShapes['square'] = knownShapes['rectangle']
 
 
 class BaseShapeStim(BaseVisualStim, ColorMixin, ContainerMixin):


### PR DESCRIPTION
Manual copying results in an error from Builder because Aperture doesn't recognise the shape `rectangle` despite being perfectly able to handle it thanks to inheriting from BaseShapeStim