### PR TITLE
BF: Coder source tree thought any variable name beginning with `def` was a function def

### DIFF
--- a/psychopy/app/coder/sourceTree.py
+++ b/psychopy/app/coder/sourceTree.py
@@ -182,6 +182,7 @@ class SourceTreePanel(wx.Panel, handlers.ThemeMixin):
             # work out which keyword the line starts with
             kwrd = None
             for i in kwrds:
+                i += " "  # add a space to avoid e.g. `defaultKeyboard` being read as a keyword
                 if lineText.startswith(i):
                     kwrd = i
             # skip if it starts with no keywords


### PR DESCRIPTION
e.g. `defaultKeyboard = ...` was picked up as a function called `=`