### PR TITLE
RF: Standardise label conventions

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -55,18 +55,18 @@ class BaseComponent:
         self.order = ['name', 'startVal', 'startEstim', 'startType', 'stopVal', 'durationEstim', 'stopType']  # name first, then timing, then others
 
         msg = _translate(
-            "Name of this component (alphanumeric or _, no spaces)")
+            "Name of this Component (alphanumeric or _, no spaces)")
         self.params['name'] = Param(name,
             valType='code', inputType="single", categ='Basic',
             hint=msg,
-            label=_localized['name'])
+            label=_translate("Name"))
 
         msg = _translate("How do you want to define your start point?")
         self.params['startType'] = Param(startType,
             valType='str', inputType="choice", categ='Basic',
             allowedVals=['time (s)', 'frame N', 'condition'],
             hint=msg, direct=False,
-            label=_localized['startType'])
+            label=_translate("Start type"))
 
         msg = _translate("How do you want to define your end point?")
         self.params['stopType'] = Param(stopType,
@@ -74,32 +74,32 @@ class BaseComponent:
             allowedVals=['duration (s)', 'duration (frames)', 'time (s)',
                          'frame N', 'condition'],
             hint=msg, direct=False,
-            label=_localized['stopType'])
+            label=_translate("Stop type"))
 
         self.params['startVal'] = Param(startVal,
             valType='code', inputType="single", categ='Basic',
-            hint=_translate("When does the component start?"), allowedTypes=[],
-            label=_localized['startVal'])
+            hint=_translate("When does the Component start?"), allowedTypes=[],
+            label=_translate("Start"))
 
         self.params['stopVal'] = Param(stopVal,
             valType='code', inputType="single", categ='Basic',
             updates='constant', allowedUpdates=[], allowedTypes=[],
-            hint=_translate("When does the component end? (blank is endless)"),
-            label=_localized['stopVal'])
+            hint=_translate("When does the Component end? (blank is endless)"),
+            label=_translate("Stop"))
 
         msg = _translate("(Optional) expected start (s), purely for "
                          "representing in the timeline")
         self.params['startEstim'] = Param(startEstim,
             valType='code', inputType="single", categ='Basic',
             hint=msg, allowedTypes=[], direct=False,
-            label=_localized['startEstim'])
+            label=_translate("Expected start (s)"))
 
         msg = _translate("(Optional) expected duration (s), purely for "
                          "representing in the timeline")
         self.params['durationEstim'] = Param(durationEstim,
             valType='code', inputType="single", categ='Basic',
             hint=msg, allowedTypes=[], direct=False,
-            label=_localized['durationEstim'])
+            label=_translate("Expected duration (s)"))
 
         msg = _translate("Store the onset/offset times in the data file "
                          "(as well as in the log file).")
@@ -115,11 +115,11 @@ class BaseComponent:
             hint=msg, allowedTypes=[],
             label=_translate('Sync timing with screen refresh'))
 
-        msg = _translate("Disable this component")
+        msg = _translate("Disable this Component")
         self.params['disabled'] = Param(disabled,
             valType='bool', inputType="bool", categ="Testing",
             hint=msg, allowedTypes=[], direct=False,
-            label=_translate('Disable component'))
+            label=_translate('Disable Component'))
 
     @property
     def _xml(self):
@@ -971,7 +971,7 @@ class BaseVisualComponent(BaseComponent):
             allowedVals=['from exp settings', 'deg', 'cm', 'pix', 'norm',
                          'height', 'degFlatPos', 'degFlat'],
             hint=msg,
-            label=_localized['units'])
+            label=_translate("Spatial units"))
 
         msg = _translate("Foreground color of this stimulus (e.g. $[1,1,0], red )")
         self.params['color'] = Param(color,
@@ -980,7 +980,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['color'])
+            label=_translate("Foreground color"))
 
         msg = _translate("In what format (color space) have you specified "
                          "the colors? (rgb, dkl, lms, hsv)")
@@ -989,7 +989,7 @@ class BaseVisualComponent(BaseComponent):
             allowedVals=['rgb', 'dkl', 'lms', 'hsv'],
             updates='constant',
             hint=msg,
-            label=_localized['colorSpace'])
+            label=_translate("Color space"))
 
         msg = _translate("Fill color of this stimulus (e.g. $[1,1,0], red )")
         self.params['fillColor'] = Param(fillColor,
@@ -997,7 +997,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant', allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['fillColor'])
+            label=_translate("Fill color"))
 
         msg = _translate("Color of this stimulus (e.g. $[1,1,0], red )")
         self.params['borderColor'] = Param(borderColor,
@@ -1005,7 +1005,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant',allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['borderColor'])
+            label=_translate("Border color"))
 
         msg = _translate("Opacity of the stimulus (1=opaque, 0=fully transparent, 0.5=translucent). "
                          "Leave blank for each color to have its own opacity (recommended if any color is None).")
@@ -1014,7 +1014,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant', allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['opacity'])
+            label=_translate("Opacity"))
 
         msg = _translate("Contrast of the stimulus (1.0=unchanged contrast, "
                          "0.5=decrease contrast, 0.0=uniform/no contrast, "
@@ -1024,7 +1024,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['contrast'])
+            label=_translate("Contrast"))
 
         msg = _translate("Position of this stimulus (e.g. [1,2] )")
         self.params['pos'] = Param(pos,
@@ -1032,7 +1032,7 @@ class BaseVisualComponent(BaseComponent):
             updates='constant', allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['pos'])
+            label=_translate("Position [x,y]"))
 
         msg = _translate("Size of this stimulus (either a single value or "
                          "x,y pair, e.g. 2.5, [1,2] ")
@@ -1041,14 +1041,14 @@ class BaseVisualComponent(BaseComponent):
             updates='constant', allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['size'])
+            label=_translate("Size [w,h]"))
 
         self.params['ori'] = Param(ori,
             valType='num', inputType="spin", categ='Layout',
             updates='constant', allowedTypes=[], allowedVals=[-360,360],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Orientation of this stimulus (in deg)"),
-            label=_localized['ori'])
+            label=_translate("Orientation"))
 
         self.params['syncScreenRefresh'].readOnly = True
 

--- a/psychopy/experiment/components/brush/__init__.py
+++ b/psychopy/experiment/components/brush/__init__.py
@@ -54,7 +54,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label= _translate('Brush Color'))
+            label= _translate("Brush color"))
 
         msg = _translate("Width of the brush's line (always in pixels and limited to 10px max width)")
         self.params['lineWidth'] = Param(
@@ -62,7 +62,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label= _translate('Brush Size'))
+            label= _translate("Brush size"))
 
         self.params['lineColorSpace'] = self.params['colorSpace']
         del self.params['colorSpace']
@@ -76,7 +76,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label= _translate('Press Button'))
+            label= _translate("Press button"))
 
         # Remove BaseVisual params which are not needed
         del self.params['color']  # because color is defined by lineColor

--- a/psychopy/experiment/components/brush/__init__.py
+++ b/psychopy/experiment/components/brush/__init__.py
@@ -54,7 +54,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label=_localized['lineColor'])
+            label= _translate('Brush Color'))
 
         msg = _translate("Width of the brush's line (always in pixels and limited to 10px max width)")
         self.params['lineWidth'] = Param(
@@ -62,7 +62,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label=_localized['lineWidth'])
+            label= _translate('Brush Size'))
 
         self.params['lineColorSpace'] = self.params['colorSpace']
         del self.params['colorSpace']
@@ -76,7 +76,7 @@ class BrushComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label=_localized['buttonRequired'])
+            label= _translate('Press Button'))
 
         # Remove BaseVisual params which are not needed
         del self.params['color']  # because color is defined by lineColor

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -81,7 +81,7 @@ class ButtonComponent(BaseVisualComponent):
             updates='constant', direct=False,
             hint=_translate("Should a response force the end of the Routine "
                             "(e.g end the trial)?"),
-            label=_localized['forceEndRoutine'])
+            label=_translate("Force end of Routine"))
 
         # If force end routine, then once per click doesn't make sense
         self.depends += [
@@ -98,44 +98,44 @@ class ButtonComponent(BaseVisualComponent):
             oncePerClick, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("Should the callback run once per click (True), or each frame until click is released (False)"),
-            label=_localized['oncePerClick']
+            label=_translate("Run once per click")
         )
         self.params['callback'] = Param(
             callback, valType='extendedCode', inputType="multi", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("Code to run when button is clicked"),
-            label=_localized['callback'])
+            label=_translate("Callback Function"))
         self.params['text'] = Param(
             text, valType='str', inputType="single", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The text to be displayed"),
-            label=_localized['text'])
+            label=_translate("Button text"))
         self.params['font'] = Param(
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The font name (e.g. Comic Sans)"),
-            label=_localized['font'])
+            label=_translate("Font"))
         self.params['letterHeight'] = Param(
             letterHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("Specifies the height of the letter (the width"
                             " is then determined by the font)"),
-            label=_localized['letterHeight'])
+            label=_translate("Letter height"))
         self.params['italic'] = Param(
             italic, valType='bool', inputType="bool", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Should text be italic?"),
-            label=_localized['italic'])
+            label=_translate("Italic"))
         self.params['bold'] = Param(
             bold, valType='bool', inputType="bool", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Should text be bold?"),
-            label=_localized['bold'])
+            label=_translate("Bold"))
         self.params['padding'] = Param(
             padding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Defines the space between text and the textbox border"),
-            label=_localized['padding'])
+            label=_translate("Padding"))
         self.params['anchor'] = Param(
             anchor, valType='str', inputType="choice", categ='Layout',
             allowedVals=['center',
@@ -150,19 +150,19 @@ class ButtonComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Should text anchor to the top, center or bottom of the box?"),
-            label=_localized['anchor'])
+            label=_translate("Anchor"))
         self.params['borderWidth'] = Param(
             borderWidth, valType='num', inputType="single", allowedTypes=[], categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Textbox border width"),
-            label=_localized['borderWidth'])
+            label=_translate("Border Width"))
         self.params['save'] = Param(
             save, valType='str', inputType="choice", categ='Data',
             allowedVals=['first click', 'last click', 'every click', 'none'],
             hint=_translate(
                 "What clicks on this button should be saved to the data output?"),
             direct=False,
-            label=_localized['save'])
+            label=_translate("Record clicks"))
         self.params['timeRelativeTo'] = Param(
             timeRelativeTo, valType='str', inputType="choice", categ='Data',
             allowedVals=['button onset', 'experiment', 'routine'],
@@ -171,7 +171,7 @@ class ButtonComponent(BaseVisualComponent):
             hint=_translate(
                 "What should the values of mouse.time should be "
                 "relative to?"),
-            label=_localized['timeRelativeTo'])
+            label=_translate("Time relative to"))
 
 
     def writeInitCode(self, buff):

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -74,7 +74,7 @@ class ButtonComponent(BaseVisualComponent):
         ]
         # params
         _allow3 = ['constant', 'set every repeat', 'set every frame']  # list
-        self.params['color'].label = _translate("Text Color")
+        self.params['color'].label = _translate("Text color")
 
         self.params['forceEndRoutine'] = Param(
             forceEndRoutine, valType='bool', inputType="bool", categ='Basic',
@@ -104,7 +104,7 @@ class ButtonComponent(BaseVisualComponent):
             callback, valType='extendedCode', inputType="multi", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("Code to run when button is clicked"),
-            label=_translate("Callback Function"))
+            label=_translate("Callback function"))
         self.params['text'] = Param(
             text, valType='str', inputType="single", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
@@ -155,7 +155,7 @@ class ButtonComponent(BaseVisualComponent):
             borderWidth, valType='num', inputType="single", allowedTypes=[], categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Textbox border width"),
-            label=_translate("Border Width"))
+            label=_translate("Border width"))
         self.params['save'] = Param(
             save, valType='str', inputType="choice", categ='Data',
             allowedVals=['first click', 'last click', 'every click', 'none'],

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -69,7 +69,7 @@ class CameraComponent(BaseComponent):
             allowedVals=["default"] + cams,
             allowedLabels=["default"] + cams,
             hint=msg,
-            label=_translate("Video Device")
+            label=_translate("Video device")
         )
 
         msg = _translate("What device would you like to use to record audio? This will only affect local "
@@ -79,7 +79,7 @@ class CameraComponent(BaseComponent):
             allowedVals=list(range(len(mics))),
             allowedLabels=[d.title() for d in list(mics)],
             hint=msg,
-            label=_translate("Audio Device")
+            label=_translate("Audio device")
         )
 
 
@@ -104,7 +104,7 @@ class CameraComponent(BaseComponent):
         self.params['saveFile'] = Param(
             saveFile, valType='bool', inputType="bool", categ="Data",
             hint=msg,
-            label=_translate("Save File?")
+            label=_translate("Save file?")
         )
 
         # msg = _translate("What kind of video codec should the output file be encoded as?")

--- a/psychopy/experiment/components/code/__init__.py
+++ b/psychopy/experiment/components/code/__init__.py
@@ -63,7 +63,7 @@ class CodeComponent(BaseComponent):
             codeType, valType='str', inputType="choice", allowedTypes=[],
             allowedVals=['Py', 'JS', 'Both', 'Auto->JS'],
             hint=msg, direct=False,
-            label=_translate("Code Type"))
+            label=_translate("Code type"))
 
         msg = _translate("Code to run before the experiment starts "
                          "(initialization); right-click checks syntax")
@@ -71,7 +71,7 @@ class CodeComponent(BaseComponent):
             beforeExp, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Before Experiment"))
+            label=_translate("Before experiment"))
 
         msg = _translate("Code at the start of the experiment ; right-click "
                          "checks syntax")
@@ -79,7 +79,7 @@ class CodeComponent(BaseComponent):
             beginExp, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Begin Experiment"))
+            label=_translate("Begin experiment"))
 
         msg = _translate("Code to be run at the start of each repeat of the "
                          "Routine (e.g. each trial); "
@@ -97,7 +97,7 @@ class CodeComponent(BaseComponent):
             eachFrame, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Each Frame"))
+            label=_translate("Each frame"))
 
         msg = _translate("Code at the end of this repeat of the Routine (e.g."
                          " getting/storing responses); "
@@ -115,7 +115,7 @@ class CodeComponent(BaseComponent):
             endExperiment, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("End Experiment"))
+            label=_translate("End experiment"))
         # todo: copy initial vals once javscript interp can do comments
         msg = _translate("Code before the start of the experiment (initialization"
                          "); right-click checks syntax")
@@ -123,14 +123,14 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Before JS Experiment"))
+            label=_translate("Before JS experiment"))
         msg = _translate("Code at the start of the experiment (initialization"
                          "); right-click checks syntax")
         self.params['Begin JS Experiment'] = Param(
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Begin JS Experiment"))
+            label=_translate("Begin JS experiment"))
 
         msg = _translate("Code to be run at the start of each repeat of the "
                          "Routine (e.g. each trial); "
@@ -148,7 +148,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Each JS Frame"))
+            label=_translate("Each JS frame"))
 
         msg = _translate("Code at the end of this repeat of the Routine (e.g."
                          " getting/storing responses); "
@@ -166,7 +166,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("End JS Experiment"))
+            label=_translate("End JS experiment"))
 
         # these inherited params are harmless but might as well trim:
         for p in ('startType', 'startVal', 'startEstim', 'stopVal',

--- a/psychopy/experiment/components/code/__init__.py
+++ b/psychopy/experiment/components/code/__init__.py
@@ -63,7 +63,7 @@ class CodeComponent(BaseComponent):
             codeType, valType='str', inputType="choice", allowedTypes=[],
             allowedVals=['Py', 'JS', 'Both', 'Auto->JS'],
             hint=msg, direct=False,
-            label=_localized['Code Type'])
+            label=_translate("Code Type"))
 
         msg = _translate("Code to run before the experiment starts "
                          "(initialization); right-click checks syntax")
@@ -71,7 +71,7 @@ class CodeComponent(BaseComponent):
             beforeExp, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Before Experiment'])
