### PR TITLE
BF: missing `psychopy.localization.available` attribute

### DIFF
--- a/psychopy/localization/__init__.py
+++ b/psychopy/localization/__init__.py
@@ -13,7 +13,8 @@ translation _translate():
 # Distributed under the terms of the GNU General Public License (GPL).
 
 try:
-    from ._localization import _translate, _localized, setLocaleWX, locname
+    from ._localization import (
+        _translate, _localized, setLocaleWX, locname, available)
 except ModuleNotFoundError:
     # if wx doesn't exist we can't translate but most other parts
     # of the _localization lib will not be relevant


### PR DESCRIPTION
This attribute was not accessible which breaks the preferences dialog.