### PR TITLE
ENH: Send Python errors to Liaison with type tag

### DIFF
--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -263,5 +263,9 @@ class WebSocketServer:
 			# send any errors to server
 			tb = traceback.format_exception(type(err), err, err.__traceback__)
 			msg = "".join(tb)
-			await websocket.send(msg)
+			err = json.dumps({
+				'type': "error",
+				'msg': msg
+			})
+			await websocket.send(err)
 			


### PR DESCRIPTION
Ensures they're valid JSON and also marks them specifically as an error