### PR TITLE
ENH: Credit authors with Author objects

### DIFF
--- a/building/searchCopyrightYear.py
+++ b/building/searchCopyrightYear.py
@@ -22,11 +22,12 @@ for line in fileinput.input(file, inplace = 1):
   print line.replace(...).strip() #--> loses initial whitespace
   line.replace(....) #--> adds quote marks around line
 """
-__author__ = 'Jeremy Gray'
 
 import os, sys, time, glob
 
-from psychopy import core
+from psychopy import core, authors
+
+__author__ = authors.jeremygray
 
 assert (sys.platform == 'darwin' or sys.platform.startswith('linux')), "This script must be run on a unix-based platform"
 perlVersion = core.shellCall('perl -V').splitlines()[0]

--- a/psychopy/authors.py
+++ b/psychopy/authors.py
@@ -1,7 +1,9 @@
+"""
+Author objects for everyone who has contributed to PsychoPy. Add yourself here and then you can credit
+your contributions importing `psychopy.authors` and pointing __author__ to your Author object.
+"""
+
 from psychopy.tools.authortools import Author
-
-
-# --- Define Author objects here ---
 
 # OST staff
 peircej = Author(
@@ -49,7 +51,7 @@ lightest = Author(
     email="nikita@opensciencetools.org", github="lightest"
 )
 
-# Former OST staff
+# former OST staff
 dvbridges = Author(
     forenames=["David"], surname="Bridges",
     email="david-bridges@hotmail.co.uk", github="dvbridges"
@@ -63,7 +65,7 @@ thewhodidthis = Author(
     github="thewhodidthis"
 )
 
-# Stakeholders
+# stakeholders
 mmacaskill = Author(
     forenames=["Michael"], surname="MacAskill",
     github="m-macaskill",
@@ -83,7 +85,7 @@ AHaffey = Author(
     forenames=["Anthony"], surname="Haffey"
 )
 
-# Other contributors
+# other contributors
 VHaenel = Author(
     forenames=["Valentin"], surname="Haenel"
 )
@@ -93,3 +95,6 @@ RSharman = Author(
 JRoberts = Author(
     forenames=["John"], surname="Roberts"
 )
+
+# gotta credit myself for this attribution system...
+__author__ = TEParsons

--- a/psychopy/authors.py
+++ b/psychopy/authors.py
@@ -1,0 +1,95 @@
+from psychopy.tools.authortools import Author
+
+
+# --- Define Author objects here ---
+
+# OST staff
+peircej = Author(
+    forenames=["Jon"], surname="Peirce",
+    email="jon@opensciencetools.org", github="peircej",
+    other={'ORCiD': "0000-0002-9504-4342"}
+)
+TEParsons = Author(
+    forenames=["Todd", "Ethan"], surname="Parsons",
+    email="todd@opensciencetools.org", github="TEParsons",
+    other={'ORCiD': "0000-0002-6192-8414",
+           'Website': "toddparsons.co.uk"}
+)
+mdcutone = Author(
+    forenames=["Matthew", "D"], surname="Cutone",
+    email="matthew@opensciencetools.org", github="mdcutone"
+)
+isolver = Author(
+    forenames=["Sol"], surname="Simpson",
+    email="sol@opensciencetools.org", github="isolver"
+)
+RHirst = Author(
+    forenames=["Rebecca"], surname="Hirst",
+    email="becca@opensciencetools.org", github="RHirst"
+)
+kimDundas = Author(
+    forenames=["Kimberley"], surname="Dundas",
+    email="kim@opensciencetools.org", github="kimDundas"
+)
+suelynnmah = Author(
+    forenames=["Sue", "Lynn"], surname="Mah",
+    email="suelynn@opensciencetools.org", github="suelynnmah"
+)
+wakecarter = Author(
+    forenames=["Wakefield"], surname="Morys-Carter",
+    email="wakefield@opensciencetools.org", github="wakecarter",
+    other={'Website': "https://moryscarter.com/"}
+)
+apitoit = Author(
+    forenames=["Alain"], surname="Pitoit",
+    email="alain@opensciencetools.org", github="apitoit"
+),
+lightest = Author(
+    forenames=["Nikita"], surname="Agafonov",
+    email="nikita@opensciencetools.org", github="lightest"
+)
+
+# Former OST staff
+dvbridges = Author(
+    forenames=["David"], surname="Bridges",
+    email="david-bridges@hotmail.co.uk", github="dvbridges"
+)
+tpronk = Author(
+    forenames=["Thomas"], surname="Pronk",
+    github="tpronk"
+)
+thewhodidthis = Author(
+    forenames=["Sotiri"], surname="Bakagiannis",
+    github="thewhodidthis"
+)
+
+# Stakeholders
+mmacaskill = Author(
+    forenames=["Michael"], surname="MacAskill",
+    github="m-macaskill",
+    other={'Website': "http://www.nzbri.org/people/macaskill"}
+)
+jeremygray = Author(
+    forenames=["Jeremy", "R"], surname="Gray",
+    email="jrgray@gmail.com", github="jeremygray"
+)
+hoechenberger = Author(
+    forenames=["Richard"], surname="Höchenberger",
+    email="richard.hoechenberger@gmail.com", github="hoechenberger",
+    other={'Website': "https://hoechenberger.net/",
+           'Mastodon': "@hoechenberger@mastodon.social"}
+)
+AHaffey = Author(
+    forenames=["Anthony"], surname="Haffey"
+)
+
+# Other contributors
+VHaenel = Author(
+    forenames=["Valentin"], surname="Haenel"
+)
+RSharman = Author(
+    forenames=["Rebecca"], surname="Sharman"
+)
+JRoberts = Author(
+    forenames=["John"], surname="Roberts"
+)

--- a/psychopy/authors.py
+++ b/psychopy/authors.py
@@ -1,6 +1,6 @@
 """
 Author objects for everyone who has contributed to PsychoPy. Add yourself here and then you can credit
