### PR TITLE
RF: Deprecate use of _localized

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -69,31 +69,6 @@ from psychopy.projects import pavlovia
 
 from psychopy.scripts.psyexpCompile import generateScript
 
-# _localized separates internal (functional) from displayed strings
-# long form here allows poedit string discovery
-_localized = {
-    'Field': _translate('Field'),
-    'Default': _translate('Default'),
-    'Favorites': _translate('Favorites'),
-    'Stimuli': _translate('Stimuli'),
-    'Responses': _translate('Responses'),
-    'Custom': _translate('Custom'),
-    'I/O': _translate('I/O'),
-    'Add to favorites': _translate('Add to favorites'),
-    'Remove from favorites': _translate('Remove from favorites'),
-    # contextMenuLabels
-    'edit': _translate('edit'),
-    'remove': _translate('remove'),
-    'copy': _translate('copy'),
-    'paste above': _translate('paste above'),
-    'paste below': _translate('paste below'),
-    'move to top': _translate('move to top'),
-    'move up': _translate('move up'),
-    'move down': _translate('move down'),
-    'move to bottom': _translate('move to bottom')
-}
-
-
 # Components which are always hidden
 alwaysHidden = [
     'SettingsComponent', 'RoutineSettingsComponent', 'UnknownComponent', 'UnknownRoutine', 'UnknownStandaloneRoutine', 'UnknownPluginComponent'
@@ -1748,12 +1723,20 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
         self.lastpos = (0, 0)
         # use the ID of the drawn icon to retrieve component name:
         self.componentFromID = {}
-        self.contextMenuItems = [
-            'copy', 'paste above', 'paste below', 'edit', 'remove',
-            'move to top', 'move up', 'move down', 'move to bottom']
-        # labels are only for display, and allow localization
-        self.contextMenuLabels = {k: _localized[k]
-                                  for k in self.contextMenuItems}
+        # define context menu items and labels
+        self.contextMenuLabels = {
+            'copy': _translate("Copy"),
+            'paste above': _translate("Paste above"),
+            'paste below': _translate("Paste below"),
+            'edit': _translate("Edit"),
+            'remove': _translate("Remove"),
+            'move to top': _translate("Move to top"),
+            'move up': _translate("Move up"),
+            'move down': _translate("Move down"),
+            'move to bottom': _translate("Move to bottom"),
+        }
+        self.contextMenuItems = list(self.contextMenuLabels)
+
         self.contextItemFromID = {}
         self.contextIDFromItem = {}
         for item in self.contextMenuItems:
@@ -2756,13 +2739,13 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             menu = wx.Menu()
             if faveLevels[self.component.__name__] > ComponentsPanel.faveThreshold:
                 # If is in favs
-                msg = "Remove from favorites"
+                msg = _translate("Remove from favorites")
                 fun = self.removeFromFavorites
             else:
                 # If is not in favs
-                msg = "Add to favorites"
+                msg = _translate("Add to favorites")
                 fun = self.addToFavorites
-            btn = menu.Append(wx.ID_ANY, _localized[msg])
+            btn = menu.Append(wx.ID_ANY, msg)
             menu.Bind(wx.EVT_MENU, fun, btn)
             # Show as popup
             self.PopupMenu(menu, evt.GetPosition())

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -41,8 +41,6 @@ from ...themes import handlers, icons
 white = wx.Colour(255, 255, 255, 255)
 codeSyntaxOkay = wx.Colour(220, 250, 220, 255)  # light green
 
-from ..localizedStrings import _localizedDialogs as _localized
-
 
 class ParamCtrls():
 
@@ -266,7 +264,7 @@ class ParamCtrls():
             self.valueCtrl.SetValidator(NameValidator())
         elif param.inputType in ("single", "multi"):
             # only want anything that is valType code, or can be with $
-            self.valueCtrl.SetValidator(CodeSnippetValidator(fieldName))
+            self.valueCtrl.SetValidator(CodeSnippetValidator(fieldName, param.label))
 
         # create the type control
         if len(param.allowedTypes):
@@ -279,9 +277,14 @@ class ParamCtrls():
                 self.typeCtrl.Disable()  # visible but can't be changed
 
         # create update control
+        _localizedUpdateLbls = {
+            'constant': _translate('constant'),
+            'set every repeat': _translate('set every repeat'),
+            'set every frame': _translate('set every frame'),
+        }
         if param.allowedUpdates is not None and len(param.allowedUpdates):
             # updates = display-only version of allowed updates
-            updateLabels = [_localized[upd] for upd in param.allowedUpdates]
+            updateLabels = [_localizedUpdateLbls.get(upd, upd) for upd in param.allowedUpdates]
             # allowedUpdates = extend version of allowed updates that includes
             # "set during:static period"
             allowedUpdates = copy.copy(param.allowedUpdates)

--- a/psychopy/app/builder/dialogs/dlgsCode.py
+++ b/psychopy/app/builder/dialogs/dlgsCode.py
@@ -400,7 +400,7 @@ class DlgCodeComponentProperties(wx.Dialog):
             sizer.Add(pyBox, 1, wx.EXPAND, 2)
             sizer.Add(jsBox, 1, wx.EXPAND, 2)
             panel.SetSizer(sizer)
-            tabLabel = _translate(tabName)
+            tabLabel = self.params.get(pyName).label
             # Add a visual indicator when tab contains code
             emptyCodeComp = CodeComponent('', '') # Spawn empty code component
             # If code tab is not empty and not the same as in empty code component, add an asterisk to tab name

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -23,7 +23,6 @@ import re
 from pathlib import Path
 
 from . import CodeBox
-from ..localizedStrings import _localizedDialogs as _localized
 from ...coder import BaseCodeEditor
 from ...themes import icons, handlers
 from ... import utils
@@ -368,10 +367,6 @@ class ChoiceCtrl(wx.Choice, _ValidatorMixin, _HideMixin):
             else:
                 _labels[value] = value
         labels = _labels
-        # Translate labels
-        for v, l in labels.items():
-            if l in _localized:
-                labels[v] = _localized[l]
         # store labels and choices
         self.labels = labels
         self.choices = choices

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -13,7 +13,6 @@ import psychopy.experiment.utils
 from psychopy.tools import stringtools
 from psychopy.localization import _translate
 from . import experiment
-from .localizedStrings import _localized
 from pkg_resources import parse_version
 from psychopy.tools.fontmanager import FontManager
 
@@ -414,18 +413,15 @@ class CodeSnippetValidator(BaseValidator):
     @see: _BaseParamsDlg
     """
 
-    def __init__(self, fieldName):
+    def __init__(self, fieldName, displayName=None):
         super(CodeSnippetValidator, self).__init__()
         self.fieldName = fieldName
-        try:
-            self.displayName = _localized[fieldName]
-        except KeyError:
-            # should have all _localized[fieldName] from .localizedStrings
-            # might as well try to do something useful if fail:
-            self.displayName = _translate(fieldName)
+        if displayName is None:
+            displayName = fieldName
+        self.displayName = displayName
 
     def Clone(self):
-        return self.__class__(self.fieldName)
+        return self.__class__(self.fieldName, self.displayName)
 
     def check(self, parent):
         """Checks python syntax of code snippets, and for self-reference.

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -79,14 +79,6 @@ try:  # needed for wx.py shell
 except Exception:
     haveCode = False
 
-_localized = {'basic': _translate('basic'),
-              'input': _translate('input'),
-              'stimuli': _translate('stimuli'),
-              'experiment control': _translate('exp control'),
-              'iohub': 'ioHub',  # no translation
-              'hardware': _translate('hardware'),
-              'timing': _translate('timing'),
-              'misc': _translate('misc')}
 
 def toPickle(filename, data):
     """save data (of any sort) as a pickle file

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -20,164 +20,6 @@ from psychopy import sound
 from psychopy.app.utils import getSystemFonts
 import collections
 
-# labels mappings for display:
-_localized = {
-    # category labels
-    'General': _translate('General'),
-    'Application': _translate('Application'),
-    'Key Bindings': _translate('Key Bindings'),
-    'Hardware': _translate('Hardware'),
-    'Connections': _translate('Connections'),
-    # section labels
-    'general': _translate('general'),
-    'app': _translate('app'),
-    'builder': "Builder",  # not localized
-    'coder': "Coder",  # not localized
-    'runner': "Runner",  # not localized
-    'hardware': _translate('Hardware'),
-    'connections': _translate('Connections'), # not 'connections'
-    'keyBindings': _translate('Key Bindings'), # not 'keyBindings'
-    # pref labels in General section
-    'winType': _translate("window type"),
-    'units': _translate("units"),
-    'fullscr': _translate("full-screen"),
-    'allowGUI': _translate("allow GUI"),
-    'paths': _translate('paths'),
-    'flac': _translate('flac audio compression'),
-    'shutdownKey': _translate("shutdown key"),
-    'shutdownKeyModifiers': _translate("shutdown key modifier keys"),
-    'gammaErrorPolicy': _translate("gammaErrorPolicy"),
-    'startUpPlugins': _translate("start up plugins"),
-    'appKeyGoogleCloud':_translate('appKeyGoogleCloud'),
-    'transcrKeyAzure':_translate('transcrKeyAzure'),
-    # pref labels in App section
-    'showStartupTips': _translate("show start-up tips"),
-    'defaultView': _translate("default view"),
-    'resetPrefs': _translate('reset preferences'),
-    'autoSavePrefs': _translate('auto-save prefs'),
-    'debugMode': _translate('debug mode'),
-    'locale': _translate('locale'),
-    'errorDialog': _translate('error dialog'),
-    'theme': _translate('theme'),
-    # pref labels in Builder section
-    'reloadPrevExp': _translate('reload previous exp'),
-    'codeComponentLanguage': _translate('Code component language'),
-    'unclutteredNamespace': _translate('uncluttered namespace'),
-    'componentsFolders': _translate('components folders'),
-    'componentFilter':_translate('componentFilter'),
-    'hiddenComponents': _translate('hidden components'),
-    'unpackedDemosDir': _translate('unpacked demos dir'),
-    'savedDataFolder': _translate('saved data folder'),
-    'builderLayout': _translate('Builder layout'),
-    'alwaysShowReadme': _translate('always show readme'),
-    'maxFavorites': _translate('max favorites'),
-    'confirmRoutineClose': _translate('confirmRoutineClose'),
-    # pref labels in Coder section
-    'readonly': _translate('read-only'),
-    'outputFont': _translate('output font'),
-    'codeFont': _translate('code font'),
-    'outputFontSize': _translate('output font size'),
-    'codeFontSize': _translate('code font size'),
-    'lineSpacing': _translate('lineSpacing'),
-    'edgeGuideColumn': _translate('edgeGuideColumn'),
-    'showSourceAsst': _translate('show source asst'),
-    'showOutput': _translate('show output'),
-    'autocomplete': _translate('auto complete'),
-    'reloadPrevFiles': _translate('reload previous files'),
-    'preferredShell': _translate('preferred shell'),
-    # pref labels in KeyBindings section
-    'open': _translate('open'),
-    'new': _translate('new'),
-    'save': _translate('save'),
-    'saveAs': _translate('save as'),
-    'print': _translate('print'),
-    'close': _translate('close'),
-    'quit': _translate('quit'),
-    'preferences': _translate('preferences'),
-    'exportHTML': _translate('export HTML'),
-    'cut': _translate('cut'),
-    'copy': _translate('copy'),
-    'paste': _translate('paste'),
-    'duplicate': _translate('duplicate'),
-    'indent': _translate('indent'),
-    'dedent': _translate('dedent'),
-    'smartIndent': _translate('smart indent'),
-    'find': _translate('find'),
-    'findAgain': _translate('find again'),
-    'undo': _translate('undo'),
-    'redo': _translate('redo'),
-    'comment': _translate('comment'),
-    'uncomment': _translate('uncomment'),
-    'toggle comment': _translate('toggle comment'),
-    'fold': _translate('fold'),
-    'enlargeFont': _translate('enlarge Font'),
-    'shrinkFont': _translate('shrink Font'),
-    'analyseCode': _translate('analyze code'),
-    'compileScript': _translate('compile script'),
-    'runScript': _translate('run script'),
-    'runnerScript': _translate('runner script'),
-    'stopScript': _translate('stop script'),
-    'toggleWhitespace': _translate('toggle whitespace'),
-    'toggleEOLs': _translate('toggle EOLs'),
-    'toggleIndentGuides': _translate('toggle indent guides'),
-    'newRoutine': _translate('new Routine'),
-    'copyRoutine': _translate('copy Routine'),
-    'pasteRoutine': _translate('paste Routine'),
-    'pasteCompon': _translate('paste Component'),
-    'toggleOutputPanel': _translate('toggle output panel'),
-    'renameRoutine': _translate('rename Routine'),
-    'cycleWindows': _translate('cycle windows'),
-    'largerFlow': _translate('larger Flow'),
-    'smallerFlow': _translate('smaller Flow'),
-    'largerRoutine': _translate('larger routine'),
-    'smallerRoutine': _translate('smaller routine'),
-    'toggleReadme': _translate('toggle readme'),
-    'pavlovia_logIn': _translate('login to pavlovia'),
-    'OSF_logIn': _translate('login to OSF'),
-    'projectsSync': _translate('sync projects'),
-    'projectsFind': _translate('find projects'),
-    'projectsOpen': _translate('open projects'),
-    'projectsNew': _translate('new projects'),
-    # pref labels in Hardware section
-    'audioLib': _translate("audio library"),
-    'audioLatencyMode': _translate("audio latency mode"),
-    'audioDriver': _translate("audio driver"),
-    'audioDevice': _translate("audio device"),
-    'parallelPorts': _translate("parallel ports"),
-    'qmixConfiguration': _translate("Qmix configuration"),
-    'highDPI': _translate('Try to support display high DPI'),
-    # pref labels in Connections section
-    'proxy': _translate('proxy'),
-    'autoProxy': _translate('auto-proxy'),
-    'allowUsageStats': _translate('allow usage stats'),
-    'checkForUpdates': _translate('check for updates'),
-    'timeout': _translate('timeout'),
-    # pref wxChoice lists:
-    'all': _translate('Builder, Coder and Runner'),
-    'keep': _translate('same as in the file'),  # line endings
-    'abort': _translate('abort'), # gammaErrorPolicy
-    'warn': _translate('warn'), # gammaErrorPolicy
-    # not translated:
-    'pix': 'pix',
-    'deg': 'deg',
-    'cm': 'cm',
-    'norm': 'norm',
-    'height': 'height',
-    'pyshell': 'pyshell',
-    'iPython': 'iPython',
-    # obsolete labels
-    'largeIcons': _translate("large icons"),
-    'darkMode': _translate("dark mode"),
-    'highDPI': _translate('highDPI'),
-    'commentFont': _translate('comment font'),
-    'switchToBuilder': _translate('switch to Builder'),
-    'switchToCoder': _translate('switch to Coder'),
-    'switchToRunner': _translate('switch to Runner'),
-    'projectsLogIn': _translate('login to projects'),
-    'useRunner': _translate("use Runner"),
-}
-# add pre-translated names-of-langauges, for display in locale pref:
-_localized.update(localization.locname)
 
 audioLatencyLabels = {0: _translate('Latency not important'),
                       1: _translate('Share low-latency driver'),
@@ -267,7 +109,7 @@ class PrefPropGrid(wx.Panel):
                                     list(sections))
         self.pageNames[name] = self.pageIdx
         self.lstPrefPages.InsertItem(
-            self.lstPrefPages.GetItemCount(), _localized[label], self.pageIdx)
+            self.lstPrefPages.GetItemCount(), label, self.pageIdx)
 
         self.pageIdx += 1
 
@@ -389,7 +231,7 @@ class PrefPropGrid(wx.Panel):
             pagePtr.Clear()
 
             for s in sections:
-                _ = pagePtr.Append(pg.PropertyCategory(_localized[s], s))
+                _ = pagePtr.Append(pg.PropertyCategory(s, s))
                 for name, prop in self.sections[s].items():
                     if name in prefs.legacy:
                         # If this is included in the config file only for legacy, don't show it
@@ -479,18 +321,18 @@ class PreferencesDlg(wx.Dialog):
 
         # add property pages to the manager
         self.proPrefs.addPage(
-            'General', 'general', ['general'],
+            _translate('General'), 'general', ['general'],
             'preferences-general')
         self.proPrefs.addPage(
-            'Application', 'app', ['app', 'builder', 'coder'],
+            _translate('Application'), 'app', ['app', 'builder', 'coder'],
             'preferences-app')
         self.proPrefs.addPage(
-            'Key Bindings', 'keyBindings', ['keyBindings'],
+            _translate('Key Bindings'), 'keyBindings', ['keyBindings'],
             'preferences-keyboard')
         self.proPrefs.addPage(
-            'Hardware', 'hardware', ['hardware'], 'preferences-hardware')
+            _translate('Hardware'), 'hardware', ['hardware'], 'preferences-hardware')
         self.proPrefs.addPage(
-            'Connections', 'connections', ['connections'],
+            _translate('Connections'), 'connections', ['connections'],
             'preferences-conn')
         self.proPrefs.populateGrid()
 
@@ -593,10 +435,7 @@ class PreferencesDlg(wx.Dialog):
                         thisPref = thisPref.replace('Ctrl+', 'Cmd+')
 
                 # can we translate this pref?
-                try:
-                    pLabel = _localized[prefName]
-                except Exception:
-                    pLabel = prefName
+                pLabel = prefName
 
                 # get tooltips from comment lines from the spec, as parsed by
                 # configobj
@@ -649,8 +488,7 @@ class PreferencesDlg(wx.Dialog):
                         # set default locale ''
                         default = locales.index('')
                     # '' must be appended after other labels are translated
-                    labels = [_translate('system locale')] + [_localized[i] 
-                                     for i in self.app.localization.available]
+                    labels = [_translate('system locale') + i for i in self.app.localization.available]
                     self.proPrefs.addEnumItem(
                             sectionName,
                             pLabel,
@@ -738,10 +576,7 @@ class PreferencesDlg(wx.Dialog):
 
                     labels = []  # display only
                     for opt in options:
-                        try:
-                            labels.append(_localized[opt])
-                        except Exception:
-                            labels.append(opt)
+                        labels.append(opt)
 
                     self.proPrefs.addEnumItem(
                             sectionName,
@@ -832,12 +667,8 @@ class PreferencesDlg(wx.Dialog):
                             newVal = eval(thisPref)
                     except Exception:
                         # if eval() failed, show warning dialog and return
-                        try:
-                            pLabel = _localized[prefName]
-                            sLabel = _localized[sectionName]
-                        except Exception:
-                            pLabel = prefName
-                            sLabel = sectionName
+                        pLabel = prefName
+                        sLabel = sectionName
                         txt = _translate(
                             'Invalid value in "%(pref)s" ("%(section)s" Tab)')
                         msg = txt % {'pref': pLabel, 'section': sLabel}

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -19,7 +19,7 @@ from psychopy.experiment.params import getCodeFromParamStr
 from psychopy.alerts import alerttools
 from psychopy.colors import nonAlphaSpaces
 
-from psychopy.localization import _translate, _localized
+from psychopy.localization import _translate
 
 
 class BaseComponent:

--- a/psychopy/experiment/components/aperture/__init__.py
+++ b/psychopy/experiment/components/aperture/__init__.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from psychopy.experiment import Param
 from psychopy.experiment.components import getInitVals, _translate
 from psychopy.experiment.components.polygon import PolygonComponent
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
 __author__ = 'Jeremy Gray, Jon Peirce'
 # March 2011; builder-component for Yuri Spitsyn's visual.Aperture class

--- a/psychopy/experiment/components/brush/__init__.py
+++ b/psychopy/experiment/components/brush/__init__.py
@@ -5,18 +5,9 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from os import path
 from pathlib import Path
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
-from psychopy import logging
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
-# only use _localized values for label values, nothing functional:
-_localized.update({'lineWidth': _translate('Brush Size'),
-                   'lineColor': _translate('Brush Color'),
-                   'lineColorSpace': _translate('Brush Color Space'),
-                   'buttonRequired':_translate('Press Button')})
 
 class BrushComponent(BaseVisualComponent):
     """A class for drawing freehand responses"""

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -11,26 +11,6 @@ from pathlib import Path
 from psychopy.alerts import alerttools
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
 from psychopy.experiment.py2js_transpiler import translatePythonToJavaScript
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'callback': _translate("Callback Function"),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'text': _translate('Button text'),
-                   'font': _translate('Font'),
-                   'letterHeight': _translate('Letter height'),
-                   'bold': _translate('Bold'),
-                   'italic': _translate('Italic'),
-                   'padding': _translate('Padding'),
-                   'anchor': _translate('Anchor'),
-                   'fillColor': _translate('Fill Colour'),
-                   'borderColor': _translate('Border Colour'),
-                   'borderWidth': _translate('Border Width'),
-                   'oncePerClick': _translate('Run once per click'),
-                   'save': _translate("Record clicks"),
-                   'timeRelativeTo': _translate("Time relative to")
-                   })
 
 
 class ButtonComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/code/__init__.py
+++ b/psychopy/experiment/components/code/__init__.py
@@ -5,27 +5,10 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
-from os import path
 from pathlib import Path
-
 from psychopy import prefs
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.alerts import alerttools
-
-_localized = {'Code Type': _translate('Code Type'),
-              'Before Experiment': _translate('Before Experiment'),
-              'Begin Experiment': _translate('Begin Experiment'),
-              'Begin Routine': _translate('Begin Routine'),
-              'Each Frame': _translate('Each Frame'),
-              'End Routine': _translate('End Routine'),
-              'End Experiment': _translate('End Experiment'),
-              'Before JS Experiment': _translate('Before JS Experiment'),
-              'Begin JS Experiment': _translate('Begin JS Experiment'),
-              'Begin JS Routine': _translate('Begin JS Routine'),
-              'Each JS Frame': _translate('Each JS Frame'),
-              'End JS Routine': _translate('End JS Routine'),
-              'End JS Experiment': _translate('End JS Experiment'),
-              }
 
 
 class CodeComponent(BaseComponent):

--- a/psychopy/experiment/components/dots/__init__.py
+++ b/psychopy/experiment/components/dots/__init__.py
@@ -8,22 +8,6 @@
 from os import path
 from pathlib import Path
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'nDots': _translate('Number of dots'),
-                   'dir': _translate('Direction'),
-                   'speed': _translate('Speed'),
-                   'coherence': _translate('Coherence'),
-                   'dotSize': _translate('Dot size'),
-                   'dotLife': _translate('Dot life-time'),
-                   'signalDots': _translate('Signal dots'),
-                   'noiseDots': _translate('Noise dots'),
-                   'fieldShape': _translate('Field shape'),
-                   'fieldSize': _translate('Field size'),
-                   'fieldPos': _translate('Field position'),
-                   'refreshDots': _translate('Dot refresh rule')})
 
 
 class DotsComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -11,9 +11,7 @@ from builtins import super  # provides Py3-style super() using python-future
 from os import path
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.localization import _localized as __localized
 from psychopy.alerts import alert
-_localized = __localized.copy()
 
 
 class EyetrackerRecordComponent(BaseComponent):

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -8,19 +8,10 @@
 from pathlib import Path
 from psychopy.experiment.components import Param, getInitVals, _translate, BaseVisualComponent
 from psychopy.tools.stimulustools import formStyles
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
 __author__ = 'Jon Peirce, David Bridges, Anthony Haffey'
 
-# only use _localized values for label values, nothing functional:
-_localized.update({'Items': _translate('Items'),
-                   'Text Height': _translate('Text Height'),
-                   'Style': _translate('Styles'),
-                   'Item Padding': _translate('Item Padding'),
-                   'Data Format': _translate('Data Format'),
-                   'Randomize': _translate('Randomize')
-                   })
+
 knownStyles = list(formStyles)
 
 

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -8,17 +8,6 @@
 from pathlib import Path
 from psychopy.experiment.components import BaseVisualComponent, Param, \
     getInitVals, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'tex': _translate('Texture'),
-                   'mask': _translate('Mask'),
-                   'sf': _translate('Spatial frequency'),
-                   'phase': _translate('Phase (in cycles)'),
-                   'texture resolution': _translate('Texture resolution'),
-                   'blendmode': _translate('OpenGL blend mode'),
-                   'interpolate': _translate('Interpolate')})
 
 
 class GratingComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -7,16 +7,7 @@
 
 from pathlib import Path
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals
-from psychopy.localization import _translate, _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'image': _translate('Image'),
-                   'mask': _translate('Mask'),
-                   'texture resolution': _translate('Texture resolution'),
-                   'flipVert': _translate('Flip vertically'),
-                   'flipHoriz': _translate('Flip horizontally'),
-                   'interpolate': _translate('Interpolate')})
+from psychopy.localization import _translate
 
 
 class ImageComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -9,17 +9,6 @@ from pathlib import Path
 
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.experiment import CodeGenerationException, valid_var_re
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'allowedKeys': _translate('Allowed buttons'),
-                   'store': _translate('Store'),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'storeCorrect': _translate('Store correct'),
-                   'correctAns': _translate('Correct answer'),
-                   'deviceNumber': _translate('Device number'),
-                   'syncScreenRefresh': _translate('sync RT with screen')})
 
 
 class JoyButtonsComponent(BaseComponent):

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -9,18 +9,7 @@ from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.experiment import valid_var_re
 from psychopy.experiment import CodeGenerationException, valid_var_re
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 import re
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'saveJoystickState': _translate('Save joystick state'),
-                   'forceEndRoutineOnPress': _translate('End Routine on press'),
-                   'timeRelativeTo': _translate('Time relative to'),
-                   'Clickable stimuli': _translate('Clickable stimuli'),
-                   'Store params for clicked': _translate('Store params for clicked'),
-                   'deviceNumber': _translate('Device number'),
-                   'allowedButtons': _translate('Allowed Buttons')})
 
 
 class JoystickComponent(BaseComponent):

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -9,21 +9,10 @@ from pathlib import Path
 
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.experiment import CodeGenerationException, valid_var_re
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 from pkgutil import find_loader
 
 # Check for psychtoolbox
 havePTB = find_loader('psychtoolbox') is not None
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'allowedKeys': _translate('Allowed keys'),
-                   'discard previous': _translate('Discard previous'),
-                   'store': _translate('Store'),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'storeCorrect': _translate('Store correct'),
-                   'correctAns': _translate('Correct answer'),
-                   'syncScreenRefresh': _translate('Sync timing with screen')})
 
 
 class KeyboardComponent(BaseComponent):

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -13,7 +13,6 @@ from psychopy.alerts import alert
 from psychopy.tools import stringtools as st, systemtools as syst, audiotools as at
 from psychopy.experiment.components import BaseComponent, Param, getInitVals, _translate
 from psychopy.tools.audiotools import sampleRateQualityLevels
-from psychopy.localization import _localized as __localized
 
 _hasPTB = True
 try:
@@ -25,10 +24,6 @@ except (ImportError, ModuleNotFoundError):
         "recording will be unavailable this session. Note that opening a "
         "microphone stream will raise an error.")
     _hasPTB = False
-
-_localized = __localized.copy()
-_localized.update({'stereo': _translate('Stereo'),
-                   'channel': _translate('Channel')})
 
 # Get list of devices
 if _hasPTB and not syst.isVM_CI():

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -7,17 +7,7 @@
 
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 import re
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'saveMouseState': _translate('Save mouse state'),
-                   'forceEndRoutineOnPress': _translate('End Routine on press'),
-                   'timeRelativeTo': _translate('Time relative to'),
-                   'Clickable stimuli': _translate('Clickable stimuli'),
-                   'Store params for clicked': _translate('Store params for clicked'),
-                   'New clicks only': _translate('New clicks only')})
 
 
 class MouseComponent(BaseComponent):

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -9,14 +9,7 @@ from pathlib import Path
 import copy
 
 from psychopy.experiment.components import BaseVisualComponent, getInitVals, Param, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
-# only use _localized values for label values, nothing functional:
-_localized.update({'movie': _translate('Movie file'),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'backend': _translate('backend'),
-                   'No audio': _translate('No audio')})
 
 class MovieComponent(BaseVisualComponent):
     """An event class for presenting movie-based stimuli"""

--- a/psychopy/experiment/components/panorama/__init__.py
+++ b/psychopy/experiment/components/panorama/__init__.py
@@ -3,10 +3,6 @@
 
 from pathlib import Path
 from psychopy.experiment.components import Param, _translate, getInitVals, BaseVisualComponent
-from psychopy import prefs
-
-# only use _localized values for label values, nothing functional:
-_localized = {'name': _translate("Name")}
 
 
 class PanoramaComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -8,15 +8,6 @@
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy import prefs
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'address': _translate('Port address'),
-                   'register': _translate('U3 Register'),
-                   'startData': _translate("Start data"),
-                   'stopData': _translate("Stop data"),
-                   'syncScreen': _translate('Sync to screen')})
 
 
 class ParallelOutComponent(BaseComponent):

--- a/psychopy/experiment/components/patch/__init__.py
+++ b/psychopy/experiment/components/patch/__init__.py
@@ -7,16 +7,6 @@
 
 from pathlib import Path
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'image': _translate('Image/tex'),
-                   'mask': _translate('Mask'),
-                   'sf': _translate('Spatial frequency'),
-                   'phase': _translate('Phase (in cycles)'),
-                   'texture resolution': _translate('Texture resolution'),
-                   'interpolate': _translate('Interpolate')})
 
 
 class PatchComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -9,18 +9,6 @@ from pathlib import Path
 
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
 from psychopy import logging
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized = _localized.copy()
-_localized.update({'nVertices': _translate('Num. vertices'),
-                   'fillColor': _translate('Fill color'),
-                   'lineColor': _translate('Line color'),
-                   'lineWidth': _translate('Line width'),
-                   'interpolate': _translate('Interpolate'),
-                   'size': _translate("Size [w,h]"),
-                   'shape': _translate("Shape")})
 
 
 class PolygonComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -8,31 +8,8 @@
 from pathlib import Path
 from psychopy.tools.stringtools import getArgs
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
 __author__ = 'Jeremy Gray'
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'visualAnalogScale': _translate('Visual analog scale'),
-                   'categoryChoices': _translate('Category choices'),
-                   'scaleDescription': _translate('Scale description'),
-                   'low': _translate('Lowest value'),
-                   'high': _translate('Highest value'),
-                   'labels': _translate('Labels'),
-                   'marker': _translate('Marker type'),
-                   'markerStart': _translate('Marker start'),
-                   'size': _translate('Size'),
-                   'pos': _translate('Position [x,y]'),
-                   'tickHeight': _translate('Tick height'),
-                   'disappear': _translate('Disappear'),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'showAccept': _translate('Show accept'),
-                   'singleClick': _translate('Single click'),
-                   'storeHistory': _translate('Store history'),
-                   'storeRating': _translate('Store rating'),
-                   'storeRatingTime': _translate('Store rating time'),
-                   'customize_everything': _translate('Customize everything :')})
 
 
 class RatingScaleComponent(BaseComponent):

--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -7,12 +7,8 @@
 
 from pathlib import Path
 
-from psychopy.alerts import alert
 from psychopy.experiment.components import Param, getInitVals, _translate, BaseVisualComponent
-from psychopy.experiment.components.eyetracker_record import EyetrackerRecordComponent
 from psychopy.experiment.components.polygon import PolygonComponent
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
 
 class RegionOfInterestComponent(PolygonComponent):

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -4,10 +4,6 @@
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
 from psychopy.experiment.utils import CodeGenerationException
-from psychopy import prefs
-
-# only use _localized values for label values, nothing functional:
-_localized = {'name': _translate("Name")}
 
 
 class RoutineSettingsComponent(BaseComponent):

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -8,15 +8,6 @@ from copy import copy
 from pathlib import Path
 from psychopy.tools import stringtools as st
 from psychopy.experiment.components import BaseComponent, Param, _translate, getInitVals
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'address': _translate('Port address'),
-                   'register': _translate('U3 Register'),
-                   'startData': _translate("Start data"),
-                   'stopData': _translate("Stop data"),
-                   'syncScreenRefresh': _translate('Sync to screen')})
 
 
 class SerialOutComponent(BaseComponent):

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -43,38 +43,6 @@ _numpyRandomImports = ['random', 'randint', 'normal', 'shuffle', 'choice as rand
 
 # this is not a standard component - it will appear on toolbar not in
 # components panel
-
-# only use _localized values for label values, nothing functional:
-_localized = {'expName': _translate("Experiment name"),
-              'Show info dlg':  _translate("Show info dialog"),
-              'Enable Escape':  _translate("Enable Escape key"),
-              'Experiment info':  _translate("Experiment info"),
-              'Data filename':  _translate("Data filename"),
-              'Data file delimiter':  _translate("Data file delimiter"),
-              'Full-screen window':  _translate("Full-screen window"),
-              'Window size (pixels)':  _translate("Window size (pixels)"),
-              'Screen': _translate('Screen'),
-              'Monitor':  _translate("Monitor"),
-              'color': _translate("Color"),
-              'colorSpace':  _translate("Color space"),
-              'Units':  _translate("Units"),
-              'blendMode':   _translate("Blend mode"),
-              'Show mouse':  _translate("Show mouse"),
-              'Save log file':  _translate("Save log file"),
-              'Save wide csv file':
-                  _translate("Save csv file (trial-by-trial)"),
-              'Save csv file': _translate("Save csv file (summaries)"),
-              'Save excel file':  _translate("Save excel file"),
-              'Save psydat file':  _translate("Save psydat file"),
-              'logging level': _translate("Logging level"),
-              'Use version': _translate("Use PsychoPy version"),
-              'Completed URL': _translate("Completed URL"),
-              'Incomplete URL': _translate("Incomplete URL"),
-              'Output path': _translate("Output path"),
-              'Additional Resources': _translate("Additional Resources"),
-              'JS libs': _translate("JS libs"),
-              'Force stereo': _translate("Force stereo"),
-              'Export HTML': _translate("Export HTML")}
 ioDeviceMap = dict(ioUtil.getDeviceNames())
 ioDeviceMap['None'] = ""
 

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -11,22 +11,10 @@ from psychopy.experiment.components import BaseVisualComponent, Param, \
 from psychopy.experiment import py2js
 from psychopy import logging
 from psychopy.data import utils
-from psychopy.localization import _localized as __localized
 from psychopy.tools.stimulustools import sliderStyles, sliderStyleTweaks
-_localized = __localized.copy()
 import copy
 
 __author__ = 'Jon Peirce'
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'categoryChoices': _translate('Category choices'),
-                   'labels': _translate('Labels'),
-                   'ticks': _translate('Ticks'),
-                   'forceEndRoutine': _translate('Force end of Routine'),
-                   'storeHistory': _translate('Store history'),
-                   'storeRating': _translate('Store rating'),
-                   'storeRatingTime': _translate('Store rating time'),
-                   'readOnly': _translate('readOnly')})
 
 knownStyles = sliderStyles
 knownStyleTweaks = sliderStyleTweaks

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -10,13 +10,6 @@ Distributed under the terms of the GNU General Public License (GPL).
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, getInitVals, _translate
 from psychopy.tools.audiotools import knownNoteNames
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'sound': _translate('Sound'),
-                   'volume': _translate('Volume'),
-                   'syncScreenRefresh': _translate('Sync Start With Screen')})
 
 
 class SoundComponent(BaseComponent):

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -7,16 +7,10 @@ Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 Distributed under the terms of the GNU General Public License (GPL).
 """
 
-from os import path
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 
 __author__ = 'Jon Peirce'
-
-# the absolute path to the folder containing this path
-_localized.update({'Custom code': _translate('Custom code')})
 
 
 class StaticComponent(BaseComponent):

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -8,16 +8,6 @@
 from pathlib import Path
 from psychopy.alerts import alerttools
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'text': _translate('Text'),
-                   'font': _translate('Font'),
-                   'letterHeight': _translate('Letter height'),
-                   'wrapWidth': _translate('Wrap width'),
-                   'flip': _translate('Flip (mirror)'),
-                   'languageStyle': _translate('Language style')})
 
 
 class TextComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -8,28 +8,7 @@
 from pathlib import Path
 from psychopy.alerts import alerttools, alert
 from psychopy.experiment.components import BaseVisualComponent, Param, getInitVals, _translate
