### PR TITLE
Fixed sounds restarting at the end of a Routine where they had perviously stopped

### DIFF
--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -566,16 +566,12 @@ class SoundPTB(_SoundBase):
             logging.exp(u"Sound %s started" % (self.name), obj=self, t=logTime)
 
     def pause(self, log=True):
-        """Toggles the pause state the sound but play will continue from here if needed
+        """Stops the sound without reset, so that play will continue from here if needed
         """
         if self.isPlaying:
             self.stop(reset=False)
             if log and self.autoLog:
                 logging.exp(u"Sound %s paused" % (self.name), obj=self)
-        else:
-            self.play()
-            if log and self.autoLog:
-                logging.exp(u"Sound %s unpaused" % (self.name), obj=self)
 
     def stop(self, reset=True, log=True):
         """Stop the sound and return to beginning


### PR DESCRIPTION
Toggling was causing sounds to restart in at the end of Routines where they had ended or had been stopped.

It was set to toggle, only for this sound backend, in 2023.1 but that was only documented in 2023.2.0 and I think we should consider it a bug rather than a feature.