-your contributions importing `psychopy.authors` and pointing __author__ to your Author object.
+your contributions by importing `psychopy.authors` and pointing __author__ to your Author object.
 """
 
 from psychopy.tools.authortools import Author

--- a/psychopy/authors.py
+++ b/psychopy/authors.py
@@ -7,7 +7,7 @@ from psychopy.tools.authortools import Author
 
 # OST staff
 peircej = Author(
-    forenames=["Jon"], surname="Peirce",
+    forenames=["Jon"], surname="Peirce", titles=["Prof"],
     email="jon@opensciencetools.org", github="peircej",
     other={'ORCiD': "0000-0002-9504-4342"}
 )
@@ -26,15 +26,15 @@ isolver = Author(
     email="sol@opensciencetools.org", github="isolver"
 )
 RHirst = Author(
-    forenames=["Rebecca"], surname="Hirst",
+    forenames=["Rebecca"], surname="Hirst", titles=["Dr"],
     email="becca@opensciencetools.org", github="RHirst"
 )
 kimDundas = Author(
-    forenames=["Kimberley"], surname="Dundas",
+    forenames=["Kimberley"], surname="Dundas", titles=["Dr"],
     email="kim@opensciencetools.org", github="kimDundas"
 )
 suelynnmah = Author(
-    forenames=["Sue", "Lynn"], surname="Mah",
+    forenames=["Sue", "Lynn"], surname="Mah", titles=["Dr"],
     email="suelynn@opensciencetools.org", github="suelynnmah"
 )
 wakecarter = Author(
@@ -57,7 +57,7 @@ dvbridges = Author(
     email="david-bridges@hotmail.co.uk", github="dvbridges"
 )
 tpronk = Author(
-    forenames=["Thomas"], surname="Pronk",
+    forenames=["Thomas"], surname="Pronk", titles=["Dr"],
     github="tpronk"
 )
 thewhodidthis = Author(
@@ -67,33 +67,33 @@ thewhodidthis = Author(
 
 # stakeholders
 mmacaskill = Author(
-    forenames=["Michael"], surname="MacAskill",
+    forenames=["Michael"], surname="MacAskill", titles=["Dr"],
     github="m-macaskill",
     other={'Website': "http://www.nzbri.org/people/macaskill"}
 )
 jeremygray = Author(
-    forenames=["Jeremy", "R"], surname="Gray",
+    forenames=["Jeremy", "R"], surname="Gray", titles=["Dr"],
     email="jrgray@gmail.com", github="jeremygray"
 )
 hoechenberger = Author(
-    forenames=["Richard"], surname="Höchenberger",
+    forenames=["Richard"], surname="Höchenberger", titles=["Dr"],
     email="richard.hoechenberger@gmail.com", github="hoechenberger",
     other={'Website': "https://hoechenberger.net/",
            'Mastodon': "@hoechenberger@mastodon.social"}
 )
 AHaffey = Author(
-    forenames=["Anthony"], surname="Haffey"
+    forenames=["Anthony"], surname="Haffey", titles=["Dr"],
 )
 
 # other contributors
 VHaenel = Author(
-    forenames=["Valentin"], surname="Haenel"
+    forenames=["Valentin"], surname="Haenel",
 )
 RSharman = Author(
-    forenames=["Rebecca"], surname="Sharman"
+    forenames=["Rebecca"], surname="Sharman", titles=["Dr"],
 )
 JRoberts = Author(
-    forenames=["John"], surname="Roberts"
+    forenames=["John"], surname="Roberts",
 )
 
 # gotta credit myself for this attribution system...

--- a/psychopy/demos/coder/experiment control/runtimeInfo.py
+++ b/psychopy/demos/coder/experiment control/runtimeInfo.py
@@ -6,14 +6,14 @@ Demo of some ways to use class psychopy.info.RunTimeInfo()
 to obtain current system and other data at run-time.
 """
 
