### PR TITLE
NF: Automatically add set/get methods for any attributeSetter or property

### DIFF
--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -1,11 +1,12 @@
 from psychopy.constants import STARTED, NOT_STARTED, PAUSED, STOPPED, FINISHED
 from psychopy.alerts import alert
 from psychopy import logging
+from psychopy.tools.attributetools import SetterAliasMixin
 from copy import copy
 import sys
 
 
-class EyetrackerControl:
+class EyetrackerControl(SetterAliasMixin):
     currentlyRecording = False
 
     def __init__(self, tracker, actionType="Start and Stop"):

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -1,12 +1,12 @@
 from psychopy.constants import STARTED, NOT_STARTED, PAUSED, STOPPED, FINISHED
 from psychopy.alerts import alert
 from psychopy import logging
-from psychopy.tools.attributetools import SetterAliasMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin
 from copy import copy
 import sys
 
 
-class EyetrackerControl(SetterAliasMixin):
+class EyetrackerControl(AttributeGetSetMixin):
     currentlyRecording = False
 
     def __init__(self, tracker, actionType="Start and Stop"):

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -68,6 +68,7 @@ import psychopy.clock
 from psychopy import logging
 from psychopy.constants import NOT_STARTED
 import time
+from psychopy.tools.attributetools import SetterAliasMixin
 
 try:
     import psychtoolbox as ptb
@@ -120,7 +121,7 @@ def getKeyboards():
     return []
 
 
-class Keyboard:
+class Keyboard(SetterAliasMixin):
     """The Keyboard class provides access to the Psychtoolbox KbQueue-based
     calls on **Python3 64-bit** with fall-back to `event.getKeys` on legacy
     systems.

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -68,7 +68,7 @@ import psychopy.clock
 from psychopy import logging
 from psychopy.constants import NOT_STARTED
 import time
-from psychopy.tools.attributetools import SetterAliasMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin
 
 try:
     import psychtoolbox as ptb
@@ -121,7 +121,7 @@ def getKeyboards():
     return []
 
 
-class Keyboard(SetterAliasMixin):
+class Keyboard(AttributeGetSetMixin):
     """The Keyboard class provides access to the Psychtoolbox KbQueue-based
     calls on **Python3 64-bit** with fall-back to `event.getKeys` on legacy
     systems.

--- a/psychopy/hardware/mouse/__init__.py
+++ b/psychopy/hardware/mouse/__init__.py
@@ -19,6 +19,7 @@ import numpy as np
 import psychopy.core as core
 import psychopy.visual.window as window
 from psychopy.tools.monitorunittools import pix2cm, pix2deg, cm2pix, deg2pix
+from psychopy.tools.attributetools import SetterAliasMixin
 
 
 # mouse button indices
@@ -45,7 +46,7 @@ MOUSE_POS_CURRENT = 0
 MOUSE_POS_PREVIOUS = 1
 
 
-class Mouse:
+class Mouse(SetterAliasMixin):
     """Class for using pointing devices (e.g., mice, trackballs, etc.) as input.
 
     PsychoPy presently only supports one pointing device input at a time.

--- a/psychopy/hardware/mouse/__init__.py
+++ b/psychopy/hardware/mouse/__init__.py
@@ -19,7 +19,7 @@ import numpy as np
 import psychopy.core as core
 import psychopy.visual.window as window
 from psychopy.tools.monitorunittools import pix2cm, pix2deg, cm2pix, deg2pix
-from psychopy.tools.attributetools import SetterAliasMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin
 
 
 # mouse button indices
@@ -46,7 +46,7 @@ MOUSE_POS_CURRENT = 0
 MOUSE_POS_PREVIOUS = 1
 
 
-class Mouse(SetterAliasMixin):
+class Mouse(AttributeGetSetMixin):
     """Class for using pointing devices (e.g., mice, trackballs, etc.) as input.
 
     PsychoPy presently only supports one pointing device input at a time.

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -13,13 +13,14 @@ import sys
 import time
 
 from psychopy import logging
+from psychopy.tools.attributetools import SetterAliasMixin
 try:
     import serial
 except ImportError:
     serial = False
 
 
-class SerialDevice:
+class SerialDevice(SetterAliasMixin):
     """A base class for serial devices, to be sub-classed by specific devices
 
     If port=None then the SerialDevice.__init__() will search for the device

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -13,14 +13,14 @@ import sys
 import time
 
 from psychopy import logging
-from psychopy.tools.attributetools import SetterAliasMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin
 try:
     import serial
 except ImportError:
     serial = False
 
 
-class SerialDevice(SetterAliasMixin):
+class SerialDevice(AttributeGetSetMixin):
     """A base class for serial devices, to be sub-classed by specific devices
 
     If port=None then the SerialDevice.__init__() will search for the device

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -13,6 +13,7 @@ from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from psychopy.tools.filetools import pathToString, defaultStim, defaultStimRoot
 from psychopy.tools.audiotools import knownNoteNames, stepsFromA
