### PR TITLE
BF: fix wx version comparison bug

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -614,7 +614,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
         # wx-windows on some platforms (Mac 10.9.4) with wx-3.0:
         v = parse_version
         if sys.platform == 'darwin':
-            if v('3.0') <= v(wx.version()) < v('4.0'):
+            if v('3.0') <= v(wx.__version__) < v('4.0'):
                 _Showgui_Hack()  # returns ~immediately, no display
                 # focus stays in never-land, so bring back to the app:
                 if prefs.app['defaultView'] in ['all', 'builder', 'coder', 'runner']:

--- a/psychopy/demos/coder/timing/timeByFrames.py
+++ b/psychopy/demos/coder/timing/timeByFrames.py
@@ -15,7 +15,7 @@ from psychopy import visual, logging, core, event
 visual.useFBO = True  # if available (try without for comparison)
 
 import matplotlib
-matplotlib.use('Qt5Agg')  # change this to control the plotting 'back end'
+matplotlib.use('QtAgg')  # change this to control the plotting 'back end'
 import pylab
 
 nIntervals = 500

--- a/psychopy/demos/coder/timing/timeByFramesEx.py
+++ b/psychopy/demos/coder/timing/timeByFramesEx.py
@@ -31,7 +31,7 @@ if disable_gc:
     gc.disable()
 
 import matplotlib
-matplotlib.use('Qt4Agg')  # change this to control the plotting 'back end'
+matplotlib.use('QtAgg')  # change this to control the plotting 'back end'
 import pylab
 
 win = visual.Window([1280, 1024], fullscr=True, allowGUI=False, waitBlanking=True)


### PR DESCRIPTION
wx.version() output is long string that fails with parse_version

bug resulted in crash on macOS. 

Traceback (most recent call last):
  File "/Users/___/venv/psychopy/bin/psychopy", line 33, in <module>
    sys.exit(load_entry_point('PsychoPy==2023.1.0', 'gui_scripts', 'psychopy')())
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/PsychoPy-2023.1.0-py3.9.egg/psychopy/app/psychopyApp.py", line 98, in main
    start_app()
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/PsychoPy-2023.1.0-py3.9.egg/psychopy/app/psychopyApp.py", line 26, in start_app
    app = startApp(showSplash=showSplash)
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/PsychoPy-2023.1.0-py3.9.egg/psychopy/app/__init__.py", line 84, in startApp
    _psychopyApp = PsychoPyApp(
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/PsychoPy-2023.1.0-py3.9.egg/psychopy/app/_psychopyApp.py", line 236, in __init__
    self.onInit(testMode=testMode, **kwargs)
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/PsychoPy-2023.1.0-py3.9.egg/psychopy/app/_psychopyApp.py", line 617, in onInit
    if v('3.0') <= v(wx.version()) < v('4.0'):
  File "/Users/___/venv/psychopy/lib/python3.9/site-packages/pkg_resources/_vendor/packaging/version.py", line 197, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")

