### PR TITLE
RF/BF: Move list of known note names to tools so that Sound Component doesn't import psychopy.sound

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -12,7 +12,7 @@ from psychopy import logging
 from psychopy.alerts import alert
 from psychopy.tools import stringtools as st, systemtools as syst, audiotools as at
 from psychopy.experiment.components import BaseComponent, Param, getInitVals, _translate
-from psychopy.sound.audiodevice import sampleRateQualityLevels
+from psychopy.tools.audiotools import sampleRateQualityLevels
 from psychopy.localization import _localized as __localized
 
 _hasPTB = True

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -9,7 +9,7 @@ Distributed under the terms of the GNU General Public License (GPL).
 
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, getInitVals, _translate
-from psychopy.sound._base import knownNoteNames
+from psychopy.tools.audiotools import knownNoteNames
 from psychopy.localization import _localized as __localized
 _localized = __localized.copy()
 

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -12,6 +12,7 @@ from psychopy import logging
 from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from psychopy.tools.filetools import pathToString, defaultStim, defaultStimRoot
+from psychopy.tools.audiotools import knownNoteNames, stepsFromA
 from sys import platform
 from .audioclip import AudioClip
 
@@ -23,26 +24,7 @@ elif platform == 'darwin':
 elif platform.startswith("linux"):
     mediaLocation = "/usr/share/sounds"
 
-stepsFromA = {
-    'C': -9,
-    'Csh': -8, 'C#': -8,
-    'Dfl': -8, 'D♭': -8,
-    'D': -7,
-    'Dsh': -6, 'D#': -6,
-    'Efl': -6, 'E♭': -6,
-    'E': -5,
-    'F': -4,
-    'Fsh': -3, 'F#': -3,
-    'Gfl': -3, 'G♭': -3,
-    'G': -2,
-    'Gsh': -1, 'G#': -1,
-    'Afl': -1, 'A♭': -1,
-    'A': +0,
-    'Ash': +1, 'A#': +1,
-    'Bfl': +1, 'B♭': +1,
-    'B': +2,
-    'Bsh': +2, 'B#': +2}
-knownNoteNames = sorted(stepsFromA.keys())
+
 
 
 def apodize(soundArray, sampleRate):

--- a/psychopy/tools/audiotools.py
+++ b/psychopy/tools/audiotools.py
@@ -24,6 +24,7 @@ __all__ = [
     'SAMPLE_RATE_96kHz',
     'SAMPLE_RATE_192kHz',
     'AUDIO_SUPPORTED_CODECS',
+    'knownNoteNames', 'stepsFromA'
 ]
 
 # Part of the PsychoPy library
@@ -41,6 +42,29 @@ from scipy import signal
 #     import pydub
 # except (ImportError, ModuleNotFoundError):
 #     _has_pydub = False
+
+
+# note names mapped to steps from A, used in Sound stimulus and Component
+stepsFromA = {
+    'C': -9,
+    'Csh': -8, 'C#': -8,
+    'Dfl': -8, 'D♭': -8,
+    'D': -7,
+    'Dsh': -6, 'D#': -6,
+    'Efl': -6, 'E♭': -6,
+    'E': -5,
+    'F': -4,
+    'Fsh': -3, 'F#': -3,
+    'Gfl': -3, 'G♭': -3,
+    'G': -2,
+    'Gsh': -1, 'G#': -1,
+    'Afl': -1, 'A♭': -1,
+    'A': +0,
+    'Ash': +1, 'A#': +1,
+    'Bfl': +1, 'B♭': +1,
+    'B': +2,
+    'Bsh': +2, 'B#': +2}
+knownNoteNames = sorted(stepsFromA.keys())
 
 # Constants for common sample rates. Some are aliased to give the programmer an
 # idea to the quality they would expect from each. It is recommended to only use


### PR DESCRIPTION
Fixes #5325