+from psychopy.tools.attributetools import SetterAliasMixin
 from sys import platform
 from .audioclip import AudioClip
 
@@ -100,7 +101,7 @@ class HammingWindow():
         return block
 
 
-class _SoundBase():
+class _SoundBase(SetterAliasMixin):
     """Base class for sound object, from one of many ways.
     """
     # Must be provided by class SoundPygame or SoundPyo:

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -13,7 +13,7 @@ from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from psychopy.tools.filetools import pathToString, defaultStim, defaultStimRoot
 from psychopy.tools.audiotools import knownNoteNames, stepsFromA
-from psychopy.tools.attributetools import SetterAliasMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin
 from sys import platform
 from .audioclip import AudioClip
 
@@ -101,7 +101,7 @@ class HammingWindow():
         return block
 
 
-class _SoundBase(SetterAliasMixin):
+class _SoundBase(AttributeGetSetMixin):
     """Base class for sound object, from one of many ways.
     """
     # Must be provided by class SoundPygame or SoundPyo:

--- a/psychopy/tests/test_tools/test_attributetools.py
+++ b/psychopy/tests/test_tools/test_attributetools.py
@@ -6,6 +6,7 @@ import scipy.stats as sp
 from psychopy.tests import skip_under_vm
 from psychopy import colors
 from psychopy.tools.attributetools import attributeSetter, logAttrib
+import case_changer as cc
 
 
 pd.options.display.float_format = "{:,.0f}".format
@@ -225,3 +226,32 @@ class TestAttributeSetterSpeed:
                     f"{faster} WAS NOT significantly faster than {slower} when {key}"
                 )
             print(out)
+
+
+def testGetSetAliases():
+    from psychopy.visual.circle import Circle
+    from psychopy.visual.textbox2.textbox2 import TextBox2
+    from psychopy.visual.button import ButtonStim
+    from psychopy.visual.movie import MovieStim
+    from psychopy.sound import Sound
+    from psychopy.hardware.mouse import Mouse
+
+    for cls in (Circle, TextBox2, ButtonStim, MovieStim, Sound, Mouse):
+        # iterate through methods
+        for name in dir(cls):
+            # get function
+            func = getattr(cls, name)
+            # ignore any which aren't attributeSetters
+            if not isinstance(func, (attributeSetter, property)):
+                continue
+            # work out getter method name
+            getterName = "get" + cc.pascal_case(name)
+            # ensure that the corresponding get function exists
+            assert hasattr(cls, getterName), f"Class '{cls.__name__}' has not attribute '{getterName}'"
+            # any non-settable properties are now done
+            if isinstance(func, property) and func.fset is None:
+                continue
+            # work out setter method name
+            setterName = "set" + cc.pascal_case(name)
+            # ensure that the corresponding set function exists
+            assert hasattr(cls, setterName), f"Class '{cls.__name__}' has not attribute '{setterName}'"

--- a/psychopy/tests/test_tools/test_attributetools.py
+++ b/psychopy/tests/test_tools/test_attributetools.py
@@ -6,7 +6,7 @@ import scipy.stats as sp
 from psychopy.tests import skip_under_vm
 from psychopy import colors
 from psychopy.tools.attributetools import attributeSetter, logAttrib
-import case_changer as cc
+from psychopy.tools.stringtools import makeValidVarName
 
 
 pd.options.display.float_format = "{:,.0f}".format
@@ -245,13 +245,13 @@ def testGetSetAliases():
             if not isinstance(func, (attributeSetter, property)):
                 continue
             # work out getter method name
-            getterName = "get" + cc.pascal_case(name)
+            getterName = "get" + makeValidVarName(name, case="title")
             # ensure that the corresponding get function exists
             assert hasattr(cls, getterName), f"Class '{cls.__name__}' has not attribute '{getterName}'"
             # any non-settable properties are now done
             if isinstance(func, property) and func.fset is None:
                 continue
             # work out setter method name
-            setterName = "set" + cc.pascal_case(name)
+            setterName = "set" + makeValidVarName(name, case="title")
             # ensure that the corresponding set function exists
             assert hasattr(cls, setterName), f"Class '{cls.__name__}' has not attribute '{setterName}'"

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -174,7 +174,7 @@ class SetterAliasMixin:
             # get function
             func = getattr(cls, name)
             # ignore any which aren't attributeSetters
-            if not isinstance(func, attributeSetter):
+            if not isinstance(func, (attributeSetter, property)):
                 continue
             # work out setter method name
             setterName = "set" + cc.pascal_case(name)

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -180,6 +180,9 @@ class SetterAliasMixin:
             # ignore any which aren't attributeSetters
             if not isinstance(func, (attributeSetter, property)):
                 continue
+            # ignore any non-settable properties
+            if isinstance(func, property) and func.fset is None:
+                continue
             # work out setter method name
             setterName = "set" + cc.pascal_case(name)
             # ignore any which already have a setter method

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -49,7 +49,7 @@ class attributeSetter:
         return repr(self.__getattribute__)
 
 
