### PR TITLE
BF: Coder was making an error when opening a new file

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2318,7 +2318,8 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.setTitle(title=self.winTitle, document=fname)
         #if len(self.getOpenFilenames()) > 0:
         self.currentDoc.analyseScript()
-        self.fileBrowserWindow.gotoDir(path)
+        if os.path.isdir(path):
+            self.fileBrowserWindow.gotoDir(path)
 
         if not keepHidden:
             self.Show()  # if the user had closed the frame it might be hidden


### PR DESCRIPTION
Because it was trying to open a directory in the File Browser when the file wasn't saved yet so there wasn't any directory