### PR TITLE
BF: Handle when Static tries to set param of deleted/disabled Component

### DIFF
--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -224,16 +224,18 @@ class StaticComponent(BaseComponent):
             buff.writeIndented(code % self.params['name'])
             # Do updates
             for update in self.updatesList:
-                # update = {'compName':compName,'fieldName':fieldName,
-                #    'routine':routine}
                 compName = update['compName']
                 fieldName = update['fieldName']
-                # routine = self.exp.routines[update['routine']]
+                # get component
                 if hasattr(compName, 'params'):
-                    prms = compName.params  # it's already a compon so get params
+                    comp = compName
                 else:
-                    # it's a name so get compon and then get params
-                    prms = self.exp.getComponentFromName(str(compName)).params
+                    comp = self.exp.getComponentFromName(str(compName))
+                # component may be disabled or otherwise not present - skip it if so
+                if comp is None:
+                    return
+                # get params
+                prms = comp.params  # it's already a compon so get params
                 # If in JS, prepare resources
                 if target == "PsychoJS" and prms[fieldName].valType == "file":
                     # Do resource manager stuff


### PR DESCRIPTION
If you set a param in a Component to be "Update during: <Static Component name>", then its name gets added to said Static's list of Components to update. If you then disable that Component, Static will still try to update it despite it not existing at run time.

Fix is to just skip writing the Param setting code if the Component can't be found.