### PR TITLE
NF: Search dialog for Builder

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -515,7 +515,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         menu.AppendSeparator()
 
         item = menu.Append(wx.ID_ANY,
-                           _translate("Find in experiment..."),
+                           _translate("&Find in experiment...\t%s") % keys['builderFind'],
                            _translate("Search the whole experiment for a specific term"))
         self.Bind(wx.EVT_MENU, self.onFindInExperiment, item)
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -58,7 +58,7 @@ from psychopy import logging, data
 from psychopy.tools.filetools import mergeFolder
 from .dialogs import (DlgComponentProperties, DlgExperimentProperties,
                       DlgCodeComponentProperties, DlgLoopProperties,
-                      ParamNotebook, DlgNewRoutine)
+                      ParamNotebook, DlgNewRoutine, BuilderFindDlg)
 from ..utils import (BasePsychopyToolbar, HoverButton, WindowFrozen,
                      FileDropTarget, FrameSwitcher, updateDemosMenu,
                      ToggleButtonArray, HoverMixin)
@@ -515,6 +515,11 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         menu.AppendSeparator()
 
         item = menu.Append(wx.ID_ANY,
+                           _translate("Find in experiment..."),
+                           _translate("Search the whole experiment for a specific term"))
+        self.Bind(wx.EVT_MENU, self.onFindInExperiment, item)
+
+        item = menu.Append(wx.ID_ANY,
                            _translate("README..."),
                            _translate("Add or edit the text shown when your experiment is opened"))
         self.Bind(wx.EVT_MENU, self.editREADME, item)
@@ -854,6 +859,10 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
     # def pluginManager(self, evt=None, value=True):
     #     """Show the plugin manager frame."""
     #     PluginManagerFrame(self).ShowModal()
+
+    def onFindInExperiment(self, evt=None):
+        dlg = BuilderFindDlg(frame=self, exp=self.exp)
+        dlg.Show()
 
     def updateReadme(self, show=None):
         """Check whether there is a readme file in this folder and try to show
@@ -2353,7 +2362,7 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
             self.frame.addToUndoStack("PASTE Component `%s`" % newName)
         dlg.Destroy()
 
-    def editComponentProperties(self, event=None, component=None):
+    def editComponentProperties(self, event=None, component=None, openToPage=None):
         # we got here from a wx.button press (rather than our own drawn icons)
         if event:
             componentName = event.EventObject.GetName()
@@ -2383,7 +2392,8 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
             _Dlg = DlgComponentProperties
         dlg = _Dlg(frame=self.frame,
                    element=component,
-                   experiment=self.frame.exp, editing=True)
+                   experiment=self.frame.exp, editing=True,
+                   openToPage=openToPage)
         if dlg.OK:
             # Redraw if force end routine has changed
             if any(key in component.params for key in ['forceEndRoutine', 'forceEndRoutineOnPress', 'endRoutineOn']):

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -26,6 +26,7 @@ from .. import experiment
 from .. validators import NameValidator, CodeSnippetValidator, WarningManager
 from .dlgsConditions import DlgConditions
 from .dlgsCode import DlgCodeComponentProperties, CodeBox
+from .findDlg import BuilderFindDlg
 from . import paramCtrls
 from psychopy import data, logging, exceptions
 from psychopy.localization import _translate
@@ -543,12 +544,13 @@ class StartStopCtrls(wx.GridBagSizer):
 
 class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
     class CategoryPage(wx.Panel, handlers.ThemeMixin):
-        def __init__(self, parent, dlg, params):
+        def __init__(self, parent, dlg, params, categ=None):
             wx.Panel.__init__(self, parent, size=(600, -1))
             self.parent = parent
             self.parent = parent
             self.dlg = dlg
             self.app = self.dlg.app
+            self.categ = categ
             # Setup sizer
             self.border = wx.BoxSizer()
             self.SetSizer(self.border)
@@ -724,7 +726,7 @@ class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
         # Setup pages
         self.paramCtrls = {}
         for categ, params in paramsByCateg.items():
-            page = self.CategoryPage(self, self.parent, params)
+            page = self.CategoryPage(self, self.parent, params, categ=categ)
             self.paramCtrls.update(page.ctrls)
             # Add page to notebook
             self.AddPage(page, _translate(categ))
@@ -788,6 +790,16 @@ class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
             del self.params[fieldName]
         return self.params
 
+    def getCategoryIndex(self, categ):
+        """
+        Get page index for a given category
+        """
+        # iterate through pages by index
+        for i in range(self.GetPageCount()):
+            # if this page is the correct category, return current index
+            if self.GetPage(i).categ == categ:
+                return i
+
     def _updateStaticUpdates(self, fieldName, updates, newUpdates):
         """If the old/new updates ctrl is using a Static component then we
         need to remove/add the component name to the appropriate static
