### PR TITLE
BF: Make sure Components from plugins are always identified

### DIFF
--- a/psychopy/demos/builder/Feature Demos/noise/noise.psyexp
+++ b/psychopy/demos/builder/Feature Demos/noise/noise.psyexp
@@ -57,7 +57,7 @@
   </Settings>
   <Routines>
     <Routine name="trial">
-      <NoiseStimComponent name="BinaryNoise">
+      <NoiseStimComponent name="BinaryNoise" plugin="psychopy-visionscience">
         <Param val="avg" valType="str" updates="constant" name="blendmode"/>
         <Param val="$[1,1,1]" valType="str" updates="constant" name="color"/>
         <Param val="rgb" valType="str" updates="constant" name="colorSpace"/>
@@ -99,7 +99,7 @@
         <Param val="512" valType="code" updates="constant" name="texture resolution"/>
         <Param val="pix" valType="str" updates="None" name="units"/>
       </NoiseStimComponent>
-      <NoiseStimComponent name="GaborNoise">
+      <NoiseStimComponent name="GaborNoise" plugin="psychopy-visionscience">
         <Param val="avg" valType="str" updates="constant" name="blendmode"/>
         <Param val="$[1,1,1]" valType="str" updates="constant" name="color"/>
         <Param val="rgb" valType="str" updates="constant" name="colorSpace"/>
@@ -141,7 +141,7 @@
         <Param val="512" valType="code" updates="constant" name="texture resolution"/>
         <Param val="deg" valType="str" updates="None" name="units"/>
       </NoiseStimComponent>
-      <NoiseStimComponent name="PinkNoise">
+      <NoiseStimComponent name="PinkNoise" plugin="psychopy-visionscience">
         <Param val="avg" valType="str" updates="constant" name="blendmode"/>
         <Param val="$[1,1,1]" valType="str" updates="constant" name="color"/>
         <Param val="rgb" valType="str" updates="constant" name="colorSpace"/>
@@ -183,7 +183,7 @@
         <Param val="512" valType="code" updates="constant" name="texture resolution"/>
         <Param val="deg" valType="str" updates="None" name="units"/>
       </NoiseStimComponent>
-      <NoiseStimComponent name="FilteredNoise">
+      <NoiseStimComponent name="FilteredNoise" plugin="psychopy-visionscience">
         <Param val="avg" valType="str" updates="constant" name="blendmode"/>
         <Param val="$[1,1,1]" valType="str" updates="constant" name="color"/>
         <Param val="rgb" valType="str" updates="constant" name="colorSpace"/>
@@ -225,7 +225,7 @@
         <Param val="512" valType="code" updates="constant" name="texture resolution"/>
         <Param val="deg" valType="str" updates="None" name="units"/>
       </NoiseStimComponent>
-      <NoiseStimComponent name="ImageNoise">
+      <NoiseStimComponent name="ImageNoise" plugin="psychopy-visionscience">
         <Param val="avg" valType="str" updates="constant" name="blendmode"/>
         <Param val="$[1,1,1]" valType="str" updates="constant" name="color"/>
         <Param val="rgb" valType="str" updates="constant" name="colorSpace"/>

--- a/psychopy/demos/builder/Feature Demos/pump/pump.psyexp
+++ b/psychopy/demos/builder/Feature Demos/pump/pump.psyexp
@@ -187,7 +187,7 @@
       </KeyboardComponent>
     </Routine>
     <Routine name="aspirate_liquid_2">
-      <QmixPumpComponent name="pump_0_2">
+      <QmixPumpComponent name="pump_0_2" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -203,7 +203,7 @@
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
       </QmixPumpComponent>
-      <QmixPumpComponent name="pump_1_2">
+      <QmixPumpComponent name="pump_1_2" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -221,7 +221,7 @@
       </QmixPumpComponent>
     </Routine>
     <Routine name="aspirate_air">
-      <QmixPumpComponent name="pump_0_1">
+      <QmixPumpComponent name="pump_0_1" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -237,7 +237,7 @@
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
       </QmixPumpComponent>
-      <QmixPumpComponent name="pump_1_1">
+      <QmixPumpComponent name="pump_1_1" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -255,7 +255,7 @@
       </QmixPumpComponent>
     </Routine>
     <Routine name="aspirate_liquid_1">
-      <QmixPumpComponent name="pump_0_0">
+      <QmixPumpComponent name="pump_0_0" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -271,7 +271,7 @@
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
       </QmixPumpComponent>
-      <QmixPumpComponent name="pump_1_0">
+      <QmixPumpComponent name="pump_1_0" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -289,7 +289,7 @@
       </QmixPumpComponent>
     </Routine>
     <Routine name="empty">
-      <QmixPumpComponent name="pump_0_3">
+      <QmixPumpComponent name="pump_0_3" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -305,7 +305,7 @@
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
       </QmixPumpComponent>
