### PR TITLE
FF: Fix routine time grid disappearing on scroll

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -3468,9 +3468,7 @@ class FlowCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
                 item.Enable(limitProgress < routine.limit or routine in flow)
             self.routinesFromID[id] = name
             menu.Bind(wx.EVT_MENU, self.onInsertRoutineSelect, id=id)
-        btnPos = self.btnInsertRoutine.GetRect()
-        menuPos = (btnPos[0], btnPos[1] + btnPos[3])
-        self.PopupMenu(menu, menuPos)
+        self.PopupMenu(menu)
         menu.Bind(wx.EVT_MENU_CLOSE, self.clearMode)
         menu.Destroy()  # destroy to avoid mem leak
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2107,6 +2107,9 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
         dc.SetTextForeground(wx.Colour(colors.app['rt_timegrid']))
         self.setFontSize(self.fontBaseSize // self.dpi, dc)
 
+        id = wx.NewIdRef()
+        dc.SetId(id)
+
         # draw horizontal lines on top and bottom
         dc.DrawLine(
             x1=int(xSt),


### PR DESCRIPTION
Was disappearing because it didn't have an ID, so it inherited the last ID the DC was drawing, which is the Settings button, so when the Settings button was off screen, the time grid wasn't drawn.