### PR TITLE
BF: Sound files were playing forever if duration set to <0.5s

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -188,7 +188,7 @@ class SoundComponent(BaseComponent):
         else:
             # sounds with stop values
             self.writeStopTestCodeJS(buff)
-            code = ("if (%(stopVal)s > 0.5) {\n"
+            code = ("if (%(stopVal)s > 0.5 || t >=  %(name)s.getDuration() + %(name)s.tStart) {\n"
                     "  %(name)s.stop();  // stop the sound (if longer than duration)\n"
                     "}\n"
                     "%(name)s.status = PsychoJS.Status.FINISHED;\n")

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -188,10 +188,10 @@ class SoundComponent(BaseComponent):
         else:
             # sounds with stop values
             self.writeStopTestCodeJS(buff)
-            code = ("if (%(stopVal)s > 0.5 || t >=  %(name)s.getDuration() + %(name)s.tStart) {\n"
+            code = ("if (t >= %(name)s.tStart + 0.5) {\n"
                     "  %(name)s.stop();  // stop the sound (if longer than duration)\n"
-                    "}\n"
-                    "%(name)s.status = PsychoJS.Status.FINISHED;\n")
+                    "  %(name)s.status = PsychoJS.Status.FINISHED;\n"
+                    "}\n")
             buff.writeIndentedLines(code % self.params)
             # because of the 'if' statement of the time test
             buff.setIndentLevel(-1, relative=True)


### PR DESCRIPTION
Seems to have been added in [825bfdb0a9c53cf71cdec349eb1e2b6b47b951ca
](https://github.com/psychopy/psychopy/commit/825bfdb0a9c53cf71cdec349eb1e2b6b47b951ca) to prevent stopping a Sound before it's started, as it can take up to 0.5s to start. But this method means Sound components with duration <0.5s play forever as `.stop` is never called. Better instead to check that t >= start + 0.5