### PR TITLE
BF: use os.linesep during data file writing

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import os
 import sys
 import copy
 import pickle
@@ -342,7 +342,7 @@ class ExperimentHandler(_ComparisonMixin):
         if not matrixOnly:
             for heading in names:
                 f.write(u'%s%s' % (heading, delim))
-            f.write('\n')
+            f.write(os.linesep)
 
         # write the data for each entry
         for entry in self.getAllEntries():
@@ -356,7 +356,7 @@ class ExperimentHandler(_ComparisonMixin):
                     f.write(fmt % (entry[name], delim))
                 else:
                     f.write(delim)
-            f.write('\n')
+            f.write(os.linesep)
         if f != sys.stdout:
             f.close()
         logging.info('saved data to %r' % f.name)

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -699,7 +699,7 @@ class TrialHandler(_BaseTrialHandler):
             for prmName in header:
                 nextLine = nextLine + prmName + delim
             # remove the final orphaned tab character
-            f.write(nextLine[:-1] + '\n')
+            f.write(nextLine[:-1] + os.linesep)
 
         # write the data matrix:
         for trial in dataOut:
@@ -708,7 +708,7 @@ class TrialHandler(_BaseTrialHandler):
                 nextLine = nextLine + str(trial[prmName]) + delim
             # remove the final orphaned tab character
             nextLine = nextLine[:-1]
-            f.write(nextLine + '\n')
+            f.write(nextLine + os.linesep)
 
         if f != sys.stdout:
             f.close()
@@ -1883,11 +1883,11 @@ class TrialHandlerExt(TrialHandler):
 
         # write a header row:
         if not matrixOnly:
-            f.write(delim.join(header) + '\n')
+            f.write(delim.join(header) + os.linesep)
         # write the data matrix:
         for trial in dataOut:
             line = delim.join([str(trial[prm]) for prm in header])
-            f.write(line + '\n')
+            f.write(line + os.linesep)
 
         if (fileName is not None) and (fileName != 'stdout'):
             f.close()


### PR DESCRIPTION
Trying to work with collaborators using old tools (written in VB6) for file reading during analysis, and the default readline does not work because the file is encoded without the windows "\r" before the "\n".
With typical python `open` and `print`, the `'\n'` gets interpreted according to the OS before writing to the file. Psychopy uses `codecs.open` and `write` which does not interpret `'\n'`.  Seems appropriate for builder-based experiments to write data according to OS format.