@@ -817,7 +829,7 @@ class _BaseParamsDlg(wx.Dialog):
                  showAdvanced=False,
                  size=wx.DefaultSize,
                  style=_style, editing=False,
-                 timeout=None):
+                 timeout=None, openToPage=None):
 
         # translate title
         if "name" in element.params:
@@ -875,6 +887,10 @@ class _BaseParamsDlg(wx.Dialog):
 
         self.ctrls = ParamNotebook(self, element, experiment)
         self.paramCtrls = self.ctrls.paramCtrls
+        # open to page
+        if openToPage is not None:
+            i = self.ctrls.getCategoryIndex(openToPage)
+            self.ctrls.ChangeSelection(i)
 
         self.mainSizer.Add(self.ctrls,  # ctrls is the notebook of params
                            proportion=1, flag=wx.EXPAND | wx.ALL, border=5)
@@ -1831,13 +1847,14 @@ class DlgComponentProperties(_BaseParamsDlg):
                  suppressTitles=True, size=wx.DefaultSize,
                  style=wx.DEFAULT_DIALOG_STYLE | wx.DIALOG_NO_PARENT,
                  editing=False,
-                 timeout=None, testing=False, type=None):
+                 timeout=None, testing=False, type=None,
+                 openToPage=None):
         style = style | wx.RESIZE_BORDER
         self.type = type or element.type
         _BaseParamsDlg.__init__(self, frame=frame, element=element, experiment=experiment,
                                 size=size,
                                 style=style, editing=editing,
-                                timeout=timeout)
+                                timeout=timeout, openToPage=openToPage)
         self.frame = frame
         self.app = frame.app
         self.dpi = self.app.dpi

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -33,7 +33,8 @@ class DlgCodeComponentProperties(wx.Dialog):
     def __init__(self, frame, element, experiment,
                  helpUrl=None, suppressTitles=True, size=(1000,600),
                  style=_style, editing=False, depends=[],
-                 timeout=None, type="Code"):
+                 timeout=None, type="Code",
+                 openToPage=None):
 
         # translate title
         if "name" in element.params:
@@ -75,7 +76,6 @@ class DlgCodeComponentProperties(wx.Dialog):
         # in FlatNoteBook the tab controls (left,right,close) are ugly on mac
         #   and also can't be killed
 
-        openToPage = None
         for paramN, paramName in enumerate(self.order):
             param = self.params.get(paramName)
             if paramName == 'name':
@@ -119,6 +119,9 @@ class DlgCodeComponentProperties(wx.Dialog):
                     _panel.tabN = len(self.tabs)
                     _panel.app = self.app
                     self.tabs[tabName] = _panel
