### PR TITLE
ENH: Add "transparent" as named color

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -38,7 +38,8 @@ colorExamples = {
 
 # Dict of named colours
 colorNames = {
-    "none": (0, 0, 0),
+    "none": (0, 0, 0, 0),
+    "transparent": (0, 0, 0, 0),
     "aliceblue": (0.882352941176471, 0.945098039215686, 1),
     "antiquewhite": (0.96078431372549, 0.843137254901961, 0.686274509803922),
     "aqua": (-1, 1, 1),


### PR DESCRIPTION
Meaning that users can specify a transparent background as `transparent` from Builder rather than `None` or just blank