### PR TITLE
BF: Python 3.10 version bump had broken GIF avatars

### DIFF
--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -1228,7 +1228,7 @@ class ImageCtrl(wx.lib.statbmp.GenStaticBitmap):
             if not len(fr):
                 fr.append(200)
             # Start animation (average framerate across frames)
-            self.frameTimer.Start(numpy.mean(fr), oneShot=False)
+            self.frameTimer.Start(int(numpy.mean(fr)), oneShot=False)
 
     def LoadBitmap(self, evt=None):
         # Open file dlg


### PR DESCRIPTION
The start time needs to be an integer in wx for Python 3.10, whereas previously it was a float