### PR TITLE
FF: Fix typo in Routine Settings JS boilerplate

### DIFF
--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -285,6 +285,7 @@ class RoutineSettingsComponent(BaseComponent):
             # Contents of if statement
             code += (
                 "    continueRoutine = False\n"
+                "}\n"
             )
             buff.writeIndentedLines(code % self.params)
 


### PR DESCRIPTION
Missing } in stop test code