### PR TITLE
Error `got an unexpected keyword argument "reset"` when trying to pause using PTB sounds

### DIFF
--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -546,14 +546,17 @@ class SoundPTB(_SoundBase):
         if log and self.autoLog:
             logging.exp(u"Sound %s started" % (self.name), obj=self, t=logTime)
 
-    def pause(self):
-        """Stop the sound but play will continue from here if needed
+    def pause(self, log=True):
+        """Toggles the pause state the sound but play will continue from here if needed
         """
         if self.isPlaying:
-            self.track.stop(reset=False)
-            self._isPlaying = False
+            self.stop(reset=False)
+            if log and self.autoLog:
+                logging.exp(u"Sound %s paused" % (self.name), obj=self)
         else:
             self.play()
+            if log and self.autoLog:
+                logging.exp(u"Sound %s unpaused" % (self.name), obj=self)
 
     def stop(self, reset=True, log=True):
         """Stop the sound and return to beginning


### PR DESCRIPTION
Pause was calling `self.track.stop` not `self.stop`

`self.track.stop` is a lower level function and doesn't have the convenience of including the reset=True/False option so users got an error:
```
...backend_ptb.py line 539, in pause
        self.track.stop(reset=False)
TypeError: stop() got an unexpected keyword argument "reset"
```