### PR TITLE
BF: fixed encoding error

### DIFF
--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -135,7 +135,9 @@ class StdStreamDispatcher:
 
         # write to log file
         if self._logFile is not None:
-            with open(self._logFile, 'a') as lf:
+            import io
+            # with open(self._logFile, 'a') as lf:
+            with io.open(self._logFile, 'a', encoding="utf-8") as lf:
                 lf.write(text)
                 lf.flush()
 

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -15,6 +15,7 @@ consoles/terminals within the PsychoPy GUI suite.
 #
 import os.path
 import sys
+import io
 
 
 class StdStreamDispatcher:
@@ -135,7 +136,6 @@ class StdStreamDispatcher:
 
         # write to log file
         if self._logFile is not None:
-            import io
             # with open(self._logFile, 'a') as lf:
             with io.open(self._logFile, 'a', encoding="utf-8") as lf:
                 lf.write(text)


### PR DESCRIPTION
Gave an encoding error in console while opening the log file. Foced encoding to "utf-8".