### PR TITLE
BF: Add JS code to set window background image on init

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1705,10 +1705,14 @@ class SettingsComponent:
                 "  fullscr: {fullScr},\n"
                 "  color: new util.Color({params[color]}),\n"
                 "  units: '{units}',\n"
-                "  waitBlanking: true\n"
-                "}});\n").format(fullScr=str(self.params['Full-screen window']).lower(),
-                                 params=self.params,
-                                 units=units)
+                "  waitBlanking: true,\n"
+                "  backgroundImage={params[backgroundImg]},\n"
+                "  backgroundFit={params[backgroundFit]},\n"
+                "}});\n").format(
+            fullScr=str(self.params['Full-screen window']).lower(),
+            params=self.params,
+            units=units
+        )
         buff.writeIndentedLines(code)
 
     def writePauseCode(self, buff):

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1706,8 +1706,8 @@ class SettingsComponent:
                 "  color: new util.Color({params[color]}),\n"
                 "  units: '{units}',\n"
                 "  waitBlanking: true,\n"
-                "  backgroundImage={params[backgroundImg]},\n"
-                "  backgroundFit={params[backgroundFit]},\n"
+                "  backgroundImage: {params[backgroundImg]},\n"
+                "  backgroundFit: {params[backgroundFit]},\n"
                 "}});\n").format(
             fullScr=str(self.params['Full-screen window']).lower(),
             params=self.params,


### PR DESCRIPTION
Added code to set each Routine according to Routine Settings, but Experiment Settings param was still ignored even though window background is (in theory) implemented online now