### PR TITLE
FF: Don't set Slider value until ticks have been created, fixes #5661 (release)

### DIFF
--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -180,7 +180,6 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         self.ori = ori
         self.flip = flip
 
-        self.startValue = self.markerPos = startValue
         self.rt = None
         self.history = []
         self.marker = None
@@ -203,6 +202,8 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         self._layout()
         # some things must wait until elements created
         self.contrast = 1.0
+
+        self.startValue = self.markerPos = startValue
 
         # set autoLog (now that params have been initialised)
         self.autoLog = autoLog


### PR DESCRIPTION
Same fix as #5691, cherry picked to the release branch