### PR TITLE
BF: Was falsely assuming nested loops to be routines

### DIFF
--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -278,7 +278,7 @@ class TrialHandler(_BaseLoopHandler):
         thisLoop = loopDict[self]  # dict containing lists of children
         code = ""
         for thisChild in thisLoop:
-            if isinstance(thisChild, LoopInitiator):
+            if isinstance(thisChild, (LoopInitiator, _BaseLoopHandler)):
                 # for a LoopInitiator
                 code += (
                     "  const {childName}LoopScheduler = new Scheduler(psychoJS);\n"


### PR DESCRIPTION
Comparing to LoopInitiator is fine for root-level loops, but once they're nested they become TrialHandler objects and so aren't detected as loops. Compare against base loop class to catch *all* loops.