-from psychopy.localization import _localized as __localized
 from ..keyboard import KeyboardComponent
-_localized = __localized.copy()
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'text': _translate('Text'),
-                   'font': _translate('Font'),
-                   'letterHeight': _translate('Letter height'),
-                   'flipHorizontal': _translate('Flip horizontal'),
-                   'flipVertical': _translate('Flip vertical'),
-                   'languageStyle': _translate('Language style'),
-                   'bold': _translate('Bold'),
-                   'italic': _translate('Italic'),
-                   'lineSpacing': _translate('Line Spacing'),
-                   'padding': _translate('Padding'),
-                   'anchor': _translate('Anchor'),
-                   'fillColor': _translate('Fill Colour'),
-                   'borderColor': _translate('Border Colour'),
-                   'borderWidth': _translate('Border Width'),
-                   'editable': _translate('Editable?'),
-                   'autoLog': _translate('Auto Log')
-                   })
 
 
 class TextboxComponent(BaseVisualComponent):

--- a/psychopy/experiment/components/unknown/__init__.py
+++ b/psychopy/experiment/components/unknown/__init__.py
@@ -3,10 +3,6 @@
 
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy import prefs
-
-# only use _localized values for label values, nothing functional:
-_localized = {'name': _translate('Name')}
 
 
 class UnknownComponent(BaseComponent):