-from psychopy import visual, logging, core
+from psychopy import visual, logging, core, authors
 import psychopy.info
 
 # author and version are used in the demo, in the way you might in your experiment.
 # They are expected to be at the top of the script that calls RunTimeInfo()),
 # with a string literal assigned to them (no variables).
 # double-quotes will be silently removed, single quotes will be left, eg, O'Connor
-__author__ = """Jeremy "R." Gray"""
+__author__ = authors.jeremygray
 __version__ = "v1.0.a"
 
 # When creating an experiment, first define your window (& monitor):

--- a/psychopy/demos/coder/hardware/ioLab_bbox.py
+++ b/psychopy/demos/coder/hardware/ioLab_bbox.py
@@ -5,11 +5,15 @@
 Demo to illustrate using ioLabs button box.
 """
 
-__author__ = 'Jonathan Roberts (orig demo); Jeremy Gray (rewrite 2013)'
 
 from psychopy.hardware import iolab
 import random
-from psychopy import core, visual, event
+from psychopy import core, visual, event, authors
+
+__author__ = [
+    authors.JRoberts,  # original
+    authors.jeremygray,  # 2013 rewrite
+]
 
 # set up the button box
 bbox = iolab.ButtonBox()

--- a/psychopy/demos/coder/hardware/ioLab_bbox.py
+++ b/psychopy/demos/coder/hardware/ioLab_bbox.py
@@ -10,7 +10,7 @@ from psychopy.hardware import iolab
 import random
 from psychopy import core, visual, event, authors
 
-__author__ = [
+__authors__ = [
     authors.JRoberts,  # original
     authors.jeremygray,  # 2013 rewrite
 ]

--- a/psychopy/experiment/components/aperture/__init__.py
+++ b/psychopy/experiment/components/aperture/__init__.py
@@ -14,7 +14,7 @@ from psychopy.experiment.components.polygon import PolygonComponent
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = [authors.jeremygray, authors.peircej]
+__authors__ = [authors.jeremygray, authors.peircej]
 # March 2011; builder-component for Yuri Spitsyn's visual.Aperture class
 # July 2011: jwp added the code for it to be enabled only when needed
 

--- a/psychopy/experiment/components/aperture/__init__.py
+++ b/psychopy/experiment/components/aperture/__init__.py
@@ -7,13 +7,14 @@
 
 from pathlib import Path
 
+from psychopy import authors
 from psychopy.experiment import Param
 from psychopy.experiment.components import getInitVals, _translate
 from psychopy.experiment.components.polygon import PolygonComponent
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = 'Jeremy Gray, Jon Peirce'
+__author__ = [authors.jeremygray, authors.peircej]
 # March 2011; builder-component for Yuri Spitsyn's visual.Aperture class
 # July 2011: jwp added the code for it to be enabled only when needed
 

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -12,7 +12,7 @@ from psychopy.visual import form
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = [authors.peircej, authors.dvbridges, authors.AHaffey]
+__authors__ = [authors.peircej, authors.dvbridges, authors.AHaffey]
 
 # only use _localized values for label values, nothing functional:
 _localized.update({'Items': _translate('Items'),

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -6,12 +6,13 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 from pathlib import Path
+from psychopy import authors
 from psychopy.experiment.components import Param, getInitVals, _translate, BaseVisualComponent
 from psychopy.visual import form
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = 'Jon Peirce, David Bridges, Anthony Haffey'
+__author__ = [authors.peircej, authors.dvbridges, authors.AHaffey]
 
 # only use _localized values for label values, nothing functional:
 _localized.update({'Items': _translate('Items'),

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -6,12 +6,13 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 from pathlib import Path
+from psychopy import authors
 from psychopy.tools.stringtools import getArgs
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = 'Jeremy Gray'
+__author__ = authors.jeremygray
 
 # only use _localized values for label values, nothing functional:
 _localized.update({'visualAnalogScale': _translate('Visual analog scale'),

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -10,13 +10,13 @@ from psychopy.experiment.components import BaseVisualComponent, Param, \
     getInitVals, _translate
 from psychopy.visual import slider
 from psychopy.experiment import py2js
-from psychopy import logging
+from psychopy import logging, authors
 from psychopy.data import utils
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 import copy
 
-__author__ = 'Jon Peirce'
+__author__ = authors.peircej
 
 # only use _localized values for label values, nothing functional:
 _localized.update({'categoryChoices': _translate('Category choices'),

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -9,11 +9,12 @@ Distributed under the terms of the GNU General Public License (GPL).
 
 from os import path
 from pathlib import Path
+from psychopy import authors
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 
-__author__ = 'Jon Peirce'
+__author__ = authors.peircej
 
 # the absolute path to the folder containing this path
 _localized.update({'Custom code': _translate('Custom code')})

--- a/psychopy/tests/test_iohub/__init__.py
+++ b/psychopy/tests/test_iohub/__init__.py
@@ -1,1 +1,3 @@
-__author__ = 'Sol'
+from psychopy import authors
+
+__author__ = authors.isolver

--- a/psychopy/tests/test_iohub/testutil.py
+++ b/psychopy/tests/test_iohub/testutil.py
@@ -1,13 +1,13 @@
 import pytest
-
-__author__ = 'Sol'
-
 import psutil, sys
+from psychopy import authors
 from psychopy.iohub import launchHubServer, Computer
 
 getTime = Computer.getTime
 
 from psychopy.tests import skip_under_vm
+
+__author__ = authors.isolver
 
 
 @skip_under_vm

--- a/psychopy/tools/authortools.py
+++ b/psychopy/tools/authortools.py
@@ -51,9 +51,8 @@ class Author:
             if self.github and other.github:
                 return self.github == other.github
             # if both have an orcid id, use that
-            if self.orcid and other.orcid:
-                print(self.orcid, other.orcid)
-                return self.orcid == other.orcid
+            if 'orcid' in self.other:
+                return self.other['orcid'] == other.other['orcid']
             # if both have an email, use that
             if self.email and other.email:
                 return self.email == other.email
@@ -69,7 +68,7 @@ class Author:
             other = other.lower().replace(".", "").replace(",", "")
             parts = other.split(" ")
             # if string is this Author's orcid, github or email, return True
-            if self.orcid in parts:
+            if 'orcid' in self.other and self.other['orcid'] in parts:
                 return True
             if self.github.lower() in parts:
                 return True

--- a/psychopy/tools/authortools.py
+++ b/psychopy/tools/authortools.py
@@ -19,7 +19,7 @@ class Author:
     """
     def __init__(
             self,
-            forenames, surname, prefices=None,
+            forenames, surname, prefices=None, titles=None,
             github=None, email=None, other=None
     ):
         # store surname
