### PR TITLE
ENH: py2js support for additional functions

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -337,8 +337,8 @@ class pythonTransformer(ast.NodeTransformer):
         # The default first argument for pop is -1 (remove the last item).
         elif func.attr == 'pop':
             func.attr = 'splice'
-            args = args if args else [ast.Constant(-1)]
-            args = [args, [ast.Constant(1)]]
+            args = args if args else [ast.Constant(value=-1, kind=None)]
+            args = [args, [ast.Constant(value=1, kind=None)]]
 
             return ast.Call(
                 func=func,
@@ -351,7 +351,7 @@ class pythonTransformer(ast.NodeTransformer):
         # Note that .insert only inserts a single element, so there should always be exactly two input args).
         elif func.attr == 'insert':
             func.attr = 'splice'
-            args = [args[0], [ast.Constant(0)], args[1]]
+            args = [args[0], [ast.Constant(value=0, kind=None)], args[1]]
 
             return ast.Call(
                 func=func,
@@ -363,7 +363,7 @@ class pythonTransformer(ast.NodeTransformer):
         # ' '.join(a) -> a.join(" ");
         # In this case func.value and args need to be switched.
         elif func.attr == 'join':
-            new_args = [ast.Constant(func.value.value)]
+            new_args = [ast.Constant(value=func.value.value, kind=None)]
             func.value = args[0]
             
             return ast.Call(
@@ -376,7 +376,7 @@ class pythonTransformer(ast.NodeTransformer):
         # a.split() -> a.split(" ")
         # Note that this function translates correctly if there's an input arg; only the default requires modification.
         elif func.attr == 'split' and not args:
-            args = [ast.Constant(" ")]
+            args = [ast.Constant(value=" ", kind=None)]
             return ast.Call(
                 func=func,
                 args=args,

--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -329,7 +329,7 @@ class pythonTransformer(ast.NodeTransformer):
                 keywords=[]
             )
 
-        # Substitutions where the function and arguments both change
+        # Substitutions where more than one of the function, value, and arguments change
         # a = [1,2,3]
         # a.pop(2) -> a.splice(2, 1);
         # a.pop() -> a.splice(-1, 1);
@@ -343,6 +343,19 @@ class pythonTransformer(ast.NodeTransformer):
             return ast.Call(
                 func=func,
                 args=args,
+                keywords=[]
+            )
+
+        # a = ['This', 'is', 'a', 'test']
+        # ' '.join(a) -> a.join(" ");
+        # In this case func.value and args need to be switched.
+        elif func.attr == 'join':
+            new_args = [ast.Constant(func.value.value)]
+            func.value = args[0]
+            
+            return ast.Call(
+                func=func,
+                args=new_args,
                 keywords=[]
             )
 

--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -346,6 +346,19 @@ class pythonTransformer(ast.NodeTransformer):
                 keywords=[]
             )
 
+        # a = [1, 2, 3, 4]
+        # a.insert(0, 5) -> a.splice(0, 0, 5);
+        # Note that .insert only inserts a single element, so there should always be exactly two input args).
+        elif func.attr == 'insert':
+            func.attr = 'splice'
+            args = [args[0], [ast.Constant(0)], args[1]]
+
+            return ast.Call(
+                func=func,
+                args=args,
+                keywords=[]
+            )
+
         # a = ['This', 'is', 'a', 'test']
         # ' '.join(a) -> a.join(" ");
         # In this case func.value and args need to be switched.

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -54,6 +54,8 @@ class TestTranspiler:
         # Define some cases which should be handled
         cases = [
             {'py': "a.append(4)", 'js': "a.push(4);\n"},
+            {'py': "a.insert(0, 5)", 'js': "a.splice(0, 0, 5);\n"},
+            {'py': "a.insert(-1, x)", 'js': "a.splice((- 1), 0, x);\n"},
             {'py': "' '.join(a)", 'js': 'a.join(" ");\n'},
             {'py': "a.index(2)", 'js': "util.index(a, 2);\n"},
             {'py': "a.count(2)", 'js': "util.count(a, 2);\n"},

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -59,10 +59,25 @@ class TestTranspiler:
             {'py': "a.lower()", 'js': "a.toLowerCase();\n"},
             {'py': "a.upper()", 'js': "a.toUpperCase();\n"},
             {'py': "a.extend([4, 5, 6])", 'js': "a.concat([4, 5, 6]);\n"},
+            {'py': "a.pop(0)", 'js': "a.splice(0, 1);\n"},
+            {'py': "a.pop()", 'js': "a.splice((- 1), 1);\n"},
         ]
         # Try each case
         for case in cases:
             self.runTranspile(case['py'], case['js'])
+
+    def test_util_substitutions(self):
+        # Define some cases which should be handled
+        cases = [
+            {'py': "shuffle(a)", 'js': "util.shuffle(a);\n"},
+            {'py': "sum(a)", 'js': "util.sum(a);\n"},
+            {'py': "average(a)", 'js': "util.average(a);\n"},
+            {'py': "core.Clock()", 'js': "new util.Clock();\n"},
+        ]
+        # Try each case
+        for case in cases:
+            self.runTranspile(case['py'], case['js'])
+
 
     def test_var_defs(self):
         cases = [
@@ -167,6 +182,8 @@ class Test_PY2JS_Compile:
         input = ['sin(t)',
                  'cos(t)',
                  'tan(t)',
+                 'floor(t)',
+                 'ceil(t)',
                  'pi',
                  'rand',
                  'random',
@@ -184,6 +201,8 @@ class Test_PY2JS_Compile:
         output = ['Math.sin(t)',
                   'Math.cos(t)',
                   'Math.tan(t)',
+                  'Math.floor(t)',
+                  'Math.ceil(t)',
                   'Math.PI',
                   'Math.random',
                   'Math.random',

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -54,6 +54,10 @@ class TestTranspiler:
         # Define some cases which should be handled
         cases = [
             {'py': "a.append(4)", 'js': "a.push(4);\n"},
+            {'py': "a.split()", 'js': 'a.split(" ");\n'},
+            {'py': "a.split('.')", 'js': 'a.split(".");\n'},
+            {'py': "a.sort(reverse=True)", 'js': "a.reverse();\n"},
+            {'py': "a.sort()", 'js': "a.sort();\n"},
             {'py': "a.insert(0, 5)", 'js': "a.splice(0, 0, 5);\n"},
             {'py': "a.insert(-1, x)", 'js': "a.splice((- 1), 0, x);\n"},
             {'py': "' '.join(a)", 'js': 'a.join(" ");\n'},

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -54,6 +54,7 @@ class TestTranspiler:
         # Define some cases which should be handled
         cases = [
             {'py': "a.append(4)", 'js': "a.push(4);\n"},
+            {'py': "' '.join(a)", 'js': 'a.join(" ");\n'},
             {'py': "a.index(2)", 'js': "util.index(a, 2);\n"},
             {'py': "a.count(2)", 'js': "util.count(a, 2);\n"},
             {'py': "a.lower()", 'js': "a.toLowerCase();\n"},


### PR DESCRIPTION
Refactoring to remove duplicate code and adding translation support for:
* math.ceil
* math.floor
* core.Clock
* 'delimiter'.join(array)
* array.pop(): correctly translate with input arguments
* array.split(): use the correct defaults when no arguments included
* array.insert()
* array.sort(reverse=True): correctly translate the 'reverse' keyword parameter

Also add tests for the above translations.