### PR TITLE
Fixed MacOS "TypeError: startswith first arg must be bytes..."

### DIFF
--- a/psychopy/iohub/client/__init__.py
+++ b/psychopy/iohub/client/__init__.py
@@ -1342,7 +1342,8 @@ class ioHubConnection():
     def _osxKillAndFreePort(self):
         server_udp_port = self._iohub_server_config.get('udp_port', 9000)
         p = subprocess.Popen(['lsof', '-i:%d'%server_udp_port, '-P'],
-                             stdout=subprocess.PIPE)
+                             stdout=subprocess.PIPE,
+                             encoding='utf-8')
         lines = p.communicate()[0]
         for line in lines.splitlines():
             if line.startswith('Python'):


### PR DESCRIPTION
Something has changed in MacOS (this code hasn't changed in PsychoPy for 9 years) and now this error is raised while PsychoPy tries to check and shut down orphan iohub processes