### PR TITLE
BF: Colored progress bar on showScreenNumbers

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -929,7 +929,8 @@ class _BaseParamsDlg(wx.Dialog):
             # Progress bar
             progBar = visual.Rect(
                 win, anchor="bottom left",
-                pos=(-1, -1), size=(0, 0.1)
+                pos=(-1, -1), size=(0, 0.1), 
+                fillColor='white'
             )
 
             # Frame loop


### PR DESCRIPTION
The progress bar was not visible (#5561), as it was the same color as the background.