@@ -34,6 +34,11 @@ class Author:
         if prefices and isinstance(prefices, str):
             prefices = [prefices]
         self.prefices = [prefix.lower().strip() for prefix in prefices]
+        # sanitize and store titles
+        titles = titles or []
+        if titles and isinstance(titles, str):
+            titles = [titles]
+        self.titles = [title.lower().strip() for title in titles]
 
         # store basic details
         github = github or ""
@@ -86,6 +91,9 @@ class Author:
     @property
     def name(self):
         content = ""
+        # full title case titles
+        if len(self.titles):
+            content += " ".join([title.capitalize() + "." for title in self.titles])
         # full capitalized firstname
         content += self.forenames[0].capitalize()
         # initialized middlenames

--- a/psychopy/tools/authortools.py
+++ b/psychopy/tools/authortools.py
@@ -94,6 +94,7 @@ class Author:
         # full title case titles
         if len(self.titles):
             content += " ".join([title.capitalize() + "." for title in self.titles])
+            content += " "
         # full capitalized firstname
         content += self.forenames[0].capitalize()
         # initialized middlenames

--- a/psychopy/tools/authortools.py
+++ b/psychopy/tools/authortools.py
@@ -4,20 +4,18 @@ class Author:
 
     Parameters
     ----------
-    github : str
-        Author's GitHub username, e.g. peircej for Jon Peirce
     surname : str
         Author's surname, e.g. Peirce for Jon Peirce
     forenames : str, list
         Author's forename, e.g. "Jon" for Jon Peirce or ["Todd", "Ethan"] for Todd Ethan Parsons
     prefices : list
         Any prefices before the surname, e.g. ["of"] for Joan of Arc
