### PR TITLE
BF: Update path of README dialog on "save as"

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -825,6 +825,13 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         dlg.Destroy()
 
         self.updateWindowTitle()
+        # update README in case the file path has changed
+        if self.prefs['alwaysShowReadme']:
+            # if prefs are to always show README, show if populated
+            self.updateReadme()
+        else:
+            # otherwise update so we have the object, but don't show until asked
+            self.updateReadme(show=False)
         return returnVal
 
     def fileExport(self, event=None, htmlPath=None):


### PR DESCRIPTION
It was already updated on "open", but if you open Builder with a new psyexp and then do Save As..., the README dialog doesn't update its understanding of where the README file should be