### PR TITLE
ENH: Give Session more control over expInfo dicts for experiments

### DIFF
--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -152,6 +152,8 @@ class Session:
             # If inputs is the name of an experiment, setup from that experiment's method
             self.setupInputsFromExperiment(inputs)
         # Store params as an aliased dict
+        if params is None:
+            params = {}
         self.params = AliasDict(params)
         # List of ExperimentHandlers from previous runs
         self.runs = []

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -5,11 +5,12 @@ import sys
 import shutil
 import threading
 import time
-import traceback
+import json
 from pathlib import Path
 
 from psychopy import experiment, logging, constants, data
-import json
+from psychopy.tools.arraytools import AliasDict
+
 from psychopy.localization import _translate
 
 
@@ -116,7 +117,8 @@ class Session:
                  loggingLevel="info",
                  inputs=None,
                  win=None,
-                 experiments=None):
+                 experiments=None,
+                 params=None):
         # Store root and add to Python path
         self.root = Path(root)
         sys.path.insert(1, str(self.root))
@@ -149,6 +151,8 @@ class Session:
         elif inputs in self.experiments:
             # If inputs is the name of an experiment, setup from that experiment's method
             self.setupInputsFromExperiment(inputs)
+        # Store params as an aliased dict
+        self.params = AliasDict(params)
         # List of ExperimentHandlers from previous runs
         self.runs = []
         # Store ref to liaison object
@@ -302,7 +306,7 @@ class Session:
             # Otherwise, return status of experiment handler
             return self.currentExperiment.status
 
-    def getExpInfoFromExperiment(self, key):
+    def getExpInfoFromExperiment(self, key, sessionParams=True):
         """
         Get the global-level expInfo object from one of this Session's experiments. This will contain all of
         the keys needed for this experiment, alongside their default values.
@@ -311,13 +315,27 @@ class Session:
         ----------
         key : str
             Key by which the experiment is stored (see `.addExperiment`).
+        sessionParams : bool
+            Should expInfo be extended with params from the Session, overriding experiment params
+            where relevant (True, default)? Or return expInfo as it is in the experiment (False)?
 
         Returns
         -------
-        bool or None
-            True if the operation completed successfully
+        dict
+            Experiment info dict
         """
