### PR TITLE
TESTS: refactor to use psychopy.tools.systemtools.icVM-CI() more widely

### DIFF
--- a/psychopy/tests/__init__.py
+++ b/psychopy/tests/__init__.py
@@ -1,19 +1,14 @@
-import os
-
-_travisTesting = bool("{}".format(os.environ.get('TRAVIS')).lower() == 'true')
-_anacondaTesting = bool("{}".format(os.environ.get('CONDA')).lower() == 'true')
-_githubActions = str(os.environ.get('GITHUB_WORKFLOW')) != 'None'
-_vmTesting = _travisTesting or _githubActions
+from psychopy.tools import systemtools
 
 # for skip_under we need pytest but we don't want that to be a requirement for normal use
 try:
     import pytest
     # some pytest decorators for those conditions
-    skip_under_travis = pytest.mark.skipif(_travisTesting,
+    skip_under_travis = pytest.mark.skipif(systemtools.isVM_CI() == 'travis',
                                            reason="Cannot run that test under Travis")
-    skip_under_ghActions = pytest.mark.skipif(_githubActions,
+    skip_under_ghActions = pytest.mark.skipif(systemtools.isVM_CI() == 'github',
                                               reason="Cannot run that test on GitHub Actions")
-    skip_under_vm = pytest.mark.skipif(_vmTesting,
+    skip_under_vm = pytest.mark.skipif(systemtools.isVM_CI(),
                                        reason="Cannot run that test on a virtual machine")
 except ImportError:
     def no_op(fn, reason=None):

--- a/psychopy/tests/__init__.py
+++ b/psychopy/tests/__init__.py
@@ -8,7 +8,7 @@ try:
                                            reason="Cannot run that test under Travis")
     skip_under_ghActions = pytest.mark.skipif(systemtools.isVM_CI() == 'github',
                                               reason="Cannot run that test on GitHub Actions")
-    skip_under_vm = pytest.mark.skipif(systemtools.isVM_CI(),
+    skip_under_vm = pytest.mark.skipif(bool(systemtools.isVM_CI()),
                                        reason="Cannot run that test on a virtual machine")
 except ImportError:
     def no_op(fn, reason=None):

--- a/psychopy/tests/test_hardware/test_CRS_bitsShaders.py
+++ b/psychopy/tests/test_hardware/test_CRS_bitsShaders.py
@@ -5,7 +5,8 @@ Created on Mon Dec 15 15:22:48 2014
 @author: lpzjwp
 """
 from psychopy import visual
-from psychopy.tests import skip_under_vm, _vmTesting
+from psychopy.tools import systemtools
+from psychopy.tests import skip_under_vm
 import numpy as np
 
 try:
@@ -94,7 +95,7 @@ def test_bitsShaders():
             #fr = np.array(win._getFrame(buffer='back').transpose(Image.ROTATE_270))
             win.flip()
             fr = np.array(win._getFrame(buffer='front').transpose(Image.ROTATE_270))
-            if not _vmTesting:
+            if not systemtools.isVM_CI():
                 assert np.alltrue(thisExpected['lowR'] == fr[0:10, -1, 0])
                 assert np.alltrue(thisExpected['lowG'] == fr[0:10, -1, 1])
                 assert np.alltrue(thisExpected['highR'] == fr[250:256, -1, 0])

--- a/psychopy/tests/test_misc/test_clock.py
+++ b/psychopy/tests/test_misc/test_clock.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from psychopy.clock import wait, StaticPeriod, CountdownTimer
 from psychopy.visual import Window
-from psychopy.tests import _vmTesting
+from psychopy.tools import systemtools
 
 
 def test_StaticPeriod_finish_on_time():
@@ -51,8 +51,8 @@ def test_StaticPeriod_screenHz():
     timer.reset(period_duration )
     static.complete()
 
-    if _vmTesting:
-        tolerance = 0.01  # without a proper screen timing might not eb sub-ms
+    if systemtools.isVM_CI():
+        tolerance = 0.01  # without a proper screen timing might not be sub-ms
     else:
         tolerance = 0.001
     assert np.allclose(timer.getTime(),

--- a/psychopy/tests/test_misc/test_core.py
+++ b/psychopy/tests/test_misc/test_core.py
@@ -29,7 +29,7 @@ from psychopy.visual import Window
 from psychopy.core import (getTime, MonotonicClock, Clock, CountdownTimer, wait,
                            StaticPeriod, shellCall)
 from psychopy.clock import monotonicClock
-from psychopy.tests import _vmTesting
+from psychopy.tools import systemtools
 
 
 def test_EmptyFunction():
@@ -375,7 +375,7 @@ def test_StaticPeriod():
     timer.reset(period_duration )
     static.complete()
 
-    if _vmTesting:
+    if systemtools.isVM_CI():
         tolerance = 0.01  # without a proper screen timing might not eb sub-ms
     else:
         tolerance = 0.001

--- a/psychopy/tests/test_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_visual/test_all_stimuli.py
@@ -17,7 +17,7 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 
 """
 
-from psychopy.tests import _travisTesting, skip_under_vm
+from psychopy.tests import skip_under_vm
 from psychopy.tools import systemtools
 
 
@@ -796,7 +796,7 @@ class TestPygletHexColor(_baseVisualTest):
         self.contextName='normHexbackground'
         self.scaleFactor=1#applied to size/pos values
 
-if not _travisTesting:
+if systemtools.isVM_CI() != 'travis':
     class TestPygletBlendAdd(_baseVisualTest):
         @classmethod
         def setup_class(self):

--- a/psychopy/tests/test_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_visual/test_all_stimuli.py
@@ -17,7 +17,8 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 
 """
 
-from psychopy.tests import _travisTesting, skip_under_vm, _vmTesting
+from psychopy.tests import _travisTesting, skip_under_vm
+from psychopy.tools import systemtools
 
 
 class Test_Window():
@@ -501,7 +502,7 @@ class _baseVisualTest():
         text.draw()
         grat1.draw()
         grat2.draw()
-        if _vmTesting:
+        if systemtools.isVM_CI():
             pytest.skip("Blendmode='add' doesn't work under a virtual machine for some reason")
         if self.win.winType != 'pygame':
             utils.compareScreenshot('blend_add_%s.png' %self.contextName,

--- a/psychopy/tests/test_visual/test_gamma.py
+++ b/psychopy/tests/test_visual/test_gamma.py
@@ -1,17 +1,16 @@
 from psychopy import visual, monitors
 import numpy
 
-from psychopy.tests import skip_under_vm, _vmTesting
-import pytest
+from psychopy.tests import skip_under_vm
 
 
 @skip_under_vm(reason="Cannot test gamma in a virtual machine")
 def test_low_gamma():
     """setting gamma low (dark screen)"""
-    win = visual.Window([600,600], gamma=0.5, autoLog=False)#should make the entire screen bright
+    win = visual.Window([600,600], gamma=0.5, autoLog=False)  # should make the entire screen bright
     for n in range(5):
         win.flip()
-    assert win.useNativeGamma==False
+    assert win.useNativeGamma == False
     win.close()
 
 

--- a/psychopy/tests/test_visual/test_ratingScale.py
+++ b/psychopy/tests/test_visual/test_ratingScale.py
@@ -2,7 +2,7 @@ from psychopy.colors import Color
 from psychopy.visual import RatingScale, Window, shape, TextStim
 from psychopy import event, core
 from psychopy.constants import (NOT_STARTED, FINISHED)
-from psychopy.tests import _vmTesting
+from psychopy.tools import systemtools
 import pytest, copy
 
 """define RatingScale configurations, test the logic
@@ -289,7 +289,7 @@ class Test_class_RatingScale:
         h = r.getHistory()
         assert h[0] == (None, 0)
         assert h[-1][0] == 1
-        if _vmTesting:
+        if systemtools.isVM_CI():
             assert 0.001 < h[-1][1] < 0.1  # virtual machines not usually great
         else:
             assert 0.001 < h[-1][1] < 0.03


### PR DESCRIPTION
1. There has been more than one option - we want only 1 way to do a thing
2. Having the VM check in the tests folder is a bad idea because the libs (e.g. the sound lib) should not import from the tests folder