+            label=_translate("Before Experiment"))
 
         msg = _translate("Code at the start of the experiment ; right-click "
                          "checks syntax")
@@ -79,7 +79,7 @@ class CodeComponent(BaseComponent):
             beginExp, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Begin Experiment'])
+            label=_translate("Begin Experiment"))
 
         msg = _translate("Code to be run at the start of each repeat of the "
                          "Routine (e.g. each trial); "
@@ -88,7 +88,7 @@ class CodeComponent(BaseComponent):
             beginRoutine, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Begin Routine'])
+            label=_translate("Begin Routine"))
 
         msg = _translate("Code to be run on every video frame during for the"
                          " duration of this Routine; "
@@ -97,7 +97,7 @@ class CodeComponent(BaseComponent):
             eachFrame, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Each Frame'])
+            label=_translate("Each Frame"))
 
         msg = _translate("Code at the end of this repeat of the Routine (e.g."
                          " getting/storing responses); "
@@ -106,7 +106,7 @@ class CodeComponent(BaseComponent):
             endRoutine, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['End Routine'])
+            label=_translate("End Routine"))
 
         msg = _translate("Code at the end of the entire experiment (e.g. "
                          "saving files, resetting computer); "
@@ -115,7 +115,7 @@ class CodeComponent(BaseComponent):
             endExperiment, valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['End Experiment'])
+            label=_translate("End Experiment"))
         # todo: copy initial vals once javscript interp can do comments
         msg = _translate("Code before the start of the experiment (initialization"
                          "); right-click checks syntax")
@@ -123,14 +123,14 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Before JS Experiment'])
+            label=_translate("Before JS Experiment"))
         msg = _translate("Code at the start of the experiment (initialization"
                          "); right-click checks syntax")
         self.params['Begin JS Experiment'] = Param(
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Begin JS Experiment'])
+            label=_translate("Begin JS Experiment"))
 
         msg = _translate("Code to be run at the start of each repeat of the "
                          "Routine (e.g. each trial); "
@@ -139,7 +139,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Begin JS Routine'])
+            label=_translate("Begin JS Routine"))
 
         msg = _translate("Code to be run on every video frame during for the"
                          " duration of this Routine; "
@@ -148,7 +148,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['Each JS Frame'])
+            label=_translate("Each JS Frame"))
 
         msg = _translate("Code at the end of this repeat of the Routine (e.g."
                          " getting/storing responses); "
@@ -157,7 +157,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['End JS Routine'])
+            label=_translate("End JS Routine"))
 
         msg = _translate("Code at the end of the entire experiment (e.g. "
                          "saving files, resetting computer); "
@@ -166,7 +166,7 @@ class CodeComponent(BaseComponent):
             '', valType='extendedCode', inputType="multi", allowedTypes=[],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['End JS Experiment'])
+            label=_translate("End JS Experiment"))
 
         # these inherited params are harmless but might as well trim:
         for p in ('startType', 'startVal', 'startEstim', 'stopVal',

--- a/psychopy/experiment/components/dots/__init__.py
+++ b/psychopy/experiment/components/dots/__init__.py
@@ -70,7 +70,7 @@ class DotsComponent(BaseVisualComponent):
             nDots, valType='int', inputType="spin", categ='Dots',
             updates='constant',
             hint=msg,
-            label=_localized['nDots'])
+            label=_translate("Number of dots"))
 
         msg = _translate("Direction of motion for the signal dots (degrees)")
         self.params['dir'] = Param(
@@ -78,7 +78,7 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['dir'])
+            label=_translate("Direction"))
 
         msg = _translate("Speed of the dots (displacement per frame in the"
                          " specified units)")
@@ -87,7 +87,7 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['speed'])
+            label=_translate("Speed"))
 
         msg = _translate("Coherence of the dots (fraction moving in the "
                          "signal direction on any one frame)")
@@ -96,7 +96,7 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['coherence'])
+            label=_translate("Coherence"))
 
         msg = _translate("Size of the dots IN PIXELS regardless of "
                          "the set units")
@@ -105,28 +105,28 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['dotSize'])
+            label=_translate("Dot size"))
 
         msg = _translate("Number of frames before each dot is killed and "
                          "randomly assigned a new position")
         self.params['dotLife'] = Param(
             dotLife, valType='num', inputType="spin", categ='Dots',
             hint=msg,
-            label=_localized['dotLife'])
+            label=_translate("Dot life-time"))
 
         msg = _translate("On each frame are the signals dots remaining "
                          "the same or changing? See Scase et al.")
         self.params['signalDots'] = Param(
             signalDots, valType='str', inputType="choice", allowedVals=['same', 'different'], categ='Dots',
             hint=msg,
-            label=_localized['signalDots'])
+            label=_translate("Signal dots"))
             
         msg = _translate("When should the whole sample of dots be refreshed")
         self.params['refreshDots'] = Param(
             refreshDots, valType='str', inputType="choice", allowedVals=['none', 'repeat'], categ='Dots',
             allowedUpdates=[],
             hint=msg, direct=False,
-            label=_localized['refreshDots'])
+            label=_translate("Dot refresh rule"))
             
 
         msg = _translate("What governs the behaviour of the noise dots? "
@@ -135,14 +135,14 @@ class DotsComponent(BaseVisualComponent):
             noiseDots, valType='str', inputType="choice", categ='Dots',
             allowedVals=['direction', 'position', 'walk'],
             hint=msg,
-            label=_localized['noiseDots'])
+            label=_translate("Noise dots"))
 
         self.params['fieldShape'] = Param(
             fieldShape, valType='str', inputType="choice", allowedVals=['circle', 'square'], categ='Layout',
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("What is the shape of the field?"),
-            label=_localized['fieldShape'])
+            label=_translate("Field shape"))
 
         msg = _translate("What is the size of the field "
                          "(in the specified units)?")
@@ -151,7 +151,7 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['fieldSize'])
+            label=_translate("Field size"))
 
         msg = _translate(
             "Where is the field centred (in the specified units)?")
@@ -160,7 +160,7 @@ class DotsComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['fieldPos'])
+            label=_translate("Field position"))
 
         self.params['anchor'] = Param(
             fieldAnchor, valType='str', inputType="choice", categ='Layout',

--- a/psychopy/experiment/components/dots/__init__.py
+++ b/psychopy/experiment/components/dots/__init__.py
@@ -176,11 +176,11 @@ class DotsComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Which point on the field should be anchored to its exact position?"),
-            label=_translate('Field Anchor'))
+            label=_translate("Field anchor"))
 
         # Reword colour parameters
-        self.params['color'].label = _translate("Dot Color")
-        self.params['colorSpace'].label = _translate("Dot Color Space")
+        self.params['color'].label = _translate("Dot color")
+        self.params['colorSpace'].label = _translate("Dot color space")
 
         del self.params['size']  # should be fieldSize
         del self.params['pos']  # should be fieldPos

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -42,8 +42,8 @@ class EyetrackerRecordComponent(BaseComponent):
         self.params['actionType'] = Param(actionType,
             valType='str', inputType='choice', categ='Basic',
             allowedVals=["Start and Stop", "Start Only", "Stop Only"],
-            hint=_translate("Should this component start and / or stop eye tracker recording?"),
-            label=_translate("Record Actions")
+            hint=_translate("Should this Component start and / or stop eye tracker recording?"),
+            label=_translate("Record actions")
         )
 
         self.depends.append(

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -90,13 +90,13 @@ class FormComponent(BaseVisualComponent):
             textHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("The size of the item text for Form"),
-            label=_translate("Text Height"))
+            label=_translate("Text height"))
 
         self.params['Font'] = Param(
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=["constant"],
             hint=_translate("The font name (e.g. Comic Sans)"),
-            label=_translate('Font'))
+            label=_translate("Font"))
 
         self.params['Randomize'] = Param(
             randomize, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
@@ -108,14 +108,14 @@ class FormComponent(BaseVisualComponent):
             itemPadding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant',
             hint=_translate("The padding or space between items."),
-            label=_translate("Item Padding"))
+            label=_translate("Item padding"))
 
         self.params['Data Format'] = Param(
             'rows', valType='str', inputType="choice", allowedTypes=[], categ='Basic',
             allowedVals=['columns', 'rows'],
             updates='constant',
             hint=_translate("Store item data by columns, or rows"),
-            label=_translate("Data Format"))
+            label=_translate("Data format"))
 
         # Appearance
         for param in ['fillColor', 'borderColor', 'itemColor', 'responseColor', 'markerColor', 'Style']:
@@ -151,21 +151,21 @@ class FormComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Base text color for questions"),
-            label=_translate("Item Color"))
+            label=_translate("Item color"))
 
         self.params['responseColor'] = Param(responseColor,
             valType='color', inputType="color", categ='Appearance',
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Base text color for responses, also sets color of lines in sliders and borders of textboxes"),
-            label=_translate("Response Color"))
+            label=_translate("Response color"))
 
         self.params['markerColor'] = Param(markerColor,
             valType='color', inputType="color", categ='Appearance',
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Color of markers and the scrollbar"),
-            label=_translate("Marker Color"))
+            label=_translate("Marker color"))
 
         self.params['pos'].allowedUpdates = []
         self.params['size'].allowedUpdates = []

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -84,13 +84,13 @@ class FormComponent(BaseVisualComponent):
             items, valType='file', inputType="table", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("The csv filename containing the items for your survey."),
-            label=_localized['Items'])
+            label=_translate("Items"))
 
         self.params['Text Height'] = Param(
             textHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("The size of the item text for Form"),
-            label=_localized['Text Height'])
+            label=_translate("Text Height"))
 
         self.params['Font'] = Param(
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
@@ -102,20 +102,20 @@ class FormComponent(BaseVisualComponent):
             randomize, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("Do you want to randomize the order of your questions?"),
-            label=_localized['Randomize'])
+            label=_translate("Randomize"))
 
         self.params['Item Padding'] = Param(
             itemPadding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant',
             hint=_translate("The padding or space between items."),
-            label=_localized['Item Padding'])
+            label=_translate("Item Padding"))
 
         self.params['Data Format'] = Param(
             'rows', valType='str', inputType="choice", allowedTypes=[], categ='Basic',
             allowedVals=['columns', 'rows'],
             updates='constant',
             hint=_translate("Store item data by columns, or rows"),
-            label=_localized['Data Format'])
+            label=_translate("Data Format"))
 
         # Appearance
         for param in ['fillColor', 'borderColor', 'itemColor', 'responseColor', 'markerColor', 'Style']:
@@ -131,7 +131,7 @@ class FormComponent(BaseVisualComponent):
             updates='constant', allowedVals=knownStyles + ["custom..."],
             hint=_translate(
                     "Styles determine the appearance of the form"),
-            label=_localized['Style'])
+            label=_translate("Styles"))
 
         for param in ['fillColor', 'borderColor', 'itemColor', 'responseColor', 'markerColor']:
             self.depends += [{

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -93,7 +93,7 @@ class GratingComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Which point on the stimulus should be anchored to its exact position?"),
-            label=_translate('Anchor'))
+            label=_translate("Anchor"))
 
         msg = _translate("Spatial positioning of the image on the grating "
                          "(wraps in range 0-1.0)")

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -59,7 +59,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['tex'])
+            label=_translate("Texture"))
 
         msg = _translate("An image to define the alpha mask (ie shape)- "
                          "gauss, circle... or a filename (including path)")
@@ -68,7 +68,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['mask'])
+            label=_translate("Mask"))
 
         msg = _translate("Spatial frequency of image repeats across the "
                          "grating in 1 or 2 dimensions, e.g. 4 or [2,3]")
@@ -77,7 +77,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['sf'])
+            label=_translate("Spatial frequency"))
 
         self.params['anchor'] = Param(
             anchor, valType='str', inputType="choice", categ='Layout',
@@ -102,7 +102,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['phase'])
+            label=_translate("Phase (in cycles)"))
 
         msg = _translate(
             "Resolution of the texture for standard ones such as sin, sqr "
@@ -112,7 +112,7 @@ class GratingComponent(BaseVisualComponent):
             valType='num', inputType="choice", allowedVals=['32', '64', '128', '256', '512'], categ='Texture',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['texture resolution'])
+            label=_translate("Texture resolution"))
 
         msg = _translate("How should the image be interpolated if/when "
                          "rescaled")
@@ -120,7 +120,7 @@ class GratingComponent(BaseVisualComponent):
             interpolate, valType='str', inputType="choice", allowedVals=['linear', 'nearest'], categ='Texture',
             updates='constant', allowedUpdates=[],
             hint=msg, direct=False,
-            label=_localized['interpolate'])
+            label=_translate("Interpolate"))
 
         msg = _translate("OpenGL Blendmode: avg gives traditional transparency,"
                          " add is important to combine gratings)]")
@@ -129,7 +129,7 @@ class GratingComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['blendmode'])
+            label=_translate("OpenGL blend mode"))
 
         del self.params['fillColor']
         del self.params['borderColor']

--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -57,7 +57,7 @@ class ImageComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized["image"])
+            label=_translate("Image"))
 
         msg = _translate(
             "An image to define the alpha mask through which the image is "
@@ -67,7 +67,7 @@ class ImageComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized["mask"])
+            label=_translate("Mask"))
 
         msg = _translate("Resolution of the mask if one is used.")
         self.params['texture resolution'] = Param(
@@ -75,7 +75,7 @@ class ImageComponent(BaseVisualComponent):
             allowedVals=['32', '64', '128', '256', '512'],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized["texture resolution"])
+            label=_translate("Texture resolution"))
 
         msg = _translate(
             "How should the image be interpolated if/when rescaled")
@@ -83,7 +83,7 @@ class ImageComponent(BaseVisualComponent):
             interpolate, valType='str', inputType="choice", allowedVals=['linear', 'nearest'], categ='Texture',
             updates='constant', allowedUpdates=[],
             hint=msg, direct=False,
-            label=_localized["interpolate"])
+            label=_translate("Interpolate"))
 
         msg = _translate(
             "Should the image be flipped vertically (top to bottom)?")
@@ -91,7 +91,7 @@ class ImageComponent(BaseVisualComponent):
             flipVert, valType='bool', inputType="bool", categ='Layout',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized["flipVert"])
+            label=_translate("Flip vertically"))
 
         msg = _translate(
             "Should the image be flipped horizontally (left to right)?")
@@ -99,7 +99,7 @@ class ImageComponent(BaseVisualComponent):
             flipHoriz, valType='bool', inputType="bool", categ='Layout',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized["flipHoriz"])
+            label=_translate("Flip horizontally"))
         self.params['anchor'] = Param(
             anchor, valType='str', inputType="choice", categ='Layout',
             allowedVals=['center',

--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -114,7 +114,7 @@ class ImageComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Which point on the stimulus should be anchored to its exact position?"),
-            label=_translate('Anchor'))
+            label=_translate("Anchor"))
 
         del self.params['fillColor']
         del self.params['borderColor']

--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -62,7 +62,7 @@ class JoyButtonsComponent(BaseComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=(msg),
-            label=_localized['allowedKeys'])
+            label=_translate("Allowed buttons"))
 
         msg = _translate("Choose which (if any) responses to store at the "
                          "end of a trial")
@@ -71,7 +71,7 @@ class JoyButtonsComponent(BaseComponent):
             allowedVals=['last key', 'first key', 'all keys', 'nothing'],
             updates='constant', direct=False,
             hint=msg,
-            label=_localized['store'])
+            label=_translate("Store"))
 
         msg = _translate("Should a response force the end of the Routine "
                          "(e.g end the trial)?")
@@ -79,7 +79,7 @@ class JoyButtonsComponent(BaseComponent):
             forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=msg,
-            label=_localized['forceEndRoutine'])
+            label=_translate("Force end of Routine"))
 
         msg = _translate("Do you want to save the response as "
                          "correct/incorrect?")
@@ -87,7 +87,7 @@ class JoyButtonsComponent(BaseComponent):
             storeCorrect, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['storeCorrect'])
