### PR TITLE
BF/FF: Fix datetime parsing when getting Pavlovia projects

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -570,6 +570,9 @@ class PavloviaProject(dict):
     .localRoot is the path to the local root
     """
 
+    # list of keys which we expect to be datetimes
+    _datetimeKeys = ("created_at", "last_activity_at")
+
     def __init__(self, id, localRoot=None):
         # Cache whatever form of ID is given, to avoid uneccesary calls to Pavlovia/GitLab later
         if isinstance(id, int):
@@ -601,9 +604,8 @@ class PavloviaProject(dict):
             else:
                 value = None
         # Transform datetimes
-        dtRegex = re.compile("\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d(.\d\d\d)?\w?")
-        if dtRegex.match(str(value)):
-            value = pandas.to_datetime(value, format="%Y-%m-%d %H:%M:%S.%f")
+        if key in self._datetimeKeys:
+            value = pandas.to_datetime(value, format=None, errors='coerce')
 
         return value
 
@@ -659,10 +661,9 @@ class PavloviaProject(dict):
             # Reinitialise dict
             dict.__init__(self, self.project.attributes)
             # Convert datetime
-            dtRegex = re.compile("\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(.\d\d\d)?")
             for key in self._info:
-                if dtRegex.match(str(self.info[key])):
-                    self._info[key] = pandas.to_datetime(self._info[key], format="%Y-%m-%d %H:%M:%S.%f")
+                if key in self._datetimeKeys:
+                    self._info[key] = pandas.to_datetime(self._info[key], format=None, errors='coerce')
             # Update base dict
             self.update(self.project.attributes)
 


### PR DESCRIPTION
Parsing is fine in release as all datetimes are in the same format, but if format differs (e.g. projects in dev now have %f to 6dp rather than 3) it was failing. Removing the regex checking altogether and simply letting pandas handle it works for both formats and gives more flexibility. We still need to identify which keys are datetimes so that e.g. name doesn't become an invalid datetime object, so this is now done by querying a list of known datetime key names.