### PR TITLE
BF: Fix ioHub keyboard timing

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -128,7 +128,6 @@ class Keyboard:
     """
     _backend = None
     _iohubKeyboard = None
-    _iohubOffset = 0.0
     _ptbOffset = 0.0
 
     def __init__(self, device=-1, bufferSize=10000, waitForStart=False, clock=None, backend=None):
@@ -188,7 +187,6 @@ class Keyboard:
 
             if ioHubConnection.getActiveConnection() and Keyboard._iohubKeyboard is None:
                 Keyboard._iohubKeyboard = ioHubConnection.getActiveConnection().getDevice('keyboard')
-                Keyboard._iohubOffset = Computer.global_clock.getLastResetTime()
                 Keyboard._backend = 'iohub'
 
         if Keyboard._backend in ['', 'ptb'] and havePTB:

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -350,7 +350,7 @@ class Keyboard:
                     tDown = k.time
 
                 kpress = KeyPress(code=k.char, tDown=tDown, name=kname)
-                kpress.rt = kpress.tDown - self.clock.getLastResetTime() + Keyboard._iohubOffset
+                kpress.rt = kpress.tDown - (self.clock.getLastResetTime() - Keyboard._iohubKeyboard.clock.getLastResetTime())
                 if hasattr(k, 'duration'):
                     kpress.duration = k.duration
 

--- a/psychopy/iohub/client/keyboard.py
+++ b/psychopy/iohub/client/keyboard.py
@@ -201,6 +201,7 @@ class Keyboard(ioHubDeviceView):
 
     def __init__(self, ioclient, dev_cls_name, dev_config):
         super(Keyboard, self).__init__(ioclient, 'client.Keyboard', dev_cls_name, dev_config)
+        self.clock = Computer.global_clock
         self._events = dict()
         self._reporting = self.isReportingEvents()
         self._pressed_keys = {}

--- a/psychopy/tests/test_hardware/test_keyboard_events.py
+++ b/psychopy/tests/test_hardware/test_keyboard_events.py
@@ -2,9 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from psychopy import event, core, iohub, visual
+from psychopy import event, core
 from psychopy.preferences import prefs
-from psychopy.hardware import keyboard
 from psychopy.visual import Window
 
 from pyglet.window.key import (MOD_SHIFT,
@@ -94,34 +93,6 @@ class TestKeyboardEvents():
         assert keys[0][1]['shift']
         assert keys[0][1]['scrolllock']
         assert isinstance(keys[0][2], float)
-
-
-class TestIohubKeyboard:
-    def setup(self):
-        self.win = visual.Window()
-        self.ioServer = iohub.launchHubServer(window=self.win)
-        self.kb = keyboard.Keyboard(backend="iohub")
-
-    def test_timestamps(self):
-        # make global clock
-        globalClock = core.Clock()
-        # sync global clock with iohub
-        self.ioServer.syncClock(globalClock)
-        # get time from a variety of sources
-        times = [
-            # ioHub process time
-            self.kb._iohubKeyboard.clock.getTime(),
-            # ioHub time in current process
-            iohub.Computer.global_clock.getTime(),
-            # experiment time
-            globalClock.getTime(),
-        ]
-        # confirm that all values are within 0.001 of eachother
-        avg = sum(times) / len(times)
-        deltas = [abs(t - avg) for t in times]
-        same = [d < 0.001 for d in deltas]
-
-        assert all(same)
 
 
 @pytest.mark.keyboard

--- a/psychopy/tests/test_hardware/test_keyboard_events.py
+++ b/psychopy/tests/test_hardware/test_keyboard_events.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from psychopy import event, core
+from psychopy import event, core, iohub, visual
 from psychopy.preferences import prefs
+from psychopy.hardware import keyboard
 from psychopy.visual import Window
 
 from pyglet.window.key import (MOD_SHIFT,
@@ -93,6 +94,34 @@ class TestKeyboardEvents():
         assert keys[0][1]['shift']
         assert keys[0][1]['scrolllock']
         assert isinstance(keys[0][2], float)
+
+
+class TestIohubKeyboard:
+    def setup(self):
+        self.win = visual.Window()
+        self.ioServer = iohub.launchHubServer(window=self.win)
+        self.kb = keyboard.Keyboard(backend="iohub")
+
+    def test_timestamps(self):
+        # make global clock
+        globalClock = core.Clock()
+        # sync global clock with iohub
+        self.ioServer.syncClock(globalClock)
+        # get time from a variety of sources
+        times = [
+            # ioHub process time
+            self.kb._iohubKeyboard.clock.getTime(),
+            # ioHub time in current process
+            iohub.Computer.global_clock.getTime(),
+            # experiment time
+            globalClock.getTime(),
+        ]
+        # confirm that all values are within 0.001 of eachother
+        avg = sum(times) / len(times)
+        deltas = [abs(t - avg) for t in times]
+        same = [d < 0.001 for d in deltas]
+
+        assert all(same)
 
 
 @pytest.mark.keyboard


### PR DESCRIPTION
Because hardware.Keyboard gets ioHub's offset on init, not on access, it fell out of sync when ioHub's clock resets.