+                # if openToPage refers to this page by name, convert to index
+                if openToPage == paramName:
+                    openToPage = _panel.tabN
 
                 self.codeBoxes[paramName] = CodeBox(_panel, wx.ID_ANY,
                                                     pos=wx.DefaultPosition,

--- a/psychopy/app/builder/dialogs/findDlg.py
+++ b/psychopy/app/builder/dialogs/findDlg.py
@@ -1,0 +1,181 @@
+import wx
+from psychopy import experiment
+from psychopy.app import utils
+from psychopy.app.themes import icons
+from psychopy.localization import _translate
+
+
+class BuilderFindDlg(wx.Dialog):
+    def __init__(self, frame, exp):
+        self.frame = frame
+        self.exp = exp
+
+        self.results = []
+
+        wx.Dialog.__init__(
+            self,
+            parent=frame,
+            title=_translate("Find in experiment..."),
+            size=(512, 512),
+            style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
+        )
+        # setup sizer
+        self.border = wx.BoxSizer(wx.VERTICAL)
+        self.SetSizer(self.border)
+        self.sizer = wx.BoxSizer(wx.VERTICAL)
+        self.border.Add(self.sizer, border=12, proportion=1, flag=wx.EXPAND | wx.ALL)
+
+        # create search box
+        self.termCtrl = wx.SearchCtrl(self)
+        self.termCtrl.Bind(wx.EVT_SEARCH, self.onSearch)
+        self.sizer.Add(self.termCtrl, border=6, flag=wx.EXPAND | wx.ALL)
+
+        # create results box
+        self.resultsCtrl = utils.ListCtrl(self, style=wx.LC_REPORT | wx.LC_SINGLE_SEL)
+        self.resetListCtrl()
+        self.resultsCtrl.Bind(wx.EVT_LIST_ITEM_SELECTED, self.onSelectResult)
+        self.resultsCtrl.Bind(wx.EVT_LIST_ITEM_DESELECTED, self.onSelectResult)
+        self.resultsCtrl.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self.onViewResult)
+        self.sizer.Add(self.resultsCtrl, border=6, proportion=1, flag=wx.EXPAND | wx.ALL)
+
+        # setup component icons
+        self.imageList = wx.ImageList(16, 16)
+        self.imageMap = {}
+        for cls in experiment.getAllElements().values():
+            i = self.imageList.Add(
+                icons.ComponentIcon(cls, theme="light", size=16).bitmap
+            )
+            self.imageMap[cls] = i
+        self.resultsCtrl.SetImageList(self.imageList, wx.IMAGE_LIST_SMALL)
+
+        # add buttons
+        btnSzr = self.CreateButtonSizer(wx.OK | wx.CANCEL)
+        self.border.Add(btnSzr, border=12, flag=wx.EXPAND | wx.ALL)
+        # relabel OK to Go
+        for child in btnSzr.GetChildren():
+            if child.Window and child.Window.GetId() == wx.ID_OK:
+                self.okBtn = child.Window
+        self.okBtn.SetLabel(_translate("Go"))
+        self.okBtn.Disable()
+        # rebind OK to view method
+        self.okBtn.Bind(wx.EVT_BUTTON, self.onViewResult)
+
+        self.Layout()
+        self.termCtrl.SetFocus()
+
+    def resetListCtrl(self):
+        self.resultsCtrl.ClearAll()
+        self.resultsCtrl.AppendColumn(_translate("Component"), width=120)
+        self.resultsCtrl.AppendColumn(_translate("Parameter"), width=120)
+        self.resultsCtrl.AppendColumn(_translate("Value"), width=-1)
+        self.resultsCtrl.resizeLastColumn(minWidth=120)
+        self.selectedResult = None
+
+    def onSearch(self, evt):
+        # get term to search
+        term = evt.GetString()
+        if term:
+            # get locations of term in experiment
+            self.results = getParamLocations(self.exp, term=term)
+        else:
+            # return nothing for blank string
+            self.results = []
+        # clear old output
+        self.resetListCtrl()
+        # show new output
+        for result in self.results:
+            # unpack result
+            rt, comp, paramName, param = result
+            # construct entry
+            entry = [comp.name, paramName, str(param.val)]
+            # add entry
+            self.resultsCtrl.Append(entry)
+            # set image for comp
+            self.resultsCtrl.SetItemImage(
+                item=self.resultsCtrl.GetItemCount()-1,
+                image=self.imageMap[type(comp)]
+            )
+        # size
+        self.resultsCtrl.Layout()
+        # disable Go button until item selected
+        self.okBtn.Disable()
+
+    def onSelectResult(self, evt):
+        if evt.GetEventType() == wx.EVT_LIST_ITEM_SELECTED.typeId:
+            # if item is selected, store its info
+            self.selectedResult = self.results[evt.GetIndex()]
+            # enable Go button
+            self.okBtn.Enable()
+        else:
+            # if no item selected, clear its info
+            self.selectedResult = None
+            # disable Go button
+            self.okBtn.Disable()
+
+        evt.Skip()
+
+    def onViewResult(self, evt):
+        # there should be a selected result if this button was enabled, but just in case...
+        if self.selectedResult is None:
+            return
+        # do usual OK button stuff
+        self.Close()
+        # unpack
+        rt, comp, paramName, param = self.selectedResult
+        # navigate to routine
+        self.frame.routinePanel.setCurrentRoutine(rt)
+        # navigate to component & category
+        page = self.frame.routinePanel.getCurrentPage()
+        if isinstance(comp, experiment.components.BaseComponent):
+            # if we have a component, open its dialog and navigate to categ page
+            if hasattr(comp, 'type') and comp.type.lower() == 'code':
+                openToPage = paramName
+            else:
+                openToPage = param.categ
+            page.editComponentProperties(component=comp, openToPage=openToPage)
+        else:
+            # if we're in a standalone routine, just navigate to categ page
+            i = page.ctrls.getCategoryIndex(param.categ)
+            page.ctrls.ChangeSelection(i)
+
+
+def getParamLocations(exp, term):
+    """
+    Get locations of params containing the given term.
+
+    Parameters
+    ----------
+    term : str
+        Term to search for
+
+    Returns
+    -------
+    list
+        List of tuples, with each tuple functioning as a path to the found
+        param
+    """
+    # array to store results in
+    found = []
+
+    # go through all routines
+    for rt in exp.routines.values():
+        if isinstance(rt, experiment.routines.BaseStandaloneRoutine):
+            # find in standalone routine
+            for paramName, param in rt.params.items():
+                if term in str(param.val):
+                    # append path (routine -> param)
+                    found.append(
+                        (rt, rt, paramName, param)
+                    )
+        if isinstance(rt, experiment.routines.Routine):
+            # find in regular routine
+            for comp in rt:
+                for paramName, param in comp.params.items():
+                    if term in str(param.val):
+                        # append path (routine -> component -> param)
+                        found.append(
+                            (rt, comp, paramName, param)
+                        )
+
+    return found
+

