### PR TITLE
TEST: Allow tests to be skipped if a given plugin isn't installed

### DIFF
--- a/psychopy/tests/__init__.py
+++ b/psychopy/tests/__init__.py
@@ -16,3 +16,32 @@ except ImportError:
     skip_under_travis = no_op
     skip_under_ghActions = no_op
     skip_under_vm = no_op
+
+
+def requires_plugin(plugin):
+    """
+    Decorator to skip test if a particular plugin is not installed.
+
+    Parameters
+    ----------
+    plugin : str
+        Name of plugin which must be installed in other for decorated test to run
+
+    Returns
+    -------
+        pytest.mark with condition on which to run the test
+
+    Examples
+    --------
+        ```
+        @requires_plugin("psychopy-visionscience")
+        def test_EnvelopeGrating():
+            win = visual.Window()
+            stim = visual.EnvelopeGrating(win)
+            stim.draw()
+            win.flip()
+        ```
+    """
+    from psychopy import plugins
+
+    return pytest.mark.skipif(plugin not in plugins.listPlugins(), reason="Cannot run that test on a virtual machine")

--- a/psychopy/tests/test_visual/test_all_stimuli.py
+++ b/psychopy/tests/test_visual/test_all_stimuli.py
@@ -17,7 +17,7 @@ To add a new stimulus test use _base so that it gets tested in all contexts
 
 """
 
-from psychopy.tests import skip_under_vm
+from psychopy.tests import skip_under_vm, requires_plugin
 from psychopy.tools import systemtools
 
 
@@ -140,6 +140,7 @@ class _baseVisualTest():
         utils.compareScreenshot('imageAndGauss_%s.png' %(self.contextName), win)
         win.flip()
 
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeGratingAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -157,7 +158,8 @@ class _baseVisualTest():
             utils.compareScreenshot('envelopeandrcos_%s.png' %(self.contextName), win)
             win.flip()
             "{}".format(image)
-            
+
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeGratingPowerAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor
@@ -176,6 +178,7 @@ class _baseVisualTest():
             win.flip()
             "{}".format(image)
 
+    @requires_plugin("psychopy-visionscience")
     def test_NoiseStim_defaults(self):
         noiseTypes = ['binary', 'uniform', 'normal', 'white', 'filtered']
 
@@ -187,6 +190,7 @@ class _baseVisualTest():
             stim.updateNoise()
             stim.draw()
 
+    @requires_plugin("psychopy-visionscience")
     def test_NoiseStim_defaults_image(self):
         noiseType = 'image'
 
@@ -197,6 +201,7 @@ class _baseVisualTest():
                              size=(32, 32),
                              units='pix')
 
+    @requires_plugin("psychopy-visionscience")
     def test_noiseAndRaisedCos(self):
         numpy.random.seed(1)
         win = self.win
@@ -239,7 +244,8 @@ class _baseVisualTest():
         utils.compareScreenshot('noiseAndRcos_%s.png' %(self.contextName), win)
         win.flip()
         str(image)
-        
+
+    @requires_plugin("psychopy-visionscience")
     def test_noiseFiltersAndRaisedCos(self):
         numpy.random.seed(1)
         win = self.win
@@ -296,6 +302,7 @@ class _baseVisualTest():
         win.flip()
         str(image)
 
+    @requires_plugin("psychopy-visionscience")
     def test_envelopeBeatAndRaisedCos(self):
         win = self.win
         size = numpy.array([2.0,2.0])*self.scaleFactor


### PR DESCRIPTION
Temporary solution until we move all plugin-specific tests out to an individual test suite for each plugin, worth keeping the decorator in just in case though as plugin developers may wish to import & use it in their tests.