### PR TITLE
FF: Make `PanoramicImageStim` work with `useFBO=True`

### DIFF
--- a/psychopy/experiment/components/panorama/__init__.py
+++ b/psychopy/experiment/components/panorama/__init__.py
@@ -29,6 +29,7 @@ class PanoramaComponent(BaseVisualComponent):
                  startEstim='', durationEstim='',
                  saveStartStop=True, syncScreenRefresh=True,
                  image="",
+                 interpolate='linear',
                  posCtrl="mouse", smooth=True, posSensitivity=1,
                  altitude="", azimuth="",
                  zoomCtrl="wheel",
@@ -71,6 +72,15 @@ class PanoramaComponent(BaseVisualComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
             label=_translate("Image"))
+
+        msg = _translate(
+            "How should the image be interpolated if/when rescaled")
+        self.params['interpolate'] = Param(
+            interpolate, valType='str', inputType="choice",
+            allowedVals=['linear', 'nearest'], categ='Basic',
+            updates='constant', allowedUpdates=[],
+            hint=msg, direct=False,
+            label=_translate("interpolate"))
 
         # Position controls
         
@@ -280,7 +290,8 @@ class PanoramaComponent(BaseVisualComponent):
             "%(name)s = visual.PanoramicImageStim(\n"
             "    win,\n"
             "    image=%(image)s,\n"
-            "    altitude=%(altitude)s, azimuth=%(azimuth)s\n"
+            "    altitude=%(altitude)s, azimuth=%(azimuth)s,\n"
+            "    interpolate=%(interpolate)s\n"
             ")\n"
             "# add attribute to keep track of last movement\n"
             "%(name)s.momentum = np.asarray([0.0, 0.0])\n"

--- a/psychopy/visual/panorama.py
+++ b/psychopy/visual/panorama.py
@@ -64,6 +64,10 @@ class PanoramicImageStim(ImageStim):
             radius=1.0,
             flipFaces=True)  # faces are on the inside of the sphere
 
+        # flip texture coords to view upright
+        textureCoords = np.ascontiguousarray(
+            np.flipud(textureCoords), dtype=textureCoords.dtype)
+
         # handle to the VAO used to draw the sphere
         self._vao = None
         self._createVAO(vertices, textureCoords, normals, faces)

--- a/psychopy/visual/panorama.py
+++ b/psychopy/visual/panorama.py
@@ -64,9 +64,14 @@ class PanoramicImageStim(ImageStim):
             radius=1.0,
             flipFaces=True)  # faces are on the inside of the sphere
 
+        # flip verts
+        vertices = np.ascontiguousarray(
+            np.flipud(vertices), dtype=vertices.dtype)
+
         # flip texture coords to view upright
+        textureCoords[:, 0] = np.flipud(textureCoords[:, 0])
         textureCoords = np.ascontiguousarray(
-            np.flipud(textureCoords), dtype=textureCoords.dtype)
+           textureCoords, dtype=textureCoords.dtype)
 
         # handle to the VAO used to draw the sphere
         self._vao = None
@@ -248,6 +253,8 @@ class PanoramicImageStim(ImageStim):
         GL.glBindTexture(GL.GL_TEXTURE_2D, self._texID)
         GL.glEnable(GL.GL_TEXTURE_2D)
 
+        GL.glFrontFace(GL.GL_CW)
+
         gt.useProgram(self.win._shaders['imageStim'])
 
         # pass values to OpenGL as material
@@ -268,6 +275,8 @@ class PanoramicImageStim(ImageStim):
         GL.glActiveTexture(GL.GL_TEXTURE0)
         GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
         GL.glDisable(GL.GL_TEXTURE_2D)
+
+        GL.glFrontFace(GL.GL_CW)
 
         # Exit 3d perspective
         win.useLights = False

--- a/psychopy/visual/panorama.py
+++ b/psychopy/visual/panorama.py
@@ -1,26 +1,31 @@
 from . import stim3d
-from .basevisual import MinimalStim
+from . import ImageStim
 from .. import constants
-from ..tools import gltools as gl, mathtools as mt, viewtools as vt
+from ..tools import gltools as gt, mathtools as mt, viewtools as vt
 import numpy as np
+import pyglet.gl as GL
+import psychopy.colors as colors
 
 from ..tools.attributetools import attributeSetter, setAttribute
 
 
-class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
-    """
-    Map an image to the inside of a sphere and allow view to be changed via latitude and longitude
-    coordinates (between -1 and 1).
+class PanoramicImageStim(ImageStim):
+    """Map an image to the inside of a sphere and allow view to be changed via
+    latitude and longitude coordinates (between -1 and 1).
 
+    Parameters
+    ----------
     win : psychopy.visual.Window
         The window to draw the stimulus to.
     image : pathlike
