### PR TITLE
RF: Updated ExpName headline in JS conversion

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -917,7 +917,7 @@ class SettingsComponent:
         # Write header comment
         starLen = "*"*(len(jsFilename) + 9)
         code = ("/%s \n"
-               " * %s Test *\n" 
+               " * %s *\n" 
                " %s/\n\n")
         buff.writeIndentedLines(code % (starLen, jsFilename.title(), starLen))
 


### PR DESCRIPTION
Removed "Test" from the "* ExpName Test *" headline written in the JS file. This probably remained from back when conversion was experimental.