### PR TITLE
BF: Fix "logFile does not exist" error when "Save log file" is False

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1149,22 +1149,22 @@ class SettingsComponent:
         buff.writeIndentedLines(code)
         buff.setIndentLevel(+1, relative=True)
 
+        # set logging level
         level = self.params['logging level'].val.upper()
+        code = (
+            "# this outputs to the screen, not a file\n"
+            "logging.console.setLevel(logging.%s)\n"
+        )
+        buff.writeIndentedLines(code % level)
 
         if self.params['Save log file'].val:
             code = (
                 "# save a log file for detail verbose info\n"
                 "logFile = logging.LogFile(filename+'.log', level=logging.%s)\n"
+                "\n"
+                "return logFile\n"
             )
             buff.writeIndentedLines(code % level)
-        buff.writeIndented("logging.console.setLevel(logging.WARNING)  "
-                           "# this outputs to the screen, not a file\n")
-
-        code = (
-            "# return log file\n"
-            "return logFile\n"
-        )
-        buff.writeIndentedLines(code)
         # Exit function def
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("\n")


### PR DESCRIPTION
Previously, `logFile` not existing was fine as it wasn't used anywhere else in the script, but now that `setupLogging` is its own function, it was raising an error as the `setupLogging` function needed to return _something_. This fixes it by only returning `logFile` if the line to create `logFile` was written, otherwise the function returns None