-        File path of image to present as a panorama. Most modern phones have a "panoramic" camera mode,
+        File path of image to present as a panorama. Most modern phones have a
+        "panoramic" camera mode,
         which will output an image with all the correct warping applied.
     altitude : float (-1 to 1)
         Initial vertical look position.
     azimuth : float (-1 to 1)
         Initial horizontal look position.
+
     """
     def __init__(self, win,
                  image=None,
@@ -28,25 +33,19 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
                  azimuth=None,
                  depth=0,
                  autoDraw=False,
+                 name=None,
                  autoLog=False):
-        # Create sphere
-        stim3d.SphereStim.__init__(
-            self, win,
-            pos=(0, 0, 0),
-            flipFaces=True,
-            autoLog=autoLog
-        )
-        # Create material to host image
-        self.material = stim3d.BlinnPhongMaterial(
-            win,
-            diffuseColor="black",
-            specularColor="black",
-            emissionColor="white",
-            shininess=1
-        )
-        # Put the panoramic image onto the texture
-        self.material.diffuseTexture = gl.createTexImage2dFromFile(image, transpose=False)
-        # Set starting lat- and long- itude
+
+        self._initParams = dir()
+        self._initParams.remove('self')
+
+        super(PanoramicImageStim, self).__init__(
+            win, image=image, units="", name=name, autoLog=autoLog)
+
+        # internal object for storing information pose
+        self._thePose = stim3d.RigidBodyPose()
+
+        # Set starting lat- and long-itude
         self.altitude = altitude
         self.azimuth = azimuth
         # Set starting zoom
@@ -58,38 +57,68 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
         # Add default attribute for control handler (updated from Builder if used)
         self.ctrl = None
 
-    @attributeSetter
-    def image(self, value):
-        # Store value
-        self.__dict__['image'] = value
-        # Set texture
-        self.material.diffuseTexture = gl.createTexImage2dFromFile(value, transpose=False)
+        # generate buffers for vertex data
+        vertices, textureCoords, normals, faces = gt.createUVSphere(
+            sectors=128,
+            stacks=256,
+            radius=1.0,
+            flipFaces=True)  # faces are on the inside of the sphere
 
-    def setImage(self, value, log=None):
-        setAttribute(self, "image", value, log=log)
+        # handle to the VAO used to draw the sphere
+        self._vao = None
+        self._createVAO(vertices, textureCoords, normals, faces)
+
+        # flag if orientation needs an update
+        self._needsOriUpdate = True
+
+    def _createVAO(self, vertices, textureCoords, normals, faces):
+        """Create a vertex array object for handling vertex attribute data.
+        """
+        # upload to buffers
+        vertexVBO = gt.createVBO(vertices)
+        texCoordVBO = gt.createVBO(textureCoords)
+        normalsVBO = gt.createVBO(normals)
+
+        # create an index buffer with faces
+        indexBuffer = gt.createVBO(
+            faces.flatten(),
+            target=GL.GL_ELEMENT_ARRAY_BUFFER,
+            dataType=GL.GL_UNSIGNED_INT)
+
+        bufferMapping = {
+            GL.GL_VERTEX_ARRAY: vertexVBO,
+            GL.GL_TEXTURE_COORD_ARRAY: texCoordVBO,
+            GL.GL_NORMAL_ARRAY: normalsVBO
+        }
+
+        self._vao = gt.createVAO(
+            bufferMapping, indexBuffer=indexBuffer, legacy=True)
 
     @attributeSetter
     def azimuth(self, value):
-        """
-        Horizontal view point between -1 (180 degrees to the left) and +1 (180 degrees to the right). Values
-        outside this range will still be accepted (e.g. -1.5 will be 270 degrees to the left).
+        """Horizontal view point between -1 (180 degrees to the left) and +1
+        (180 degrees to the right). Values outside this range will still be
+        accepted (e.g. -1.5 will be 270 degrees to the left).
         """
         if value is None:
             value = 0
+
         # Store value
         self.__dict__['azimuth'] = self.__dict__['longitude'] = value
+
         # Shift 90deg left so centre of image is azimuth 0
         value = value + 0.5
+
         # Get lat and long in degrees
         value = self._normToDegrees(value)
+
         # Calculate ori
         self.latQuat = mt.quatFromAxisAngle((0, 0, 1), value, degrees=True)
         self._needsOriUpdate = True
 
     @attributeSetter
     def longitude(self, value):
-        """
-        Alias of azimuth
+        """Alias of `azimuth`.
         """
         self.azimuth = value
 
@@ -101,9 +130,9 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
 
     @attributeSetter
     def altitude(self, value):
-        """
-        Vertical view point between -1 (directly downwards) and 1 (directly upwards). Values outside this range will
-        be clipped to within range (e.g. -1.5 will be directly downwards).
+        """Vertical view point between -1 (directly downwards) and 1 (directly
+        upwards). Values outside this range will be clipped to within range
+        (e.g. -1.5 will be directly downwards).
         """
         if value is None:
             value = 0