+            label=_translate("Store correct"))
 
         self.depends += [  # allows params to turn each other off/on
             {"dependsOn": "storeCorrect",  # must be param name
@@ -106,7 +106,7 @@ class JoyButtonsComponent(BaseComponent):
             correctAns, valType='list', inputType="single", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['correctAns'])
+            label=_translate("Correct answer"))
 
         msg = _translate(
             "A reaction time to a visual stimulus should be based on when "
@@ -115,7 +115,7 @@ class JoyButtonsComponent(BaseComponent):
             syncScreenRefresh, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['syncScreenRefresh'])
+            label=_translate("sync RT with screen"))
 
         msg = _translate(
             "Device number, if you have multiple devices which"
@@ -124,7 +124,7 @@ class JoyButtonsComponent(BaseComponent):
             deviceNumber, valType='int', inputType="int", allowedTypes=[], categ='Hardware',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['deviceNumber'])
+            label=_translate("Device number"))
 
     def writeStartCode(self, buff):
         code = ("from psychopy.hardware import joystick as joysticklib  "

--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -115,7 +115,7 @@ class JoyButtonsComponent(BaseComponent):
             syncScreenRefresh, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=msg,
-            label=_translate("sync RT with screen"))
+            label=_translate("Sync RT with screen"))
 
         msg = _translate(
             "Device number, if you have multiple devices which"

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -64,7 +64,7 @@ class JoystickComponent(BaseComponent):
             hint=msg, direct=False,
             label=_translate("Save joystick state"))
 
-        msg = _translate("Should a button press force the end of the routine"
+        msg = _translate("Should a button press force the end of the Routine"
                          " (e.g end the trial)?")
         if forceEndRoutineOnPress is True:
             forceEndRoutineOnPress = 'any click'
@@ -123,7 +123,7 @@ class JoystickComponent(BaseComponent):
             allowedButtons, valType='list', inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_translate("Allowed Buttons"))
+            label=_translate("Allowed buttons"))
 
     @property
     def _clickableParamsList(self):

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -62,7 +62,7 @@ class JoystickComponent(BaseComponent):
             save, valType='str', inputType="choice", categ='Data',
             allowedVals=['final', 'on click', 'every frame', 'never'],
             hint=msg, direct=False,
-            label=_localized['saveJoystickState'])
+            label=_translate("Save joystick state"))
 
         msg = _translate("Should a button press force the end of the routine"
                          " (e.g end the trial)?")
@@ -75,7 +75,7 @@ class JoystickComponent(BaseComponent):
             allowedVals=['never', 'any click', 'valid click'],
             updates='constant',
             hint=msg, direct=False,
-            label=_localized['forceEndRoutineOnPress'])
+            label=_translate("End Routine on press"))
 
         msg = _translate("What should the values of joystick.time should be "
                          "relative to?")
@@ -84,7 +84,7 @@ class JoystickComponent(BaseComponent):
             allowedVals=['joystick onset', 'experiment', 'routine'],
             updates='constant', direct=False,
             hint=msg,
-            label=_localized['timeRelativeTo'])
+            label=_translate("Time relative to"))
 
         msg = _translate('A comma-separated list of your stimulus names that '
                          'can be "clicked" by the participant. '
@@ -94,7 +94,7 @@ class JoystickComponent(BaseComponent):
             '', valType='list', inputType="single", categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['Clickable stimuli'])
+            label=_translate("Clickable stimuli"))
 
         msg = _translate('The params (e.g. name, text), for which you want '
                          'to store the current value, for the stimulus that was'
@@ -105,7 +105,7 @@ class JoystickComponent(BaseComponent):
             'name,', valType='list', inputType="single", categ='Data',
             updates='constant', allowedUpdates=[],
             hint=msg, direct=False,
-            label=_localized['Store params for clicked'])
+            label=_translate("Store params for clicked"))
 
         msg = _translate('Device number, if you have multiple devices which'
                          ' one do you want (0, 1, 2...)')
@@ -114,7 +114,7 @@ class JoystickComponent(BaseComponent):
             deviceNumber, valType='int', inputType="single", allowedTypes=[], categ='Hardware',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['deviceNumber'])
+            label=_translate("Device number"))
 
         msg = _translate('Buttons to be read (blank for any) numbers separated by '
                          'commas')
@@ -123,7 +123,7 @@ class JoystickComponent(BaseComponent):
             allowedButtons, valType='list', inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['allowedButtons'])
+            label=_translate("Allowed Buttons"))
 
     @property
     def _clickableParamsList(self):

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -68,7 +68,7 @@ class KeyboardComponent(BaseComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat'],
             hint=(msg),
-            label=_localized['allowedKeys'])
+            label=_translate("Allowed keys"))
 
         msg = _translate(
             "When should the keypress be registered? As soon as pressed, or when released?")
@@ -88,7 +88,7 @@ class KeyboardComponent(BaseComponent):
             discardPrev, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['discard previous'])
+            label=_translate("Discard previous"))
 
         msg = _translate("Choose which (if any) responses to store at the "
                          "end of a trial")
@@ -97,7 +97,7 @@ class KeyboardComponent(BaseComponent):
             allowedVals=['last key', 'first key', 'all keys', 'nothing'],
             updates='constant', direct=False,
             hint=msg,
-            label=_localized['store'])
+            label=_translate("Store"))
 
         msg = _translate("Should a response force the end of the Routine "
                          "(e.g end the trial)?")
@@ -105,7 +105,7 @@ class KeyboardComponent(BaseComponent):
             forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=msg,
-            label=_localized['forceEndRoutine'])
+            label=_translate("Force end of Routine"))
 
         msg = _translate("Do you want to save the response as "
                          "correct/incorrect?")
@@ -113,7 +113,7 @@ class KeyboardComponent(BaseComponent):
             storeCorrect, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['storeCorrect'])
+            label=_translate("Store correct"))
 
         self.depends += [  # allows params to turn each other off/on
             {"dependsOn": "storeCorrect",  # must be param name
@@ -132,7 +132,7 @@ class KeyboardComponent(BaseComponent):
             correctAns, valType='str', inputType="single", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg, direct=False,
-            label=_localized['correctAns'])
+            label=_translate("Correct answer"))
 
         msg = _translate(
             "A reaction time to a visual stimulus should be based on when "
@@ -141,7 +141,7 @@ class KeyboardComponent(BaseComponent):
             syncScreenRefresh, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=msg,
-            label=_localized['syncScreenRefresh'])
+            label=_translate("Sync timing with screen"))
 
     def writeInitCode(self, buff):
         code = "%(name)s = keyboard.Keyboard()\n"

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -111,7 +111,7 @@ class MicrophoneComponent(BaseComponent):
             channels, valType='str', inputType="choice", categ='Hardware',
             allowedVals=['auto', 'mono', 'stereo'],
             hint=msg,
-            label=_translate('Channels'))
+            label=_translate("Channels"))
 
         msg = _translate(
             "How many samples per second (Hz) to record at")
@@ -119,14 +119,14 @@ class MicrophoneComponent(BaseComponent):
             sampleRate, valType='num', inputType="choice", categ='Hardware',
             allowedVals=list(sampleRates),
             hint=msg, direct=False,
-            label=_translate('Sample Rate (Hz)'))
+            label=_translate("Sample rate (hz)"))
 
         msg = _translate(
             "To avoid excessively large output files, what is the biggest file size you are likely to expect?")
         self.params['maxSize'] = Param(
             maxSize, valType='num', inputType="single", categ='Hardware',
             hint=msg,
-            label=_translate('Max Recording Size (kb)'))
+            label=_translate("Max recording size (kb)"))
 
         msg = _translate(
             "What file type should output audio files be saved as?")
@@ -134,7 +134,7 @@ class MicrophoneComponent(BaseComponent):
             outputType, valType='code', inputType='choice', categ='Data',
             allowedVals=["default"] + at.AUDIO_SUPPORTED_CODECS,
             hint=msg,
-            label=_translate("Output File Type")
+            label=_translate("Output file type")
         )
 
         msg = _translate(
@@ -142,7 +142,7 @@ class MicrophoneComponent(BaseComponent):
         self.params['speakTimes'] = Param(
             speakTimes, valType='bool', inputType='bool', categ='Data',
             hint=msg,
-            label=_translate("Speaking Start / Stop Times")
+            label=_translate("Speaking start / stop times")
         )
 
         msg = _translate(
@@ -150,7 +150,7 @@ class MicrophoneComponent(BaseComponent):
         self.params['trimSilent'] = Param(
             trimSilent, valType='bool', inputType='bool', categ='Data',
             hint=msg,
-            label=_translate("Trim Silent")
+            label=_translate("Trim silent")
         )
 
         # Transcription params
@@ -163,7 +163,7 @@ class MicrophoneComponent(BaseComponent):
         self.params['transcribe'] = Param(
             transcribe, valType='bool', inputType='bool', categ='Transcription',
             hint=_translate("Whether to transcribe the audio recording and store the transcription"),
-            label=_translate("Transcribe Audio")
+            label=_translate("Transcribe audio")
         )
 
         for depParam in ['transcribeBackend', 'transcribeLang', 'transcribeWords']:
@@ -179,13 +179,13 @@ class MicrophoneComponent(BaseComponent):
             transcribeBackend, valType='code', inputType='choice', categ='Transcription',
             allowedVals=list(allTranscribers), direct=False,
             hint=_translate("What transcription service to use to transcribe audio?"),
-            label=_translate("Transcription Backend")
+            label=_translate("Transcription backend")
         )
 
         self.params['transcribeLang'] = Param(
             transcribeLang, valType='str', inputType='single', categ='Transcription',
             hint=_translate("What language you expect the recording to be spoken in, e.g. en-US for English"),
-            label=_translate("Transcription Language")
+            label=_translate("Transcription language")
         )
 
         self.params['transcribeWords'] = Param(
@@ -193,7 +193,7 @@ class MicrophoneComponent(BaseComponent):
             hint=_translate("Set list of words to listen for - if blank will listen for all words in chosen language. \n\n"
                             "If using the built-in transcriber, you can set a minimum % confidence level using a colon "
                             "after the word, e.g. 'red:100', 'green:80'. Otherwise, default confidence level is 80%."),
-            label=_translate("Expected Words")
+            label=_translate("Expected words")
         )
 
     def writeStartCode(self, buff):

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -62,7 +62,7 @@ class MouseComponent(BaseComponent):
             hint=msg, direct=False,
             label=_translate("Save mouse state"))
 
-        msg = _translate("Should a button press force the end of the routine"
+        msg = _translate("Should a button press force the end of the Routine"
                          " (e.g end the trial)?")
         if forceEndRoutineOnPress is True:
             forceEndRoutineOnPress = 'any click'
@@ -121,7 +121,7 @@ class MouseComponent(BaseComponent):
             storeCorrect, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg,
-            label=_translate('storeCorrect'))
+            label=_translate("Store correct"))
 
         self.depends += [  # allows params to turn each other off/on
             {"dependsOn": "storeCorrect",  # must be param name
@@ -133,13 +133,13 @@ class MouseComponent(BaseComponent):
         ]
 
         msg = _translate(
-            "What is the 'correct' object? To specify an area, remember that you can create a Shape component with 0 "
+            "What is the 'correct' object? To specify an area, remember that you can create a shape Component with 0 "
             "opacity.")
         self.params['correctAns'] = Param(
             correctAns, valType='list', inputType="single", allowedTypes=[], categ='Data',
             updates='constant',
             hint=msg, direct=False,
-            label=_translate('correctAns'))
+            label=_translate("Correct answer"))
 
     @property
     def _clickableParamsList(self):

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -60,7 +60,7 @@ class MouseComponent(BaseComponent):
             save, valType='str', inputType="choice", categ='Data',
             allowedVals=['final', 'on click', 'on valid click', 'every frame', 'never'],
             hint=msg, direct=False,
-            label=_localized['saveMouseState'])
+            label=_translate("Save mouse state"))
 
         msg = _translate("Should a button press force the end of the routine"
                          " (e.g end the trial)?")
@@ -73,7 +73,7 @@ class MouseComponent(BaseComponent):
             allowedVals=['never', 'any click', 'valid click', 'correct click'],
             updates='constant', direct=False,
             hint=msg,
-            label=_localized['forceEndRoutineOnPress'])
+            label=_translate("End Routine on press"))
 
         msg = _translate("What should the values of mouse.time should be "
                          "relative to?")
@@ -82,7 +82,7 @@ class MouseComponent(BaseComponent):
             allowedVals=['mouse onset', 'experiment', 'routine'],
             updates='constant',
             hint=msg, direct=False,
-            label=_localized['timeRelativeTo'])
+            label=_translate("Time relative to"))
 
         msg = _translate('If the mouse button is already down when we start '
                          'checking then wait for it to be released before '
@@ -92,7 +92,7 @@ class MouseComponent(BaseComponent):
             True, valType='bool', inputType="bool", categ='Basic',
             updates='constant',
             hint=msg,
-            label=_localized['New clicks only'])
+            label=_translate("New clicks only"))
 
         msg = _translate('A comma-separated list of your stimulus names that '
                          'can be "clicked" by the participant. '
@@ -102,7 +102,7 @@ class MouseComponent(BaseComponent):
             '', valType='list', inputType="single", categ='Basic',
             updates='constant',
             hint=msg,
-            label=_localized['Clickable stimuli'])
+            label=_translate("Clickable stimuli"))
 
         msg = _translate('The params (e.g. name, text), for which you want '
                          'to store the current value, for the stimulus that was'
@@ -113,7 +113,7 @@ class MouseComponent(BaseComponent):
             'name,', valType='list', inputType="single", categ='Data',
             updates='constant', allowedUpdates=[], direct=False,
             hint=msg,
-            label=_localized['Store params for clicked'])
+            label=_translate("Store params for clicked"))
 
         msg = _translate("Do you want to save the response as "
                          "correct/incorrect?")

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -18,9 +18,6 @@ _localized.update({'movie': _translate('Movie file'),
                    'backend': _translate('backend'),
                    'No audio': _translate('No audio')})
 
-if _localized['backend'] == 'backend': # this is the only non-capitals label
-    _localized['backend'] = 'Backend'
-
 class MovieComponent(BaseVisualComponent):
     """An event class for presenting movie-based stimuli"""
 
@@ -62,21 +59,21 @@ class MovieComponent(BaseVisualComponent):
             movie, valType='file', inputType="file", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=['constant', 'set every repeat'],
             hint=msg,
-            label=_localized['movie'])
+            label=_translate("Movie file"))
 
         msg = _translate("What underlying lib to use for loading movies")
         self.params['backend'] = Param(
             backend, valType='str', inputType="choice", categ='Playback',
             allowedVals=['ffpyplayer', 'moviepy', 'opencv', 'vlc'],
             hint=msg, direct=False,
-            label=_localized['backend'])
+            label=_translate("Backend"))
 
         msg = _translate("Prevent the audio stream from being loaded/processed "
                "(moviepy and opencv only)")
         self.params["No audio"] = Param(
             noAudio, valType='bool', inputType="bool", categ='Playback',
             hint=msg,
-            label=_localized['No audio'])
+            label=_translate("No audio"))
 
         self.depends.append(
             {"dependsOn": "No audio",  # must be param name
@@ -99,7 +96,7 @@ class MovieComponent(BaseVisualComponent):
             forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['forceEndRoutine'])
+            label=_translate("Force end of Routine"))
 
         msg = _translate("Whether the movie should loop back to the beginning "
                          "on completion.")

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -51,7 +51,7 @@ class MovieComponent(BaseVisualComponent):
 
         # params
         self.params['stopVal'].hint = _translate(
-            "When does the component end? (blank to use the duration of "
+            "When does the Component end? (blank to use the duration of "
             "the media)")
 
         msg = _translate("A filename for the movie (including path)")
