### PR TITLE
DOC: Update index.rst

### DIFF
--- a/docs/source/api/visual/index.rst
+++ b/docs/source/api/visual/index.rst
@@ -38,7 +38,6 @@ Shapes (all special classes of :class:`ShapeStim`):
 
 Images and patterns:
 
-* :class:`.ImageStim` to show images
 * :class:`.SimpleImageStim` to show images without bells and whistles
 * :class:`.GratingStim` to show gratings
 * :class:`.RadialStim` to show annulus, a rotating wedge, a checkerboard etc


### PR DESCRIPTION
Removed this line, as it repeats the reference to ImageStim already included in the [file](https://github.com/psychopy/psychopy/blob/96a22f84d1af9d11637b6e56283fc9be49d04f5d/docs/source/api/visual/index.rst?plain=1#L26).

