### PR TITLE
Changed assignment of self.currentDoc.fileModTime from string to float

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2343,7 +2343,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
                     n += 1
 
                 # create modification time for in memory document
-                self.currentDoc.fileModTime = time.ctime()
+                self.currentDoc.fileModTime = time.time()
 
             self.currentDoc.EmptyUndoBuffer()
 


### PR DESCRIPTION
This change aims to solve the bug described under issue #5345.

- Run all tests in suite. The 2 failed tests are unrelated to the changes. 
- Tested manually by editing the source code of a separate, standalone installation (Version 2022.2.4). 