### PR TITLE
FF: CountdownTimer init use reset instead of add for initial time

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -223,7 +223,7 @@ class CountdownTimer(Clock):
         super(CountdownTimer, self).__init__()
         self._countdown_duration = start
         if start:
-            self.add(start)
+            self.reset()
 
     def getTime(self):
         """Returns the current time left on this timer in seconds with sub-ms
@@ -255,11 +255,9 @@ class CountdownTimer(Clock):
             received, this will be the new time on the clock.
 
         """
-        if t is None:
-            Clock.reset(self, self._countdown_duration)
-        else:
+        if t is not None:
             self._countdown_duration = t
-            Clock.reset(self, t)
+        Clock.reset(self, self._countdown_duration)
 
 
 class StaticPeriod:


### PR DESCRIPTION
Following the example & documentation,
```py
timer = core.CountdownTimer(5)
```
would cause the warning to show
> WARNING     We strongly recommend you activate the PTB sound engine in PsychoPy prefs as the preferred audio engine. Its timing is vastly superior. Your prefs are currently set to use ['sounddevice', 'PTB', 'pyo', 'pygame'] (in that order).

How I found it (if that's at all useful) is to replace the `Clock.add` function to raise an exception to get the traceback.
```py
def newAdd(self, x):
    raise Exception("Clock.add is deprecated")

core.Clock.add = newAdd
```
which resulted in the traceback:
```py
  File "XXX\experiment1.py", line 330, in testF
    timer = core.CountdownTimer(2)
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\clock.py", line 226, in __init__
    self.add(start)
  File "XXX\experiment1.py", line 30, in newAdd
    raise Exception("Clock.add is deprecated")
```

While I was there, I also simplified the `CountdownTimer.reset()` function a little.