### PR TITLE
BF: Ignore spaces when getting variables from name

### DIFF
--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -35,7 +35,7 @@ def getFromNames(names, namespace):
     # If single name, put in list
     from collections.abc import Iterable
     if isinstance(names, str) or not isinstance(names, Iterable):
-        names = [names]
+        names = [names.strip()]
 
     # Get objects
     objs = []

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -41,7 +41,8 @@ def getFromNames(names, namespace):
     objs = []
     for nm in names:
         # Strip spaces
-        nm = nm.strip()
+        if isinstance(nm, str):
+            nm = nm.strip()
         # Get (use original value if not present)
         obj = namespace.get(nm, nm)
         # Append

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -35,11 +35,13 @@ def getFromNames(names, namespace):
     # If single name, put in list
     from collections.abc import Iterable
     if isinstance(names, str) or not isinstance(names, Iterable):
-        names = [names.strip()]
+        names = [names]
 
     # Get objects
     objs = []
     for nm in names:
+        # Strip spaces
+        nm = nm.strip()
         # Get (use original value if not present)
         obj = namespace.get(nm, nm)
         # Append


### PR DESCRIPTION
Prevents e.g.
```
text1 = visual.TextStim(win, ...)
mouse1 = event.Mouse(win, ...)
clickables = environmenttools.getFromNames(" text1", namespace=locals())
for obj in clickables:
    if obj.contains(mouse1):
        continueRoutine = False
```
from raising a "str has no attribute `contains`" error