### PR TITLE
FF: Fixed `isFinished` typo

### DIFF
--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -341,7 +341,7 @@ class SoundPTB(_SoundBase):
         return self._isPlaying
 
     @property
-    def isFinsihed(self):
+    def isFinished(self):
         """`True` if the audio playback has completed."""
         return self._isFinished
 


### PR DESCRIPTION
Fixed typo with `isFinished`