### PR TITLE
BF: Joystick component - SyntaxError in generated code

### DIFF
--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -439,7 +439,7 @@ class JoystickComponent(BaseComponent):
                     #"print({name}.pressedButtons)\n"
                     #"print({name}.newPressedButtons)\n"
                     "[logging.data(\"joystick_{{}}_button: {{}}, pos=({{:1.4f}},{{:1.4f}})\".format("
-                    "{name}.device_number, i, {name}.getX(), {name}.getY()) for i in {name}.pressedButtons]\n"
+                    "{name}.device_number, i, {name}.getX(), {name}.getY())) for i in {name}.pressedButtons]\n"
             )
             buff.writeIndentedLines(code.format(**self.params))
 


### PR DESCRIPTION
Solving issue #5600. 
The list comprehension expression in the generated code was missing the closing parenthesis. 