### PR TITLE
Mobile-friendly viewport settings.

### DIFF
--- a/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
+++ b/psychopy/experiment/components/settings/JS_htmlHeader.tmpl
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <title>{name} [PsychoPy]</title>
     <!-- styles -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.12.1/jquery-ui.min.css">


### PR DESCRIPTION
Results in page being displayed in a proper scale.
Before:
![sc](https://user-images.githubusercontent.com/2725889/218613028-002db4f2-27aa-4d01-9070-5685cfb9c6b3.jpeg)

After:
![screenshot_20230214_010312_chrome](https://user-images.githubusercontent.com/2725889/218613059-460f4eec-1c9a-4e37-be16-5968a32072a3.jpg)

With scrollable parameters:
![image](https://user-images.githubusercontent.com/2725889/218898026-e46ba610-2e16-49f6-a9c7-451ff97ce589.png)

