### PR TITLE
NF: Return data from _createTexture

### DIFF
--- a/psychopy/tests/test_visual/test_image.py
+++ b/psychopy/tests/test_visual/test_image.py
@@ -1,5 +1,8 @@
 from pathlib import Path
 
+import cv2
+import numpy as np
+
 from psychopy import visual, colors, core
 from .test_basevisual import _TestUnitsMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
@@ -108,9 +111,18 @@ class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
             self.win.flip()
 
     def test_img_data(self):
-        """Test the accessibility of image array values"""
-        img_ar = self.getImageData()
-        assert isinstance(img_ar, np.ndarray)
+        """Test the accessibility of image array values."""
+        img_path = "default.png"
+        ar = cv2.imread(img_path)
+        
+        # Test when image input is an array
+        self.obj.setImage(ar)
+        np.testing.assert_array_equal(ar, self.getImageData())
+        # Test when image input is path
+        self.obj.setImage(img_path)
+        np.testing.assert_array_equal(ar, self.getImageData())
+
+        
 
 
 class TestImageAnimation:

--- a/psychopy/tests/test_visual/test_image.py
+++ b/psychopy/tests/test_visual/test_image.py
@@ -117,10 +117,10 @@ class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
         
         # Test when image input is an array
         self.obj.setImage(ar)
-        np.testing.assert_array_equal(ar, self.getImageData())
+        np.testing.assert_array_equal(ar, self.obj.getImageData())
         # Test when image input is path
         self.obj.setImage(img_path)
-        np.testing.assert_array_equal(ar, self.getImageData())
+        np.testing.assert_array_equal(ar, self.obj.getImageData())
 
         
 

--- a/psychopy/tests/test_visual/test_image.py
+++ b/psychopy/tests/test_visual/test_image.py
@@ -107,6 +107,11 @@ class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
             utils.compareScreenshot(Path(utils.TESTS_DATA_PATH) / filename, self.win, crit=7)
             self.win.flip()
 
+    def test_img_data(self):
+        """Test the accessibility of image array values"""
+        img_ar = self.getImageData()
+        assert isinstance(img_ar, np.ndarray)
+
 
 class TestImageAnimation:
     """

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -971,6 +971,12 @@ class TextureMixin:
         wrapping : bool
             Enable wrapping of the texture. A texture will be set to repeat (or
             tile).
+        
+        Returns
+        -------
+        tuple :  
+            A tuple of bool indicating whether data includes luminosity (True) or 
+            RGB (False) values, and a numpy.ndarray of shape (Height, Width, 3). 
         """
 
         # transform all variants of `None` to that, simplifies conditions below
@@ -1257,7 +1263,7 @@ class TextureMixin:
         # unbind our texture so that it doesn't affect other rendering
         GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
 
-        return wasLum
+        return wasLum, data
 
     def clearTextures(self):
         """Clear all textures associated with the stimulus.

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -386,7 +386,7 @@ class ImageStim(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin,
         if type(value) != numpy.ndarray and value in (None, "None", "none"):
             self.isLumImage = True
         else:
-            self.isLumImage = self._createTexture(
+            self.isLumImage, self._img_data = self._createTexture(
                 value, id=self._texID,
                 stim=self,
                 pixFormat=GL.GL_RGB,

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -413,6 +413,9 @@ class ImageStim(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin,
         """
         setAttribute(self, 'image', value, log)
 
+    def getImageData(self):
+        return self._img_data
+
     @property
     def aspectRatio(self):
         """


### PR DESCRIPTION
This addition aims to make the array of image values being available by default, as an attribute of ImageStim. 