### PR TITLE
ENH: Add templates for GitHub issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug Report
+description: File a bug report
+labels: 🐞 bug
+title: "[Bug]: "
+body:
+  - type: input
+    id: psychopy-version
+    attributes:
+      label: PsychoPy Version
+      description: What version of PsychoPy are you using?
+      placeholder: "e.g. 2023.1.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: What OS are your PsychoPy running on?
+      description: Please mention the name and version of the Operation System that you are using?
+      multiple: true
+      options:
+        - Windows 10
+        - Windows 11
+        - macOS Intel
+        - macOS Silicon
+        - Linux-based systems
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: |
+        Please tell us what happened.
+        Note: You can attach images or log info by dragging files in this input field.
+      placeholder: "Describe the issue in detail"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: Expected Behaviour
+      description: Please tell us what should have happened instead of the bug.
+      placeholder: "The correct behavior I expected is..."
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Can you reproduce the bug? If so, please let us know what steps you take to reproduce this bug.
+      value: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id: bug-additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: Request a new feature, or an enhancement to an existing functionality
+labels: 🌟 enhancement
+title: "[Feature Request]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please try to describe your request or enhancement as detailed as possible.
+  - type: textarea
+    id: feature-short-description
+    attributes:
+      label: Description
+      description: Please describe this feature or enhancement here.
+    validations:
+      required: false
+  - type: textarea
+    id: feature-purpose
+    attributes:
+      label: Purpose
+      description: What is the purpose of this feature or enhancement, or give some use cases?
+    validations:
+      required: false
+  - type: textarea
+    id: feature-is-related-to-a-problem
+    attributes:
+      label: Is your feature request related to a problem? 
+      description: A clear and concise description of what the problem is, note if it's a bug please report it in [Bug] template.
+    validations:
+      required: false
+  - type: textarea
+    id: feature-solution-description
+    attributes:
+      label: Describe the solution you would like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: false
+  - type: textarea
+    id: feature-alternative
+    attributes:
+      label: Describe alternatives that you have considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    id: feature-additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false


### PR DESCRIPTION
Now we can collect bugs and enhancements using a unified template, which helps us to triage issues, and if needed, we can even maintain it automatically (e.g. assign maintainers, auto-tag).

A demo in my fork [repo](https://github.com/shun2wang/psychopy/issues).

I cannot assign a reviewer, so could @peircej have a look. with thanks.