@@ -123,8 +152,7 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
 
     @attributeSetter
     def latitude(self, value):
-        """
-        Alias of altitude
+        """Alias of `altitude`.
         """
         self.altitude = value
 
@@ -146,9 +174,12 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
 
     @attributeSetter
     def fov(self, value):
+        """Set the field-of-view (FOV).
+        """
         if 'fov' in self.__dict__ and value == self.__dict__['fov']:
             # Don't recalculate if value hasn't changed
             return
+
         self.__dict__['fov'] = value
         fov = vt.computeFrustumFOV(
             scrFOV=80,
@@ -161,18 +192,79 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
         setAttribute(self, "fov", value, operation=operation, log=log)
 
     def draw(self, win=None):
-        # Substitude with own win if none given
+        # substitute with own win if none given
         if win is None:
             win = self.win
+        self._selectWindow(win)
+
+        # check the type of image we're dealing with
+        if (type(self.image) != np.ndarray and
+                self.image in (None, "None", "none")):
+            return
+
+        # check if we need to update the texture
+        if self._needTextureUpdate:
+            self.setImage(value=self._imName, log=False)
+
+        # Calculate ori from latitude and longitude quats if needed
+        if self._needsOriUpdate:
+            self._thePose.ori = mt.multQuat(self.longQuat, self.latQuat)
+            win.viewMatrix = self._thePose.getViewMatrix(inverse=True)
+
         # Enter 3d perspective
         win.projectionMatrix = self._projectionMatrix
         win.applyEyeTransform()
         win.useLights = True
-        # Calculate ori from latitude and longitude quats if needed
-        if self._needsOriUpdate:
-            self.ori = mt.multQuat(self.longQuat, self.latQuat)
-        # Do base sphere drawing
-        stim3d.SphereStim.draw(self, win=win)
+
+        # setup the shaderprogram
+        if self.isLumImage:
+            # for a luminance image do recoloring
+            _prog = self.win._progSignedTexMask
+            GL.glUseProgram(_prog)
+            # set the texture to be texture unit 0
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
+            # mask is texture unit 1
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
+        else:
+            # for an rgb image there is no recoloring
+            _prog = self.win._progImageStim
+            GL.glUseProgram(_prog)
+            # set the texture to be texture unit 0
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"texture"), 0)
+            # mask is texture unit 1
+            GL.glUniform1i(GL.glGetUniformLocation(_prog, b"mask"), 1)
+
+        # mask
+        GL.glActiveTexture(GL.GL_TEXTURE1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._maskID)
+        GL.glEnable(GL.GL_TEXTURE_2D)  # implicitly disables 1D
+
+        # main texture
+        GL.glActiveTexture(GL.GL_TEXTURE0)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, self._texID)
+        GL.glEnable(GL.GL_TEXTURE_2D)
+
+        gt.useProgram(self.win._shaders['imageStim'])
+
+        # pass values to OpenGL as material
+        r, g, b = self._foreColor.render('rgb')
+        color = np.ctypeslib.as_ctypes(
+            np.array((r, g, b, 1.0), np.float32))
+        GL.glColor4f(*color)
+
+        gt.drawVAO(self._vao, GL.GL_TRIANGLES)
+
+        gt.useProgram(0)
+
+        # unbind the textures
+        GL.glActiveTexture(GL.GL_TEXTURE1)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+        GL.glDisable(GL.GL_TEXTURE_2D)  # implicitly disables 1D
+        # main texture
+        GL.glActiveTexture(GL.GL_TEXTURE0)
+        GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+        GL.glDisable(GL.GL_TEXTURE_2D)
+
         # Exit 3d perspective
         win.useLights = False
         win.resetEyeTransform()
@@ -196,3 +288,7 @@ class PanoramicImageStim(stim3d.SphereStim, MinimalStim):
         value -= 1
 
         return value
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/visual/panorama.py
+++ b/psychopy/visual/panorama.py
@@ -32,6 +32,7 @@ class PanoramicImageStim(ImageStim):
                  altitude=None,
                  azimuth=None,
                  depth=0,
+                 interpolate=True,
                  autoDraw=False,
                  name=None,
                  autoLog=False):
@@ -40,7 +41,8 @@ class PanoramicImageStim(ImageStim):
         self._initParams.remove('self')
 
         super(PanoramicImageStim, self).__init__(
-            win, image=image, units="", name=name, autoLog=autoLog)
+            win, image=image, units="", interpolate=interpolate, name=name,
+            autoLog=autoLog)
 
         # internal object for storing information pose
         self._thePose = stim3d.RigidBodyPose()


### PR DESCRIPTION
This PR refactors `PanoramicImageStim` to be based around `ImageStim`. This allows the texture to be rendered with an FBO enabled and provides better adherence with PsychoPy's conventions for loading and rendering images.