### PR TITLE
ENH: Improved plugin installation method

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -257,6 +257,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             return
 
         # load any plugins
+        import psychopy.tools.pkgtools as pkgtools
+        pkgtools.refreshPackages()
         from psychopy.plugins import scanPlugins, loadPlugin, listPlugins
 
         # if we find valid plugins, attempt to load them

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -218,7 +218,7 @@ class Job:
         self._stdoutReader = None
         self._stderrReader = None
 
-    def start(self, cwd=None):
+    def start(self, cwd=None, env=None):
         """Start the subprocess.
 
         Parameters
@@ -226,6 +226,9 @@ class Job:
         cwd : str or None
             Working directory for the subprocess. Leave `None` to use the same
             as the application.
+        env : dict or None
+            Environment variables to pass to the subprocess. Leave `None` to
+            use the same as the application.
 
         Returns
         -------
@@ -254,7 +257,7 @@ class Job:
                 preexec_fn=None,
                 shell=False,
                 cwd=cwd,
-                env=None,
+                env=env,
                 universal_newlines=True,  # gives us back a string instead of bytes
                 creationflags=0,
                 text=True

--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -220,24 +220,24 @@ class EnvironmentManagerDlg(wx.Dialog):
         # interpreter path
         pyExec = sys.executable
 
-        # determine installation path for bundle, create it if needed
-        bundlePath = plugins.getBundleInstallTarget(packageName)
-        if not os.path.exists(bundlePath):
-            self.output.writeStdOut(
-                "Creating bundle path `{}` for package `{}`.".format(
-                    bundlePath, packageName))
-            os.mkdir(bundlePath)  # make the directory
-        else:
-            self.output.writeStdOut(
-                "Using existing bundle path `{}` for package `{}`.".format(
-                    bundlePath, packageName))
+        # # determine installation path for bundle, create it if needed
+        # bundlePath = plugins.getBundleInstallTarget(packageName)
+        # if not os.path.exists(bundlePath):
+        #     self.output.writeStdOut(
+        #         "Creating bundle path `{}` for package `{}`.".format(
+        #             bundlePath, packageName))
+        #     os.mkdir(bundlePath)  # make the directory
+        # else:
+        #     self.output.writeStdOut(
+        #         "Using existing bundle path `{}` for package `{}`.".format(
+        #             bundlePath, packageName))
 
         # add the bundle to path, refresh makes it discoverable after install
-        if bundlePath not in sys.path:
-            sys.path.insert(0, bundlePath)
+        # if bundlePath not in sys.path:
+        #     sys.path.insert(0, bundlePath)
 
         # build the shell command to run the script
-        command = [pyExec, '-m', 'pip', 'install', packageName, '--target', bundlePath]
+        command = [pyExec, '-m', 'pip', 'install', packageName, '--user']
         # write command to output panel
         self.output.writeCmd(" ".join(command))
         # append own name to extra
@@ -246,6 +246,10 @@ class EnvironmentManagerDlg(wx.Dialog):
         extra.update(
             {'pipname': packageName}
         )
+        
+        # set the environment variable 
+        env = os.environ.copy()
+        env['PYTHONUSERBASE'] = prefs.paths['packages']
 
         # create a new job with the user script
         self.pipProcess = jobs.Job(
@@ -257,7 +261,7 @@ class EnvironmentManagerDlg(wx.Dialog):
             terminateCallback=self.onInstallExit,
             extra=extra
         )
-        self.pipProcess.start()
+        self.pipProcess.start(env=env)
 
     def installPlugin(self, pluginInfo, version=None):
         """Install a package.

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -33,7 +33,18 @@ import os
 import os.path
 import requests
 import shutil
+import site
 
+# On import we want to configure the user site-packages dir and add it to the
+# import path. 
+
+# set user site-packages dir
+site.USER_BASE = prefs.paths['packages']
+site.USER_SITE = None  # clear, recompute this value 
+logging.debug('User site-packages dir set to: %s' % site.getusersitepackages())
+
+if not site.USER_SITE in sys.path:
+    site.addsitedir(site.getusersitepackages()) 
 
 # add packages dir to import path
 if prefs.paths['packages'] not in pkg_resources.working_set.entries:
@@ -136,8 +147,10 @@ def installPackage(package, target=None, upgrade=False, forceReinstall=False,
         Package name (e.g., `'psychopy-connect'`, `'scipy'`, etc.) with version
         if needed. You may also specify URLs to Git repositories and such.
     target : str or None
-        Location to install packages to. This defaults to the 'packages' folder
-        in the user PsychoPy folder if `None`.
+        Location to install packages to directly to. If `None`, the user's
+        package directory is set at the prefix and the package is installed
+        there. If a `target` is specified, the package top-level directory
+        must be added to `sys.path` manually.
     upgrade : bool
         Upgrade the specified package to the newest available version.
     forceReinstall : bool
@@ -165,9 +178,15 @@ def installPackage(package, target=None, upgrade=False, forceReinstall=False,
             'exist.'.format(package, target))
 
     # construct the pip command and execute as a subprocess
-    cmd = [sys.executable, "-m", "pip", "install", package, "--target", target]
+    cmd = [sys.executable, "-m", "pip", "install", package]
 
     # optional args
+    if target is None:  # default to user packages dir
+        cmd.append('--prefix')
+        cmd.append(prefs.paths['packages'])
+    else:
+        cmd.append('--target')
+        cmd.append(target)
     if upgrade:
         cmd.append('--upgrade')
     if forceReinstall:
@@ -415,12 +434,18 @@ def uninstallPackage(package):
         # construct the pip command and execute as a subprocess
         cmd = [sys.executable, "-m", "pip", "uninstall", package, "--yes",
                '--no-input', '--no-color']
+
+        # setup the environment to use the user's site-packages
+        env = os.environ.copy()
+        env["PYTHONUSERBASE"] = site.USER_BASE
+
         # run command in subprocess
         output = sp.Popen(
             cmd,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
             shell=False,
+            env=env,
             universal_newlines=True)
         stdout, stderr = output.communicate()  # blocks until process exits
 


### PR DESCRIPTION
This PR modifies how plugins are installed by setting the installation prefix parameter to the `package` directory. This allows pip to work it's magic without requiring custom package installation methods. This will break plugin installation in a virtual environments unless `include-system-site-packages = true` is specified in `pyenv.cfg`. 

Some plugin packages will be broken after this change if they have dependency conflicts with the venv.