### PR TITLE
BF: `AudioClip` handling with PTB backend error

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -206,8 +206,8 @@ class _SoundBase():
             self._setSndFromArray(numpy.array(value))
         elif isinstance(value, AudioClip):
             # from an audio clip object
-            self._setSndFromArray(value.samples)
             self.sampleRate = value.sampleRateHz
+            self._setSndFromArray(value.samples)
         # did we succeed?
         if self._snd is None:
             pass  # raise ValueError, "Could not make a "+value+" sound"

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -45,7 +45,7 @@ class RecordingBuffer:
     ----------
     sampleRateHz : int
         Sampling rate for audio recording in Hertz (Hz). By default, 48kHz
-        (``sampleRateHz=480000``) is used which is adequate for most consumer
+        (``sampleRateHz=48000``) is used which is adequate for most consumer
         grade microphones (headsets and built-in).
     channels : int
         Number of channels to record samples to `1=Mono` and `2=Stereo`.
@@ -323,7 +323,7 @@ class Microphone:
         (`int`) or descriptor (`AudioDevice`).
     sampleRateHz : int
         Sampling rate for audio recording in Hertz (Hz). By default, 48kHz
-        (``sampleRateHz=480000``) is used which is adequate for most consumer
+        (``sampleRateHz=48000``) is used which is adequate for most consumer
         grade microphones (headsets and built-in).
     channels : int
         Number of channels to record samples to `1=Mono` and `2=Stereo`.


### PR DESCRIPTION
Fixes an issue where `AudioClip` objects weren't being correctly used by the PsychToolbox  `Sound` backend. The sample rate needed to be set prior to running the `_setSndFromArray` call to work correctly. 

Workaround for current versions:
```
snd = Sound(clip.samples, sampleRate=clip.sampleRateHz)
```

After this patch:
```
snd = Sound(clip)
```