### PR TITLE
FF: gitignore had been accidentally told to ignore all new files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-*
-@ -1,110 +1,3 @@
+
 #########################################
 # Editor temporary/working/backup files #
 .#*
@@ -19,7 +18,6 @@
 /.cache
 /.idea
 /.untitled.py
-*
 
 # Compiled source #
 ###################


### PR DESCRIPTION
Looks like commit 9a158f3db1254aff28 added an accidental row (or 2) that meant all new files in the project (e.g. in docs) were accidentally git-ignored