### PR TITLE
BF: Fix "eyetracker is not defined" error on experiment quit

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1865,7 +1865,7 @@ class SettingsComponent:
             "    win.close()\n"
             "if inputs is not None:\n"
             "    if 'eyetracker' in inputs and inputs['eyetracker'] is not None:\n"
-            "        eyetracker.setConnectionState(False)\n"
+            "        inputs['eyetracker'].setConnectionState(False)\n"
         )
         if self.params['Save log file'].val:
             code += (


### PR DESCRIPTION
Was because `quit` function used name `eyetracker`, which was fine before the quit code was its own function but now that variable doesn't exist