--- a/psychopy/app/builder/dialogs/findDlg.py
+++ b/psychopy/app/builder/dialogs/findDlg.py
@@ -95,7 +95,7 @@ class BuilderFindDlg(wx.Dialog):
                         val = line
                         break
             # construct entry
-            entry = [comp.name, paramName, val]
+            entry = [comp.name, param.label, val]
             # add entry
             self.resultsCtrl.Append(entry)
             # set image for comp

--- a/psychopy/app/builder/dialogs/findDlg.py
+++ b/psychopy/app/builder/dialogs/findDlg.py
@@ -86,8 +86,16 @@ class BuilderFindDlg(wx.Dialog):
         for result in self.results:
             # unpack result
             rt, comp, paramName, param = result
+            # sanitize val for display
+            val = str(param.val)
+            if "\n" in val:
+                # if multiline, show first line with match
+                for line in val.split("\n"):
+                    if self.termCtrl.GetValue() in line:
+                        val = line
+                        break
             # construct entry
-            entry = [comp.name, paramName, str(param.val)]
+            entry = [comp.name, paramName, val]
             # add entry
             self.resultsCtrl.Append(entry)
             # set image for comp

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -126,9 +126,9 @@
 
 # Settings for hardware
 [hardware]
-    # choice of audio library
+    # LEGACY: choice of audio library
     audioLib = list(default=list('sounddevice','PTB', 'pyo', 'pygame'))
