### PR TITLE
BF: Removed redundant "MainLoop" call

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -17,14 +17,14 @@ import psychopy.locale_setup  # noqa
 
 
 def start_app():
-    from psychopy.app import startApp
+    from psychopy.app import startApp, quitApp
 
     showSplash = True
     if '--no-splash' in sys.argv:
         showSplash = False
         del sys.argv[sys.argv.index('--no-splash')]
-    app = startApp(showSplash=showSplash)
-    app.MainLoop()
+    _ = startApp(showSplash=showSplash)  # main loop
+    quitApp()
 
 
 def main():


### PR DESCRIPTION
This PR removes the redundant `MainLoop` call in `start_app()` which causes crashes on exit if some dialogs are left open.