### PR TITLE
RF: Move environment management functions to tools

### DIFF
--- a/psychopy/core.py
+++ b/psychopy/core.py
@@ -166,59 +166,6 @@ def shellCall(shellCmd, stdin='', stderr=False, env=None, encoding=None):
         return stdoutData.strip()
 
 
-def getFromNames(names, namespace=None):
-    """
-    Get a component, or any other object handle, from a string containing its variable name.
-
-    Parameters
-    ==========
-    names : str, list or tuple
-        String representing the name of a variable, or a list/tuple (or listlike string) of names.
-    namespace : dict or None
-        dict mapping names to values, if None will use `globals()`
-    """
-    # If listlike string, split into list
-    if isinstance(names, str) and "," in names:
-        # Strip perentheses
-        if (
-                (names.startswith("[") and names.endswith("]"))
-                or (names.startswith("(") and names.endswith(")"))
-        ):
-            names = names[1:-1]
-        # Split at commas
-        namesList = []
-        for thisName in names.split(","):
-            # Strip spaces
-            thisName = thisName.strip()
-            # Strip quotes
-            if (
-                    (thisName.startswith('"') and thisName.endswith('"'))
-                    or (thisName.startswith("'") and thisName.endswith("'"))
-            ):
-                thisName = thisName[1:-1]
-            # Append
-            namesList.append(thisName)
-        names = namesList
-
-    # If single name, put in list
-    from collections.abc import Iterable
-    if isinstance(names, str) or not isinstance(names, Iterable):
-        names = [names]
-
-    # Get objects
-    objs = []
-    for nm in names:
-        # Get from globals if no namespace
-        if namespace is None:
-            namespace = globals()
-        # Get (use original value if not present)
-        obj = namespace.get(nm, nm)
-        # Append
-        objs.append(obj)
-
-    return objs
-
-
 class ComponentPlaceholder:
     """
     When a component is not implemented, we need an object to represent it when running, which will accept any

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -173,7 +173,7 @@ class MouseComponent(BaseComponent):
             "# check whether click was in correct object\n"
             "if gotValidClick:\n"
             "    corr = 0\n"
-            "    corrAns = core.getFromNames(%(correctAns)s, namespace=locals())\n"
+            "    corrAns = environmenttools.getFromNames(%(correctAns)s, namespace=locals())\n"
             "    for obj in corrAns:\n"
             "        # is this object clicked on?\n"
             "        if obj.contains(%(name)s):\n"

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -755,6 +755,7 @@ class SettingsComponent:
             )
         buff.write(
             "from psychopy import %s\n" % ', '.join(psychopyImports) +
+            "from psychopy.tools import environmenttools"
             "from psychopy.constants import (NOT_STARTED, STARTED, PLAYING,"
             " PAUSED,\n"
             "                                STOPPED, FINISHED, PRESSED, "

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -755,7 +755,7 @@ class SettingsComponent:
             )
         buff.write(
             "from psychopy import %s\n" % ', '.join(psychopyImports) +
-            "from psychopy.tools import environmenttools"
+            "from psychopy.tools import environmenttools\n"
             "from psychopy.constants import (NOT_STARTED, STARTED, PLAYING,"
             " PAUSED,\n"
             "                                STOPPED, FINISHED, PRESSED, "

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -1,0 +1,62 @@
+def getFromNames(names, namespace=None):
+    """
+    Get a component, or any other object handle, from a string containing its variable name.
+
+    Parameters
+    ==========
+    names : str, list or tuple
+        String representing the name of a variable, or a list/tuple (or listlike string) of names.
+    namespace : dict or None
+        dict mapping names to values, if None will use `globals()`
+    """
+    # If listlike string, split into list
+    if isinstance(names, str) and "," in names:
+        # Strip perentheses
+        if (
+                (names.startswith("[") and names.endswith("]"))
+                or (names.startswith("(") and names.endswith(")"))
+        ):
+            names = names[1:-1]
+        # Split at commas
+        namesList = []
+        for thisName in names.split(","):
+            # Strip spaces
+            thisName = thisName.strip()
+            # Strip quotes
+            if (
+                    (thisName.startswith('"') and thisName.endswith('"'))
+                    or (thisName.startswith("'") and thisName.endswith("'"))
+            ):
+                thisName = thisName[1:-1]
+            # Append
+            namesList.append(thisName)
+        names = namesList
+
+    # If single name, put in list
+    from collections.abc import Iterable
+    if isinstance(names, str) or not isinstance(names, Iterable):
+        names = [names]
+
+    # Get objects
+    objs = []
+    for nm in names:
+        # Get from globals if no namespace
+        if namespace is None:
+            namespace = globals()
+        # Get (use original value if not present)
+        obj = namespace.get(nm, nm)
+        # Append
+        objs.append(obj)
+
+    return objs
+
+
+def setExecEnvironment(env):
+    # Get builtin exec function
+    import builtins
+    # Create new exec function in given environment
+    def exec(call_str):
+        builtins.exec(call_str, env)
+    exec.__doc__ = builtins.exec.__doc__
+    # Return function
+    return exec


### PR DESCRIPTION
We'd somehow got the commit which updates `core.getFromNames` to `environmenttools.getFromNames` in release but the commits to move the functions only existed in dev.