### PR TITLE
ENH: Speed up app by using faster string tools for labels and methods

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -33,7 +33,6 @@ from ..pavlovia_ui.search import SearchFrame
 from ..pavlovia_ui.user import UserFrame
 from ...experiment import getAllElements, getAllCategories
 from ...experiment.routines import Routine, BaseStandaloneRoutine
-from ...tools.stringtools import prettyname
 
 try:
     import markdown_it as md
@@ -66,7 +65,7 @@ from ..utils import (BasePsychopyToolbar, HoverButton, WindowFrozen,
 from psychopy.experiment import getAllStandaloneRoutines
 from psychopy.app import pavlovia_ui
 from psychopy.projects import pavlovia
-
+from psychopy.tools import stringtools as st
 from psychopy.scripts.psyexpCompile import generateScript
 
 # _localized separates internal (functional) from displayed strings
@@ -2671,11 +2670,16 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             self.parent = parent
             self.component = comp
             self.category = cat
-            # Get a shorter, title case version of component name
+            # construct label
             label = name
+            # remove "Component" from the end
             for redundant in ['component', 'Component', "ButtonBox"]:
                 label = label.replace(redundant, "")
-            label = prettyname(label, wrap=10)
+            # convert to title case
+            label = st.CaseSwitcher.pascal2title(label)
+            # wrap
+            label = st.wrap(label, 10)
+
             # Make button
             wx.Button.__init__(self, parent, wx.ID_ANY,
                                label=label, name=name,
@@ -2799,11 +2803,15 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             self.parent = parent
             self.routine = rt
             self.category = cat
-            # Get a shorter, title case version of routine name
+            # construct label
             label = name
+            # remove "Routine" from the end
             for redundant in ['routine', 'Routine', "ButtonBox"]:
                 label = label.replace(redundant, "")
-            label = prettyname(label, wrap=10)
+            # convert to title case
+            label = st.CaseSwitcher.pascal2title(label)
+            # wrap
+            label = st.wrap(label, 10)
             # Make button
             wx.Button.__init__(self, parent, wx.ID_ANY,
                                label=label, name=name,

--- a/psychopy/tests/test_tools/test_attributetools.py
+++ b/psychopy/tests/test_tools/test_attributetools.py
@@ -6,7 +6,7 @@ import scipy.stats as sp
 from psychopy.tests import skip_under_vm
 from psychopy import colors
 from psychopy.tools.attributetools import attributeSetter, logAttrib
-from psychopy.tools.stringtools import makeValidVarName
+from psychopy.tools.stringtools import CaseSwitcher
 
 
 pd.options.display.float_format = "{:,.0f}".format
@@ -245,13 +245,13 @@ def testGetSetAliases():
             if not isinstance(func, (attributeSetter, property)):
                 continue
             # work out getter method name
-            getterName = "get" + makeValidVarName(name, case="title")
+            getterName = "get" + CaseSwitcher.camel2pascal(name)
             # ensure that the corresponding get function exists
             assert hasattr(cls, getterName), f"Class '{cls.__name__}' has not attribute '{getterName}'"
             # any non-settable properties are now done
             if isinstance(func, property) and func.fset is None:
                 continue
             # work out setter method name
-            setterName = "set" + makeValidVarName(name, case="title")
+            setterName = "set" + CaseSwitcher.camel2pascal(name)
             # ensure that the corresponding set function exists
             assert hasattr(cls, setterName), f"Class '{cls.__name__}' has not attribute '{setterName}'"

--- a/psychopy/tests/test_tools/test_stringtools.py
+++ b/psychopy/tests/test_tools/test_stringtools.py
@@ -8,18 +8,17 @@ import pytest
 @pytest.mark.stringtools
 def test_name_wrap():
     exemplars = [
-        {"text": "Hello There", "wrap": 10, "ans": "Hello There"},  # No wrap
-        {"text": "Hello There", "wrap": 6, "ans": "Hello\nThere"},  # Basic wrap
-        {"text": "Hello There Hello There Hello There", "wrap": 11, "ans": "Hello There\nHello There\nHello There"},  # Multiple wraps
+        {"text": "Hello There", "wrap": 12, "ans": "Hello There"},  # No wrap
+        {"text": "Hello There", "wrap": 8, "ans": "Hello \nThere"},  # Basic wrap
+        {"text": "Hello There Hello There Hello There", "wrap": 11, "ans": "Hello There \nHello There \nHello There"},  # Multiple wraps
     ]
     tykes = [
-        {"text": "Eyetracker Calibration", "wrap": 10, "ans": "Eyetracker\nCalibration"},  # One word longer than wrap length
-        {"text": "EyetrackerCalibration", "wrap": 10, "ans": "Eyetracker\nCalibration"},  # TitleCase
-        {"text": "Hello There", "wrap": 1, "ans": "Hello\nThere"},  # Wrap = 1
-        {"text": "Hello There", "wrap": 0, "ans": "Hello There"},  # Wrap = 0
+        {"text": "Eyetracker Calibration", "wrap": 10, "ans": "Eyetracker \nCalibration"},  # One word longer than wrap length
+        {"text": "Hello There", "wrap": 1, "ans": "Hello \nThere"},  # Wrap = 1
+        {"text": "Hello There", "wrap": 0, "ans": "Hello \nThere"},  # Wrap = 0
     ]
     for case in exemplars + tykes:
-        assert tools.prettyname(case['text'], case['wrap']) == case['ans']
+        assert tools.wrap(case['text'], case['wrap']) == case['ans']
 
 
 @pytest.mark.stringtools

--- a/psychopy/tests/test_tools/test_stringtools.py
+++ b/psychopy/tests/test_tools/test_stringtools.py
@@ -104,3 +104,33 @@ def test_make_valid_name():
 
     for case in cases:
         assert tools.makeValidVarName(name=case['in'], case=case['case']) == case['out']
+
+
+def test_CaseSwitcher():
+
+    cases = [
+        # already valid names
+        {'fcn': "pascal2camel", 'in': "alreadyValidCamel", 'out': "alreadyValidCamel"},
+        {'fcn': "title2camel", 'in': "alreadyValidCamel", 'out': "alreadyValidCamel"},
+        {'fcn': "camel2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
+        {'fcn': "title2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
+        {'fcn': "camel2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
+        {'fcn': "pascal2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
+        # to camel
+        {'fcn': "pascal2camel", 'in': "MakeCamel", 'out': "makeCamel"},
+        {'fcn': "title2camel", 'in': "Make Camel", 'out': "makeCamel"},
+        # to pascal
+        {'fcn': "camel2pascal", 'in': "makePascal", 'out': "MakePascal"},
+        {'fcn': "title2pascal", 'in': "Make Pascal", 'out': "MakePascal"},
+        # to title
+        {'fcn': "camel2title", 'in': "makeTitle", 'out': "Make Title"},
+        {'fcn': "pascal2title", 'in': "MakeTitle", 'out': "Make Title"},
+    ]
+
+    for case in cases:
+        # get function
+        fcn = getattr(tools.CaseSwitcher, case['fcn'])
+        # call function
+        case['result'] = fcn(case['in'])
+        # check result
+        assert case['result'] == case['out'], "CaseSwitcher.{fcn}({in}) should be {out}, was {result}.".format(case)

--- a/psychopy/tests/test_tools/test_stringtools.py
+++ b/psychopy/tests/test_tools/test_stringtools.py
@@ -109,22 +109,34 @@ def test_make_valid_name():
 def test_CaseSwitcher():
 
     cases = [
-        # already valid names
+        # to camel
         {'fcn': "pascal2camel", 'in': "alreadyValidCamel", 'out': "alreadyValidCamel"},
         {'fcn': "title2camel", 'in': "alreadyValidCamel", 'out': "alreadyValidCamel"},
-        {'fcn': "camel2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
-        {'fcn': "title2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
-        {'fcn': "camel2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
-        {'fcn': "pascal2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
-        # to camel
+        {'fcn': "snake2camel", 'in': "alreadyValidCamel", 'out': "alreadyValidCamel"},
         {'fcn': "pascal2camel", 'in': "MakeCamel", 'out': "makeCamel"},
         {'fcn': "title2camel", 'in': "Make Camel", 'out': "makeCamel"},
+        {'fcn': "snake2camel", 'in': "make_camel", 'out': "makeCamel"},
         # to pascal
+        {'fcn': "camel2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
+        {'fcn': "title2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
+        {'fcn': "snake2pascal", 'in': "AlreadyValidPascal", 'out': "AlreadyValidPascal"},
         {'fcn': "camel2pascal", 'in': "makePascal", 'out': "MakePascal"},
         {'fcn': "title2pascal", 'in': "Make Pascal", 'out': "MakePascal"},
+        {'fcn': "snake2pascal", 'in': "make_pascal", 'out': "MakePascal"},
         # to title
+        {'fcn': "camel2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
+        {'fcn': "pascal2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
+        {'fcn': "snake2title", 'in': "Already Valid Title", 'out': "Already Valid Title"},
         {'fcn': "camel2title", 'in': "makeTitle", 'out': "Make Title"},
         {'fcn': "pascal2title", 'in': "MakeTitle", 'out': "Make Title"},
+        {'fcn': "snake2title", 'in': "make_title", 'out': "Make Title"},
+        # to snake
+        {'fcn': "camel2snake", 'in': "already_valid_snake", 'out': "already_valid_snake"},
+        {'fcn': "pascal2snake", 'in': "already_valid_snake", 'out': "already_valid_snake"},
+        {'fcn': "title2snake", 'in': "already_valid_snake", 'out': "already_valid_snake"},
+        {'fcn': "camel2snake", 'in': "makeSnake", 'out': "make_snake"},
+        {'fcn': "pascal2snake", 'in': "MakeSnake", 'out': "make_snake"},
+        {'fcn': "title2snake", 'in': "Make Snake", 'out': "make_snake"},
     ]
 
     for case in cases:
@@ -133,4 +145,4 @@ def test_CaseSwitcher():
         # call function
         case['result'] = fcn(case['in'])
         # check result
-        assert case['result'] == case['out'], "CaseSwitcher.{fcn}({in}) should be {out}, was {result}.".format(case)
+        assert case['result'] == case['out'], "CaseSwitcher.{fcn}({in}) should be {out}, was {result}.".format(**case)

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -11,7 +11,7 @@
 import numpy
 from psychopy import logging
 from functools import partialmethod
-from psychopy.tools.stringtools import makeValidVarName
+from psychopy.tools.stringtools import CaseSwitcher
 
 
 class attributeSetter:
@@ -182,7 +182,7 @@ class AttributeGetSetMixin:
             if not isinstance(func, (attributeSetter, property)):
                 continue
             # work out getter method name
-            getterName = "get" + makeValidVarName(name, case="title")
+            getterName = "get" + CaseSwitcher.camel2pascal(name)
             # ignore any which already have a getter method
             if not hasattr(cls, getterName):
                 # create a pre-populated caller for getattr
@@ -193,7 +193,7 @@ class AttributeGetSetMixin:
             if isinstance(func, property) and func.fset is None:
                 continue
             # work out setter method name
-            setterName = "set" + makeValidVarName(name, case="title")
+            setterName = "set" + CaseSwitcher.camel2pascal(name)
             # ignore any which already have a setter method
             if not hasattr(cls, setterName):
                 # create a pre-populated caller for setAttribute

--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -11,8 +11,6 @@
 import re
 import ast
 
-__all__ = ["prettyname"]
-
 # Regex for identifying a valid Pavlovia project name
 import urllib
 from pathlib import Path
@@ -352,39 +350,6 @@ def makeValidVarName(name, case="camel"):
     if core:
         # If styled like a core variable (e.g. __file__), append __
         name = name + "__"
-    return name
-
-
-
-def prettyname(name, wrap=False):
-    """Convert a camelCase, TitleCase or underscore_delineated title to Full Title Case"""
-    # Replace _ with space
-    name = name.replace("_", " ")
-    # Put a space before any capital letter, apart from at the beginning, or already after a space
-    name = name[0] + re.sub('(?<![ -.])([A-Z])', r' \1', name[1:])
-    # Capitalise first letter of each word
-    name = name.title()
-    # Treat the word "PsychoPy" as a special case
-    name = name.replace("Psycho Py", "PsychoPy")
-    # Split into multiple lines if wrap is requested
-    if wrap:
-        sentence = []
-        letter = 0
-        # Iterate through each word
-        for n, word in enumerate(name.split(" ")):
-            # Count its letters
-            letter += len(word)
-            if letter > wrap and n > 0:
-                # If this brings the current letters this line to more than the wrap limit, insert a line break
-                sentence.append("\n")
-                letter = len(word)
-            # Insert word
-            sentence.append(word)
-        # Recombine name
-        name = " ".join(sentence)
-        # Remove spaces after line
-        name = re.sub(r" *\n *", "\n", name)
-
     return name
 
 

--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -57,6 +57,94 @@ def is_file(source):
     return isFile
 
 
+class CaseSwitcher:
+    """
+    Collection of static methods for switching case in strings. Can currently convert between:
+    - camelCase
+    - PascalCase
+    - Title Case
+    """
+
+    @staticmethod
+    def camel2pascal(value):
+        """
+        Convert from camelCase to PascalCase
+        """
+        # capitalise first letter
+        value = value[0].upper() + value[1:]
+
+        return value
+
+    @staticmethod
+    def camel2title(value):
+        """
+        Convert from camelCase to Title Case
+        """
+        # convert to pascal
+        value = CaseSwitcher.camel2pascal(value)
+        # convert to title
+        value = CaseSwitcher.pascal2title(value)
+
+        return value
+
+    @staticmethod
+    def pascal2camel(value):
+        """
+        Convert from PascalCase to camelCase
+        """
+        # decapitalise first letter
+        value = value[0].lower() + value[1:]
+
+        return value
+
+    @staticmethod
+    def pascal2title(value):
+        """
+        Convert from PascalCase to Title Case
+        """
+        def _titleize(match):
+            """
+            Replace a regex match for a lowercase letter followed by an uppercase letter with the same two letters, in
+            uppercase, with a space inbetween.
+            """
+            # get matching text (should be a lower case letter then an upper case letter)
+            txt = match[0]
+            # add a space
+            txt = txt[0] + " " + txt[1]
+
+            return txt
+        # make regex substitution
+        value = re.sub(
+            pattern=r"([a-z][A-Z])",
+            repl=_titleize,
+            string=value
+        )
+
+        return value
+
+    @staticmethod
+    def title2camel(value):
+        """
+        Convert from PascalCase to camelCase
+        """
+        # convert to pascal
+        value = CaseSwitcher.title2pascal(value)
+        # convert to camel
+        value = CaseSwitcher.pascal2camel(value)
+
+        return value
+
+    @staticmethod
+    def title2pascal(value):
+        """
+        Convert from PascalCase to Title Case
+        """
+        # remove spaces
+        value = value.replace(" ", "")
+
+        return value
+
+
 def makeValidVarName(name, case="camel"):
     """
     Transform a string into a valid variable name

--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -232,6 +232,41 @@ class CaseSwitcher:
         return value
 
 
+def wrap(value, chars, delim=r"\s"):
+    """
+    Wrap a string at a number of characters.
+
+    Parameters
+    ----------
+    value : str
+        String to wrap
+    chars : int
+        Number of characters to split at
+    delim : str
+        Regex string delimeter to split words at, default is a space (r"\s")
+
+    Returns
+    -------
+    str
+        Wrapped string
+    """
+    newValue = ""
+    letter = 0
+    # iterate through each word
+    for n, word in enumerate(re.split(pattern=r"(" + delim + r")", string=value)):
+        # count its letters
+        letter += len(word)
+        # if this brings the current letters this line to more than the wrap limit, insert a line break
+        if letter > chars and n > 0 and not re.match(pattern=delim, string=word):
+            newValue += "\n"
+            letter = len(word)
+
+        # insert word
+        newValue += word
+
+    return newValue
+
+
 def makeValidVarName(name, case="camel"):
     """
     Transform a string into a valid variable name

--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -88,6 +88,18 @@ class CaseSwitcher:
         return value
 
     @staticmethod
+    def camel2snake(value):
+        """
+        Convert from camelCase to snake_case
+        """
+        # convert to title
+        value = CaseSwitcher.camel2title(value)
+        # convert to snake
+        value = CaseSwitcher.title2snake(value)
+
+        return value
+
+    @staticmethod
     def pascal2camel(value):
         """
         Convert from PascalCase to camelCase
@@ -123,9 +135,21 @@ class CaseSwitcher:
         return value
 
     @staticmethod
+    def pascal2snake(value):
+        """
+        Convert from PascalCase to snake_case
+        """
+        # convert to title
+        value = CaseSwitcher.pascal2title(value)
+        # convert to snake
+        value = CaseSwitcher.title2snake(value)
+
+        return value
+
+    @staticmethod
     def title2camel(value):
         """
-        Convert from PascalCase to camelCase
+        Convert from Title Case to camelCase
         """
         # convert to pascal
         value = CaseSwitcher.title2pascal(value)
@@ -137,10 +161,73 @@ class CaseSwitcher:
     @staticmethod
     def title2pascal(value):
         """
-        Convert from PascalCase to Title Case
+        Convert from Title Case to PascalCase
         """
         # remove spaces
         value = value.replace(" ", "")
+
+        return value
+
+    @staticmethod
+    def title2snake(value):
+        """
+        Convert from Title Case to snake_case
+        """
+        # lowercase
+        value = value.lower()
+        # replace spaces with underscores
+        value = value.replace(" ", "_")
+
+        return value
+
+    @staticmethod
+    def snake2camel(value):
+        """
+        Convert from snake_case to camelCase
+        """
+        # convert to pascal
+        value = CaseSwitcher.snake2pascal(value)
+        # convert to camel
+        value = CaseSwitcher.pascal2camel(value)
+
+        return value
+
+    @staticmethod
+    def snake2pascal(value):
+        """
+        Convert from snake_case to PascalCase
+        """
+        # convert to title
+        value = CaseSwitcher.snake2title(value)
+        # convert to pascal
+        value = CaseSwitcher.title2pascal(value)
+
+        return value
+
+    @staticmethod
+    def snake2title(value):
+        """
+        Convert from snake_case to Title Case
+        """
+        def _titleize(match):
+            """
+            Replace a regex match for a lowercase letter followed by an uppercase letter with the same two letters, in
+            uppercase, with a space inbetween.
+            """
+            # get matching text (should be a lower case letter then an upper case letter)
+            txt = match[0]
+            # add a space and capitalise
+            txt = " " + txt[1].upper()
+
+            return txt
+        # make regex substitution
+        value = re.sub(
+            pattern=r"(_[a-z])",
+            repl=_titleize,
+            string=value
+        )
+        # capitalise first letter
+        value = value[0].upper() + value[1:]
 
         return value
 


### PR DESCRIPTION
Profiling the app (see #5825) revealed that `makeValidVarName` contributed to some of the slowness on app launch.

The function is still needed for working out the name to give to a microphone/camera/serial device object, but because it also guesses the case of a word and does a slower-but-general conversion, using it to convert e.g. our own attribute names (which we already know are camelCase) meant unnecessary overhead. Replacing it with faster, specific functions should reduce load time.