### PR TITLE
Allow the app to load when no audio lib installed

### DIFF
--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -206,7 +206,7 @@ if Sound is not None:
     logging.info('sound is using audioLib: %s' % audioLib)
 else:
     # if we get here, there is no audioLib that is supported
-    raise DependencyError(
+    logging.error(
         "No audioLib could be loaded. Tried: {}\n Check whether the necessary "
         "audioLibs are installed".format(prefs.hardware['audioLib']))
 


### PR DESCRIPTION
Transforms the `DependencyError` exception to a log error to prevent the app from crashing on startup when no sound library is installed.