### PR TITLE
TEST: Add local-only test to generate speed profile for app launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ psychopy/demos/*/*/html
 psychopy/tests/*Out.*
 psychopy/tests/data/*_local.png
 psychopy/tests/fails/*/*
+psychopy/tests/reports/*/*
 psychopy/tests/*htmlcov*
 
 # compile from psychopy/changelog.txt

--- a/psychopy/tests/test_app/test_speed.py
+++ b/psychopy/tests/test_app/test_speed.py
@@ -4,6 +4,7 @@ import numpy
 from pathlib import Path
 
 from ..utils import TESTS_DATA_PATH, TESTS_PATH
+from psychopy.tests import skip_under_vm
 
 import shutil
 from tempfile import mkdtemp
@@ -152,7 +153,7 @@ class TestSpeed:
         dur = finish - start
         return dur
 
-
+@skip_under_vm
 def test_profile():
 
     # --- Run ---

--- a/psychopy/tests/test_app/test_speed.py
+++ b/psychopy/tests/test_app/test_speed.py
@@ -204,7 +204,7 @@ def test_profile():
         processed = ourBusiness.sort_values(col, ascending=False)
         colnm = col.replace('.', '_')
         processed.to_csv(str(REPORTS_PATH / f"profile_by_{colnm}.csv"))
-        output[colnm] = ourBusiness[ourBusiness[col] > ourBusiness[col].quantile(.95)]
+        output[colnm] = processed[processed[col] > processed[col].quantile(.95)]
         output[colnm + "str"] = pd.DataFrame(output[colnm]).to_markdown()
     # save markdown summary
     content = (

--- a/psychopy/tests/test_app/test_speed.py
+++ b/psychopy/tests/test_app/test_speed.py
@@ -18,7 +18,6 @@ import cProfile
 import pstats
 import io
 import pandas as pd
-import tabulate
 
 from ... import logging
 
@@ -201,6 +200,7 @@ def test_profile():
         'total': stop - start,
     }
     # store table variants
+    import tabulate
     for col in ("tottime", "cumtime", "percall", "percall.1"):
         processed = ourBusiness.sort_values(col, ascending=False)
         colnm = col.replace('.', '_')

--- a/psychopy/tests/test_app/test_speed.py
+++ b/psychopy/tests/test_app/test_speed.py
@@ -152,8 +152,9 @@ class TestSpeed:
         dur = finish - start
         return dur
 
+
 @skip_under_vm
-def test_profile():
+def profile_app():
 
     # --- Run ---
 
@@ -200,7 +201,6 @@ def test_profile():
         'total': stop - start,
     }
     # store table variants
-    import tabulate
     for col in ("tottime", "cumtime", "percall", "percall.1"):
         processed = ourBusiness.sort_values(col, ascending=False)
         colnm = col.replace('.', '_')


### PR DESCRIPTION
Saves some handy CSV files and a markdown summary in tests->reports->test_speed

Written for use locally, would probably stall the vm test suite