### PR TITLE
TEST: Fix test install dependencies failing on macOS 

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: Install PsychoPy and dependencies
       run: |
         # for pocketsphinx we need this adapted package:
-        brew install swig vlc
+        brew install swig vlc portaudio portmidi liblo
         # install optional components
         pip install psychopy-sounddevice psychopy-pyo psychopy-legacy-mic psychopy-connect psychopy-crs psychopy-emotiv psychopy-gammasci psychopy-mri-emulator psychopy-visionscience
         # then use the standard requirements:


### PR DESCRIPTION
It is because `portaudio portmidi liblo` dev library cannot found when build to install Pyo things on macOS.

Or is this related to https://github.com/psychopy/psychopy/issues/5475? if so, should we including this into require text?