### PR TITLE
BF: Fixed incorrect formatting in `AudioDeviceInfo` `__repr__`

### DIFF
--- a/psychopy/sound/audiodevice.py
+++ b/psychopy/sound/audiodevice.py
@@ -181,8 +181,8 @@ class AudioDeviceInfo:
 
     def __repr__(self):
         return (f"AudioDeviceInfo(deviceIndex={self.deviceIndex}, "
-                f"deviceName={self.deviceName}, "
-                f"hostAPIName={self.hostAPIName}, "
+                f"deviceName={repr(self.deviceName)}, "
+                f"hostAPIName={repr(self.hostAPIName)}, "
                 f"outputChannels={self.outputChannels}, "
                 f"outputLatency={repr(self.outputLatency)}, "
                 f"inputChannels={self.inputChannels}, "
@@ -464,7 +464,7 @@ class AudioDeviceStatus:
                  cpuLoad=0.0,
                  predictedLatency=0.0,
                  latencyBias=0.0,
-                 sampleRate=SAMPLE_RATE_48kHz,
+                 sampleRate=SAMPLE_RATE_44p1kHz,
                  outDeviceIndex=0,
                  inDeviceIndex=0,
                  audioLib=u'Null Audio Library'):


### PR DESCRIPTION
Quick fix for keyword args not being correctly formatted 