### PR TITLE
BF: Fix `MovieStim` stalling during sequential playback

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -10,7 +10,8 @@
 
 __all__ = ['MovieStim']
 
-
+import logging
+import sys
 import ctypes
 import os.path
 from pathlib import Path
@@ -210,6 +211,13 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
             # If given a recording component, use its last clip
             if hasattr(filename, "lastClip"):
                 filename = filename.lastClip
+
+        # stop and unload the video before creating a new one
+        if self._player is not None:
+            logging.warn("Player is: " + repr(self._player) + " eval as " + str(self._player is not None))
+            #logging.flush()
+            self._player.stop()
+            self._player.unload()
 
         self._filename = filename
         self._player.load(self._filename)

--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -214,8 +214,6 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
 
         # stop and unload the video before creating a new one
         if self._player is not None:
-            logging.warn("Player is: " + repr(self._player) + " eval as " + str(self._player is not None))
-            #logging.flush()
             self._player.stop()
             self._player.unload()
 

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -808,9 +808,10 @@ class FFPyPlayer(BaseMoviePlayer):
     def unload(self):
         """Unload the video stream and reset.
         """
-        self._tStream.shutdown()
-        self._tStream.join()  # wait until thread exits
-        self._tStream = None
+        if self._tStream is not None:
+            self._tStream.shutdown()
+            self._tStream.join()  # wait until thread exits
+            self._tStream = None
 
         # if self._handle is not None:
         #     self._handle.close_player()
@@ -955,7 +956,9 @@ class FFPyPlayer(BaseMoviePlayer):
             Log the stop event.
 
         """
-        self._tStream.stop()
+        if self._tStream  is not None:
+            self._tStream.stop()
+
         self._status = STOPPED
 
     def pause(self, log=False):


### PR DESCRIPTION
Fixes an issue where `setMovie()` wasn't stopping and cleaning up previous streams when called again. 