### PR TITLE
ENH: Send experiment data to Liaison each time a trial completes

### DIFF
--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -328,7 +328,7 @@ class TrialHandler(_BaseLoopHandler):
                 "thisExp.nextEntry(t=globalClock.getTime())\n"
                 "if thisSession is not None:\n"
                 "    # if running in a Session with a Liaison client, send data up to now\n"
-                "    thisSession.sendData()\n"
+                "    thisSession.sendExperimentData()\n"
                 "\n"
             )
         # end of the loop. dedent
@@ -529,7 +529,7 @@ class StairHandler(_BaseLoopHandler):
                 "thisExp.nextEntry(t=globalClock.getTime())\n"
                 "if thisSession is not None:\n"
                 "    # if running in a Session with a Liaison client, send data up to now\n"
-                "    thisSession.sendData()\n"
+                "    thisSession.sendExperimentData()\n"
                 "\n"
             )
         # end of the loop. dedent
@@ -761,7 +761,7 @@ class MultiStairHandler(_BaseLoopHandler):
                 "thisExp.nextEntry(t=globalClock.getTime())\n"
                 "if thisSession is not None:\n"
                 "    # if running in a Session with a Liaison client, send data up to now\n"
-                "    thisSession.sendData()\n"
+                "    thisSession.sendExperimentData()\n"
                 "\n"
             )
         # end of the loop. dedent

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -324,7 +324,13 @@ class TrialHandler(_BaseLoopHandler):
     def writeLoopEndCode(self, buff):
         # Just within the loop advance data line if loop is whole trials
         if self.params['isTrials'].val == True:
-            buff.writeIndentedLines("thisExp.nextEntry(t=globalClock.getTime())\n\n")
+            buff.writeIndentedLines(
+                "thisExp.nextEntry(t=globalClock.getTime())\n"
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendData()\n"
+                "\n"
+            )
         # end of the loop. dedent
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndented("# completed %s repeats of '%s'\n"
@@ -519,7 +525,13 @@ class StairHandler(_BaseLoopHandler):
     def writeLoopEndCode(self, buff):
         # Just within the loop advance data line if loop is whole trials
         if self.params['isTrials'].val:
-            buff.writeIndentedLines("thisExp.nextEntry()\n\n")
+            buff.writeIndentedLines(
+                "thisExp.nextEntry(t=globalClock.getTime())\n"
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendData()\n"
+                "\n"
+            )
         # end of the loop. dedent
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndented("# staircase completed\n")
@@ -745,7 +757,13 @@ class MultiStairHandler(_BaseLoopHandler):
     def writeLoopEndCode(self, buff):
         # Just within the loop advance data line if loop is whole trials
         if self.params['isTrials'].val:
-            buff.writeIndentedLines("thisExp.nextEntry()\n\n")
+            buff.writeIndentedLines(
+                "thisExp.nextEntry(t=globalClock.getTime())\n"
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendData()\n"
+                "\n"
+            )
         # end of the loop. dedent
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndented("# all staircases completed\n")

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -887,7 +887,7 @@ class Session:
             return
         # If ExperimentHandler, get its data as a list of dicts
         if isinstance(value, data.ExperimentHandler):
-            value = value.getJSON()
+            value = value.getJSON(salienceThreshold=self.salienceThreshold)
         # Convert to JSON
         value = json.dumps(value)
         # Send

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -115,6 +115,7 @@ class Session:
                  root,
                  liaison=None,
                  loggingLevel="info",
+                 salienceThreshold=constants.SALIENCE_EXCLUDE+1,
                  inputs=None,
                  win=None,
                  experiments=None,
@@ -127,6 +128,8 @@ class Session:
             self.root / (self.root.stem + '.log'),
             level=getattr(logging, loggingLevel.upper())
         )
+        # Store salience threshold
+        self.salienceThreshold = salienceThreshold
         # Add experiments
         self.experiments = {}
         if experiments is not None:
@@ -830,6 +833,34 @@ class Session:
             blocking=blocking
         )
 
+    def sendExperimentData(self, key=None):
+        """
+        Send last ExperimentHandler for an experiment to liaison. If no experiment is given, sends the currently
+        running experiment.
+
+        Parameters
+        ----------
+        key : str or None
+            Name of the experiment whose data to send, or None to send the current experiment's data.
+
+        Returns
+        -------
+        bool
+            True if data was sent, otherwise False
+        """
+        # Sub None for current
+        if key is None:
+            key = self.currentExperiment.name
+        # Get last experiment data
+        for run in reversed(self.runs):
+            if run.name == key:
+                # Send experiment data
+                self.sendToLiaison(run)
+                return True
+
+        # Return False if nothing sent
+        return False
+
     def sendToLiaison(self, value):
         """
         Send data to this Session's `Liaison` object.
@@ -852,7 +883,7 @@ class Session:
             return
         # If ExperimentHandler, get its data as a list of dicts
         if isinstance(value, data.ExperimentHandler):
-            value = value.entries
+            value = value.getJSON()
         # Convert to JSON
         value = json.dumps(value)
         # Send

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -848,6 +848,10 @@ class Session:
         bool
             True if data was sent, otherwise False
         """
+        # Skip if there's no liaison
+        if self.liaison is None:
+            return
+
         # Sub None for current
         if key is None:
             key = self.currentExperiment.name


### PR DESCRIPTION
Includes a new `getJSON` method for ExperimentHandler.

Will filter columns by salience threshold, a threshold can be supplied to Session on init (param is `salienceThreshold`)