### PR TITLE
FF: Force reload of `pkg_resources` on scan to avoid using stale path list

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -247,9 +247,6 @@ def scanPlugins():
         return the names of the found plugins.
 
     """
-    import importlib
-    importlib.reload(pkg_resources)  # reload this to make `working_set` current
-
     global _installed_plugins_
     _installed_plugins_ = {}  # clear installed plugins
 

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -26,8 +26,8 @@ import inspect
 import collections
 import hashlib
 import importlib
-import pkg_resources
 import psychopy.tools.pkgtools as pkgtools
+import pkg_resources
 from psychopy import logging
 from psychopy.preferences import prefs
 
@@ -247,6 +247,9 @@ def scanPlugins():
         return the names of the found plugins.
 
     """
+    import importlib
+    importlib.reload(pkg_resources)  # reload this to make `working_set` current
+
     global _installed_plugins_
     _installed_plugins_ = {}  # clear installed plugins
 
@@ -785,6 +788,7 @@ def startUpPlugins(plugins, add=True, verify=True):
         return
 
     # check if the plugins are installed before adding to `startUpPlugins`
+    scanPlugins()
     installedPlugins = listPlugins()
     if verify:
         notInstalled = [plugin not in installedPlugins for plugin in plugins]
@@ -925,6 +929,7 @@ def getWindowBackends():
         fqn, resolve=(fqn not in sys.modules), error=False)
     # Return winTypes array from backend object
     return backend.winTypes
+
 
 def discoverModuleClasses(nameSpace, classType, includeUnbound=True):
     """Discover classes and sub-classes matching a specific type within a

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -412,8 +412,6 @@ def uninstallPackage(package):
         # if any error, return code should be False
         retcode = bool(stderr)
 
-    refreshPackages()
-
     # Return the return code and a dict of information from the console
     return retcode, {"cmd": cmd, "stdout": stdout, "stderr": stderr}
 
@@ -462,8 +460,6 @@ def getInstalledPackages():
         '2021.3.1')`.
 
     """
-    refreshPackages()
-
     # this is like calling `pip freeze` and parsing the output, but faster!
     installedPackages = []
     for pkg in pkg_resources.working_set:


### PR DESCRIPTION
Fixes packages not showing up after installation. Should make them loadable right after install (in theory).