### PR TITLE
BF: Fix "<variable> does not exist" error on loading some conditions files

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -423,7 +423,13 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                 if (isinstance(val, str) and
                         (val.startswith('[') and val.endswith(']') or
                                  val.startswith('(') and val.endswith(')'))):
-                    val = eval(val)
+                    # strip parentheses
+                    val = val[1:-1]
+                    # split by commas
+                    val = val.split(",")
+                    # strip spaces
+                    val = [subval.strip() for subval in val]
+
                 # if it has any line breaks correct them
                 if isinstance(val, str):
                     val = val.replace('\\n', '\n')

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -18,7 +18,6 @@ from pkg_resources import parse_version
 
 from psychopy import logging, exceptions
 from psychopy.tools.filetools import pathToString
-from psychopy.tools.environmenttools import getFromNames
 from psychopy.localization import _translate
 
 try:
@@ -430,8 +429,6 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                     val = val.split(",")
                     # strip spaces
                     val = [subval.strip() for subval in val]
-                    # evaluate variable names
-                    val = getFromNames(val, namespace=globals())
 
                 # if it has any line breaks correct them
                 if isinstance(val, str):

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -18,6 +18,7 @@ from pkg_resources import parse_version
 
 from psychopy import logging, exceptions
 from psychopy.tools.filetools import pathToString
+from psychopy.tools.environmenttools import getFromNames
 from psychopy.localization import _translate
 
 try:
@@ -429,6 +430,8 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                     val = val.split(",")
                     # strip spaces
                     val = [subval.strip() for subval in val]
+                    # evaluate variable names
+                    val = getFromNames(val, namespace=globals())
 
                 # if it has any line breaks correct them
                 if isinstance(val, str):

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -42,6 +42,8 @@ def getFromNames(names, namespace):
     for nm in names:
         # fallback is to use original value
         obj = nm
+        # convert to a string
+        nm = str(nm)
         if nm in namespace:
             # if in namespace, return value from namespace
             obj = namespace[nm]

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -51,7 +51,8 @@ def getFromNames(names, namespace):
             # if otherwise safely evaluable, evaluate
             obj = eval(nm)
         # Append
-        objs.append(obj)
+        if len(nm):
+            objs.append(obj)
 
     return objs
 

--- a/psychopy/tools/environmenttools.py
+++ b/psychopy/tools/environmenttools.py
@@ -40,8 +40,14 @@ def getFromNames(names, namespace):
     # Get objects
     objs = []
     for nm in names:
-        # Get (use original value if not present)
-        obj = namespace.get(nm, nm)
+        # fallback is to use original value
+        obj = nm
+        if nm in namespace:
+            # if in namespace, return value from namespace
+            obj = namespace[nm]
+        elif nm.replace(".", "").replace("-", "").isnumeric() or nm in ("None", "True", "False"):
+            # if otherwise safely evaluable, evaluate
+            obj = eval(nm)
         # Append
         objs.append(obj)
 


### PR DESCRIPTION
Means that:
```
[text1, text2]
```
works even if text1 and text2 don't exist yet (which will be the case when loading conditions in Builder). If they don't exist yet, it just keeps them as strings.