-def setAttribute(self, attrib, value, log,
+def setAttribute(self, attrib, value, log=None,
                  operation=False, stealth=False):
     """This function is useful to direct the old set* functions to the
     @attributeSetter.
@@ -168,7 +168,7 @@ class SetterAliasMixin:
     """
     Makes aliases of all attributeSetter functions which are their names capitalized, preceeded by `set`
     """
-    def __new__(cls, *args, **kwargs):
+    def __init_subclass__(cls, **kwargs):
         # iterate through methods
         for name in dir(cls):
             # get function

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -11,7 +11,7 @@
 import numpy
 from psychopy import logging
 from functools import partialmethod
-import case_changer as cc
+from psychopy.tools.stringtools import makeValidVarName
 
 
 class attributeSetter:
@@ -182,7 +182,7 @@ class AttributeGetSetMixin:
             if not isinstance(func, (attributeSetter, property)):
                 continue
             # work out getter method name
-            getterName = "get" + cc.pascal_case(name)
+            getterName = "get" + makeValidVarName(name, case="title")
             # ignore any which already have a getter method
             if not hasattr(cls, getterName):
                 # create a pre-populated caller for getattr
@@ -193,7 +193,7 @@ class AttributeGetSetMixin:
             if isinstance(func, property) and func.fset is None:
                 continue
             # work out setter method name
-            setterName = "set" + cc.pascal_case(name)
+            setterName = "set" + makeValidVarName(name, case="title")
             # ignore any which already have a setter method
             if not hasattr(cls, setterName):
                 # create a pre-populated caller for setAttribute

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -75,6 +75,10 @@ def setAttribute(self, attrib, value, log=None,
     Even though it looks complex, it is very fast :-)
     """
 
+    # if log is None, use autoLog
+    if log is None:
+        log = getattr(self, "autoLog", False)
+
     # Change the value of "value" if there is an operation. Even if it is '',
     # which indicates that this value could potentially be subjected to an
     # operation.

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -37,7 +37,7 @@ from psychopy import logging
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import (attributeSetter, logAttrib,
-                                           setAttribute, SetterAliasMixin)
+                                           setAttribute, AttributeGetSetMixin)
 from psychopy.tools.monitorunittools import (cm2pix, deg2pix, pix2cm,
                                              pix2deg, convertToPix)
 from psychopy.visual.helpers import (pointInPolygon, polygonsOverlap,
@@ -81,7 +81,7 @@ mixin(s) as needed to add functionality.
 """
 
 
-class MinimalStim(SetterAliasMixin):
+class MinimalStim(AttributeGetSetMixin):
     """Non-visual methods and attributes for BaseVisualStim and RatingScale.
 
     Includes: name, autoDraw, autoLog, status, __str__

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -37,7 +37,7 @@ from psychopy import logging
 # (JWP has no idea why!)
 from psychopy.tools.arraytools import val2array
 from psychopy.tools.attributetools import (attributeSetter, logAttrib,
-                                           setAttribute)
+                                           setAttribute, SetterAliasMixin)
 from psychopy.tools.monitorunittools import (cm2pix, deg2pix, pix2cm,
                                              pix2deg, convertToPix)
 from psychopy.visual.helpers import (pointInPolygon, polygonsOverlap,
@@ -81,7 +81,7 @@ mixin(s) as needed to add functionality.
 """
 
 
-class MinimalStim:
+class MinimalStim(SetterAliasMixin):
     """Non-visual methods and attributes for BaseVisualStim and RatingScale.
 
     Includes: name, autoDraw, autoLog, status, __str__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ dependencies = [
     "python-bidi",
     "arabic-reshaper",
     "javascripthon",
-    "case-changer",
     "websockets",  # new in 2023.2 for session.py
     # for the app
     "wxPython >= 4.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "python-bidi",
     "arabic-reshaper",
     "javascripthon",
+    "case-changer",
     "websockets",  # new in 2023.2 for session.py
     # for the app
     "wxPython >= 4.1.1",


### PR DESCRIPTION
- Any method marked as @ attributeSetter or @ property will now have matching methods to get/set its value (e.g. `.color` has `.getColor` and `.setColor`)
- set methods all use setAttribute so that logging and etc. is handled
- get methods are just a wrapper around `getattr`
- If a class already has a set/get method, it's not overwritten - so we can still define custom set/get functions
- To get these methods, a class has to be derived from tools.attributetools.AttributeGetSetMixin (grandparentage is fine, so all visual stim have this via MinimalStim)
- I added `case-changer` as a dependency as it's tiny and means the name stuff isn't subject to my errors doing it manually (we should use this for boilerplate too)
- Added a test for the existence of get/set methods

Hopefully this should mean no more "...has no attribute 'set...'" errors from us/contributors forgetting to include get/set methods for attributes!