### PR TITLE
BF: Set movie opacity AFTER color

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -122,10 +122,10 @@ class MovieStim(BaseVisualStim, ColorMixin, ContainerMixin):
         self.ori = ori
         self.size = size
         self.depth = depth
-        self.opacity = opacity
         self.anchor = anchor
         self.colorSpace = colorSpace
         self.color = color
+        self.opacity = opacity
 
         # playback stuff
         self._filename = pathToString(filename)


### PR DESCRIPTION
Setting opacity sets the alpha channel of each color, if you set opacity then set a new color (and that new color has an alpha channel, as is the case most of the time with movies as the default is "white" aka `(1, 1, 1, 1)`), then the effects of changing the opacity are overwritten.