### PR TITLE
NF: Added abort method to `MultiStairHandler`

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -1965,6 +1965,8 @@ class MultiStairHandler(_BaseTrialHandler):
                     exp.addData(self.name + '.stepType', stair.stepType)
 
                 exp.addData(self.name + '.intensity', self._nextIntensity)
+
+            self._trialAborted = False  # reset this flag
             return self._nextIntensity, self.currentStaircase.condition
         else:
             raise StopIteration
@@ -2002,6 +2004,45 @@ class MultiStairHandler(_BaseTrialHandler):
     def intensity(self, intensity):
         """The intensity (level) of the current staircase"""
         self.currentStaircase._nextIntensity = intensity
+
+    def abortCurrentTrial(self, action='random'):
+        """Abort the current trial (staircase).
+
+        Calling this during an experiment abort the current staircase used this
+        trial. The current staircase will be reshuffled into available 
+        staircases depending on the `action` parameter.
+
+        Parameters
+        ----------
+        action : str
+            Action to take with the aborted trial. Can be either of `'random'`,
+            or `'append'`. The default action is `'random'`.
+
+        Notes
+        -----
+        * When using `action='random'`, the RNG state for the trial handler is
+          not used.
+
+        """
+        # check if value for parameter `action` is valid
+        if not isinstance(action, str):  # type checks for params
+            raise TypeError(
+                "Parameter `action` specified incorrect type, must be `str`.")
+        
+        # reinsert the current staircase into the list of running staircases
+        if action == 'append':
+            self.thisPassRemaining.append(self.currentStaircase)
+        elif action == 'random':
+            self.thisPassRemaining.append(self.currentStaircase)
+            # shuffle using the numpy RNG to preserve state
+            np.random.shuffle(self.thisPassRemaining)
+        else:
+            raise ValueError(
+                "Value for parameter `action` must be either 'random' or "
+                "'append'.")
+
+        # set flag to indicate that the trial was aborted
+        self._trialAborted = True  
 
     def addResponse(self, result, intensity=None):
         """Add a 1 or 0 to signify a correct / detected or
@@ -2198,3 +2239,7 @@ class MultiStairHandler(_BaseTrialHandler):
             label = thisStair.condition['label']
             thisStair.saveAsText(fileName='stdout', delim=delim,
                                  matrixOnly=thisMatrixOnly)
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
This PR adds a method which can be used to abort trials when using the `MultiStairHandler` class.