@@ -91,7 +91,7 @@ class MovieComponent(BaseVisualComponent):
             label=_translate("Volume"))
 
         msg = _translate("Should the end of the movie cause the end of "
-                         "the routine (e.g. trial)?")
+                         "the Routine (e.g. trial)?")
         self.params['forceEndRoutine'] = Param(
             forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=[],
@@ -103,7 +103,7 @@ class MovieComponent(BaseVisualComponent):
         self.params['loop'] = Param(
             loop, valType='bool', inputType="bool", categ='Playback',
             hint=msg,
-            label=_translate('Loop playback'))
+            label=_translate("Loop playback"))
         self.params['anchor'] = Param(
             anchor, valType='str', inputType="choice", categ='Layout',
             allowedVals=['center',
@@ -118,7 +118,7 @@ class MovieComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Which point on the stimulus should be anchored to its exact position?"),
-            label=_translate('Anchor'))
+            label=_translate("Anchor"))
 
         # these are normally added but we don't want them for a movie
         del self.params['color']

--- a/psychopy/experiment/components/panorama/__init__.py
+++ b/psychopy/experiment/components/panorama/__init__.py
@@ -6,7 +6,7 @@ from psychopy.experiment.components import Param, _translate, getInitVals, BaseV
 from psychopy import prefs
 
 # only use _localized values for label values, nothing functional:
-_localized = {'name': _translate('Name')}
+_localized = {'name': _translate("Name")}
 
 
 class PanoramaComponent(BaseVisualComponent):
@@ -80,7 +80,7 @@ class PanoramaComponent(BaseVisualComponent):
             allowedVals=['linear', 'nearest'], categ='Basic',
             updates='constant', allowedUpdates=[],
             hint=msg, direct=False,
-            label=_translate("interpolate"))
+            label=_translate("Interpolate"))
 
         # Position controls
         
@@ -95,7 +95,7 @@ class PanoramaComponent(BaseVisualComponent):
                 "Mouse", "Drag", "Keyboard (Arrow Keys)", "Keyboard (WASD)", "Keyboard (Custom keys)", "Custom"],
             updates="constant",
             hint=msg,
-            label=_translate("Position Control")
+            label=_translate("Position control")
         )
         
         self.depends.append(
@@ -194,7 +194,7 @@ class PanoramaComponent(BaseVisualComponent):
         self.params['posSensitivity'] = Param(
             posSensitivity, valType='code', inputType="single", categ="Basic",
             hint=msg,
-            label=_translate("Movement Sensitivity")
+            label=_translate("Movement sensitivity")
         )
 
         # Zoom controls
@@ -210,11 +210,11 @@ class PanoramaComponent(BaseVisualComponent):
                 "Mouse Wheel", "Mouse Wheel (Inverted)", "Keyboard (Arrow Keys)", "Keyboard (+-)", "Keyboard (Custom keys)", "Custom"],
             updates="constant",
             hint=msg,
-            label=_translate("Zoom Control")
+            label=_translate("Zoom control")
         )
 
         keys = {'inKey': inKey, 'outKey': outKey}
-        labels = {'inKey': _translate("Zoom In"), 'outKey': _translate("Zoom Out")}
+        labels = {'inKey': _translate("Zoom in"), 'outKey': _translate("Zoom out")}
         for key, val in keys.items():
             # Only show key controls if zoom type is custom keys
             self.depends.append(
@@ -271,7 +271,7 @@ class PanoramaComponent(BaseVisualComponent):
         self.params['zoomSensitivity'] = Param(
             zoomSensitivity, valType='code', inputType="single", categ="Basic",
             hint=msg,
-            label=_translate("Zoom Sensitivity")
+            label=_translate("Zoom sensitivity")
         )
 
 

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -58,7 +58,7 @@ class ParallelOutComponent(BaseComponent):
                          "options in preferences>general)")
         self.params['address'] = Param(
             address, valType='str', inputType="choice", allowedVals=addressOptions,
-            categ='Hardware', hint=msg, label=_localized['address'])
+            categ='Hardware', hint=msg, label=_translate("Port address"))
 
         self.depends.append(
             {"dependsOn": "address",  # must be param name
@@ -72,17 +72,17 @@ class ParallelOutComponent(BaseComponent):
         msg = _translate("U3 Register to write byte to")
         self.params['register'] = Param(register, valType='str',
                                         inputType="choice", allowedVals=['EIO', 'FIO'],
-                                        categ='Hardware', hint=msg, label=_localized['register'])
+                                        categ='Hardware', hint=msg, label=_translate("U3 Register"))
 
         self.params['startData'] = Param(
             startData, valType='code', inputType="single", allowedTypes=[], categ='Data',
             hint=_translate("Data to be sent at 'start'"),
-            label=_localized['startData'])
+            label=_translate("Start data"))
 
         self.params['stopData'] = Param(
             stopData, valType='code', inputType="single", allowedTypes=[], categ='Data',
             hint=_translate("Data to be sent at 'end'"),
-            label=_localized['stopData'])
+            label=_translate("Stop data"))
 
         msg = _translate("If the parallel port data relates to visual "
                          "stimuli then sync its pulse to the screen refresh")
@@ -91,7 +91,7 @@ class ParallelOutComponent(BaseComponent):
             allowedVals=[True, False],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['syncScreen'])
+            label=_translate("Sync to screen"))
 
     def writeInitCode(self, buff):
         if self.params['address'].val == 'LabJack U3':

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -72,7 +72,7 @@ class ParallelOutComponent(BaseComponent):
         msg = _translate("U3 Register to write byte to")
         self.params['register'] = Param(register, valType='str',
                                         inputType="choice", allowedVals=['EIO', 'FIO'],
-                                        categ='Hardware', hint=msg, label=_translate("U3 Register"))
+                                        categ='Hardware', hint=msg, label=_translate("U3 register"))
 
         self.params['startData'] = Param(
             startData, valType='code', inputType="single", allowedTypes=[], categ='Data',

--- a/psychopy/experiment/components/patch/__init__.py
+++ b/psychopy/experiment/components/patch/__init__.py
@@ -54,7 +54,7 @@ class PatchComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['image'])
+            label=_translate("Image/tex"))
 
         msg = _translate("An image to define the alpha mask (ie shape)- "
                          "gauss, circle... or a filename (including path)")
@@ -63,7 +63,7 @@ class PatchComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['mask'])
+            label=_translate("Mask"))
 
         msg = _translate("Spatial frequency of image repeats across the "
                          "patch, e.g. 4 or [2,3]")
@@ -72,7 +72,7 @@ class PatchComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['sf'])
+            label=_translate("Spatial frequency"))
 
         msg = _translate(
             "Spatial positioning of the image on the patch (in range 0-1.0)")
@@ -81,7 +81,7 @@ class PatchComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['phase'])
+            label=_translate("Phase (in cycles)"))
 
         msg = _translate(
             "Resolution of the texture for standard ones such as sin, sqr "
@@ -91,7 +91,7 @@ class PatchComponent(BaseVisualComponent):
             allowedVals=['32', '64', '128', '256', '512'],
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['texture resolution'])
+            label=_translate("Texture resolution"))
 
         msg = _translate(
             "How should the image be interpolated if/when rescaled")
@@ -99,7 +99,7 @@ class PatchComponent(BaseVisualComponent):
             interpolate, valType='str', inputType="choice", allowedVals=['linear', 'nearest'], categ='Texture',
             updates='constant', allowedUpdates=[],
             hint=msg,
-            label=_localized['interpolate'])
+            label=_translate("Interpolate"))
 
     def writeInitCode(self, buff):
         # do we need units code?

--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -77,7 +77,7 @@ class PolygonComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_translate('Num. vertices'))
+            label=_translate("Num. vertices"))
 
         msg = _translate("What are the vertices of your polygon? Should be an nx2 array or a list of [x, y] lists")
         self.params['vertices'] = Param(
@@ -123,7 +123,7 @@ class PolygonComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_translate('Line width'))
+            label=_translate("Line width"))
 
         msg = _translate(
             "How should the image be interpolated if/when rescaled")
@@ -131,7 +131,7 @@ class PolygonComponent(BaseVisualComponent):
             interpolate, valType='str', inputType="choice", allowedVals=['linear', 'nearest'], categ='Texture',
             updates='constant', allowedUpdates=[], direct=False,
             hint=msg,
-            label=_translate('Interpolate'))
+            label=_translate("Interpolate"))
 
 
         self.params['size'].hint = _translate(

--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -77,7 +77,7 @@ class PolygonComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['nVertices'])
+            label=_translate('Num. vertices'))
 
         msg = _translate("What are the vertices of your polygon? Should be an nx2 array or a list of [x, y] lists")
         self.params['vertices'] = Param(
@@ -123,7 +123,7 @@ class PolygonComponent(BaseVisualComponent):
             updates='constant',
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=msg,
-            label=_localized['lineWidth'])
+            label=_translate('Line width'))
 
         msg = _translate(
             "How should the image be interpolated if/when rescaled")
@@ -131,7 +131,7 @@ class PolygonComponent(BaseVisualComponent):
             interpolate, valType='str', inputType="choice", allowedVals=['linear', 'nearest'], categ='Texture',
             updates='constant', allowedUpdates=[], direct=False,
             hint=msg,
-            label=_localized['interpolate'])
+            label=_translate('Interpolate'))
 
 
         self.params['size'].hint = _translate(

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -87,50 +87,50 @@ class RatingScaleComponent(BaseComponent):
             hint=_translate("Show a continuous visual analog scale; returns"
                             " 0.00 to 1.00; takes precedence over numeric "
                             "scale or categorical choices"),
-            label=_localized['visualAnalogScale'])
+            label=_translate("Visual analog scale"))
         self.params['categoryChoices'] = Param(
             categoryChoices, valType='list',  inputType="single", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=[],
             hint=_translate("A list of categories (non-numeric alternatives)"
                             " to present, space or comma-separated; these "
                             "take precedence over a numeric scale"),
-            label=_localized['categoryChoices'])
+            label=_translate("Category choices"))
         self.params['scaleDescription'] = Param(
             scaleDescription, valType='str',  inputType="single", allowedTypes=[], categ='Basic',
             updates='constant', allowedUpdates=[],
             hint=_translate("Brief instructions, such as a description of "
                             "the scale numbers as seen by the subject."),
-            label=_localized['scaleDescription'])
+            label=_translate("Scale description"))
         self.params['low'] = Param(
             low, valType='num',  inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=_translate("Lowest rating (low end of the scale); not"
                             " used for categories."),
-            label=_localized['low'])
+            label=_translate("Lowest value"))
         self.params['high'] = Param(
             high, valType='num',  inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=_translate("Highest rating (top end of the scale); "
                             "not used for categories."),
-            label=_localized['high'])
+            label=_translate("Highest value"))
         self.params['labels'] = Param(
             labels, valType='list',  inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],  # categ="Advanced",
             hint=_translate("Labels for the ends of the scale, "
                             "separated by commas"),
-            label=_localized['labels'])
+            label=_translate("Labels"))
         self.params['marker'] = Param(
             marker, valType='str', inputType="choice", allowedTypes=[], categ='Interface',
             allowedVals=['triangle', 'circle', 'glow', 'slider', 'hover'],
             updates='constant', allowedUpdates=[],  # categ="Advanced",
             hint=_translate("Style for the marker: triangle, circle, glow, "
                             "slider, hover"),
-            label=_localized['marker'])
+            label=_translate("Marker type"))
         self.params['markerStart'] = Param(
             markerStart, valType='num',  inputType="single", allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],  # categ="Advanced",
             hint=_translate("initial position for the marker"),
-            label=_localized['markerStart'])
+            label=_translate("Marker start"))
 
         # advanced params:
         self.params['singleClick'] = Param(
@@ -138,46 +138,46 @@ class RatingScaleComponent(BaseComponent):
             updates='constant', allowedUpdates=[], categ="Interface",
             hint=_translate("Should clicking the line accept that rating "
                             "(without needing to confirm via 'accept')?"),
-            label=_localized['singleClick'])
+            label=_translate("Single click"))
         self.params['disappear'] = Param(
             disappear, valType='bool',  inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Interface",
             hint=_translate("Hide the scale when a rating has been accepted;"
                             " False to remain on-screen"),
-            label=_localized['disappear'])
+            label=_translate("Disappear"))
         self.params['showAccept'] = Param(
             showAccept, valType='bool',  inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Interface",
             hint=_translate("Should the accept button by visible?"),
-            label=_localized['showAccept'])
+            label=_translate("Show accept"))
         self.params['storeRating'] = Param(
             storeRating, valType='bool', inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Data",
             hint=_translate("store the rating"),
-            label=_localized['storeRating'])
+            label=_translate("Store rating"))
         self.params['storeRatingTime'] = Param(
             storeRatingTime, valType='bool',  inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Data",
             hint=_translate("store the time taken to make the choice (in "
                             "seconds)"),
-            label=_localized['storeRatingTime'])
+            label=_translate("Store rating time"))
         self.params['storeHistory'] = Param(
             storeHistory, valType='bool', inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Data",
             hint=_translate("store the history of (selection, time)"),
-            label=_localized['storeHistory'])
+            label=_translate("Store history"))
         self.params['forceEndRoutine'] = Param(
             forceEndRoutine, valType='bool',  inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Basic",
             hint=_translate("Should accepting a rating cause the end of the "
                             "routine (e.g. trial)?"),
-            label=_localized['forceEndRoutine'])
+            label=_translate("Force end of Routine"))
         self.params['tickHeight'] = Param(
             tickHeight, valType='num', inputType="single", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Interface",
             hint=_translate("height of tick marks (1 is upward, 0 is hidden,"
                             " -1 is downward)"),
-            label=_localized['tickHeight'])
+            label=_translate("Tick height"))
 
         # customization:
         self.params['customize_everything'] = Param(
@@ -187,7 +187,7 @@ class RatingScaleComponent(BaseComponent):
                             " would in a code component; overrides all"
                             " dialog settings except time parameters, "
                             "forceEndRoutine, storeRatingTime, storeRating"),
-            label=_localized['customize_everything'])
+            label=_translate("Customize everything :"))
 
         self.params['size'] = Param(size,
             valType='list', inputType="single", categ='Layout',
@@ -195,14 +195,14 @@ class RatingScaleComponent(BaseComponent):
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Size of this stimulus (either a single value or "
                          "x,y pair, e.g. 2.5, [1,2] "),
-            label=_localized['size'])
+            label=_translate("Size"))
 
         self.params['pos'] = Param(pos,
             valType='list', inputType="single", categ='Layout',
             updates='constant', allowedTypes=[],
             allowedUpdates=['constant', 'set every repeat', 'set every frame'],
             hint=_translate("Position of this stimulus (e.g. [1,2] )"),
-            label=_localized['pos'])
+            label=_translate("Position [x,y]"))
 
     def writeInitCode(self, buff):
         # build up an initialization string for RatingScale():

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -170,7 +170,7 @@ class RatingScaleComponent(BaseComponent):
             forceEndRoutine, valType='bool',  inputType="bool", allowedTypes=[],
             updates='constant', allowedUpdates=[], categ="Basic",
             hint=_translate("Should accepting a rating cause the end of the "
-                            "routine (e.g. trial)?"),
+                            "Routine (e.g. trial)?"),
             label=_translate("Force end of Routine"))
         self.params['tickHeight'] = Param(
             tickHeight, valType='num', inputType="single", allowedTypes=[],

--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -44,13 +44,13 @@ class ResourceManagerComponent(BaseComponent):
         self.params['checkAll'] = Param(resources,
             valType='bool', inputType="bool", categ='Basic',
             hint=_translate("When checking these resources, also check for all currently downloading?"),
-            label=_translate("Check All"))
+            label=_translate("Check all"))
 
         self.params['actionType'] = Param(actionType,
             valType='str', inputType='choice', categ='Basic',
             allowedVals=["Start and Check", "Start Only", "Check Only"],
-            hint=_translate("Should this component start an / or check resource preloading?"),
-            label=_translate("Preload Actions")
+            hint=_translate("Should this Component start an / or check resource preloading?"),
+            label=_translate("Preload actions")
         )
 
         msg = _translate("Should we end the Routine when the resource download is complete?")
