### PR TITLE
FF: Use `wx.SP_NOBORDER` for styling Runner dialog splitter

### DIFF
--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -605,7 +605,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
 
         # Setup splitter
         self.mainSizer = wx.BoxSizer()
-        self.splitter = wx.SplitterWindow(self)
+        self.splitter = wx.SplitterWindow(self, style=wx.SP_NOBORDER)
         self.mainSizer.Add(self.splitter, proportion=1, border=0, flag=wx.EXPAND | wx.ALL)
 
         # Setup panel for top half (experiment control and toolbar)


### PR DESCRIPTION
Runner window splitter renders a sunken border on MacOS which looks visually inconsistent. Fixed by adding the `wx.SP_NOBORDER` style flag.