### PR TITLE
BF: Stop plugin output panel spamming new lines at the end

### DIFF
--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -145,17 +145,17 @@ class EnvironmentManagerDlg(wx.Dialog):
         self.output.open()
 
         if pkgtools._isUserPackage(packageName):
-            msg = 'Uninstalling package bundle for `{}` ...\n'.format(
+            msg = 'Uninstalling package bundle for `{}` ...'.format(
                 packageName)
             self.output.writeStdOut(msg)
 
             success = pkgtools._uninstallUserPackage(packageName)
             if success:
-                msg = 'Successfully removed package `{}`.\n'.format(
+                msg = 'Successfully removed package `{}`.'.format(
                     packageName)
             else:
                 msg = ('Failed to remove package `{}`, check log for '
-                       'details.\n').format(packageName)
+                       'details.').format(packageName)
 
             self.output.writeStdOut(msg)
 
@@ -224,12 +224,12 @@ class EnvironmentManagerDlg(wx.Dialog):
         bundlePath = plugins.getBundleInstallTarget(packageName)
         if not os.path.exists(bundlePath):
             self.output.writeStdOut(
-                "Creating bundle path `{}` for package `{}`.\n".format(
+                "Creating bundle path `{}` for package `{}`.".format(
                     bundlePath, packageName))
             os.mkdir(bundlePath)  # make the directory
         else:
             self.output.writeStdOut(
-                "Using existing bundle path `{}` for package `{}`.\n".format(
+                "Using existing bundle path `{}` for package `{}`.".format(
                     bundlePath, packageName))
 
         # add the bundle to path, refresh makes it discoverable after install
@@ -337,13 +337,10 @@ class EnvironmentManagerDlg(wx.Dialog):
             # show info link
             if pluginInfo.docs:
                 msg = _translate(
-                    "\n"
-                    "\n"
-                    "For more information about the %s plugin, read the documentation at:\n"
+                    "For more information about the %s plugin, read the documentation at:"
                 ) % pluginInfo.name
                 self.output.writeStdOut(msg)
                 self.output.writeLink(pluginInfo.docs, link=pluginInfo.docs)
-                self.output.writeStdOut("\n")
 
         # clear pip process
         self.pipProcess = None
@@ -356,7 +353,7 @@ class EnvironmentManagerDlg(wx.Dialog):
         if any(["uninstalled" in changes for changes in pluginChanges.values()]):
             msg = _translate(
                 "It looks like you've uninstalled some plugins. In order for this to take effect, you will need to "
-                "restart the PsychoPy app.\n"
+                "restart the PsychoPy app."
             )
             dlg = wx.MessageDialog(
                 None, msg,

--- a/psychopy/app/plugin_manager/output.py
+++ b/psychopy/app/plugin_manager/output.py
@@ -58,7 +58,7 @@ class InstallStdoutPanel(wx.Panel, handlers.ThemeMixin):
         if "i" in style:
             self.output.BeginItalic()
         # Write content
-        self.output.WriteText(content)
+        self.output.WriteText(f"\n{content}")
         # End style
         self.output.EndTextColour()
         self.output.EndBold()
@@ -88,7 +88,7 @@ class InstallStdoutPanel(wx.Panel, handlers.ThemeMixin):
         cmd : bytes or str
             Command which was supplied to the subprocess
         """
-        self.write(f">> {cmd}\n", style="bi")
+        self.write(f">> {cmd}", style="bi")
 
     def writeStdOut(self, lines=""):
         """
@@ -99,7 +99,7 @@ class InstallStdoutPanel(wx.Panel, handlers.ThemeMixin):
         lines : bytes or str
             String to print, can also be bytes (as is the case when retrieved directly from the subprocess).
         """
-        self.write(f"{lines}\n")
+        self.write(lines)
 
     def writeStdErr(self, lines=""):
         """
@@ -110,7 +110,7 @@ class InstallStdoutPanel(wx.Panel, handlers.ThemeMixin):
         lines : bytes or str
             String to print, can also be bytes (as is the case when retrieved directly from the subprocess).
         """
-        self.write(f"{lines}\n", color=colors.scheme["red"])
+        self.write(lines, color=colors.scheme["red"])
 
     def writeTerminus(self, msg="Process completed"):
         """
@@ -122,7 +122,7 @@ class InstallStdoutPanel(wx.Panel, handlers.ThemeMixin):
             Message to be printed flanked by `#` characters.
         """
         # Construct a close message, shows the exit code
-        closeMsg = f" {msg} ".center(80, '#') + '\n'
+        closeMsg = f" {msg} ".center(80, '#')
         # Write close message
         self.write(closeMsg, color=colors.scheme["green"])
 


### PR DESCRIPTION
The problem is that a newline has no position, so when the final line is a newline & we tell the cursor to move to the end, it moves to just before the newline, so to get things to actually line break we had to double up on newlines & the duplicates were stacking up at the end. Putting the newline in front of each message rather than behind means the line break is respected without duplication.