### PR TITLE
BF: changed PyQt style to get around the weird greyed-out OK btn bug

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -48,6 +48,7 @@ def ensureQtApp():
     # dialog
     if qtapp is None:
         qtapp = QtWidgets.QApplication(sys.argv)
+        qtapp.setStyle('Fusion')  # use this to avoid annoying PyQt bug with OK being greyed-out
 
 
 wasMouseVisible = True
@@ -334,6 +335,8 @@ class Dlg(QtWidgets.QDialog):
         QtWidgets.QDialog.show(self)
         self.raise_()
         self.activateWindow()
+        if self.inputFields:
+            self.inputFields[0].setFocus()
 
         self.OK = False
         if QtWidgets.QDialog.exec_(self) == QtWidgets.QDialog.Accepted:


### PR DESCRIPTION
PyQt has this weird bug where the OK button of the expInfo dlg is greyed out (only in version >5.15.0)

Using Fusion style instead makes the button nicer, but in this the focus isn't set to the first input field so we have to set that manually as well