### PR TITLE
BF: Mouse position incorrect when desktop scaling not 1:1 on Windows

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -633,7 +633,9 @@ class Mouse():
                 if self.win.useRetina:
                     newPosPix = numpy.array(self.win.size) / 4 + newPosPix / 2
                 else:
-                    newPosPix = numpy.array(self.win.size) / 2 + newPosPix
+                    wsf = self._winScaleFactor 
+                    newPosPix = \
+                        numpy.array(self.win.size) / (2 * wsf) + newPosPix / wsf
                 x, y = int(newPosPix[0]), int(newPosPix[1])
                 self.win.winHandle.set_mouse_position(x, y)
                 self.win.winHandle._mouse_x = x

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -605,6 +605,9 @@ class Mouse():
         if newPos is not None:
             self.setPos(newPos)
 
+        # get the scaling factors for the display
+        self._winScaleFactor = self.win.getContentScaleFactor()
+
     @property
     def units(self):
         """The units for this mouse
@@ -669,7 +672,8 @@ class Mouse():
             if self.win.useRetina:
                 lastPosPix = lastPosPix * 2 - numpy.array(self.win.size) / 2
             else:
-                lastPosPix = lastPosPix - numpy.array(self.win.size) / 2
+                wsf = self._winScaleFactor 
+                lastPosPix = lastPosPix * wsf - numpy.array(self.win.size) / 2
 
         self.lastPos = self._pix2windowUnits(lastPosPix)
 

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -590,6 +590,13 @@ class Mouse():
                 logging.error('Mouse: failed to get a default visual.Window'
                               ' (need to create one first)')
                 self.win = None
+
+        # get the scaling factors for the display
+        if self.win is not None:
+            self._winScaleFactor = self.win.getContentScaleFactor()
+        else:
+            self._winScaleFactor = 1.0
+
         # for builder: set status to STARTED, NOT_STARTED etc
         self.status = None
         self.mouseClock = psychopy.core.Clock()
@@ -604,9 +611,6 @@ class Mouse():
         self.setVisible(visible)
         if newPos is not None:
             self.setPos(newPos)
-
-        # get the scaling factors for the display
-        self._winScaleFactor = self.win.getContentScaleFactor()
 
     @property
     def units(self):

--- a/psychopy/hardware/mouse/__init__.py
+++ b/psychopy/hardware/mouse/__init__.py
@@ -181,6 +181,9 @@ class Mouse:
     # have the window automatically be set when a cursor hovers over it
     _autoFocus = True
 
+    # scaling factor for highdpi displays
+    _winScaleFactor = 1.0
+
     def __init__(self, win=None, pos=(0, 0), visible=True, exclusive=False,
                  autoFocus=True):
         # only setup if previously not instanced
@@ -189,7 +192,10 @@ class Mouse:
             self.visible = visible
             self.exclusive = exclusive
             self.autoFocus = autoFocus
-            self._winScaleFactor = self.win.getContentScaleFactor()
+            if self.win is not None:
+                self._winScaleFactor = self.win.getContentScaleFactor()
+            else:
+                self._winScaleFactor = 1.0   # default to 1.0
 
             if self.win is not None and pos is not None:
                 self.setPos(pos)

--- a/psychopy/hardware/mouse/__init__.py
+++ b/psychopy/hardware/mouse/__init__.py
@@ -189,6 +189,7 @@ class Mouse:
             self.visible = visible
             self.exclusive = exclusive
             self.autoFocus = autoFocus
+            self._winScaleFactor = self.win.getContentScaleFactor()
 
             if self.win is not None and pos is not None:
                 self.setPos(pos)
@@ -374,6 +375,8 @@ class Mouse:
         if self.win.units == 'pix':
             if self.win.useRetina:
                 pos /= 2.0
+            else:
+                pos /= self._winScaleFactor
             return pos
         elif self.win.units == 'norm':
             return pos * 2.0 / self.win.size
@@ -405,6 +408,10 @@ class Mouse:
             return pos
 
         if self.win.units == 'pix':
+            if self.win.useRetina:
+                pos *= 2.0
+            else:
+                pos *= self._winScaleFactor
             return pos
         elif self.win.units == 'norm':
             return pos * self.win.size / 2.0


### PR DESCRIPTION
Fixes getting the mouse position on Windows when scaling is not 1:1, much like we do with retina displays.