-      <QmixPumpComponent name="pump_1_3">
+      <QmixPumpComponent name="pump_1_3" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -323,7 +323,7 @@
       </QmixPumpComponent>
     </Routine>
     <Routine name="fill">
-      <QmixPumpComponent name="pump_0_4">
+      <QmixPumpComponent name="pump_0_4" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>
@@ -339,7 +339,7 @@
         <Param name="syncToScreen" updates="None" val="True" valType="bool"/>
         <Param name="syringeType" updates="None" val="50 mL glass" valType="str"/>
       </QmixPumpComponent>
-      <QmixPumpComponent name="pump_1_4">
+      <QmixPumpComponent name="pump_1_4" plugin="psychopy-qmix">
         <Param name="durationEstim" updates="None" val="" valType="code"/>
         <Param name="flowRate" updates="None" val="1.0" valType="code"/>
         <Param name="flowRateUnit" updates="None" val="mL/s" valType="str"/>

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -52,7 +52,8 @@ RequiredImport = namedtuple('RequiredImport',
                                          'importAs'))
 
 
-# Some params have previously had types which cause errors compiling in new versions, so we need to keep track of them and force them to the new type if needed
+# some params have previously had types which cause errors compiling in new versions, so we need to keep track of
+# them and force them to the new type if needed
 forceType = {
     'pos': 'list',
     'size': 'list',
@@ -78,6 +79,18 @@ forceType = {
     ('SliderComponent', 'ticks'): 'list',
     ('SliderComponent', 'labels'): 'list',
     ('SliderComponent', 'styleTweaks'): 'list'
+}
+
+# some components in plugins used to be in the main lib, keep track of which plugins they're in
+pluginComponents = {
+    'QmixPumpComponent': "psychopy-qmix",
+    'PeristalticPumpComponent': "psychopy-labeotech",
+    'ioLabsButtonBoxComponent': "psychopy-iolabs",
+    'cedrusButtonBoxComponent': "psychopy-cedrus",
+    'EmotivRecordingComponent': "psychopy-emotiv",
+    'EmotivMarkingComponent': "psychopy-emotiv",
+    'EnvGratingComponent': "psychopy-visionscience",
+    'NoiseStimComponent': "psychopy-visionscience",
 }
 
 # # Code to generate force list
@@ -760,7 +773,10 @@ class Experiment:
                 for componentNode in routineNode:
 
                     componentType = componentNode.tag
+                    # get plugin, if any
                     plugin = componentNode.get('plugin')
+                    if plugin is None and componentNode.tag in pluginComponents:
+                        plugin = pluginComponents[componentNode.tag]
 
                     if componentType == "RoutineSettingsComponent":
                         # if settings, use existing component

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -775,7 +775,7 @@ class Experiment:
                     componentType = componentNode.tag
                     # get plugin, if any
                     plugin = componentNode.get('plugin')
-                    if plugin is None and componentNode.tag in pluginComponents:
+                    if plugin in ("None", None) and componentNode.tag in pluginComponents:
                         plugin = pluginComponents[componentNode.tag]
 
                     if componentType == "RoutineSettingsComponent":

--- a/psychopy/tests/test_demos/test_builder_demos.py
+++ b/psychopy/tests/test_demos/test_builder_demos.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from psychopy.demos import builder
+from psychopy import experiment
+from psychopy.experiment.routines import Routine
+from psychopy.experiment.components.unknown import UnknownComponent
+from psychopy.experiment.routines.unknown import UnknownRoutine
+
+
+def test_plugin_components_indicated():
+    """
+    Test that all components in Builder demos which come from plugins are marked as being from plugins.
+    """
+    # blank experiment for reading files
+    exp = experiment.Experiment()
+    # root Builder demos folder
+    demosDir = Path(builder.__file__).parent
+    # for all psyexp files in builder demos folder...
+    for file in demosDir.glob("**/*.psyexp"):
+        # load experiment
+        exp.loadFromXML(str(file))
+        # get all elements (Components and StandaloneRoutines) in the experiment
+        emts = []
+        for rt in exp.routines.values():
+            if isinstance(rt, Routine):
+                for comp in rt:
+                    emts.append(comp)
+            else:
+                emts.append(rt)
+        # check that each element is known
+        for emt in emts:
+            assert not isinstance(emt, (UnknownComponent, UnknownRoutine)), (
+                f"Component/Routine `{emt.name}` ({type(emt).__name__}) from `{file.relative_to(demosDir)}` is "
+                f"not known to PsychoPy and experiment file did not indicate that it's from a plugin."
+            )


### PR DESCRIPTION
- If psyexp doesn't indicate which plugin an unrecognised Component came from, PsychoPy has an internal reference to the formerly-base-psychopy Components which have been moved to plugins
- Added test to make sure plugin components in Builder demos are all marked with their plugin
- Updated demos to include references to plugins