### PR TITLE
FF: Fix bug when opening staircase loop dialog

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -1305,7 +1305,8 @@ class DlgLoopProperties(_BaseParamsDlg):
         self.paramCtrls.update(self.staircaseCtrls)
         self.paramCtrls.update(self.multiStairCtrls)
 
-        self.updateSummary()
+        if "conditionsFile" in self.globalCtrls:
+            self.updateSummary()
 
         # show dialog and get most of the data
         self.show()


### PR DESCRIPTION
Happened for any loop dialog which didn't involve a conditions file as the new `updateSummary` method assumes there's one present. Fix is to just not call that function if there's no conditions file field.