--- a/psychopy/experiment/components/unknownPlugin/__init__.py
+++ b/psychopy/experiment/components/unknownPlugin/__init__.py
@@ -3,10 +3,6 @@
 
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy import prefs
-
-# only use _localized values for label values, nothing functional:
-_localized = {'name': _translate('Name')}
 
 
 class UnknownPluginComponent(BaseComponent):

--- a/psychopy/experiment/components/variable/__init__.py
+++ b/psychopy/experiment/components/variable/__init__.py
@@ -9,20 +9,7 @@ Distributed under the terms of the GNU General Public License (GPL).
 
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy.localization import _localized as __localized
-_localized = __localized.copy()
 import numpy as np
-
-# only use _localized values for label values, nothing functional:
-_localized.update({'name': _translate('Name'),
-                   'startExpValue': _translate('Experiment start value'),
-                   'startRoutineValue': _translate('Routine start value'),
-                   'startFrameValue': _translate('Frame start value'),
-                   'saveStartExp': _translate('Save exp start value'),
-                   'saveStartRoutine': _translate('Save routine start value'),
-                   'saveFrameValue': _translate('Save frame value'),
-                   'saveEndRoutine': _translate('Save routine end value'),
-                   'saveEndExp': _translate('Save exp end value')})
 
 
 class VariableComponent(BaseComponent):

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -20,7 +20,7 @@ from copy import deepcopy
 from xml.etree.ElementTree import Element
 
 from psychopy.experiment import getInitVals
