### PR TITLE
NF: Adding data file separator to expInfo

### DIFF
--- a/psychopy/experiment/components/settings/JS_setupExp.tmpl
+++ b/psychopy/experiment/components/settings/JS_setupExp.tmpl
@@ -21,6 +21,7 @@ async function updateInfo() {{
 
   
   psychoJS.experiment.dataFileName = (("." + "/") + {filename});
+  psychoJS.experiment.field_separator = {field_separator};
 
 
   return Scheduler.Event.NEXT;

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -975,8 +975,10 @@ class SettingsComponent:
             'semicolon': ";",
             'tab': r"\t"
             }
-        delim = delim_options.get(self.params['Data file delimiter'], 
-                                 genDelimiter(self.params['Data filename']))
+        delim = delim_options.get(
+            self.params['Data file delimiter'].val,
+            genDelimiter(self.params['Data filename'].val)
+        )
 
         setRedirectURL = ''
         if len(self.params['Completed URL'].val) or len(self.params['Incomplete URL'].val):

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -14,6 +14,7 @@ from psychopy.experiment import utils as exputils
 from psychopy.monitors import Monitor
 from psychopy.iohub import util as ioUtil
 from psychopy.alerts import alert
+from psychopy.tools.filetools import genDelimiter
 
 # for creating html output folders:
 import shutil
@@ -1049,6 +1050,17 @@ class SettingsComponent:
         else:
             buff.writeIndented("filename = _thisDir + os.sep + %s\n" %
                                self.params['Data filename'])
+
+        # Add the delimiter to expInfo (to be picked up by psychoJS)
+        buff.writeIndentedLines("\n# Add the data file delimiter to the experiment code (for psychoJS)")
+        delim = self.params['Data file delimiter'].val
+        delimOptions = {
+            'comma': ",",
+            'semicolon': ";",
+            'tab': r"\t"
+        }
+        delim = delimOptions.get(delim, genDelimiter(filename))
+        buff.writeIndentedLines(f"expInfo['field_separator'] = '{delim}'")
 
         # set up the ExperimentHandler
         code = ("\n# An ExperimentHandler isn't essential but helps with "

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -14,6 +14,7 @@ from psychopy.experiment import utils as exputils
 from psychopy.monitors import Monitor
 from psychopy.iohub import util as ioUtil
 from psychopy.alerts import alert
+from psychopy.tools.filetools import genDelimiter
 
 # for creating html output folders:
 import shutil
@@ -963,9 +964,20 @@ class SettingsComponent:
 
     def writeExpSetupCodeJS(self, buff, version):
 
+        
         # write the code to set up experiment
         buff.setIndentLevel(0, relative=False)
         template = readTextFile("JS_setupExp.tmpl")
+
+        # Get file delimiter character
+        delim_options = {
+            'comma': ",",
+            'semicolon': ";",
+            'tab': r"\t"
+            }
+        delim = delim_options.get(self.params['Data file delimiter'], 
+                                 genDelimiter(self.params['Data filename']))
+
         setRedirectURL = ''
         if len(self.params['Completed URL'].val) or len(self.params['Incomplete URL'].val):
             setRedirectURL = ("psychoJS.setRedirectUrls({completedURL}, {incompleteURL});\n"
@@ -978,13 +990,15 @@ class SettingsComponent:
         # else:
         #     saveType = "EXPERIMENT_SERVER"
         #     projID = 'undefined'
+
         code = template.format(
             params=self.params,
             filename=str(self.params['Data filename']),
             name=self.params['expName'].val,
             loggingLevel=self.params['logging level'].val.upper(),
             setRedirectURL=setRedirectURL,
-            version=version,
+            version=version, 
+            field_separator=delim
         )
         buff.writeIndentedLines(code)
 

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -14,7 +14,6 @@ from psychopy.experiment import utils as exputils
 from psychopy.monitors import Monitor
 from psychopy.iohub import util as ioUtil
 from psychopy.alerts import alert
-from psychopy.tools.filetools import genDelimiter
 
 # for creating html output folders:
 import shutil
@@ -1050,17 +1049,6 @@ class SettingsComponent:
         else:
             buff.writeIndented("filename = _thisDir + os.sep + %s\n" %
                                self.params['Data filename'])
-
-        # Add the delimiter to expInfo (to be picked up by psychoJS)
-        buff.writeIndentedLines("\n# Add the data file delimiter to the experiment code (for psychoJS)")
-        delim = self.params['Data file delimiter'].val
-        delimOptions = {
-            'comma': ",",
-            'semicolon': ";",
-            'tab': r"\t"
-        }
-        delim = delimOptions.get(delim, genDelimiter(filename))
-        buff.writeIndentedLines(f"expInfo['field_separator'] = '{delim}'")
 
         # set up the ExperimentHandler
         code = ("\n# An ExperimentHandler isn't essential but helps with "


### PR DESCRIPTION
This comes to solve issue #5141, a feature-request to be able to pass the data file separator to psychoJS (currently uses only comma). 

The changes proposed here should be reviewed alongside [this modification](https://github.com/psychopy/psychojs/pull/566).