### PR TITLE
RF: Cleanup of unused assignment

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -101,8 +101,6 @@ keyboardBackendMap = {
 class SettingsComponent:
     """This component stores general info about how to run the experiment
     """
-    targets = ['PsychoPy']
-
     categories = ['Custom']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'settings.png'


### PR DESCRIPTION
`targets` is overwritten two lines below, so it seems to be redundant. 