### PR TITLE
BF: Don't check for default stim if value is not a string

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -164,7 +164,7 @@ class _SoundBase():
         # Re-init sound to ensure bad values will raise error during setting:
         self._snd = None
 
-        if value in defaultStim:
+        if isinstance(value, str) and value in defaultStim:
             value = defaultStimRoot / defaultStim[value]
 
         # Coerces pathlib obj to string, else returns inputted value


### PR DESCRIPTION
Fixes issue raised here: https://github.com/psychopy/psychopy/commit/45ed546b8e0a25ddb87156ef400687aaf31baf39#commitcomment-104348592