### PR TITLE
FF: Remove reference to `eyetracker` from endExperiment boilerplate

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1801,7 +1801,7 @@ class SettingsComponent:
             "# shut down eyetracker, if there is one\n"
             "if inputs is not None:\n"
             "    if 'eyetracker' in inputs and inputs['eyetracker'] is not None:\n"
-            "        eyetracker.setConnectionState(False)\n"
+            "        inputs['eyetracker'].setConnectionState(False)\n"
         )
         if self.params['Save log file'].val:
             code += (


### PR DESCRIPTION
As `endExperiment` is its own function now, the variable `eyetracker` doesn't exist locally, instead we need to use `inputs['eyetracker']` in this context