-from psychopy.localization import _localized, _translate
+from psychopy.localization import _translate
 from psychopy.experiment.params import Param
 from .components import getInitVals, getAllComponents
 
@@ -93,34 +93,34 @@ class TrialHandler(_BaseLoopHandler):
         self.params = {}
         self.params['name'] = Param(
             name, valType='code', inputType="single", updates=None, allowedUpdates=None,
-            label=_localized['Name'],
+            label=_translate('Name'),
             hint=_translate("Name of this loop"))
         self.params['nReps'] = Param(
             nReps, valType='num', inputType="spin", updates=None, allowedUpdates=None,
-            label=_localized['nReps'],
+            label=_translate('nReps'),
             hint=_translate("Number of repeats (for each condition)"))
         self.params['conditions'] = Param(
             list(conditions), valType='str', inputType="single",
             updates=None, allowedUpdates=None,
-            label=_localized['conditions'],
+            label=_translate('Conditions'),
             hint=_translate("A list of dictionaries describing the "
                             "parameters in each condition"))
         self.params['conditionsFile'] = Param(
             conditionsFile, valType='file', inputType="table", updates=None, allowedUpdates=None,
-            label=_localized['conditions'],
+            label=_translate('Conditions'),
             hint=_translate("Name of a file specifying the parameters for "
                             "each condition (.csv, .xlsx, or .pkl). Browse "
                             "to select a file. Right-click to preview file "
                             "contents, or create a new file."))
         self.params['endPoints'] = Param(
             list(endPoints), valType='num', inputType="single", updates=None, allowedUpdates=None,
-            label=_localized['endPoints'],
+            label=_translate('End points'),
             hint=_translate("The start and end of the loop (see flow "
                             "timeline)"))
         self.params['Selected rows'] = Param(
             selectedRows, valType='str', inputType="single",
             updates=None, allowedUpdates=None,
-            label=_localized['Selected rows'],
+            label=_translate('Selected rows'),
             hint=_translate("Select just a subset of rows from your condition"
                             " file (the first is 0 not 1!). Examples: 0, "
                             "0:5, 5:-1"))