-    # latency mode for PsychToolbox audio (3 is good for most applications. See
+    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
     audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('coreaudio', 'portaudio'))
@@ -234,6 +234,8 @@
     pasteRoutine = string(default='Ctrl+Shift+V')
     # Builder: paste the copied component
     pasteCompon = string(default='Ctrl+Alt+V')
+    # Builder: find
+    builderFind = string(default='Ctrl+F')
     # Coder: show / hide the output panel
     toggleOutputPanel = string(default='Ctrl+Shift+O')
     #Builder: rename an existing routine

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -126,9 +126,9 @@
 
 # Settings for hardware
 [hardware]
-    # choice of audio library
+    # LEGACY: choice of audio library
     audioLib = list(default=list('sounddevice','PTB', 'pyo', 'pygame'))
-    # latency mode for PsychToolbox audio (3 is good for most applications. See
+    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
     audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
@@ -234,6 +234,8 @@
     pasteRoutine = string(default='Ctrl+Shift+V')
     # Builder: paste the copied component
     pasteCompon = string(default='Ctrl+Alt+V')
+    # Builder: find
+    builderFind = string(default='Ctrl+F')
     # Coder: show / hide the output panel
     toggleOutputPanel = string(default='Ctrl+Shift+O')
     #Builder: rename an existing routine

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -126,9 +126,9 @@
 
 # Settings for hardware
 [hardware]
-    # choice of audio library
+    # LEGACY: choice of audio library
     audioLib = list(default=list('sounddevice','PTB', 'pyo', 'pygame'))
-    # latency mode for PsychToolbox audio (3 is good for most applications. See
+    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
     audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
@@ -234,6 +234,8 @@
     pasteRoutine = string(default='Ctrl+Shift+V')
     # Builder: paste the copied component
     pasteCompon = string(default='Ctrl+Alt+V')
+    # Builder: find
+    builderFind = string(default='Ctrl+F')
     # Coder: show / hide the output panel
     toggleOutputPanel = string(default='Ctrl+Shift+O')
     #Builder: rename an existing routine

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -126,9 +126,9 @@
 
 # Settings for hardware
 [hardware]
-    # choice of audio library
+    # LEGACY: choice of audio library
     audioLib = list(default=list('sounddevice','PTB', 'pyo', 'pygame'))
-    # latency mode for PsychToolbox audio (3 is good for most applications. See
+    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
     audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
@@ -234,6 +234,8 @@
     pasteRoutine = string(default='Ctrl+Shift+V')
     # Builder: paste the copied component
     pasteCompon = string(default='Ctrl+Alt+V')
+    # Builder: find
+    builderFind = string(default='Ctrl+F')
     # Coder: show / hide the output panel
     toggleOutputPanel = string(default='Ctrl+Shift+O')
     #Builder: rename an existing routine

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -230,6 +230,8 @@
     pasteRoutine = string(default='Ctrl+Shift+V')
     # Builder: paste the copied component
     pasteCompon = string(default='Ctrl+Alt+V')
+    # Builder: find
+    builderFind = string(default='Ctrl+F')
     # Coder: show / hide the output panel
     toggleOutputPanel = string(default='Ctrl+Shift+O')
     #Builder: rename an existing routine


### PR DESCRIPTION
Suggested by @suelynnmah, search for a phrase and get a list of parameters (and containing components) containing that phrase, double clicking on a parameter will take you to it.

Useful for when you've got a lot of Code components and can't remember which one sets a particular variable.

Screenshot of it in action:
![image](https://github.com/psychopy/psychopy/assets/25686106/33d87e61-e67f-48bc-8b8e-bfc336d4eebb)