@@ -58,7 +58,7 @@ class ResourceManagerComponent(BaseComponent):
             forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=msg,
-            label=_translate('forceEndRoutine'))
+            label=_translate("Force end Routine"))
 
         self.params['stopVal'].label = _translate("Check")
 

--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -60,7 +60,7 @@ class RegionOfInterestComponent(PolygonComponent):
             valType='str', inputType='choice', categ='Basic',
             allowedVals=["look at", "look away", "none"],
             hint=_translate("Under what condition should this ROI end the routine?"),
-            label=_translate("End Routine On...")
+            label=_translate("End Routine on...")
         )
 
         self.depends.append(
@@ -75,14 +75,14 @@ class RegionOfInterestComponent(PolygonComponent):
         self.params['lookDur'] = Param(lookDur,
             valType='num', inputType='single', categ='Basic',
             hint=_translate("Minimum dwell time within roi (look at) or outside roi (look away)."),
-            label=_translate("Min. Look Time")
+            label=_translate("Min. look time")
         )
 
         self.params['debug'] = Param(
             debug, valType='bool', inputType='bool', categ='Testing',
             hint=_translate("In debug mode, the ROI is drawn in red. Use this to see what area of the "
                             "screen is in the ROI."),
-            label=_translate("Debug Mode")
+            label=_translate("Debug mode")
         )
 
         self.params['save'] = Param(
@@ -91,7 +91,7 @@ class RegionOfInterestComponent(PolygonComponent):
             direct=False,
             hint=_translate(
                 "What looks on this ROI should be saved to the data output?"),
-            label=_translate('Save...'))
+            label=_translate("Save..."))
 
         self.params['timeRelativeTo'] = Param(
             timeRelativeTo, valType='str', inputType="choice", categ='Data',
@@ -100,7 +100,7 @@ class RegionOfInterestComponent(PolygonComponent):
             hint=_translate(
                 "What should the values of roi.time should be "
                 "relative to?"),
-            label=_translate('Time Relative To...'))
+            label=_translate("Time relative to..."))
 
     def writePreWindowCode(self, buff):
         pass

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -7,7 +7,7 @@ from psychopy.experiment.utils import CodeGenerationException
 from psychopy import prefs
 
 # only use _localized values for label values, nothing functional:
-_localized = {'name': _translate('Name')}
+_localized = {'name': _translate("Name")}
 
 
 class RoutineSettingsComponent(BaseComponent):
@@ -105,14 +105,14 @@ class RoutineSettingsComponent(BaseComponent):
             useWindowParams, valType="bool", inputType="bool", categ="Window",
             label=_translate("Different window settings?"),
             hint=_translate(
-                "Should the appearance of the window change while this routine "
+                "Should the appearance of the window change while this Routine "
                 "is running?"
             ))
         self.params['color'] = Param(
             color, valType='color', inputType="color", categ="Window",
             label=_translate("Background color"),
             hint=_translate(
-                "Color of the screen this routine (e.g. black, $[1.0,1.0,1.0],"
+                "Color of the screen this Routine (e.g. black, $[1.0,1.0,1.0],"
                 " $variable. Right-click to bring up a "
                 "color-picker.)"
             ))
@@ -121,7 +121,7 @@ class RoutineSettingsComponent(BaseComponent):
             hint=_translate("Needed if color is defined numerically (see "
                             "PsychoPy documentation on color spaces)"),
             allowedVals=['rgb', 'dkl', 'lms', 'hsv', 'hex'],
-            label=_translate("colorSpace"))
+            label=_translate("Color space"))
         self.params['backgroundImg'] = Param(
             backgroundImg, valType="str", inputType="file", categ="Window",
             hint=_translate("Image file to use as a background (leave blank for no image)"),
@@ -154,7 +154,7 @@ class RoutineSettingsComponent(BaseComponent):
                 "continueRoutine = continueRoutine and not (%(skipIf)s)\n"
             )
             buff.writeIndentedLines(code % params)
-        # Change window appearance for this routine (if requested)
+        # Change window appearance for this Routine (if requested)
         if params['useWindowParams']:
             code = (
                 "win.color = %(color)s\n"
@@ -186,19 +186,19 @@ class RoutineSettingsComponent(BaseComponent):
             if self.params['stopType'].val == 'duration (s)':
                 # Stop after given number of seconds
                 code = (
-                    f"# is it time to end the routine? (based on local clock)\n"
+                    f"# is it time to end the Routine? (based on local clock)\n"
                     f"if tThisFlip > %(stopVal)s-frameTolerance:\n"
                 )
             elif self.params['stopType'].val == 'frame N':
                 # Stop at given frame num
                 code = (
-                    f"# is it time to end the routine? (based on frames since Routine start)\n"
+                    f"# is it time to end the Routine? (based on frames since Routine start)\n"
                     f"if frameN >= %(stopVal)s:\n"
                 )
             elif self.params['stopType'].val == 'condition':
                 # Stop when condition is True
                 code = (
-                    f"# is it time to end the routine? (based on condition)\n"
+                    f"# is it time to end the Routine? (based on condition)\n"
                     f"if bool(%(stopVal)s):\n"
                 )
             else:
@@ -212,7 +212,7 @@ class RoutineSettingsComponent(BaseComponent):
 
     def writeRoutineEndCode(self, buff):
         params = self.params.copy()
-        # Restore window appearance after this routine (if changed)
+        # Restore window appearance after this Routine (if changed)
         if params['useWindowParams']:
             code = (
                 "setupWindow(expInfo=expInfo, win=win)\n"

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -78,18 +78,18 @@ class SerialOutComponent(BaseComponent):
         self.params['timeout'] = Param(
             timeout, valType='int', inputType="single", allowedTypes=[], categ='Hardware',
             hint=_translate("Time at which to give up listening for a response (leave blank for no limit)"),
-            label=_translate('Timeout'))
+            label=_translate("Timeout"))
 
         self.params['startdata'] = Param(
             startdata, valType='str', inputType="single", allowedTypes=[], categ='Basic',
             hint=_translate("Data to be sent at start of pulse. Data will be converted to bytes, so to specify a"
                             "numeric value directly use $chr(...)."),
-            label=_translate('Start data'))
+            label=_translate("Start data"))
         self.params['stopdata'] = Param(
             stopdata, valType='str', inputType="single", allowedTypes=[], categ='Basic',
             hint=_translate("String data to be sent at end of pulse. Data will be converted to bytes, so to specify a"
                             "numeric value directly use $chr(...)."),
-            label=_translate('Stop data'))
+            label=_translate("Stop data"))
         self.params['getResponse'] = Param(
             getResponse, valType='bool', inputType='bool', categ="Data",
             hint=_translate("After sending a signal, should PsychoPy read and record a response from the port?"),

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -174,7 +174,7 @@ class SettingsComponent:
             expName, valType='str',  inputType="single", allowedTypes=[],
             hint=_translate("Name of the entire experiment (taken by default"
                             " from the filename on save)"),
-            label=_localized["expName"])
+            label=_translate("Experiment name"))
         self.depends.append(
             {"dependsOn": "Show info dlg",  # must be param name
              "condition": "==True",  # val to check for
@@ -187,17 +187,17 @@ class SettingsComponent:
             showExpInfo, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Start the experiment with a dialog to set info"
                             " (e.g.participant or condition)"),
-            label=_localized["Show info dlg"], categ='Basic')
+            label=_translate("Show info dialog"), categ='Basic')
         self.params['Enable Escape'] = Param(
             enableEscape, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Enable the <esc> key, to allow subjects to quit"
                             " / break out of the experiment"),
-            label=_localized["Enable Escape"])
+            label=_translate("Enable Escape key"))
         self.params['Experiment info'] = Param(
             expInfo, valType='code', inputType="dict", allowedTypes=[],
             hint=_translate("The info to present in a dialog box. Right-click"
                             " to check syntax and preview the dialog box."),
-            label=_localized["Experiment info"], categ='Basic')
+            label=_translate("Experiment info"), categ='Basic')
         self.params['Use version'] = Param(
             useVersion, valType='str', inputType="choice",
             # search for options locally only by default, otherwise sluggish
@@ -206,13 +206,13 @@ class SettingsComponent:
                         + versions._versionFilter(versions.availableVersions(), wx_version),
             hint=_translate("The version of PsychoPy to use when running "
                             "the experiment."),
-            label=_localized["Use version"], categ='Basic')
+            label=_translate("Use PsychoPy version"), categ='Basic')
 
         # screen params
         self.params['Full-screen window'] = Param(
             fullScr, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Run the experiment full-screen (recommended)"),
-            label=_localized["Full-screen window"], categ='Screen')
+            label=_translate("Full-screen window"), categ='Screen')
         self.params['winBackend'] = Param(
             winBackend, valType='str', inputType="choice", categ="Screen",
             allowedVals=plugins.getWindowBackends(),
@@ -222,29 +222,29 @@ class SettingsComponent:
         self.params['Window size (pixels)'] = Param(
             winSize, valType='list', inputType="single", allowedTypes=[],
             hint=_translate("Size of window (if not fullscreen)"),
-            label=_localized["Window size (pixels)"], categ='Screen')
+            label=_translate("Window size (pixels)"), categ='Screen')
         self.params['Screen'] = Param(
             screen, valType='num', inputType="spin", allowedTypes=[],
             hint=_translate("Which physical screen to run on (1 or 2)"),
-            label=_localized["Screen"], categ='Screen')
+            label=_translate("Screen"), categ='Screen')
         self.params['Monitor'] = Param(
             monitor, valType='str', inputType="single", allowedTypes=[],
             hint=_translate("Name of the monitor (from Monitor Center). Right"
                             "-click to go there, then copy & paste a monitor "
                             "name here."),
-            label=_localized["Monitor"], categ="Screen")
+            label=_translate("Monitor"), categ="Screen")
         self.params['color'] = Param(
             color, valType='color', inputType="color", allowedTypes=[],
             hint=_translate("Color of the screen (e.g. black, $[1.0,1.0,1.0],"
                             " $variable. Right-click to bring up a "
                             "color-picker.)"),
-            label=_localized["color"], categ='Screen')
+            label=_translate("Color"), categ='Screen')
         self.params['colorSpace'] = Param(
             colorSpace, valType='str', inputType="choice",
             hint=_translate("Needed if color is defined numerically (see "
                             "PsychoPy documentation on color spaces)"),
             allowedVals=['rgb', 'dkl', 'lms', 'hsv', 'hex'],
-            label=_localized["colorSpace"], categ="Screen")
+            label=_translate("Color space"), categ="Screen")
         self.params['backgroundImg'] = Param(
             backgroundImg, valType="str", inputType="file", categ="Screen",
             hint=_translate("Image file to use as a background (leave blank for no image)"),
@@ -262,18 +262,18 @@ class SettingsComponent:
                          'degFlatPos', 'degFlat'],
             hint=_translate("Units to use for window/stimulus coordinates "
                             "(e.g. cm, pix, deg)"),
-            label=_localized["Units"], categ='Screen')
+            label=_translate("Units"), categ='Screen')
         self.params['blendMode'] = Param(
             blendMode, valType='str', inputType="choice",
             allowedVals=['add', 'avg', 'nofbo'],
             allowedLabels=['add', 'average', 'average (no FBO)'],
             hint=_translate("Should new stimuli be added or averaged with "
                             "the stimuli that have been drawn already"),
-            label=_localized["blendMode"], categ='Screen')
+            label=_translate("Blend mode"), categ='Screen')
         self.params['Show mouse'] = Param(
             showMouse, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Should the mouse be visible on screen? Only applicable for fullscreen experiments."),
-            label=_localized["Show mouse"], categ='Screen')
+            label=_translate("Show mouse"), categ='Screen')
         # self.depends.append(
         #     {"dependsOn": 'Full-screen window',  # must be param name
         #      "condition": "==True",  # val to check for
@@ -287,7 +287,7 @@ class SettingsComponent:
         self.params['Force stereo'] = Param(
             enableEscape, valType='bool', inputType="bool", allowedTypes=[], categ="Audio",
             hint=_translate("Force audio to stereo (2-channel) output"),
-            label=_localized["Force stereo"])
+            label=_translate("Force stereo"))
         self.params['Audio lib'] = Param(
             'ptb', valType='str', inputType="choice",
             allowedVals=['ptb', 'pyo', 'sounddevice', 'pygame'],
@@ -313,7 +313,7 @@ class SettingsComponent:
             filename, valType='code', inputType="single", allowedTypes=[],
             hint=_translate("Code to create your custom file name base. Don"
                             "'t give a file extension - this will be added."),
-            label=_localized["Data filename"], categ='Data')
+            label=_translate("Data filename"), categ='Data')
         self.params['Data file delimiter'] = Param(
             savedDataDelim, valType='str', inputType="choice",
             allowedVals=['auto', 'comma', 'semicolon', 'tab'],
@@ -324,27 +324,27 @@ class SettingsComponent:
             saveLogFile, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Save a detailed log (more detailed than the "
                             "excel/csv files) of the entire experiment"),
-            label=_localized["Save log file"], categ='Data')
+            label=_translate("Save log file"), categ='Data')
         self.params['Save wide csv file'] = Param(
             saveWideCSVFile, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Save data from loops in comma-separated-value "
                             "(.csv) format for maximum portability"),
-            label=_localized["Save wide csv file"], categ='Data')
+            label=_translate("Save csv file (trial-by-trial)"), categ='Data')
         self.params['Save csv file'] = Param(
             saveCSVFile, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Save data from loops in comma-separated-value "
                             "(.csv) format for maximum portability"),
-            label=_localized["Save csv file"], categ='Data')
+            label=_translate("Save csv file (summaries)"), categ='Data')
         self.params['Save excel file'] = Param(
             saveXLSXFile, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Save data from loops in Excel (.xlsx) format"),
-            label=_localized["Save excel file"], categ='Data')
+            label=_translate("Save excel file"), categ='Data')
         self.params['Save psydat file'] = Param(
             savePsydatFile, valType='bool', inputType="bool", allowedVals=[True],
             hint=_translate("Save data from loops in psydat format. This is "
                             "useful for python programmers to generate "
                             "analysis scripts."),
-            label=_localized["Save psydat file"], categ='Data')
+            label=_translate("Save psydat file"), categ='Data')
         self.params['Save hdf5 file'] = Param(
             saveHDF5File, valType='bool', inputType="bool",
             hint=_translate("Save data from eyetrackers in hdf5 format. This is "
@@ -355,7 +355,7 @@ class SettingsComponent:
             allowedVals=['error', 'warning', 'data', 'exp', 'info', 'debug'],
             hint=_translate("How much output do you want in the log files? "
                             "('error' is fewest messages, 'debug' is most)"),
-            label=_localized["logging level"], categ='Data')
+            label=_translate("Logging level"), categ='Data')
 
         # HTML output params
         # self.params['OSF Project ID'] = ProjIDParam(
@@ -388,7 +388,7 @@ class SettingsComponent:
             exportHTML, valType='str', inputType="choice",
             allowedVals=['on Save', 'on Sync', 'manually'],
             hint=_translate("When to export experiment to the HTML folder."),
-            label=_localized["Export HTML"], categ='Online')
+            label=_translate("Export HTML"), categ='Online')
 
         # Eyetracking params
         self.order += ["eyetracker",

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -192,7 +192,7 @@ class SettingsComponent:
             enableEscape, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Enable the <esc> key, to allow subjects to quit"
                             " / break out of the experiment"),