@@ -129,19 +129,19 @@ class TrialHandler(_BaseLoopHandler):
             loopType, valType='str', inputType="choice",
             allowedVals=['random', 'sequential', 'fullRandom',
                          'staircase', 'interleaved staircases'],
-            label=_localized['loopType'],
+            label=_translate('Loop type'),
             hint=_translate("How should the next condition value(s) be "
                             "chosen?"))
         self.params['random seed'] = Param(
             randomSeed, valType='code', inputType="single", updates=None, allowedUpdates=None,
-            label=_localized['random seed'],
+            label=_translate('Random seed'),
             hint=_translate("To have a fixed random sequence provide an "
                             "integer of your choosing here. Leave blank to "
                             "have a new random sequence on each run of the "
                             "experiment."))
         self.params['isTrials'] = Param(
             isTrials, valType='bool', inputType="bool", updates=None, allowedUpdates=None,
-            label=_localized["Is trials"],
+            label=_translate("Is trials"),
             hint=_translate("Indicates that this loop generates TRIALS, "
                             "rather than BLOCKS of trials or stimuli within "
                             "a trial. It alters how data files are output"))
@@ -427,47 +427,47 @@ class StairHandler(_BaseLoopHandler):
         self.params['name'] = Param(
             name, valType='code',
             hint=_translate("Name of this loop"),
-            label=_localized['Name'])
+            label=_translate('Name'))
         self.params['nReps'] = Param(
             nReps, valType='num', inputType='spin',
-            label=_localized['nReps'],
+            label=_translate('nReps'),
             hint=_translate("(Minimum) number of trials in the staircase"))
         self.params['start value'] = Param(
             startVal, valType='num', inputType='single',
-            label=_localized['start value'],
+            label=_translate('Start value'),
             hint=_translate("The initial value of the parameter"))
         self.params['max value'] = Param(
             maxVal, valType='num', inputType='single',
-            label=_localized['max value'],
+            label=_translate('Max value'),
             hint=_translate("The maximum value the parameter can take"))
         self.params['min value'] = Param(
             minVal, valType='num', inputType='single',
-            label=_localized['min value'],
+            label=_translate('Min value'),
             hint=_translate("The minimum value the parameter can take"))
         self.params['step sizes'] = Param(
             stepSizes, valType='list', inputType='single',
-            label=_localized['step sizes'],
+            label=_translate('Step sizes'),
             hint=_translate("The size of the jump at each step (can change"
                             " on each 'reversal')"))
         self.params['step type'] = Param(
             stepType, valType='str', inputType='choice', allowedVals=['lin', 'log', 'db'],
-            label=_localized['step type'],
+            label=_translate('Step type'),
             hint=_translate("The units of the step size (e.g. 'linear' will"
                             " add/subtract that value each step, whereas "
                             "'log' will ad that many log units)"))
         self.params['N up'] = Param(
             nUp, valType='num', inputType='spin',
-            label=_localized['N up'],
+            label=_translate('N up'),
             hint=_translate("The number of 'incorrect' answers before the "
                             "value goes up"))
         self.params['N down'] = Param(
             nDown, valType='num', inputType='spin',
-            label=_localized['N down'],
+            label=_translate('N down'),
             hint=_translate("The number of 'correct' answers before the "
                             "value goes down"))
         self.params['N reversals'] = Param(
             nReversals, valType='num', inputType='spin',
-            label=_localized['N reversals'],
+            label=_translate('N reversals'),
             hint=_translate("Minimum number of times the staircase must "
                             "change direction before ending"))
         # these two are really just for making the dialog easier (they won't
