### PR TITLE
FF: Clear autodraw stimuli when experiment ends without terminating Python

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1743,6 +1743,8 @@ class SettingsComponent:
         # Write code to end experiment
         code = (
             "if win is not None:\n"
+            "    # remove autodraw from all current components\n"
+            "    win.clearAutoDraw()\n"
             "    # Flip one final time so any remaining win.callOnFlip() \n"
             "    # and win.timeOnFlip() tasks get executed\n"
             "    win.flip()\n"

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -1073,6 +1073,15 @@ class Window():
         """
         Window.backend.dispatchEvents()
 
+    def clearAutoDraw(self):
+        """
+        Remove all autoDraw components, meaning they get autoDraw set to False and are not
+        added to any list (as in .stashAutoDraw)
+        """
+        for thisStim in self._toDraw.copy():
+            # set autoDraw to False
+            thisStim.autoDraw = False
+
     def stashAutoDraw(self):
         """
         Put autoDraw components on 'hold', meaning they get autoDraw set to False but


### PR DESCRIPTION
Usually the components would be deleted anyway because Python would terminate, but Session means the Python process endures after the experiment ends, so we need to make sure stimuli don't continue drawing