### PR TITLE
BF: Color picker was broken in Python 3.10

### DIFF
--- a/psychopy/app/colorpicker/__init__.py
+++ b/psychopy/app/colorpicker/__init__.py
@@ -133,7 +133,7 @@ class PsychoColorPicker(ColorPickerDialog):
         self.sldRedChannel.SetMax(SLIDER_RES)
         self.sldGreenChannel.SetMax(SLIDER_RES)
         self.sldBlueChannel.SetMax(SLIDER_RES)
-        self.sldHueChannel.SetRange(0.0, 360.0)
+        self.sldHueChannel.SetRange(0, 360)
         self.sldStaturationChannel.SetRange(0, SLIDER_RES)
         self.sldValueChannel.SetRange(0, SLIDER_RES)
 
@@ -225,7 +225,7 @@ class PsychoColorPicker(ColorPickerDialog):
             raise ValueError('Color channel format not supported.')
 
         # update the HSV page
-        previewRGB = self.color.rgb255
+        previewRGB = [int(gun) for gun in self.color.rgb255]
         r, g, b = previewRGB
         self.pnlColorPreview.SetBackgroundColour(
             wx.Colour(r, g, b, alpha=wx.ALPHA_OPAQUE))
@@ -239,7 +239,7 @@ class PsychoColorPicker(ColorPickerDialog):
 
         """
         # get colors and convert to format wxPython controls can accept
-        hsvColor = self.color.hsv
+        hsvColor = [int(gun) for gun in self.color.hsv]
         self.sldHueChannel.SetValue(hsvColor[0])
         self.sldStaturationChannel.SetValue(hsvColor[1] * SLIDER_RES)
         self.sldValueChannel.SetValue(hsvColor[2] * SLIDER_RES)

--- a/psychopy/app/colorpicker/__init__.py
+++ b/psychopy/app/colorpicker/__init__.py
@@ -239,10 +239,10 @@ class PsychoColorPicker(ColorPickerDialog):
 
         """
         # get colors and convert to format wxPython controls can accept
-        hsvColor = [int(gun) for gun in self.color.hsv]
-        self.sldHueChannel.SetValue(hsvColor[0])
-        self.sldStaturationChannel.SetValue(hsvColor[1] * SLIDER_RES)
-        self.sldValueChannel.SetValue(hsvColor[2] * SLIDER_RES)
+        hsvColor = self.color.hsv
+        self.sldHueChannel.SetValue(int(hsvColor[0]))
+        self.sldStaturationChannel.SetValue(int(hsvColor[1] * SLIDER_RES))
+        self.sldValueChannel.SetValue(int(hsvColor[2] * SLIDER_RES))
 
         # set the value in the new range
         self.spnHueChannel.SetValue(hsvColor[0])


### PR DESCRIPTION
Due to values being float