### PR TITLE
ENH: fixing slow color __deepcopy__ resulting from unnecessary validation

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -270,11 +270,15 @@ class Color:
         self._requestedSpace = None
 
         self.set(color=color, space=space)
-
+    
+    perform_validation = True # Static flag
     def validate(self, color, space=None):
         """
         Check that a color value is valid in the given space, or all spaces if space==None.
         """
+        if (not Color.perform_validation):
+            return color, space
+
         # Treat None as a named color
         if color is None:
             color = "none"
@@ -487,10 +491,18 @@ class Color:
         return self.__deepcopy__()
 
     def __deepcopy__(self):
+        # optimization to disable validation while copying
+        # since it isn't necessary and is very slow
+        original_perform_validation = Color.perform_validation
+        Color.perform_validation = False
+
         dupe = self.__class__(
             self._requested, self._requestedSpace, self.contrast)
         dupe.rgba = self.rgba
         dupe.valid = self.valid
+
+        Color.perform_validation = original_perform_validation
+
         return dupe
 
     def getReadable(self, contrast=4.5/21):


### PR DESCRIPTION
Hi I noticed an extremely poorly performing part of the psychopy code. When you make duplicate of a color (which also happens if you perform math with a color e.g. mycolor + .1) the new color gets validated repeatedly (not only validated in the color.set function, but also validated in the individual setter functions as well) which really eats performance.

This validation is pointless since if we are copying a color we already know if the color is valid or not (see the valid flag)

So my solution is just to add a static feature flag to disable validation.

In this particular situation where we repeatedly draw textboxes, this improves performance by ~30%. Color manipulation is such a common operation I think this is worth fixing.

Attached is the code for the psychopy experiment which I used to do my profiling.
[badcolorcopyperfdemo.zip](https://github.com/psychopy/psychopy/files/12273471/badcolorcopyperfdemo.zip)
