### PR TITLE
FF: Fix background image fit setting after creation

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -2879,7 +2879,7 @@ class Window():
             self._backgroundImage.pos = (0, 0)
         if value in ("contain", "cover"):
             # If value is contain or cover, set one dimension to fill screen and the other to maintain ratio
-            ratios = numpy.asarray(self._backgroundImage.size) / numpy.asarray(self.size)
+            ratios = numpy.asarray(self._backgroundImage._origSize) / numpy.asarray(self.size)
             if value == "cover":
                 i = ratios.argmin()
             else:


### PR DESCRIPTION
Using `_backgroundImage.size` is fine when the image has just been set, but if changing fit afterwards then we need to use `_origSize`, otherwise calculation will be done based on already adjusted size.