### PR TITLE
DOC: Update standalone version on download.rst

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -15,7 +15,7 @@ For the easiest installation download and install the Standalone package.
 
     let filename;
     let url;
-    let version='2022.2.5';
+    let version='2023.1.2';
 
     let clientInfo = UAParser(navigator.userAgent);
     var osLabel;


### PR DESCRIPTION
Solving issue #5532 - updating the version on the "Download recent version" button to 2023.1.2.