@@ -476,17 +476,17 @@ class StairHandler(_BaseLoopHandler):
             'staircase', valType='str', inputType='choice',
             allowedVals=['random', 'sequential', 'fullRandom', 'staircase',
                          'interleaved staircases'],
-            label=_localized['loopType'],
+            label=_translate('Loop type'),
             hint=_translate("How should the next trial value(s) be chosen?"))
         # NB this is added for the sake of the loop properties dialog
         self.params['endPoints'] = Param(
             list(endPoints), valType='num', inputType='spin',
-            label=_localized['endPoints'],
+            label=_translate('End points'),
             hint=_translate('Where to loop from and to (see values currently'
                             ' shown in the flow view)'))
         self.params['isTrials'] = Param(
             isTrials, valType='bool', inputType='bool', updates=None, allowedUpdates=None,
-            label=_localized["Is trials"],
+            label=_translate("Is trials"),
             hint=_translate("Indicates that this loop generates TRIALS, "
                             "rather than BLOCKS of trials or stimuli within"
                             " a trial. It alters how data files are output"))
@@ -581,21 +581,21 @@ class MultiStairHandler(_BaseLoopHandler):
         self.params = {}
         self.params['name'] = Param(
             name, valType='code', inputType='single',
-            label=_localized['Name'],
+            label=_translate('Name'),
             hint=_translate("Name of this loop"))
         self.params['nReps'] = Param(
             nReps, valType='num', inputType='spin',
-            label=_localized['nReps'],
+            label=_translate('nReps'),
             hint=_translate("(Minimum) number of trials in *each* staircase"))
         self.params['stairType'] = Param(
             stairType, valType='str', inputType='choice',
             allowedVals=['simple', 'QUEST', 'questplus'],
-            label=_localized['stairType'],
+            label=_translate('Stair type'),
             hint=_translate("How to select the next staircase to run"))
         self.params['switchMethod'] = Param(
             switchStairs, valType='str', inputType='choice',
             allowedVals=['random', 'sequential', 'fullRandom'],
-            label=_localized['switchMethod'],
+            label=_translate('Switch method'),
             hint=_translate("How to select the next staircase to run"))
         # these two are really just for making the dialog easier (they won't
         # be used to generate code)