-            label=_translate("Enable Escape key"))
+            label=_translate("Enable escape key"))
         self.params['Experiment info'] = Param(
             expInfo, valType='code', inputType="dict", allowedTypes=[],
             hint=_translate("The info to present in a dialog box. Right-click"
@@ -338,11 +338,11 @@ class SettingsComponent:
         self.params['Save excel file'] = Param(
             saveXLSXFile, valType='bool', inputType="bool", allowedTypes=[],
             hint=_translate("Save data from loops in Excel (.xlsx) format"),
-            label=_translate("Save excel file"), categ='Data')
+            label=_translate("Save Excel file"), categ='Data')
         self.params['Save psydat file'] = Param(
             savePsydatFile, valType='bool', inputType="bool", allowedVals=[True],
             hint=_translate("Save data from loops in psydat format. This is "
-                            "useful for python programmers to generate "
+                            "useful for Python programmers to generate "
                             "analysis scripts."),
             label=_translate("Save psydat file"), categ='Data')
         self.params['Save hdf5 file'] = Param(
@@ -365,25 +365,25 @@ class SettingsComponent:
         self.params['HTML path'] = Param(
             '', valType='str', inputType="single", allowedTypes=[],
             hint=_translate("Place the HTML files will be saved locally "),
-            label="Output path", categ='Online')
+            label=_translate("Output path"), categ='Online')
         self.params['Resources'] = Param(
             [], valType='list', inputType="fileList", allowedTypes=[],
             hint=_translate("Any additional resources needed"),
-            label="Additional Resources", categ='Online')
+            label=_translate("Additional resources"), categ='Online')
         self.params['End Message'] = Param(
             endMessage, valType='str', inputType='single',
             hint=_translate("Message to display to participants upon completing the experiment"),
-            label="End Message", categ='Online')
+            label=_translate("End message"), categ='Online')
         self.params['Completed URL'] = Param(
             '', valType='str', inputType="single",
             hint=_translate("Where should participants be redirected after the experiment on completion, e.g.\n"
                             "https://pavlovia.org/surveys/XXXXXX-XXXX-XXXXXXX?tab=0"),
-            label="Completed URL", categ='Online')
+            label=_translate("Completed URL"), categ='Online')
         self.params['Incomplete URL'] = Param(
             '', valType='str', inputType="single",
             hint=_translate("Where participants are redirected if they do not complete the task, e.g.\n"
                             "https://pavlovia.org/surveys/XXXXXX-XXXX-XXXXXXX?tab=0"),
-            label="Incomplete URL", categ='Online')
+            label=_translate("Incomplete URL"), categ='Online')
         self.params['exportHTML'] = Param(
             exportHTML, valType='str', inputType="choice",
             allowedVals=['on Save', 'on Sync', 'manually'],
@@ -431,7 +431,7 @@ class SettingsComponent:
             allowedVals=list(ioDeviceMap),
             hint=_translate("What kind of eye tracker should PsychoPy use? Select 'MouseGaze' to use "
                             "the mouse to simulate eye movement (for debugging without a tracker connected)"),
-            label=_translate("Eyetracker Device"), categ="Eyetracking"
+            label=_translate("Eyetracker device"), categ="Eyetracking"
         )
 
         #mousegaze
@@ -439,33 +439,33 @@ class SettingsComponent:
             mgMove, valType='str', inputType="choice",
             allowedVals=['CONTINUOUS', 'LEFT_BUTTON', 'MIDDLE_BUTTON', 'RIGHT_BUTTON'],
             hint=_translate("Mouse button to press for eye movement."),
-            label=_translate("Move Button"), categ="Eyetracking"
+            label=_translate("Move button"), categ="Eyetracking"
         )
 
         self.params['mgBlink'] = Param(
             mgBlink, valType='list', inputType="multiChoice",
             allowedVals=['LEFT_BUTTON', 'MIDDLE_BUTTON', 'RIGHT_BUTTON'],
             hint=_translate("Mouse button to press for a blink."),
-            label=_translate("Blink Button"), categ="Eyetracking"
+            label=_translate("Blink button"), categ="Eyetracking"
         )
 
         self.params['mgSaccade'] = Param(
             mgSaccade, valType='num', inputType="single",
             hint=_translate("Visual degree threshold for Saccade event creation."),
-            label=_translate("Saccade Threshold"), categ="Eyetracking"
+            label=_translate("Saccade threshold"), categ="Eyetracking"
         )
 
         # gazepoint
         self.params['gpAddress'] = Param(
             gpAddress, valType='str', inputType="single",
             hint=_translate("IP Address of the computer running GazePoint Control."),
-            label=_translate("GazePoint IP Address"), categ="Eyetracking"
+            label=_translate("GazePoint IP address"), categ="Eyetracking"
         )
 
         self.params['gpPort'] = Param(
             gpPort, valType='num', inputType="single",
             hint=_translate("Port of the GazePoint Control server. Usually 4242."),
-            label=_translate("GazePoint Port"), categ="Eyetracking"
+            label=_translate("GazePoint port"), categ="Eyetracking"
         )
         # eyelink
         self.params['elModel'] = Param(
@@ -473,27 +473,27 @@ class SettingsComponent:
             allowedVals=['EYELINK 1000 DESKTOP', 'EYELINK 1000 TOWER', 'EYELINK 1000 REMOTE',
                          'EYELINK 1000 LONG RANGE'],
             hint=_translate("Eye tracker model."),
-            label=_translate("Model Name"), categ="Eyetracking"
+            label=_translate("Model name"), categ="Eyetracking"
         )
 
         self.params['elSimMode'] = Param(
             elSimMode, valType='bool', inputType="bool",
             hint=_translate("Set the EyeLink to run in mouse simulation mode."),
-            label=_translate("Mouse Simulation Mode"), categ="Eyetracking"
+            label=_translate("Mouse simulation mode"), categ="Eyetracking"
         )
 
         self.params['elSampleRate'] = Param(
             elSampleRate, valType='num', inputType="choice",
             allowedVals=['250', '500', '1000', '2000'],
             hint=_translate("Eye tracker sampling rate."),
-            label=_translate("Sampling Rate"), categ="Eyetracking"
+            label=_translate("Sampling rate"), categ="Eyetracking"
         )
 
         self.params['elTrackEyes'] = Param(
             elTrackEyes, valType='str', inputType="choice",
             allowedVals=['LEFT_EYE', 'RIGHT_EYE', 'BOTH'],
             hint=_translate("Select with eye(s) to track."),
-            label=_translate("Track Eyes"), categ="Eyetracking"
+            label=_translate("Track eyes"), categ="Eyetracking"
         )
 
         self.params['elLiveFiltering'] = Param(
@@ -501,7 +501,7 @@ class SettingsComponent:
             allowedVals=['FILTER_LEVEL_OFF', 'FILTER_LEVEL_1', 'FILTER_LEVEL_2'],
             hint=_translate("Filter eye sample data live, as it is streamed to the driving device. "
                             "This may reduce the sampling speed."),
-            label=_translate("Live Sample Filtering"), categ="Eyetracking"
+            label=_translate("Live sample filtering"), categ="Eyetracking"
         )
 
         self.params['elDataFiltering'] = Param(
@@ -509,102 +509,102 @@ class SettingsComponent:
             allowedVals=['FILTER_LEVEL_OFF', 'FILTER_LEVEL_1', 'FILTER_LEVEL_2'],
             hint=_translate("Filter eye sample data when it is saved to the output file. This will "
                             "not affect the sampling speed."),
-            label=_translate("Saved Sample Filtering"), categ="Eyetracking"
+            label=_translate("Saved sample filtering"), categ="Eyetracking"
         )
 
         self.params['elTrackingMode'] = Param(
             elTrackingMode, valType='str', inputType="choice",
             allowedVals=['PUPIL_CR_TRACKING', 'PUPIL_ONLY_TRACKING'],
             hint=_translate("Track Pupil-CR or Pupil only."),
-            label=_translate("Pupil Tracking Mode"), categ="Eyetracking"
+            label=_translate("Pupil tracking mode"), categ="Eyetracking"
         )
 
         self.params['elPupilAlgorithm'] = Param(
             elPupilAlgorithm, valType='str', inputType="choice",
             allowedVals=['ELLIPSE_FIT', 'CENTROID_FIT'],
             hint=_translate("Algorithm used to detect the pupil center."),
-            label=_translate("Pupil Center Algorithm"), categ="Eyetracking"
+            label=_translate("Pupil center algorithm"), categ="Eyetracking"
         )
 
         self.params['elPupilMeasure'] = Param(
             elPupilMeasure, valType='str', inputType="choice",
             allowedVals=['PUPIL_AREA', 'PUPIL_DIAMETER', 'NEITHER'],
             hint=_translate("Type of pupil data to record."),
-            label=_translate("Pupil Data Type"), categ="Eyetracking"
+            label=_translate("Pupil data type"), categ="Eyetracking"
         )
 
         self.params['elAddress'] = Param(
             elAddress, valType='str', inputType="single",
             hint=_translate("IP Address of the EyeLink *Host* computer."),
-            label=_translate("EyeLink IP Address"), categ="Eyetracking"
+            label=_translate("EyeLink IP address"), categ="Eyetracking"
         )
 
         # tobii
         self.params['tbModel'] = Param(
             tbModel, valType='str', inputType="single",
             hint=_translate("Eye tracker model."),
-            label=_translate("Model Name"), categ="Eyetracking"
+            label=_translate("Model name"), categ="Eyetracking"
         )
 
         self.params['tbLicenseFile'] = Param(
             tbLicenseFile, valType='str', inputType="file",
             hint=_translate("Eye tracker license file (optional)."),
-            label=_translate("License File"), categ="Eyetracking"
+            label=_translate("License file"), categ="Eyetracking"
         )
 
         self.params['tbSerialNo'] = Param(
             tbSerialNo, valType='str', inputType="single",
             hint=_translate("Eye tracker serial number (optional)."),
-            label=_translate("Serial Number"), categ="Eyetracking"
+            label=_translate("Serial number"), categ="Eyetracking"
         )
 
         self.params['tbSampleRate'] = Param(
             tbSampleRate, valType='num', inputType="single",
             hint=_translate("Eye tracker sampling rate."),
-            label=_translate("Sampling Rate"), categ="Eyetracking"
+            label=_translate("Sampling rate"), categ="Eyetracking"
         )
 
         # pupil labs
         self.params['plPupillometryOnly'] = Param(
             plPupillometryOnly, valType='bool', inputType="bool",
             hint=_translate("Subscribe to pupil data only, does not require calibration or surface setup"),
-            label=_translate("Pupillometry Only"),
+            label=_translate("Pupillometry only"),
             categ="Eyetracking"
         )
         self.params['plSurfaceName'] = Param(
             plSurfaceName, valType='str', inputType="single",
             hint=_translate("Name of the Pupil Capture surface"),
-            label=_translate("Surface Name"), categ="Eyetracking"
+            label=_translate("Surface name"), categ="Eyetracking"
         )
         self.params['plConfidenceThreshold'] = Param(
             plConfidenceThreshold, valType='num', inputType="single",
-            hint=_translate("Gaze Confidence Threshold"),
-            label=_translate("Gaze Confidence Threshold"), categ="Eyetracking"
+            hint=_translate("Gaze confidence threshold"),
+            label=_translate("Gaze confidence threshold"), categ="Eyetracking"
         )
         self.params['plPupilRemoteAddress'] = Param(
             plPupilRemoteAddress, valType='str', inputType="single",
-            hint=_translate("Pupil Remote Address"),
-            label=_translate("Pupil Remote Address"), categ="Eyetracking"
+            hint=_translate("Pupil remote address"),
+            label=_translate("Pupil remote address"), categ="Eyetracking"
         )
         self.params['plPupilRemotePort'] = Param(
             plPupilRemotePort, valType='num', inputType="single",
-            hint=_translate("Pupil Remote Port"),
-            label=_translate("Pupil Remote Port"), categ="Eyetracking"
+            hint=_translate("Pupil remote port"),
+            label=_translate("Pupil remote port"), categ="Eyetracking"
         )
         self.params['plPupilRemoteTimeoutMs'] = Param(
             plPupilRemoteTimeoutMs, valType='num', inputType="single",
-            hint=_translate("Pupil Remote Timeout (ms)"),
-            label=_translate("Pupil Remote Timeout (ms)"), categ="Eyetracking"
+            hint=_translate("Pupil remote timeout (ms)"),
+            label=_translate("Pupil remote timeout (ms)"), categ="Eyetracking"
         )
         self.params['plPupilCaptureRecordingEnabled'] = Param(
             plPupilCaptureRecordingEnabled, valType='bool', inputType="bool",
-            hint=_translate("Pupil Capture Recording Enabled"),
-            label=_translate("Pupil Capture Recording Enabled"), categ="Eyetracking"
+            hint=_translate("Pupil capture recording enabled"),
+            label=_translate("Pupil capture recording enabled"), categ="Eyetracking"
         )
         self.params['plPupilCaptureRecordingLocation'] = Param(
             plPupilCaptureRecordingLocation, valType='str', inputType="single",
-            hint=_translate("Pupil Capture Recording Location"),
-            label=_translate("Pupil Capture Recording Location"), categ="Eyetracking"
+            hint=_translate("Pupil capture recording location"),
+            label=_translate("Pupil capture recording location"), categ="Eyetracking"
         )
 
         # Input
@@ -612,7 +612,7 @@ class SettingsComponent:
             keyboardBackend, valType='str', inputType="choice",
             allowedVals=list(keyboardBackendMap),
             hint=_translate("What Python package should PsychoPy use to get keyboard input?"),
-            label=_translate("Keyboard Backend"), categ="Input"
+            label=_translate("Keyboard backend"), categ="Input"
         )
 
     @property

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -128,7 +128,7 @@ class SliderComponent(BaseVisualComponent):
         self.params['initVal'] = Param(
             initVal, valType='code', inputType="single", categ='Basic',
             hint=_translate("Value of the slider befre any response, leave blank to hide the marker until clicked on"),
-            label=_translate("Starting Value")
+            label=_translate("Starting value")
         )
         self.params['granularity'] = Param(
                 granularity, valType='num', inputType="single", allowedTypes=[], categ='Basic',
@@ -136,7 +136,7 @@ class SliderComponent(BaseVisualComponent):
                 hint=_translate("Specifies the minimum step size "
                                 "(0 for a continuous scale, 1 for integer "
                                 "rating scale)"),
-                label=_translate('Granularity'))
+                label=_translate("Granularity"))
         self.depends.append(
             {
                 # if...
@@ -155,13 +155,13 @@ class SliderComponent(BaseVisualComponent):
                 forceEndRoutine, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
                 updates='constant', allowedUpdates=[],
                 hint=_translate("Should setting a rating (releasing the mouse) "
-                                "cause the end of the routine (e.g. trial)?"),
+                                "cause the end of the Routine (e.g. trial)?"),
                 label=_translate("Force end of Routine"))
         self.params['readOnly'] = Param(
             readOnly, valType='bool', allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=_translate("Should participant be able to change the rating on the Slider?"),
-            label=_translate("readOnly"))
+            label=_translate("Read only"))
 
         # advanced params:
         self.params['flip'] = Param(
@@ -171,14 +171,14 @@ class SliderComponent(BaseVisualComponent):
                         "By default the labels will be on the bottom or "
                         "left of the scale, but this can be flipped to the "
                         "other side."),
-                label=_translate('Flip'))
+                label=_translate("Flip"))
 
         # Color changes
-        self.params['color'].label = _translate("Label Color")
+        self.params['color'].label = _translate("Label color")
         self.params['color'].hint = _translate("Color of all labels on this slider (might be overridden by the style setting)")
-        self.params['fillColor'].label = _translate("Marker Color")
+        self.params['fillColor'].label = _translate("Marker color")
         self.params['fillColor'].hint = _translate("Color of the marker on this slider (might be overridden by the style setting)")
