### PR TITLE
DOCS hint to install wxPython linux deb-systems using libwebkitgtk-1.0.0

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -123,6 +123,14 @@ and having downloaded the right wheel you can then install it with something lik
 wxPython>4.0 and doesn't have universal wheels yet which is why you have to
 find and install the correct wheel for your particular flavor of linux.
 
+For some reasons wxPython (wx.html2) is using an older version of libwebkitgtk
+e.g. psychopy will not show up
+to fix this (of our own risk):
+sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu bionic main universe'
+sudo apt install -t bionic libwebkitgtk-1.0-0
+
+
+
 **Building Python PsychToolbox bindings:**
 
 The PsychToolbox bindings for Python provide superior timing for sounds and


### PR DESCRIPTION
DOCS update installation hint  for wxPython on linux debian systems, 
wxPython  (wx.html2) needs older version of libwebkitgtk  (libwebkitgtk-1.0.0)
