### PR TITLE
BF: Use SetStyle rather than SetFont to style text inputs on Linux

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -75,18 +75,20 @@ class _ValidatorMixin:
             # Name is never code
             valType = "str"
 
-        fontNormal = self.GetTopLevelParent().app._mainFont
+        # get font
         if valType == "code" or hasattr(self, "dollarLbl"):
-            # Set font
-            fontCode = self.GetTopLevelParent().app._codeFont
-            fontCodeBold = fontCode.Bold()
-            if fontCodeBold.IsOk():
-                self.SetFont(fontCodeBold)
-            else:
-                # use normal font if the bold version is invalid on the system
-                self.SetFont(fontCode)
+            font = self.GetTopLevelParent().app._codeFont.Bold()
         else:
-            self.SetFont(fontNormal)
+            font = self.GetTopLevelParent().app._mainFont
+
+        # set font
+        if sys.platform == "linux":
+            # have to go via SetStyle on Linux
+            style = wx.TextAttr(self.GetForegroundColour(), font=font)
+            self.SetStyle(0, len(self.GetValue()), style)
+        else:
+            # otherwise SetFont is fine
+            self.SetFont(font)
 
 
 class _FileMixin(_FrameMixin):

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -68,6 +68,9 @@ class _ValidatorMixin:
         if not hasattr(self, "SetFont"):
             # Skip if font not applicable to object type
             return
+        if sys.platform == "linux":
+            # Skip on Linux, which doesn't like changing font after init
+            return
         if self.GetName() == "name":
             # Name is never code
             valType = "str"

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -68,9 +68,6 @@ class _ValidatorMixin:
         if not hasattr(self, "SetFont"):
             # Skip if font not applicable to object type
             return
-        if sys.platform == "linux":
-            # Skip on Linux, which doesn't like changing font after init
-            return
         if self.GetName() == "name":
             # Name is never code
             valType = "str"


### PR DESCRIPTION
wx on Linux seg faults when a font is set on a ctrl after init, so don't style code

Fixes #5518 and fixes #4207