### PR TITLE
BF: Fix GH workflow install dependencies on Linux

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -172,7 +172,7 @@ jobs:
         sudo apt-get install -y -qq libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
         sudo apt-get install -y -qq libportaudio2
         # virtual frame buffer
-        sudo apt install llvm-6.0-dev  # for xvfb
+        sudo apt install llvm-13-dev  # for xvfb
         sudo apt install xvfb xauth libgl1-mesa-dri
 
         # set up fake sound device?

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -169,7 +169,7 @@ jobs:
         sudo apt-get install -y -qq libgstreamer1.0-0 gstreamer1.0-plugins-base
         sudo apt-get install -y -qq libwebkit2gtk-4.0-dev
         sudo apt-get install -y -qq libpng-dev libjpeg-dev libtiff-dev libnotify-dev libsm-dev
-        sudo apt-get install -y -qq libsdl-dev libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
+        sudo apt-get install -y -qq libsdl2-mixer-2.0-0 libsdl2-image-2.0-0 libsdl2-2.0-0
         sudo apt-get install -y -qq libportaudio2
         # virtual frame buffer
         sudo apt install llvm-6.0-dev  # for xvfb


### PR DESCRIPTION
Some dependencies packages had no longer available for Ubuntu-latest(22.04 LTS).
Not sure if this will break the environment for unit testing but this will let workflow continue to unit tests steps.  [logs](https://github.com/shun2wang/psychopy/actions/runs/4221398747/jobs/7328642335) on my test branch.


If we want to use a specific version of the dependencies, we may need to specify the installation in other ways, such as lowering the operating system image version(Ubuntu 20.04 LTS) or compiling the installation from other installation sources.