-        return self.experiments[key].expInfo
+        # Get params from experiment
+        expInfo = self.experiments[key].expInfo
+        if sessionParams:
+            # If alias of a key in params exists in expInfo, delete it
+            for key in self.params.aliases:
+                if key in expInfo:
+                    del expInfo[key]
+            # Replace with Session params
+            for key in self.params:
+                expInfo[key] = self.params[key]
+
+        return expInfo
 
     def showExpInfoDlgFromExperiment(self, key, expInfo=None):
         """
@@ -853,6 +871,7 @@ if __name__ == "__main__":
         session.liaison = liaisonServer
         # Add session to liaison server
         liaisonServer.registerMethods(session, "session")
+        liaisonServer.registerMethods(session.params, "params")
         # Create thread to run liaison server in
         liaisonThread = threading.Thread(
             target=liaisonServer.start,

--- a/psychopy/tests/test_tools/test_arraytools.py
+++ b/psychopy/tests/test_tools/test_arraytools.py
@@ -2,7 +2,7 @@
 """Tests for psychopy.tools.arraytools
 """
 
-from psychopy.tools.arraytools import *
+from psychopy.tools import arraytools as at
 import pytest
 import numpy
 
@@ -21,7 +21,7 @@ def test_xys():
     for case in cases:
         # Check equality
         assert numpy.allclose(
-            createXYs(x=case['x'], y=case['y']),
+            at.createXYs(x=case['x'], y=case['y']),
             case['ans']
         )
 
@@ -34,7 +34,7 @@ def test_xys():
     for case in cases:
         # Check equality
         assert numpy.allclose(
-            extendArr(case['arr'], case['size']),
+            at.extendArr(case['arr'], case['size']),
             case['ans']
         )
 
@@ -55,12 +55,13 @@ def test_makeRadialMatrix():
     ]
     for case in cases:
         assert numpy.allclose(
-            numpy.round(makeRadialMatrix(case['size']), 8),
+            numpy.round(at.makeRadialMatrix(case['size']), 8),
             case['ans']
         )
     # also test that matrixSize=0 raises an error
     with pytest.raises(ValueError):
-        makeRadialMatrix(0)
+        at.makeRadialMatrix(0)
+
 
 def test_ratioRange():
     cases = [
@@ -78,7 +79,7 @@ def test_ratioRange():
 
     for case in cases:
         assert numpy.allclose(
-            ratioRange(case['start'], nSteps=case['nSteps'], stop=case['stop'], stepRatio=case['stepRatio'], stepdB=case['stepdB'], stepLogUnits=case['stepLogUnits']),
+            at.ratioRange(case['start'], nSteps=case['nSteps'], stop=case['stop'], stepRatio=case['stepRatio'], stepdB=case['stepdB'], stepLogUnits=case['stepLogUnits']),
             case['ans']
         )
 
@@ -96,7 +97,34 @@ def test_val2array():
     ]
     for case in cases:
         assert numpy.allclose(
-            val2array(case['value'], withNone=case['withNone'], withScalar=case['withScalar'], length=case['length']),
+            at.val2array(case['value'], withNone=case['withNone'], withScalar=case['withScalar'], length=case['length']),
             case['ans'],
             equal_nan=True
         )
+
+
+def test_AliasDict():
+    """
+    Test that the AliasDict class works as expected.
+    """
+    # make alias
+    params = at.AliasDict({'patient': 1})
+    params.alias("patient", alias="participant")
+    # test that aliases are counted in contains method
+    assert 'participant' in params
+    # test that aliases are not included in iteration
+    for key in params:
+        assert key != 'participant'
+    # test that participant and patient return the same value
+    assert params['patient'] == params['participant'] == 1
+    # test that setting the alias sets the original
+    params['participant'] = 2
+    assert params['patient'] == params['participant'] == 2
+    # test that setting the original sets the alias
+    params['patient'] = 3
+    assert params['patient'] == params['participant'] == 3
+    # test that adding an alias to a new object doesn't affect the original
+    params2 = at.AliasDict({"1": 1})
+    params2.alias("1", alias="one")
+    assert "one" not in params.aliases
+    assert "1" not in params.aliases

--- a/psychopy/tools/arraytools.py
+++ b/psychopy/tools/arraytools.py
@@ -457,5 +457,58 @@ def createLumPattern(patternType, res, texParams=None, maskParams=None):
     return intensity
 
 
+class AliasDict(dict):
+    """
+    Similar to a dict, but with the option to alias certain keys such that they always have the same value.
+    """
+    def __getitem__(self, k):
+        # if key is aliased, use its alias
+        if k in self.aliases:
+            k = self.aliases[k]
+        # get as normal
+        return dict.__getitem__(self, k)
+
+    def __setitem__(self, k, v):
+        # if key is aliased, set its alias
+        if k in self.aliases:
+            k = self.aliases[k]
+        # set as normal
+        return dict.__setitem__(self, k, v)
+    set = __setitem__
+
+    def __contains__(self, item):
+        # return True to "in" queries if item is in aliases
+        return dict.__contains__(self, item) or item in self.aliases
+
+    @property
+    def aliases(self):
+        """
+        Dict mapping name aliases to the key they are an alias for
+        """
+        # if not set yet, set as blank dict
+        if not hasattr(self, "_aliases"):
+            self._aliases = {}
+
+        return self._aliases
+
+    @aliases.setter
+    def aliases(self, value: dict):
+        self._aliases = value
+
+    def alias(self, key, alias):
+        """
+        Add an alias for a key in this dict. Setting/getting one key will set/get the other.
+
+        Parameters
+        ----------
+        key : str
+            Key to alias
+        alias : str
+            Name to alias key with
+        """
+        # assign alias
+        self.aliases[alias] = key
+
+
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
e.g.

You have an experiment with:
```
expInfo = {'participant': "jwp", 'font': "Arial"}
```

You make a Session like this:
```
thisSession = Session(
    ...whatever...
    params={'patient': "tep", 'group': 1}
```

You decide to alias "patient" with "participant":
```
thisSession.params.alias("patient", alias="participant")
```

If you call `getExpInfoFromExperiment`, or run the experiment without supplying `expInfo` (which will call this method), you'll get this as expInfo
```
{'patient': "tep", 'group': 1, 'font': "Arial"}
```