### PR TITLE
BF: Fixed <expname>_legacy-legacy-browser.js is not a file

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -926,7 +926,7 @@ class SettingsComponent:
         # create resources folder
         if self.exp.htmlFolder:
             self.prepareResourcesJS()
-        jsFilename = os.path.basename(os.path.splitext(self.exp.filename)[0])
+        jsFilename = self.params['expName'].val
 
         # configure the PsychoJS version number from current/requested versions
         useVer = self.params['Use version'].val


### PR DESCRIPTION
Because useVersion is working from a sanitized variant of the psyexp file, index.html was constructing the JS filename from its filename rather than the (correct) experiment name in params