@@ -603,27 +603,27 @@ class MultiStairHandler(_BaseLoopHandler):
             'staircase', valType='str', inputType='choice',
             allowedVals=['random', 'sequential', 'fullRandom', 'staircase',
                          'interleaved staircases'],
-            label=_localized['loopType'],
+            label=_translate('Loop type'),
             hint=_translate("How should the next trial value(s) be chosen?"))
         self.params['endPoints'] = Param(
             list(endPoints), valType='num', inputType='spin',
-            label=_localized['endPoints'],
+            label=_translate('End points'),
             hint=_translate('Where to loop from and to (see values currently'
                             ' shown in the flow view)'))
         self.params['conditions'] = Param(
             list(conditions), valType='list', inputType='single',
             updates=None, allowedUpdates=None,
-            label=_localized['conditions'],
+            label=_translate('Conditions'),
             hint=_translate("A list of dictionaries describing the "
                             "differences between each staircase"))
         self.params['conditionsFile'] = Param(
             conditionsFile, valType='file', inputType='table', updates=None, allowedUpdates=None,
-            label=_localized['conditions'],
+            label=_translate('Conditions'),
             hint=_translate("An xlsx or csv file specifying the parameters "
                             "for each condition"))
         self.params['isTrials'] = Param(
             isTrials, valType='bool', inputType='bool', updates=None, allowedUpdates=None,
-            label=_localized["Is trials"],
+            label=_translate("Is trials"),
             hint=_translate("Indicates that this loop generates TRIALS, "
                             "rather than BLOCKS of trials or stimuli within "
                             "a trial. It alters how data files are output"))

--- a/psychopy/localization/__init__.py
+++ b/psychopy/localization/__init__.py
@@ -14,10 +14,9 @@ translation _translate():
 
 try:
     from ._localization import (
-        _translate, _localized, setLocaleWX, locname, available)
+        _translate, setLocaleWX, locname, available)
 except ModuleNotFoundError:
     # if wx doesn't exist we can't translate but most other parts
     # of the _localization lib will not be relevant
     def _translate(val):
         return val
-    _localized = {}

--- a/psychopy/localization/_localization.py
+++ b/psychopy/localization/_localization.py
@@ -148,55 +148,6 @@ _translate = _  # noqa: F821
 # Note that _ is created by gettext, in builtins namespace
 del(__builtins__['_'])
 
-
-# some common ones that will be used by many components etc
-_localized = {
-    # for BaseComponent:
-    'name': _translate('Name'),  # fieldName: display label
-    'startType': _translate('start type'),
-    'stopType': _translate('stop type'),
-    'startVal': _translate('Start'),
-    'stopVal': _translate('Stop'),
-    'startEstim': _translate('Expected start (s)'),
-    'durationEstim': _translate('Expected duration (s)'),
-
-    # for BaseVisualComponent:
-    'units': _translate('Spatial Units'),
-    'color': _translate('Foreground Color'),
-    'colorSpace': _translate('Color Space'),
-    'fillColor': _translate('Fill Color'),
-    'fillColorSpace': _translate('Fill Color Space'),
-    'borderColor': _translate('Border Color'),
-    'borderColorSpace': _translate('Border Color Space'),
-    'contrast': _translate('Contrast'),
-    'opacity': _translate('Opacity'),
-    'pos': _translate('Position [x,y]'),
-    'ori': _translate('Orientation'),
-    'size': _translate('Size [w,h]'),
-
-    # for loops
-    'Name': _translate('Name'),
-    'nReps': _translate('nReps'),
-    'conditions': _translate('Conditions'),  # not the same
-    'conditionsFile':_translate('conditionsFile'),
-    'endPoints': _translate('endPoints'),
-    'Selected rows': _translate('Selected rows'),
-    'loopType': _translate('loopType'),
-    'random seed': _translate('random seed'),
-    'Is trials': _translate('Is trials'),
-    'min value': _translate('min value'),
-    'N reversals': _translate('N reversals'),
-    'start value': _translate('start value'),
-    'N up': _translate('N up'),
-    'max value': _translate('max value'),
-    'N down': _translate('N down'),
-    'step type': _translate('step type'),
-    'step sizes': _translate('step sizes'),
-    'stairType': _translate('stairType'),
-    'switchMethod': _translate('switchMethod')
-}
-
-
 # __builtins__['_'] = wx.GetTranslation
 # this seems to have no effect, needs more investigation:
 # path = os.path.join(os.path.dirname(__file__), '..', 'locale',

--- a/psychopy/tests/__init__.py
+++ b/psychopy/tests/__init__.py
@@ -16,3 +16,32 @@ except ImportError:
     skip_under_travis = no_op
     skip_under_ghActions = no_op
     skip_under_vm = no_op
