### PR TITLE
FF: Install plugins to subdirectories

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -18,9 +18,12 @@ __all__ = [
     'isPluginLoaded',
     'isStartUpPlugin',
     'activatePlugins',
-    'discoverModuleClasses'
+    'discoverModuleClasses',
+    'getBundleInstallTarget',
+    'refreshBundlePaths'
 ]
 
+import os
 import sys
 import inspect
 import collections
@@ -230,6 +233,77 @@ def computeChecksum(fpath, method='sha256', writeOut=None):
     return checksumStr
 
 
+def getBundleInstallTarget(projectName):
+    """Get the path to a bundle given a package name.
+
+    This returns the installation path for a bundle with the specified project
+    name. This is used to either generate installation target directories.
+
+    Parameters
+    ----------
+    projectName : str
+        Project name for the main package within the bundle.
+
+    Returns
+    -------
+    str
+        Path to the bundle with a given project name. Project name is converted
+        to a 'safe name'.
+
+    """
+    return os.path.join(
+        prefs.paths['packages'], pkg_resources.safe_name(projectName))
+
+
+def refreshBundlePaths():
+    """Find package bundles within the PsychoPy user plugin directory.
+
+    This finds subdirectories inside the PsychoPy user package directory
+    containing distributions, then add them to the search path for packages.
+
+    These are referred to as 'bundles' since each subdirectory contains the
+    plugin package code and all extra dependencies related to it. This allows
+    plugins to be uninstalled cleanly along with all their supporting libraries.
+    A directory is considered a bundle if it contains a package at the top-level
+    whose project name matches the name of the directory. If not, the directory
+    will not be appended to `sys.path`.
+
+    This is called implicitly when :func:`scanPlugins()` is called.
+
+    Returns
+    -------
+    list
+        List of bundle names found in the plugin directory which have been
+        added to `sys.path`.
+
+    """
+    pluginBaseDir = prefs.paths['packages']  # directory packages are in
+
+    foundBundles = []
+    pluginTopLevelDirs = os.listdir(pluginBaseDir)
+    for pluginDir in pluginTopLevelDirs:
+        fullPath = os.path.join(pluginBaseDir, pluginDir)
+        allDists = pkg_resources.find_distributions(fullPath, only=False)
+        if not allDists:  # no packages found, move on
+            continue
+
+        # does the sud-directory contain an appropriately named distribution?
+        validDist = any([dist.project_name == pluginDir for dist in allDists])
+        if not validDist:
+            continue
+
+        # add to path if the subdir has a valid distribution in it
+        if fullPath not in sys.path:
+            sys.path.append(fullPath)  # add to path
+
+        foundBundles.append(pluginDir)
+
+    # refresh package index since the working set is now stale
+    pkgtools.refreshPackages()
+
+    return foundBundles
+
+
 def scanPlugins():
     """Scan the system for installed plugins.
 
@@ -249,6 +323,8 @@ def scanPlugins():
     """
     global _installed_plugins_
     _installed_plugins_ = {}  # clear installed plugins
+
+    refreshBundlePaths()  # refresh plugin bundles directory
 
     # make sure we have the plugin directory in the working set
     pluginDir = prefs.paths['packages']


### PR DESCRIPTION
Creates subdirectories in the `packages` folder, then installs plugins and extra packages into them. Puts the package on the path when a scan is done.