-        self.params['borderColor'].label = _translate("Line Color")
+        self.params['borderColor'].label = _translate("Line color")
         self.params['borderColor'].hint = _translate("Color of all lines on this slider (might be overridden by the style setting)")
 
         self.params['font'] = Param(
@@ -186,28 +186,28 @@ class SliderComponent(BaseVisualComponent):
                 updates='constant',
                 hint=_translate(
                         "Font for the labels"),
-                label=_translate('Font'))
+                label=_translate("Font"))
 
         self.params['letterHeight'] = Param(
                 letterHeight, valType='num', inputType="single", categ='Formatting',
                 updates='constant',
                 hint=_translate(
                         "Letter height for text in labels"),
-                label=_translate('Letter height'))
+                label=_translate("Letter height"))
 
         self.params['styles'] = Param(
                 style, valType='str', inputType="choice", categ='Basic',
                 updates='constant', allowedVals=knownStyles,
                 hint=_translate(
                         "Discrete styles to control the overall appearance of the slider."),
-                label=_translate('Styles'))
+                label=_translate("Styles"))
 
         self.params['styleTweaks'] = Param(
                 styleTweaks, valType='list', inputType="multiChoice", categ='Appearance',
                 updates='constant', allowedVals=knownStyleTweaks,
                 hint=_translate(
                         "Tweaks to change the appearance of the slider beyond its style."),
-                label=_translate('Style Tweaks'))
+                label=_translate("Style tweaks"))
 
         # data params
         self.params['storeRating'] = Param(

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -104,7 +104,7 @@ class SliderComponent(BaseVisualComponent):
                 updates='constant',
                 hint=_translate("Tick positions (numerical) on the scale, "
                                 "separated by commas"),
-                label=_localized['ticks'])
+                label=_translate("Ticks"))
         self.depends.append(
             {
                 # if...
@@ -124,7 +124,7 @@ class SliderComponent(BaseVisualComponent):
                 updates='constant',
                 hint=_translate("Labels for the tick marks on the scale, "
                                 "separated by commas"),
-                label=_localized['labels'])
+                label=_translate("Labels"))
         self.params['initVal'] = Param(
             initVal, valType='code', inputType="single", categ='Basic',
             hint=_translate("Value of the slider befre any response, leave blank to hide the marker until clicked on"),
@@ -156,12 +156,12 @@ class SliderComponent(BaseVisualComponent):
                 updates='constant', allowedUpdates=[],
                 hint=_translate("Should setting a rating (releasing the mouse) "
                                 "cause the end of the routine (e.g. trial)?"),
-                label=_localized['forceEndRoutine'])
+                label=_translate("Force end of Routine"))
         self.params['readOnly'] = Param(
             readOnly, valType='bool', allowedTypes=[], categ='Data',
             updates='constant', allowedUpdates=[],
             hint=_translate("Should participant be able to change the rating on the Slider?"),
-            label=_localized['readOnly'])
+            label=_translate("readOnly"))
 
         # advanced params:
         self.params['flip'] = Param(
@@ -214,18 +214,18 @@ class SliderComponent(BaseVisualComponent):
                 storeRating, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
                 updates='constant', allowedUpdates=[],
                 hint=_translate("store the rating"),
-                label=_localized['storeRating'])
+                label=_translate("Store rating"))
         self.params['storeRatingTime'] = Param(
                 storeRatingTime, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
                 updates='constant', allowedUpdates=[],
                 hint=_translate("Store the time taken to make the choice (in "
                                 "seconds)"),
-                label=_localized['storeRatingTime'])
+                label=_translate("Store rating time"))
         self.params['storeHistory'] = Param(
                 storeHistory, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
                 updates='constant', allowedUpdates=[],
                 hint=_translate("store the history of (selection, time)"),
-                label=_localized['storeHistory'])
+                label=_translate("Store history"))
 
     def writeInitCode(self, buff):
 

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -47,7 +47,7 @@ class SoundComponent(BaseComponent):
         self.params['stopType'].allowedVals = ['duration (s)']
         self.params['stopType'].hint = _translate('The maximum duration of a'
                                                   ' sound in seconds')
-        hnt = _translate("When does the component end? (blank to use the "
+        hnt = _translate("When does the Component end? (blank to use the "
                          "duration of the media)")
         self.params['stopVal'].hint = hnt
 
@@ -71,13 +71,13 @@ class SoundComponent(BaseComponent):
             syncScreenRefresh, valType='bool', inputType="bool", categ='Basic',
             updates='constant',
             hint=msg,
-            label=_translate("Sync Start With Screen"))
+            label=_translate("Sync start with screen"))
         self.params['hamming'] = Param(
             True, valType='bool', inputType="bool", updates='constant', categ='Playback',
             hint=_translate(
-                  "For tones we can apply a Hamming window to prevent 'clicks' that "
+                  "For tones we can apply a hamming window to prevent 'clicks' that "
                   "are caused by a sudden onset. This delays onset by roughly 1ms."),
-            label=_translate('Hamming window'))
+            label=_translate("Hamming window"))
 
     def writeInitCode(self, buff):
         # replaces variable params with sensible defaults

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -57,13 +57,13 @@ class SoundComponent(BaseComponent):
             sound, valType='str', inputType="file", allowedTypes=[], updates='constant', categ='Basic',
             allowedUpdates=['constant', 'set every repeat'],
             hint=hnt,
-            label=_localized['sound'])
+            label=_translate("Sound"))
         _allowed = ['constant', 'set every repeat', 'set every frame']
         self.params['volume'] = Param(
             volume, valType='num', inputType="single", allowedTypes=[], updates='constant', categ='Playback',
             allowedUpdates=_allowed[:],  # use a copy
             hint=_translate("The volume (in range 0 to 1)"),
-            label=_localized["volume"])
+            label=_translate("Volume"))
         msg = _translate(
             "A reaction time to a sound stimulus should be based on when "
             "the screen flipped")
@@ -71,7 +71,7 @@ class SoundComponent(BaseComponent):
             syncScreenRefresh, valType='bool', inputType="bool", categ='Basic',
             updates='constant',
             hint=msg,
-            label=_localized['syncScreenRefresh'])
+            label=_translate("Sync Start With Screen"))
         self.params['hamming'] = Param(
             True, valType='bool', inputType="bool", updates='constant', categ='Playback',
             hint=_translate(

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -49,7 +49,7 @@ class StaticComponent(BaseComponent):
             "Custom code to be run during the static period (after updates)")
         self.params['code'] = Param("", valType='code', inputType="multi", categ='Custom',
                                     hint=hnt,
-                                    label=_localized['Custom code'])
+                                    label=_translate("Custom code"))
 
     def addComponentUpdate(self, routine, compName, fieldName):
         self.updatesList.append({'compName': compName,

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -61,37 +61,37 @@ class TextComponent(BaseVisualComponent):
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The text to be displayed"),
             canBePath=False,
-            label=_localized['text'])
+            label=_translate("Text"))
         self.params['font'] = Param(
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The font name (e.g. Comic Sans)"),
-            label=_localized['font'])
+            label=_translate("Font"))
         del self.params['size']  # because you can't specify width for text
         self.params['letterHeight'] = Param(
             letterHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("Specifies the height of the letter (the width"
                             " is then determined by the font)"),
-            label=_localized['letterHeight'])
+            label=_translate("Letter height"))
 
         self.params['wrapWidth'] = Param(
             wrapWidth, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant', allowedUpdates=['constant'],
             hint=_translate("How wide should the text get when it wraps? (in"
                             " the specified units)"),
-            label=_localized['wrapWidth'])
+            label=_translate("Wrap width"))
         self.params['flip'] = Param(
             flip, valType='str', inputType="single", allowedTypes=[], categ='Layout',
             allowedVals=["horiz", "vert", "None"], updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("horiz = left-right reversed; vert = up-down"
                             " reversed; $var = variable"),
-            label=_localized['flip'])
+            label=_translate("Flip (mirror)"))
         self.params['languageStyle'] = Param(
             languageStyle, valType='str', inputType="choice", categ='Formatting',
             allowedVals=['LTR', 'RTL', 'Arabic'],
             hint=_translate("Handle right-to-left (RTL) languages and Arabic reshaping"),
-            label=_localized['languageStyle'])
+            label=_translate("Language style"))
 
         del self.params['fillColor']
         del self.params['borderColor']

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -82,7 +82,7 @@ class TextboxComponent(BaseVisualComponent):
         self.order.insert(self.order.index("units"), "padding") # Add "padding" just before spatial units
         # params
         _allow3 = ['constant', 'set every repeat', 'set every frame']  # list
-        self.params['color'].label = _translate("Text Color")
+        self.params['color'].label = _translate("Text color")
 
         self.params['text'] = Param(
             text, valType='str', inputType="multi", allowedTypes=[], categ='Basic',
@@ -103,7 +103,7 @@ class TextboxComponent(BaseVisualComponent):
             placeholder, valType='str', inputType="single", categ='Basic',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Placeholder text to show when there is no text contents."),
-            label=_translate("Placeholder Text"))
+            label=_translate("Placeholder text"))
         self.params['font'] = Param(
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
@@ -146,7 +146,7 @@ class TextboxComponent(BaseVisualComponent):
             lineSpacing, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Defines the space between lines"),
-            label=_translate("Line Spacing"))
+            label=_translate("Line spacing"))
         self.params['padding'] = Param(
             padding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant', allowedUpdates=_allow3[:],
@@ -166,7 +166,7 @@ class TextboxComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("Which point on the stimulus should be anchored to its exact position?"),
-            label=_translate('Anchor'))
+            label=_translate("Anchor"))
         self.params['alignment'] = Param(
             alignment, valType='str', inputType="choice", categ='Formatting',
             allowedVals=['center',
@@ -190,7 +190,7 @@ class TextboxComponent(BaseVisualComponent):
                          ],
             updates='constant',
             hint=_translate("If the text is bigger than the textbox, how should it behave?"),
-            label=_translate('Overflow'))
+            label=_translate("Overflow"))
         self.params['speechPoint'] = Param(
             speechPoint, valType='list', inputType="single", categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:], direct=False,
@@ -201,7 +201,7 @@ class TextboxComponent(BaseVisualComponent):
             borderWidth, valType='num', inputType="single", allowedTypes=[], categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Textbox border width"),
-            label=_translate("Border Width"))
+            label=_translate("Border width"))
         self.params['editable'] = Param(
             editable, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
@@ -212,7 +212,7 @@ class TextboxComponent(BaseVisualComponent):
             updates='constant',
             hint=_translate(
                     'Automatically record all changes to this in the log file'),
-            label=_translate("Auto Log"))
+            label=_translate("Auto log"))
 
     def writeInitCode(self, buff):
         # do we need units code?

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -89,7 +89,7 @@ class TextboxComponent(BaseVisualComponent):
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The text to be displayed"),
             canBePath=False,
-            label=_localized['text'])
+            label=_translate("Text"))
         self.depends.append(
             {
                 "dependsOn": "editable",  # if...
@@ -108,50 +108,50 @@ class TextboxComponent(BaseVisualComponent):
             font, valType='str', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("The font name (e.g. Comic Sans)"),
-            label=_localized['font'])
+            label=_translate("Font"))
         self.params['letterHeight'] = Param(
             letterHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant', allowedUpdates=_allow3[:],  # copy the list
             hint=_translate("Specifies the height of the letter (the width"
                             " is then determined by the font)"),
-            label=_localized['letterHeight'])
+            label=_translate("Letter height"))
         self.params['flipHoriz'] = Param(
             flipHoriz, valType='bool', inputType="bool", allowedTypes=[], categ='Layout',
             updates='constant',
             hint=_translate("horiz = left-right reversed; vert = up-down"
                             " reversed; $var = variable"),
-            label=_localized['flipHorizontal'])
+            label=_translate("Flip horizontal"))
         self.params['flipVert'] = Param(
             flipVert, valType='bool', inputType="bool", allowedTypes=[], categ='Layout',
             updates='constant',
             hint=_translate("horiz = left-right reversed; vert = up-down"
                             " reversed; $var = variable"),
-            label=_localized['flipVertical'])
+            label=_translate("Flip vertical"))
         self.params['languageStyle'] = Param(
             languageStyle, valType='str', inputType="choice", categ='Formatting',
             allowedVals=['LTR', 'RTL', 'Arabic'],
             hint=_translate("Handle right-to-left (RTL) languages and Arabic reshaping"),
-            label=_localized['languageStyle'])
+            label=_translate("Language style"))
         self.params['italic'] = Param(
             italic, valType='bool', inputType="bool", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Should text be italic?"),
-            label=_localized['italic'])
+            label=_translate("Italic"))
         self.params['bold'] = Param(
             bold, valType='bool', inputType="bool", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Should text be bold?"),
-            label=_localized['bold'])
+            label=_translate("Bold"))
         self.params['lineSpacing'] = Param(
             lineSpacing, valType='num', inputType="single", allowedTypes=[], categ='Formatting',
             updates='constant',
             hint=_translate("Defines the space between lines"),
-            label=_localized['lineSpacing'])
+            label=_translate("Line Spacing"))
         self.params['padding'] = Param(
             padding, valType='num', inputType="single", allowedTypes=[], categ='Layout',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Defines the space between text and the textbox border"),
-            label=_localized['padding'])
+            label=_translate("Padding"))
         self.params['anchor'] = Param(
             anchor, valType='str', inputType="choice", categ='Layout',
             allowedVals=['center',
@@ -201,18 +201,18 @@ class TextboxComponent(BaseVisualComponent):
             borderWidth, valType='num', inputType="single", allowedTypes=[], categ='Appearance',
             updates='constant', allowedUpdates=_allow3[:],
             hint=_translate("Textbox border width"),
-            label=_localized['borderWidth'])
+            label=_translate("Border Width"))
         self.params['editable'] = Param(
             editable, valType='bool', inputType="bool", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("Should textbox be editable?"),
-            label=_localized['editable'])
+            label=_translate("Editable?"))
         self.params['autoLog'] = Param(
             autoLog, valType='bool', inputType="bool", allowedTypes=[], categ='Data',
             updates='constant',
             hint=_translate(
                     'Automatically record all changes to this in the log file'),
-            label=_localized['autoLog'])
+            label=_translate("Auto Log"))
 
     def writeInitCode(self, buff):
         # do we need units code?

--- a/psychopy/experiment/components/variable/__init__.py
+++ b/psychopy/experiment/components/variable/__init__.py
@@ -64,31 +64,31 @@ class VariableComponent(BaseComponent):
             hint=hnt,
             label=_translate("Frame start value"))
         # Save options
-        hnt = _translate('Save the experiment start value in data file.')
+        hnt = _translate("Save the experiment start value in data file.")
         self.params['saveStartExp'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
             label=_translate("Save exp start value"))
-        hnt = _translate('Save the experiment end value in data file.')
+        hnt = _translate("Save the experiment end value in data file.")
         self.params['saveEndExp'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
             label=_translate("Save exp end value"))
-        hnt = _translate('Save the routine start value in data file.')
+        hnt = _translate("Save the Routine start value in data file.")
         self.params['saveStartRoutine'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_translate("Save routine start value"))
-        hnt = _translate('Save the routine end value in data file.')
+            label=_translate("Save Routine start value"))
+        hnt = _translate("Save the Routine end value in data file.")
         self.params['saveEndRoutine'] = Param(
             True, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_translate("Save routine end value"))
-        hnt = _translate('Save choice of frame value in data file.')
+            label=_translate("Save Routine end value"))
+        hnt = _translate("Save choice of frame value in data file.")
         self.params['saveFrameValue'] = Param(
             'never', valType='str', inputType="choice", categ='Data',
             allowedVals=['first', 'last', 'all', 'never'],

--- a/psychopy/experiment/components/variable/__init__.py
+++ b/psychopy/experiment/components/variable/__init__.py
@@ -52,49 +52,49 @@ class VariableComponent(BaseComponent):
         self.params['startExpValue'] = Param(
             startExpValue, valType='code', inputType="single", allowedTypes=[], updates='constant', categ='Basic',
             hint=hnt,
-            label=_localized['startExpValue'])
+            label=_translate("Experiment start value"))
         hnt = _translate("Set the value for the beginning of each routine.")
         self.params['startRoutineValue'] = Param(
             startRoutineValue, valType='code', inputType="single", allowedTypes=[], updates='constant', categ='Basic',
             hint=hnt,
-            label=_localized['startRoutineValue'])
+            label=_translate("Routine start value"))
         hnt = _translate("Set the value for the beginning of every screen refresh.")
         self.params['startFrameValue'] = Param(
             startFrameValue, valType='code', inputType="single", allowedTypes=[], categ='Basic',
             hint=hnt,
-            label=_localized['startFrameValue'])
+            label=_translate("Frame start value"))
         # Save options
         hnt = _translate('Save the experiment start value in data file.')
         self.params['saveStartExp'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_localized['saveStartExp'])