+
+
+def requires_plugin(plugin):
+    """
+    Decorator to skip test if a particular plugin is not installed.
+
+    Parameters
+    ----------
+    plugin : str
+        Name of plugin which must be installed in other for decorated test to run
+
+    Returns
+    -------
+        pytest.mark with condition on which to run the test
+
+    Examples
+    --------
+        ```
+        @requires_plugin("psychopy-visionscience")
+        def test_EnvelopeGrating():
+            win = visual.Window()
+            stim = visual.EnvelopeGrating(win)
+            stim.draw()
+            win.flip()
+        ```
+    """
+    from psychopy import plugins
+
+    return pytest.mark.skipif(plugin not in plugins.listPlugins(), reason="Cannot run that test on a virtual machine")

--- a/psychopy/tests/test_app/test_builder/test_BuilderFrame.py
+++ b/psychopy/tests/test_app/test_builder/test_BuilderFrame.py
@@ -127,6 +127,8 @@ class Test_BuilderFrame():
             {'fieldName': "correctAns", 'param': Param(val="'space'", valType="code"), 'msg': ""}, # Single-element lists should not cause warning
         ]
         for case in tykes:
+            # Give each param a label
+            case['param'].label = case['fieldName']
             # Add each param to the component
             comp.params[case['fieldName']] = case['param']
 
@@ -139,6 +141,11 @@ class Test_BuilderFrame():
         # Does the message delivered by the validator match what is expected?
         for case in tykes:
             if case['msg']:
-                assert case['msg'].format(**case) in dlg.warnings.messages
+                assert case['msg'].format(**case) in dlg.warnings.messages, (
+                    "Error for param {fieldName} with value `{val}` should include:\n"
+                    "'{msg}'\n"
+                    "but instead was:\n"
+                    "{actual}\n"
+                ).format(**case, val=case['param'].val.format(**case), actual=dlg.warnings.messages)
         # Cleanup
         dlg.Destroy()

--- a/psychopy/tests/test_app/test_builder/test_ComponentDialogs.py
+++ b/psychopy/tests/test_app/test_builder/test_ComponentDialogs.py
@@ -74,7 +74,7 @@ class TestComponentDialogs:
             pg = dlg.codeNotebook.GetCurrentPage()
             i = dlg.codeNotebook.FindPage(pg)
             tabLabel = dlg.codeNotebook.GetPageText(i)
-            assert case['first'] in tabLabel, (
+            assert case['first'].lower() in tabLabel.lower(), (
                 f"Tab {case['first']} should be opened first when the following fields are populated:\n"
                 f"{_nl.join(case['params'])}\n"
                 f"Instead, first tab open was {tabLabel}"
@@ -82,7 +82,7 @@ class TestComponentDialogs:
             # Check that correct tabs are starred
             for i in range(dlg.codeNotebook.GetPageCount()):
                 tabLabel = dlg.codeNotebook.GetPageText(i)
-                populated = any(name in tabLabel for name in case['starred'])
+                populated = any(name.lower() in tabLabel.lower() for name in case['starred'])
 
                 if populated:
                     assert "*" in tabLabel, (

--- a/psychopy/tests/test_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_visual/test_all_stimuli.py
@@ -17,7 +17,7 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 
 """
 
-from psychopy.tests import skip_under_vm
+from psychopy.tests import skip_under_vm, requires_plugin
 from psychopy.tools import systemtools
 
 
@@ -140,6 +140,7 @@ class _baseVisualTest():
         utils.compareScreenshot('imageAndGauss_%s.png' %(self.contextName), win)
         win.flip()
 
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeGratingAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -157,7 +158,8 @@ class _baseVisualTest():
             utils.compareScreenshot('envelopeandrcos_%s.png' %(self.contextName), win)
             win.flip()
             "{}".format(image)
-            
+
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeGratingPowerAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -176,6 +178,7 @@ class _baseVisualTest():
             win.flip()
             "{}".format(image)
 
+    @requires_plugin("psychopy-visionscience")
     def test_NoiseStim_defaults(self):
         noiseTypes = ['binary', 'uniform', 'normal', 'white', 'filtered']
 
@@ -187,6 +190,7 @@ class _baseVisualTest():
             stim.updateNoise()
             stim.draw()
 
+    @requires_plugin("psychopy-visionscience")
     def test_NoiseStim_defaults_image(self):
         noiseType = 'image'
 
@@ -197,6 +201,7 @@ class _baseVisualTest():
                              size=(32, 32),
                              units='pix')
 
+    @requires_plugin("psychopy-visionscience")
     def test_noiseAndRaisedCos(self):
         numpy.random.seed(1)
         win = self.win
@@ -239,7 +244,8 @@ class _baseVisualTest():
         utils.compareScreenshot('noiseAndRcos_%s.png' %(self.contextName), win)
         win.flip()
         str(image)
-        
+
+    @requires_plugin("psychopy-visionscience")
     def test_noiseFiltersAndRaisedCos(self):
         numpy.random.seed(1)
         win = self.win
@@ -296,6 +302,7 @@ class _baseVisualTest():
         win.flip()
         str(image)
 
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeBeatAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor

--- a/psychopy/tools/wizard.py
+++ b/psychopy/tools/wizard.py
@@ -26,41 +26,9 @@ else:
 from psychopy.localization import _translate
 from psychopy import (info, data, visual, gui, core, __version__,
                       prefs, event)
-
-# set values, using a form that poedit can discover:
-_localized = {
-    'Benchmark': _translate('Benchmark'),
-    'benchmark version': _translate('benchmark version'),
-    'full-screen': _translate('full-screen'),
-    'dots_circle': _translate('dots_circle'),
-    'dots_square': _translate('dots_square'),
-    'available memory': _translate('available memory'),
-    'python version': _translate('python version'),
-    'locale': _translate('locale'),
-    'Visual': _translate('Visual'),
-    'openGL version': _translate('openGL version'),
-    'openGL vendor': _translate('openGL vendor'),
-    'screen size': _translate('screen size'),
-    'have shaders': _translate('have shaders'),
-    'refresh stability (SD)': _translate('refresh stability (SD)'),
-    'no dropped frames': _translate('no dropped frames'),
-    'pyglet avbin': _translate('pyglet avbin'),
-    'Audio': _translate('Audio'),
-    'microphone latency': _translate('microphone latency'),
-    'microphone': _translate('microphone'),
-    'speakers latency': _translate('speakers latency'),
-    'speakers': _translate('speakers'),
-    'Numeric': _translate('Numeric'),
-    'System': _translate('System'),
-    'platform': _translate('platform'),
-    'internet access': _translate('internet access'),
-    'auto proxy': _translate('auto proxy'),
-    'proxy setting': _translate('proxy setting'),
-    'background processes': _translate('background processes'),
-    'CPU speed test': _translate('CPU speed test'),
-    'visual sync (refresh)': _translate('visual sync (refresh)')}
 # can't just do the following, or messes up poedit autodiscovery:
 # _localized = {k: _translate(k) for k in _loKeys}
+
 
 class BaseWizard():
     """Base class of ConfigWizard and BenchmarkWizard.


### PR DESCRIPTION
Dict is no longer needed as _translate is cached, and attempting to index _localized without wx raises errors (while calling _translate returns the input unchanged, without error)

Also seems to have the happy side-effect of speeding up the app, presumably because we aren't defining & updating dicts so much:

| --- | Before | After |
| --- | --- | --- |
| Builder frame | 0.561022997 | 0.537538528 |
| Coder frame | 0.51135087 | 0.498919249 |
| Runner frame | 0.11471653 | 0.07901001 |
| Change theme | 0.334387779 | 0.30944705 |

(from psychopy.tests.test_app.test_speed.TestSpeed)


















































































































