### PR TITLE
BF: expInfo was defined too soon, so it couldn't use values from Code components

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -263,18 +263,15 @@ class Experiment:
 
         if target == "PsychoPy":
             # Imports
-            self_copy.settings.writeInitCode(script, self_copy.psychopyVersion,
-                                             localDateTime)
-            # Global variables
-            self_copy.settings.writeGlobals(script, version=self_copy.psychopyVersion)
-
+            self_copy.settings.writeInitCode(script, self_copy.psychopyVersion, localDateTime)
             # Write "run once" code sections
             for entry in self_copy.flow:
                 # NB each entry is a routine or LoopInitiator/Terminator
                 self_copy._currentRoutine = entry
                 if hasattr(entry, 'writePreCode'):
                     entry.writePreCode(script)
-
+            # global variables
+            self_copy.settings.writeGlobals(script, version=self_copy.psychopyVersion)
             # present info
             self_copy.settings.writeExpInfoDlgCode(script)
             # setup data and saving


### PR DESCRIPTION
The order changed because of modularisation - creating the expInfo dict and showing the expInfo dialog are now disentangled, so I just put expInfo as early as possible for safety, but as [this user](https://discourse.psychopy.org/t/expected-behavior-code-in-before-experiment-now-gets-executed-after-definition-of-global-variables/36150/2) points out this causes problems when setting expInfo using values defined in a Code component