### PR TITLE
FF: Fix find dialog "open to page" function

### DIFF
--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -132,7 +132,7 @@ class DlgCodeComponentProperties(wx.Dialog):
                 self.codeBoxes[paramName].AddText(param.val)
                 self.codeBoxes[paramName].Bind(wx.EVT_KEY_UP, self.onKeyUp)  # For real time translation
 
-                if len(param.val.strip()) and hasattr(_panel, "tabN"):
+                if len(param.val.strip()) and hasattr(_panel, "tabN") and not isinstance(openToPage, str):
                     if openToPage is None or openToPage > _panel.tabN:
                         # index of first non-blank page
                         openToPage = _panel.tabN


### PR DESCRIPTION
It should substitute the name of a param for its index, but if the param is a JS field it was attempting to open before substituting for the index also matches the corresponding Py field. Solution is to just not attempt to set the page unless the index is already numeric