### PR TITLE
ENH: Use Textbox `lineSpacing` param in JS boilerplate

### DIFF
--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -268,7 +268,9 @@ class TextboxComponent(BaseVisualComponent):
                 "  text: %(text)s,\n"
                 "  placeholder: %(placeholder)s,\n"
                 "  font: %(font)s,\n" 
-                "  pos: %(pos)s, letterHeight: %(letterHeight)s,\n"
+                "  pos: %(pos)s, \n"
+                "  letterHeight: %(letterHeight)s,\n"
+                "  lineSpacing: %(lineSpacing)s,\n"
                 "  size: %(size)s," + unitsStr +
                 "  color: %(color)s, colorSpace: %(colorSpace)s,\n"
                 "  fillColor: %(fillColor)s, borderColor: %(borderColor)s,\n"


### PR DESCRIPTION
Not implemented online yet I don't think, but just supplying the param shouldn't break anything so it's worth doing