### PR TITLE
NF: Print all logging messages to console

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
 
 import sys
 import os
+import io
 from .console import StdStreamDispatcher
 from .frametracker import openFrames
 
@@ -96,7 +97,15 @@ def startApp(showSplash=True, testMode=False, safeMode=False):
             'this is not permitted.')
 
     stdDisp = StdStreamDispatcher(_psychopyApp, prefLogFilePath)
+    lastRunLog.close()  # close after redircet
     stdDisp.redirect()
+
+    if prefLogFilePath is not None:
+        # write all messages that came up in the log file to console
+        with io.open(sys.__stdout__.fileno(), 'w', encoding="utf-8") as f:
+            with open(prefLogFilePath, 'r') as lf:
+                f.write(lf.read())
+                f.flush()
 
     if not testMode:
         # Setup redirection of errors to the error reporting dialog box. We

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -66,9 +66,15 @@ def startApp(showSplash=True, testMode=False, safeMode=False):
         raise RuntimeError(
             '`StdStreamDispatcher` instance initialized outside of `startApp`, '
             'this is not permitted.')
-            
+
     userPrefsDir = prefs.paths['userPrefsDir']
     prefLogFilePath = os.path.join(userPrefsDir, 'last_app_load.log')
+
+    # clear the log file
+    with io.open(prefLogFilePath, 'w', encoding='utf-8') as f:
+        f.write('')
+
+    # redirect logging
     stdDisp = StdStreamDispatcher(None, prefLogFilePath)
     stdDisp.redirect()
 

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -141,6 +141,11 @@ class StdStreamDispatcher:
                 lf.write(text)
                 lf.flush()
 
+        # print text to stdout
+        with io.open(sys.__stdout__.fileno(), 'w', encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+
     def flush(self):
         pass
 

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -159,6 +159,25 @@ class StdStreamDispatcher:
     def flush(self):
         pass
 
+    def __enter__(self):
+        """Context manager entry point.
+        """
+        self.open()
+        return self
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
+    def open(self):
+        """Open the log writer.
+        
+        This redirects stdout and stderr. Same as calling `redirect()` but
+        included for compatibility with context managers.
+        
+        """
+        sys.stdout = self
+        sys.stderr = self
+
     def close(self):
         """Close sthe log writer.
         

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -174,6 +174,11 @@ class StdStreamDispatcher:
         if runner is not None:
             runner.stdOut.Clear()
 
+    def __del__(self):
+        # restore stdout and stderr
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
 
 if __name__ == "__main__":
     pass

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -85,6 +85,16 @@ class StdStreamDispatcher:
         return cls._initialized
 
     @property
+    def app(self):
+        """Handle to the app (`PsychopyApp` or `None`).
+        """
+        return self._app
+
+    @app.setter
+    def app(self, val):
+        self._app = val
+
+    @property
     def logFile(self):
         """Log file for standard streams (`str` or `None`).
         """
@@ -102,7 +112,7 @@ class StdStreamDispatcher:
     def write(self, text):
         """Send text standard output to all listeners (legacy). This method is
         used for compatibility for older code. This makes it so an instance of
-        this object looks like a ...
+        this object looks like a file object.
 
         Parameters
         ----------
@@ -121,9 +131,21 @@ class StdStreamDispatcher:
             Text to broadcast to all standard output windows.
 
         """
+        # write to log file
+        if self._logFile is not None:
+            # with open(self._logFile, 'a') as lf:
+            with io.open(self._logFile, 'a', encoding="utf-8") as lf:
+                lf.write(text)
+                lf.flush()
+
+        # print text to stdout
+        with io.open(sys.__stdout__.fileno(), 'w', encoding="utf-8") as sdto:
+            sdto.write(text)
+            sdto.flush()
+
         # do nothing is the app isn't fully realized
-        if not self._app.appLoaded:
-            return
+        if self.app is None or not self.app.appLoaded:
+            return 
 
         coder = self._app.coder
         if coder is not None:
@@ -133,18 +155,6 @@ class StdStreamDispatcher:
         runner = self._app.runner
         if runner is not None:
             runner.stdOut.write(text)
-
-        # write to log file
-        if self._logFile is not None:
-            # with open(self._logFile, 'a') as lf:
-            with io.open(self._logFile, 'a', encoding="utf-8") as lf:
-                lf.write(text)
-                lf.flush()
-
-        # print text to stdout
-        with io.open(sys.__stdout__.fileno(), 'w', encoding="utf-8") as f:
-            f.write(text)
-            f.flush()
 
     def flush(self):
         pass

--- a/psychopy/app/console.py
+++ b/psychopy/app/console.py
@@ -159,6 +159,15 @@ class StdStreamDispatcher:
     def flush(self):
         pass
 
+    def close(self):
+        """Close sthe log writer.
+        
+        This unredirects stdout and stderr.
+        
+        """
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
     def clear(self):
         """Clear all output windows."""
         # do nothing is the app isn't fully realized


### PR DESCRIPTION
Fixes #5853 by writing log messages to console. It dumps the contents of the last application load to console and then prints all messages to console thereafter. This is okay if the app doesn't crash before stdout is redirected to the dispatcher.