+            label=_translate("Save exp start value"))
         hnt = _translate('Save the experiment end value in data file.')
         self.params['saveEndExp'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_localized['saveEndExp'])
+            label=_translate("Save exp end value"))
         hnt = _translate('Save the routine start value in data file.')
         self.params['saveStartRoutine'] = Param(
             False, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_localized['saveStartRoutine'])
+            label=_translate("Save routine start value"))
         hnt = _translate('Save the routine end value in data file.')
         self.params['saveEndRoutine'] = Param(
             True, valType='bool', inputType="bool", categ='Data',
             updates='constant',
             hint=hnt,
-            label=_localized['saveEndRoutine'])
+            label=_translate("Save routine end value"))
         hnt = _translate('Save choice of frame value in data file.')
         self.params['saveFrameValue'] = Param(
             'never', valType='str', inputType="choice", categ='Data',
             allowedVals=['first', 'last', 'all', 'never'],
             updates='constant', direct=False,
             hint=hnt,
-            label=_localized['saveFrameValue'])
+            label=_translate("Save frame value"))
 
     def writeInitCode(self, buff):
         """Write variable initialisation code."""

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -38,16 +38,16 @@ class BaseStandaloneRoutine:
         self.order = ['stopVal', 'stopType', 'name']
 
         msg = _translate(
-            "Name of this routine (alphanumeric or _, no spaces)")
+            "Name of this Routine (alphanumeric or _, no spaces)")
         self.params['name'] = Param(name,
                                     valType='code', inputType="single", categ='Basic',
                                     hint=msg,
-                                    label=_translate('name'))
+                                    label=_translate('Name'))
 
         self.params['stopVal'] = Param(stopVal,
             valType='num', inputType="single", categ='Basic',
             updates='constant', allowedUpdates=[], allowedTypes=[],
-            hint=_translate("When does the routine end? (blank is endless)"),
+            hint=_translate("When does the Routine end? (blank is endless)"),
             label=_translate('Stop'))
 
         msg = _translate("How do you want to define your end point?")
@@ -55,14 +55,14 @@ class BaseStandaloneRoutine:
             valType='str', inputType="choice", categ='Basic',
             allowedVals=['duration (s)', 'duration (frames)', 'condition'],
             hint=msg, direct=False,
-            label=_translate('Stop Type...'))
+            label=_translate('Stop type...'))
 
         # Testing
-        msg = _translate("Disable this routine")
+        msg = _translate("Disable this Routine")
         self.params['disabled'] = Param(disabled,
             valType='bool', inputType="bool", categ="Testing",
             hint=msg, allowedTypes=[], direct=False,
-            label=_translate('Disable routine'))
+            label=_translate('Disable Routine'))
 
     def __repr__(self):
         _rep = "psychopy.experiment.routines.%s(name='%s', exp=%s)"

--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -41,16 +41,16 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                             valType='str', inputType="choice", categ='Basic',
                                             allowedVals=['THREE_POINTS', 'FIVE_POINTS', 'NINE_POINTS', "THIRTEEN_POINTS"],
                                             hint=_translate("Pre-defined target layouts"),
-                                            label=_translate("Target Layout"))
+                                            label=_translate("Target layout"))
 
         self.params['randomisePos'] = Param(randomisePos,
                                             valType='bool', inputType="bool", categ='Basic',
                                             hint=_translate("Should the order of target positions be randomised?"),
-                                            label=_translate("Randomise Target Positions"))
+                                            label=_translate("Randomise target positions"))
         self.params['textColor'] = Param(textColor,
                                      valType='color', inputType="color", categ='Basic',
                                      hint=_translate("Text foreground color"),
-                                     label=_translate("Text Color"))
+                                     label=_translate("Text color"))
         # Target Params
         self.order += [
             "targetStyle",
@@ -68,55 +68,55 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
         self.params['innerFillColor'] = Param(innerFillColor,
                                      valType='color', inputType="color", categ='Target',
                                      hint=_translate("Fill color of the inner part of the target"),
-                                     label=_translate("Inner Fill Color"))
+                                     label=_translate("Inner fill color"))
 
         self.params['innerBorderColor'] = Param(innerBorderColor,
                                            valType='color', inputType="color", categ='Target',
                                            hint=_translate("Border color of the inner part of the target"),
-                                           label=_translate("Inner Border Color"))
+                                           label=_translate("Inner border color"))
 
         self.params['fillColor'] = Param(fillColor,
                                          valType='color', inputType="color", categ='Target',
                                          hint=_translate("Fill color of the outer part of the target"),
-                                         label=_translate("Outer Fill Color"))
+                                         label=_translate("Outer fill color"))
 
         self.params['borderColor'] = Param(borderColor,
                                            valType='color', inputType="color", categ='Target',
                                            hint=_translate("Border color of the outer part of the target"),
-                                           label=_translate("Outer Border Color"))
+                                           label=_translate("Outer border color"))
 
         self.params['colorSpace'] = Param(colorSpace,
                                           valType='str', inputType="choice", categ='Target',
                                           allowedVals=['rgb', 'dkl', 'lms', 'hsv'],
                                           hint=_translate(
                                               "In what format (color space) have you specified the colors? (rgb, dkl, lms, hsv)"),
-                                          label=_translate("Color Space"))
+                                          label=_translate("Color space"))
 
         self.params['borderWidth'] = Param(borderWidth,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Width of the line around the outer part of the target"),
-                                           label=_translate("Outer Border Width"))
+                                           label=_translate("Outer border width"))
 
         self.params['innerBorderWidth'] = Param(innerBorderWidth,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Width of the line around the inner part of the target"),
-                                           label=_translate("Inner Border Width"))
+                                           label=_translate("Inner border width"))
 
         self.params['outerRadius'] = Param(outerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the outer part of the target"),
-                                           label=_translate("Outer Radius"))
+                                           label=_translate("Outer radius"))
 
         self.params['innerRadius'] = Param(innerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the inner part of the target"),
-                                           label=_translate("Inner Radius"))
+                                           label=_translate("Inner radius"))
 
         self.params['units'] = Param(units,
                                      valType='str', inputType="choice", categ='Target',
                                      allowedVals=['from exp settings'], direct=False,
                                      hint=_translate("Units of dimensions for this stimulus"),
-                                     label=_translate("Spatial Units"))
+                                     label=_translate("Spatial units"))
 
         # Animation Params
         self.order += [
@@ -134,7 +134,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                             allowedVals=["space key", "time"],
                                             hint=_translate("Should the target move to the next position after a "
                                                             "keypress or after an amount of time?"),
-                                            label=_translate("Progress Mode"))
+                                            label=_translate("Progress mode"))
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -149,7 +149,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                          valType='num', inputType="single", categ='Animation',
                                          hint=_translate(
                                              "Time limit (s) after which progress to next position"),
-                                         label=_translate("Target Duration"))
+                                         label=_translate("Target duration"))
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -164,18 +164,18 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                          valType='num', inputType="single", categ='Animation',
                                          hint=_translate(
                                              "Duration of the target expand/contract animation"),
-                                         label=_translate("Expand / Contract Duration"))
+                                         label=_translate("Expand / contract duration"))
 
         self.params['expandScale'] = Param(expandScale,
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate("How many times bigger than its size the target grows"),
-                                           label=_translate("Expand Scale"))
+                                           label=_translate("Expand scale"))
 
         self.params['movementAnimation'] = Param(movementAnimation,
                                                  valType='bool', inputType="bool", categ='Animation',
                                                  hint=_translate(
                                                      "Enable / disable animations as target stim changes position"),
-                                                 label=_translate("Animate Position Changes"))
+                                                 label=_translate("Animate position changes"))
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -190,7 +190,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate(
                                                "Duration of the animation during position changes."),
-                                           label=_translate("Movement Duration"))
+                                           label=_translate("Movement duration"))
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -205,7 +205,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate(
                                                "Duration of the delay between positions."),
-                                           label=_translate("Target Delay"))
+                                           label=_translate("Target delay"))
 
     def writeMainCode(self, buff):
         # Alert user if eyetracking isn't setup

--- a/psychopy/experiment/routines/eyetracker_validate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_validate/__init__.py
@@ -60,7 +60,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                             valType='str', inputType="choice", categ='Basic',
                                             allowedVals=positions + ["CUSTOM..."],
                                             hint=_translate("Pre-defined target layouts"),
-                                            label=_translate("Target Layout"))
+                                            label=_translate("Target layout"))
 
         self.depends.append(
             {"dependsOn": "targetLayout",  # must be param name
@@ -75,22 +75,22 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                                valType='list', inputType="single", categ='Basic',
                                                hint=_translate(
                                                    "List of positions (x, y) at which the target can appear"),
-                                               label=_translate("Target Positions"))
+                                               label=_translate("Target positions"))
 
         self.params['randomisePos'] = Param(randomisePos,
                                             valType='bool', inputType="bool", categ='Basic',
                                             hint=_translate("Should the order of target positions be randomised?"),
-                                            label=_translate("Randomise Target Positions"))
+                                            label=_translate("Randomise target positions"))
 
         self.params['cursorFillColor'] = Param(cursorFillColor,
                                                valType="color", inputType="color", categ="Basic",
                                                hint=_translate("Fill color of the gaze cursor"),
-                                               label=_translate("Gaze Cursor Color"))
+                                               label=_translate("Gaze cursor color"))
 
         self.params['textColor'] = Param(textColor,
                                                valType="color", inputType="color", categ="Basic",
                                                hint=_translate("Color of text used in validation procedure."),
-                                               label=_translate("Text Color"))
+                                               label=_translate("Text color"))
 
         # Target Params
         self.order += [
@@ -109,56 +109,56 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
         self.params['innerFillColor'] = Param(innerFillColor,
                                               valType='color', inputType="color", categ='Target',
                                               hint=_translate("Fill color of the inner part of the target"),
-                                              label=_translate("Inner Fill Color"))
+                                              label=_translate("Inner fill color"))
 
         self.params['innerBorderColor'] = Param(innerBorderColor,
                                                 valType='color', inputType="color", categ='Target',
                                                 hint=_translate("Border color of the inner part of the target"),
-                                                label=_translate("Inner Border Color"))
+                                                label=_translate("Inner border color"))
 
         self.params['fillColor'] = Param(fillColor,
                                          valType='color', inputType="color", categ='Target',
                                          hint=_translate("Fill color of the outer part of the target"),
-                                         label=_translate("Outer Fill Color"))
+                                         label=_translate("Outer fill color"))
 
         self.params['borderColor'] = Param(borderColor,
                                            valType='color', inputType="color", categ='Target',
                                            hint=_translate("Border color of the outer part of the target"),
-                                           label=_translate("Outer Border Color"))
+                                           label=_translate("Outer border color"))
 
         self.params['colorSpace'] = Param(colorSpace,
                                           valType='str', inputType="choice", categ='Target',
                                           allowedVals=['rgb', 'dkl', 'lms', 'hsv'],
                                           hint=_translate(
                                               "In what format (color space) have you specified the colors? (rgb, dkl, lms, hsv)"),
-                                          label=_translate("Color Space"))
+                                          label=_translate("Color space"))
 
         self.params['borderWidth'] = Param(borderWidth,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Width of the line around the outer part of the target"),
-                                           label=_translate("Outer Border Width"))
+                                           label=_translate("Outer border width"))
 
         self.params['innerBorderWidth'] = Param(innerBorderWidth,
                                                 valType='num', inputType="single", categ='Target',
                                                 hint=_translate(
                                                     "Width of the line around the inner part of the target"),
-                                                label=_translate("Inner Border Width"))
+                                                label=_translate("Inner border width"))
 
         self.params['outerRadius'] = Param(outerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the outer part of the target"),
-                                           label=_translate("Outer Radius"))
+                                           label=_translate("Outer radius"))
 
         self.params['innerRadius'] = Param(innerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the inner part of the target"),
-                                           label=_translate("Inner Radius"))
+                                           label=_translate("Inner radius"))
 
         self.params['units'] = Param(units,
                                      valType='str', inputType="choice", categ='Target',
                                      allowedVals=['from exp settings'], direct=False,
                                      hint=_translate("Units of dimensions for this stimulus"),
-                                     label=_translate("Spatial Units"))
+                                     label=_translate("Spatial units"))
 
         # Animation Params
         self.order += [
@@ -176,7 +176,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                             allowedVals=["space key", "time"],
                                             hint=_translate("Should the target move to the next position after a "
                                                             "keypress or after an amount of time?"),
-                                            label=_translate("Progress Mode"))
+                                            label=_translate("Progress mode"))
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -191,7 +191,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                             valType='num', inputType="single", categ='Animation',
                                             hint=_translate(
                                                 "Time limit (s) after which progress to next position"),
-                                            label=_translate("Target Duration"))
+                                            label=_translate("Target duration"))
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -206,17 +206,17 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate(
                                                "Duration of the target expand/contract animation"),
-                                           label=_translate("Expand / Contract Duration"))
+                                           label=_translate("Expand / contract duration"))
 
         self.params['expandScale'] = Param(expandScale,
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate("How many times bigger than its size the target grows"),
-                                           label=_translate("Expand Scale"))
+                                           label=_translate("Expand scale"))
 
         self.params['movementAnimation'] = Param(movementAnimation,
                                            valType='bool', inputType="bool", categ='Animation',
                                            hint=_translate("Enable / disable animations as target stim changes position"),
-                                           label=_translate("Animate Position Changes"))
+                                           label=_translate("Animate position changes"))
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -231,7 +231,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate(
                                                "Duration of the animation during position changes."),
-                                           label=_translate("Movement Duration"))
+                                           label=_translate("Movement duration"))
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -246,7 +246,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate(
                                                "Duration of the delay between positions."),
-                                           label=_translate("Target Delay"))
+                                           label=_translate("Target delay"))
 
         # Data params
         self.order += [
@@ -258,13 +258,13 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
             valType='bool', inputType="bool", categ='Data',
             hint=_translate(
                 "Save results as an image"),
-            label=_translate("Save As Image"))
+            label=_translate("Save as image"))
 
         self.params['showResults'] = Param(showResults,
             valType='bool', inputType="bool", categ='Data',
             hint=_translate(
                 "Show a screen with results after completion?"),
-            label=_translate("Show Results Screen"))
+            label=_translate("Show results screen"))
 
     def writeMainCode(self, buff):
         # Alert user if eyetracking isn't setup

--- a/psychopy/experiment/routines/pavlovia_survey/__init__.py
+++ b/psychopy/experiment/routines/pavlovia_survey/__init__.py
@@ -38,7 +38,7 @@ class PavloviaSurveyRoutine(BaseStandaloneRoutine):
         self.params['surveyType'] = Param(
             surveyType, valType='code', inputType="richChoice", categ='Basic',
             allowedVals=["id", "json"], allowedLabels=[
-                {'label': _translate("Survey ID"),
+                {'label': _translate("Survey id"),
                  'body': _translate(
                      "Linking to a survey ID from Pavlovia Surveys means that the content will automatically update "
                      "if that survey changes (better for dynamic use)"),
@@ -69,7 +69,7 @@ class PavloviaSurveyRoutine(BaseStandaloneRoutine):
             hint=_translate(
                 "The ID for your survey on Pavlovia. Tip: Right click to open the survey in your browser!"
             ),
-            label=_translate("Survey ID"))
+            label=_translate("Survey id"))
 
         self.depends += [{
             "dependsOn": "surveyType",  # must be param name


### PR DESCRIPTION
Three key things:
- Use _translate rather than indexing _localized, as the latter seems to cause problems with the MindTrace app for some reason (from MSI, at least)
- Use sentence case
- Capitalize PsychoPy keywords (Routine, Component, etc.)