### PR TITLE
NF: Added plugin support for standalone plugins

### DIFF
--- a/psychopy/experiment/routines/__init__.py
+++ b/psychopy/experiment/routines/__init__.py
@@ -1,15 +1,80 @@
-from importlib import import_module
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Classes and functions for routines in Builder.
+"""
 
+# Part of the PsychoPy library
+# Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+from importlib import import_module
 from ._base import BaseStandaloneRoutine, Routine
 from .unknown import UnknownRoutine
 from pathlib import Path
 
+# Standalone components loaded from plugins are stored in this dictionary. These
+# are added by calling `addStandaloneRoutine`. Plugins will always override
+# builtin components with the same name.
+pluginRoutines = {} 
+
+
+def addStandaloneRoutine(routineClass):
+    """Add a standalone routine to Builder.
+
+    This function will override any routine already loaded with the same
+    class name. Usually, this function is called by the plugin system. The user
+    typically does not need to call this directly.
+
+    Parameters
+    ----------
+    routineClass : object
+        Standalone routine class. Should be a subclass of 
+        `BaseStandaloneRoutine`.
+
+    """
+    global pluginRoutines  # components loaded at runtime
+
+    routineName = routineClass.__name__
+    logging.debug("Registering Builder routine class `{}`.".format(routineName))
+
+    # check type and attributes of the class
+    if not issubclass(routineClass, BaseStandaloneRoutine):
+        logging.warning(
+            "Component `{}` does not appear to be a subclass of "
+            "`psychopy.experiment.routines._base.BaseStandaloneRoutine`. This "
+            " may not work correcty.".format(routineName))
+    elif not hasattr(routineClass, 'categories'):
+        logging.warning(
+            "Routine `{}` does not define a `.categories` attribute.".format(
+                routineName))
+
+    pluginRoutines[compName] = routineClass
+
 
 def getAllStandaloneRoutines(fetchIcons=True):
+    """Get a mapping of all standalone routines.
+
+    This function will return a dictionary of all standalone routines
+    available in Builder. The dictionary is indexed by the class name of the
+    routine. The values are the routine classes themselves.
+
+    Parameters
+    ----------
+    fetchIcons : bool
+        If `True`, the routine classes will be asked to fetch their icons.
+
+    Returns
+    -------
+    dict
+        Dictionary of all standalone routines available in Builder, including
+        those added by plugins.
+
+    """
     # Safe import all modules within this folder (apart from protected ones with a _)
     for loc in Path(__file__).parent.glob("*"):
         if loc.is_dir() and not loc.name.startswith("_"):
             import_module("." + loc.name, package="psychopy.experiment.routines")
+
     # Get list of subclasses of BaseStandalone
     classList = BaseStandaloneRoutine.__subclasses__()
     # Remove unknown
@@ -18,4 +83,14 @@ def getAllStandaloneRoutines(fetchIcons=True):
     # Get list indexed by class name with Routine removed
     classDict = {c.__name__: c for c in classList}
 
+    # merge with plugin components
+    global pluginRoutines
+    if pluginRoutines:
+        logging.debug("Merging plugin routines with builtin Builder routines.")
+        classDict.update(pluginRoutines)
+
     return classDict
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -747,6 +747,8 @@ def loadPlugin(plugin):
                 _registerWindowBackend(attr, ep)
             elif fqn == 'psychopy.experiment.components':  # if component
                 _registerBuilderComponent(ep)
+            elif fqn == 'psychopy.experiment.routine':  # if component
+                _registerBuilderStandaloneRoutine(ep)
             elif fqn == 'psychopy.hardware.photometer':  # photometer
                 _registerPhotometer(ep)
 
@@ -1135,7 +1137,8 @@ def discoverModuleClasses(nameSpace, classType, includeUnbound=True):
 # Registration functions
 #
 # These functions are called to perform additional operations when a plugin is
-# loaded.
+# loaded. Most plugins that specify an entry point elsewhere will not need to
+# use these functions to appear in the application.
 #
 
 def _registerWindowBackend(attr, ep):
@@ -1236,6 +1239,38 @@ def _registerBuilderComponent(ep):
     else:
         raise AttributeError(
             "Cannot find function `addComponent()` in namespace "
+            "`{}`".format(fqn))
+
+
+def _registerBuilderStandaloneRoutine(ep):
+    """Register a PsychoPy builder standalone routine module.
+
+    This function is called by :func:`loadPlugin` when encountering an entry
+    point group for :mod:`psychopy.experiment.routine`.
+
+    This function is called by :func:`loadPlugin`, it should not be used for any
+    other purpose.
+
+    Parameters
+    ----------
+    ep : ClassType
+        Class defining the standalone routine.
+
+    """
+    # get reference to the backend class
+    fqn = 'psychopy.experiment.routines'
+    routinePkg = resolveObjectFromName(
+        fqn, resolve=(fqn not in sys.modules), error=False)
+
+    if routinePkg is None:
+        logging.error("Failed to resolve name `{}`.".format(fqn))
+        return
+
+    if hasattr(routinePkg, 'addStandaloneRoutine'):
+        routinePkg.addStandaloneRoutine(ep)
+    else:
+        raise AttributeError(
+            "Cannot find function `addStandaloneRoutine()` in namespace "
             "`{}`".format(fqn))
 
 


### PR DESCRIPTION
This PR allows standalone plugins to be added from plugins by providing a loader interface for `psychopy.experiment.routines`.