### PR TITLE
Fix VlcMovieStim

### DIFF
--- a/psychopy/visual/vlcmoviestim.py
+++ b/psychopy/visual/vlcmoviestim.py
@@ -403,6 +403,11 @@ class VlcMovieStim(BaseVisualStim, ContainerMixin):
         # Set callbacks since we have the resources to write to.
         thisInstance = ctypes.cast(
             ctypes.pointer(ctypes.py_object(self)), ctypes.c_void_p)
+        
+        # we need to increment the ref count
+        ctypes.pythonapi.Py_IncRef(ctypes.py_object(thisInstance))
+        
+
         self._player.video_set_callbacks(
             vlcLockCallback, vlcUnlockCallback, vlcDisplayCallback,
             thisInstance)


### PR DESCRIPTION
As is, VlcMovieStim segfaults for me (tested on Win 10, Win 11, Ubuntu 22..10 and latest Linux Mint) when playing a movie. I don't really have time to investigate atm, but increasing the ref count seems to fix the problem.