### PR TITLE
FF: Fixes to README dialog

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -265,6 +265,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # self.SetAutoLayout(True)
         self.Bind(wx.EVT_CLOSE, self.closeFrame)
         self.Bind(wx.EVT_SIZE, self.onResize)
+        self.Bind(wx.EVT_SHOW, self.onShow)
 
         self.app.trackFrame(self)
         self.SetDropTarget(FileDropTarget(targetFrame=self))
@@ -639,6 +640,12 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.flowPanel.canvas.Refresh()
         event.Skip()
 
+    def onShow(self, event):
+        """Called when the frame is shown"""
+        event.Skip()
+        # if README was updated when frame wasn't shown, it won't be show either - so update again
+        self.updateReadme()
+
     @property
     def filename(self):
         """Name of the currently open file"""
@@ -904,6 +911,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # Show/hide frame as appropriate
         if show is None:
             show = len(self.readmeFrame.ctrl.getValue()) > 0
+        show = show and self.IsShown()
         self.readmeFrame.show(show)
 
     def showReadme(self, evt=None, value=True):

--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -565,14 +565,15 @@ class MarkdownCtrl(wx.Panel, handlers.ThemeMixin):
             # get raw text
             rawText = self.rawTextCtrl.Value
             # remove images (wx doesn't like rendering them)
-            imgBuffer = rawText.split("![")
-            output = []
-            for cell in imgBuffer:
-                if ")" in cell:
-                    output.extend(cell.split(")")[1:])
-                else:
-                    output.append(cell)
-            rawText = "".join(output)
+            if "![" in rawText:
+                imgBuffer = rawText.split("![")
+                output = []
+                for cell in imgBuffer:
+                    if ")" in cell:
+                        output.extend(cell.split(")")[1:])
+                    else:
+                        output.append(cell)
+                rawText = "".join(output)
             # This could also be done by regex, we're avoiding regex for readability
             # rawText = re.sub(r"\!\[.*\]\(.*\)", "", rawText)
             # render markdown

--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -566,17 +566,7 @@ class MarkdownCtrl(wx.Panel, handlers.ThemeMixin):
             # get raw text
             rawText = self.rawTextCtrl.Value
             # remove images (wx doesn't like rendering them)
-            if "![" in rawText:
-                imgBuffer = rawText.split("![")
-                output = []
-                for cell in imgBuffer:
-                    if ")" in cell:
-                        output.extend(cell.split(")")[1:])
-                    else:
-                        output.append(cell)
-                rawText = "".join(output)
-            # This could also be done by regex, we're avoiding regex for readability
-            # rawText = re.sub(r"\!\[.*\]\(.*\)", "", rawText)
+            rawText = rawText.replace("![", "[")
             # render markdown
             renderedText = md.MarkdownIt("default").render(rawText)
         else:

--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -478,6 +478,7 @@ class MarkdownCtrl(wx.Panel, handlers.ThemeMixin):
         self.rawTextCtrl.Bind(wx.stc.EVT_STC_MODIFIED, self.onEdit)
         self.contentSizer.Add(self.rawTextCtrl, proportion=1, border=3, flag=wx.ALL | wx.EXPAND)
         self.rawTextCtrl.SetReadOnly(self.readonly)
+        self.rawTextCtrl.SetWrapMode(wx.stc.STC_WRAP_WORD)
 
         # Make HTML preview
         self.htmlPreview = HtmlWindow(self, wx.ID_ANY)


### PR DESCRIPTION
- Image removal was catching links (due to closed bracket) when no image is present
- Markdown wasn't wrapped in Edit mode
- README was shown during splash screen