+        github : str
+        Author's GitHub username, if they have one. e.g. peircej for Jon Peirce
     email : str
         Author's email address, if they have one. e.g. jon@opensciencetools.org for Jon Peirce
-    orcid : str or int
-        Author's ORCiD, if they have one. e.g. 0000000261928414 for Todd Parsons
     other : dict
-        Any other links or details the author may want included, such as a website link or Twitter username.
+        Any other links or details the author may want included, such as a website link, ORCiD or Twitter username.
     """
     def __init__(
             self,

--- a/psychopy/tools/authortools.py
+++ b/psychopy/tools/authortools.py
@@ -1,0 +1,135 @@
+class Author:
+    """
+    An easily referenceable author.
+
+    Parameters
+    ----------
+    github : str
+        Author's GitHub username, e.g. peircej for Jon Peirce
+    surname : str
+        Author's surname, e.g. Peirce for Jon Peirce
+    forenames : str, list
+        Author's forename, e.g. "Jon" for Jon Peirce or ["Todd", "Ethan"] for Todd Ethan Parsons
+    prefices : list
+        Any prefices before the surname, e.g. ["of"] for Joan of Arc
+    email : str
+        Author's email address, if they have one. e.g. jon@opensciencetools.org for Jon Peirce
+    orcid : str or int
+        Author's ORCiD, if they have one. e.g. 0000000261928414 for Todd Parsons
+    other : dict
+        Any other links or details the author may want included, such as a website link or Twitter username.
+    """
+    def __init__(
+            self,
+            forenames, surname, prefices=None,
+            github=None, email=None, other=None
+    ):
+        # store surname
+        self.surname = surname.lower().strip()
+        # sanitize and store forenames
+        forenames = forenames or []
+        if isinstance(forenames, str):
+            forenames = [forenames]
+        self.forenames = [forename.lower().strip() for forename in forenames]
+        # sanitize and store prefices
+        prefices = prefices or []
+        if prefices and isinstance(prefices, str):
+            prefices = [prefices]
+        self.prefices = [prefix.lower().strip() for prefix in prefices]
+
+        # store basic details
+        github = github or ""
+        self.github = github.strip()
+        email = email or ""
+        self.email = email.lower().strip()
+        # store other references
+        other = other or {}
+        self.other = {key: str(val).lower().strip() for key, val in other.items()}
+
+    def __eq__(self, other):
+        # comparing to another Author...
+        if isinstance(other, self.__class__):
+            # if both have a github username, use that
+            if self.github and other.github:
+                return self.github == other.github
+            # if both have an orcid id, use that
+            if self.orcid and other.orcid:
+                print(self.orcid, other.orcid)
+                return self.orcid == other.orcid
+            # if both have an email, use that
+            if self.email and other.email:
+                return self.email == other.email
+            # otherwise, compare fore and last names
+            same = self.surname == other.surname
+            for i in range(min(len(self.forenames), len(other.forenames))):
+                same = same and self.forenames[i] == other.forenames[i]
+            return same
+
+        # comparing to a string
+        if isinstance(other, str):
+            # standardise and split
+            other = other.lower().replace(".", "").replace(",", "")
+            parts = other.split(" ")
+            # if string is this Author's orcid, github or email, return True
+            if self.orcid in parts:
+                return True
+            if self.github.lower() in parts:
+                return True
+            if self.email in parts:
+                return True
+            # otherwise compare names
+            same = parts[-1] == self.surname
+            for i in range(min(len(self.forenames), len(parts))):
+                isName = parts[i] == self.forenames[i]
+                isPrefix = parts[i] in self.prefices
+                isInitial = parts[i] == self.forenames[i][0]
+                same = same and (isName or isPrefix or isInitial)
+            return same
+
+    @property
+    def name(self):
+        content = ""
+        # full capitalized firstname
+        content += self.forenames[0].capitalize()
+        # initialized middlenames
+        if len(self.forenames) > 1:
+            content += " "
+            content += " ".join([name[0].capitalize() + "." for name in self.forenames[1:]])
+        # full lowercase prefices
+        if len(self.prefices):
+            content += " "
+            content += " ".join(self.prefices)
+        # full capitalized surname
+        content += " "
+        content += self.surname.capitalize()
+
+        return content
+
+    def __repr__(self):
+        content = f"<Author: {self.name}"
+        if self.github:
+            content += f", @{self.github}"
+        content += ">"
+
+        return content
+
+    def __str__(self):
+        # start with name
+        content = self.name
+        # add details
+        if self.github or self.email or self.other:
+            other = []
+            # github username
+            if self.github:
+                other.append(f"GitHub: @{self.github}")
+            # email
+            if self.email:
+                other.append(f"Email: {self.email}")
+            # other
+            for key, val in self.other.items():
+                other.append(f"{key}: {val}")
+            content += " ("
+            content += ", ".join(other)
+            content += ")"
+
+        return content

--- a/psychopy/visual/brush.py
+++ b/psychopy/visual/brush.py
@@ -9,11 +9,11 @@ Inspired by rockNroll87q - https://github.com/rockNroll87q/pyDrawing
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from psychopy import event, logging
+from psychopy import event, logging, authors
 from .shape import ShapeStim
 from .basevisual import MinimalStim
 
-__author__ = 'David Bridges'
+__author__ = authors.dvbridges
 
 from ..tools.attributetools import attributeSetter
 

--- a/psychopy/visual/button.py
+++ b/psychopy/visual/button.py
@@ -8,13 +8,13 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 import numpy as np
 
-from psychopy import event, core, layout
+from psychopy import event, core, layout, authors
 from psychopy.tools.attributetools import attributeSetter
 from psychopy.visual import TextBox2
 from psychopy.visual.shape import ShapeStim
 from psychopy.constants import (NOT_STARTED, STARTED, PLAYING, PAUSED, STOPPED, FINISHED, PRESSED, RELEASED, FOREVER)
 
-__author__ = 'Anthony Haffey & Todd Parsons'
+__author__ = [authors.AHaffey, authors.TEParsons]
 
 
 class ButtonStim(TextBox2):

--- a/psychopy/visual/button.py
+++ b/psychopy/visual/button.py
@@ -14,7 +14,7 @@ from psychopy.visual import TextBox2
 from psychopy.visual.shape import ShapeStim
 from psychopy.constants import (NOT_STARTED, STARTED, PLAYING, PAUSED, STOPPED, FINISHED, PRESSED, RELEASED, FOREVER)
 
-__author__ = [authors.AHaffey, authors.TEParsons]
+__authors__ = [authors.AHaffey, authors.TEParsons]
 
 
 class ButtonStim(TextBox2):

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -13,13 +13,12 @@ from psychopy.data.utils import importConditions, listFromString
 from psychopy.visual.basevisual import (BaseVisualStim,
                                         ContainerMixin,
                                         ColorMixin)
-from psychopy import logging, layout
+from psychopy import logging, layout, authors
+from ..colors import Color
 from random import shuffle
 from pathlib import Path
 
-__author__ = 'Jon Peirce, David Bridges, Anthony Haffey'
-
-from ..colors import Color
+__author__ = [authors.peircej, authors.TEParsons, authors.dvbridges, authors.AHaffey]
 
 _REQUIRED = -12349872349873  # an unlikely int
 

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -18,7 +18,7 @@ from ..colors import Color
 from random import shuffle
 from pathlib import Path
 
-__author__ = [authors.peircej, authors.TEParsons, authors.dvbridges, authors.AHaffey]
+__authors__ = [authors.peircej, authors.TEParsons, authors.dvbridges, authors.AHaffey]
 
 _REQUIRED = -12349872349873  # an unlikely int
 


### PR DESCRIPTION
Benefits:
- Easily confirm that two `__author__` variables refer to the same author without worrying about grammar (e.g. Jon Peirce vs jon peirce)
- Include details on authors such as email or github username
- Opens the door to auto-generating references, e.g.
```
f"{','.join(author.apa for author in module.__author__)} (2023). PsychoPy: {module.name} [Python Module]. Open Science Tools, UK.
```

I've added OST staff and existing credited authors as objects and included just the info available from their GitHub profiles.