### PR TITLE
BF: add plugins paths to sys.path during psychopy init

### DIFF
--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -42,9 +42,15 @@ if __git_sha__ == 'n/a':
 # update preferences and the user paths
 if 'installing' not in locals():
     from psychopy.preferences import prefs
-    for pathName in prefs.general['paths']:
-        sys.path.append(pathName)
-
+    import pathlib as _pathlib
+    # add paths from user prefs (where they specify custom locations)
+    for _pathName in prefs.general['paths']:
+        sys.path.append(_pathName)
+    # add paths from plugins/packages (installed by plugins manager)
+    for _pathName in _pathlib.Path(prefs.paths['packages']).glob("*"):
+        if _pathName.is_dir():
+            sys.path.append(str(_pathName))
+    
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
 
 if sys.version_info.major < 3:


### PR DESCRIPTION
This means that plugins can be imported without needing scanPlugins() to be called first

We should only need scanPlugins() if we need to change the namespace