### PR TITLE
BF: Fix getting ioHub YAML config files from plugin packages

### DIFF
--- a/psychopy/iohub/devices/deviceConfigValidation.py
+++ b/psychopy/iohub/devices/deviceConfigValidation.py
@@ -8,7 +8,7 @@ import os
 import numbers  # numbers.Integral is like (int, long) but supports Py3
 from psychopy import colors
 from psychopy.tools import arraytools
-from ..util import yload, yLoader, module_directory
+from ..util import yload, yLoader, module_directory, getSupportedConfigSettings
 from ..errors import print2err
 
 # Takes a device configuration yaml dict and processes it based on the devices
@@ -489,7 +489,9 @@ def validateDeviceConfiguration(
     """Validate the device configuration settings provided.
     """
     validation_module = importlib.import_module(relative_module_path)
-    validation_file_path = validation_module.yamlFile
+    validation_file_path = getSupportedConfigSettings(validation_module)
+
+    # use a default config if we can't get the YAML file
     if not os.path.exists(validation_file_path):
         validation_file_path = os.path.join(
             _current_dir, 

--- a/psychopy/iohub/devices/deviceConfigValidation.py
+++ b/psychopy/iohub/devices/deviceConfigValidation.py
@@ -486,22 +486,30 @@ def validateDeviceConfiguration(
         relative_module_path,
         device_class_name,
         current_device_config):
-    validation_file_path = os.path.join(_current_dir,
-                                        relative_module_path[len('psychopy.iohub.devices.'):].replace('.', os.path.sep),
-                                        'supported_config_settings_{0}.yaml'.format(device_class_name.lower()))
+    """Validate the device configuration settings provided.
+    """
+    validation_module = importlib.import_module(relative_module_path)
+    validation_file_path = validation_module.yamlFile
     if not os.path.exists(validation_file_path):
-        validation_file_path = os.path.join(_current_dir,
-                                            relative_module_path[len('psychopy.iohub.devices.'):].replace('.',
-                                                                                                          os.path.sep),
-                                            'supported_config_settings.yaml')
-    device_settings_validation_dict = yload(open(validation_file_path, 'r'), Loader=yLoader)
-    device_settings_validation_dict = device_settings_validation_dict[list(device_settings_validation_dict.keys())[0]]
+        validation_file_path = os.path.join(
+            _current_dir, 
+            relative_module_path[len('psychopy.iohub.devices.'):].replace(
+                '.', os.path.sep),
+        'supported_config_settings.yaml')
+
+    device_settings_validation_dict = yload(
+        open(validation_file_path, 'r'), Loader=yLoader)
+    device_settings_validation_dict = device_settings_validation_dict[
+        list(device_settings_validation_dict.keys())[0]]
 
     param_validation_func_mapping = dict()
     parent_config_param_path = None
-    buildConfigParamValidatorMapping(device_settings_validation_dict, param_validation_func_mapping,
-                                     parent_config_param_path)
+    buildConfigParamValidatorMapping(
+        device_settings_validation_dict, 
+        param_validation_func_mapping,
+        parent_config_param_path)
 
-    validation_results = validateConfigDictToFuncMapping(param_validation_func_mapping, current_device_config, None)
+    validation_results = validateConfigDictToFuncMapping(
+        param_validation_func_mapping, current_device_config, None)
 
     return validation_results

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/__init__.py
@@ -4,18 +4,14 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
-import psyhopy.iohub.util as _util
 
 try:
-    from psychopy_eyetracker_gazepoint import gp3, __file__
+    from psychopy_eyetracker_gazepoint import gp3
 except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "The Gazepoint eyetracker requires package " 
         "'psychopy-eyetracker-gazepoint' to be installed. Please install this "
         "package and restart the session to enable support.")
-
-# get configuration from plugin
-yamlFile = _util.getSupportedConfigSettings(gp3)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/__init__.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
+import psyhopy.iohub.util as _util
 
 try:
     from psychopy_eyetracker_gazepoint import gp3
@@ -12,6 +13,9 @@ except (ModuleNotFoundError, ImportError, NameError):
         "The Gazepoint eyetracker requires package " 
         "'psychopy-eyetracker-gazepoint' to be installed. Please install this "
         "package and restart the session to enable support.")
+
+# get configuration from plugin
+yamlFile = _util.getSupportedConfigSettings(gp3)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/__init__.py
@@ -5,3 +5,6 @@
 from .eyetracker import EyeTracker
 from psychopy.iohub.devices.eyetracker import (MonocularEyeSampleEvent, FixationStartEvent, FixationEndEvent,
                                                SaccadeEndEvent, SaccadeStartEvent, BlinkEndEvent, BlinkStartEvent)
+
+# builtin mouse device
+yamlFile = __file__.replace('__init__.py', 'supported_config_settings.yaml')

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/__init__.py
@@ -6,5 +6,3 @@ from .eyetracker import EyeTracker
 from psychopy.iohub.devices.eyetracker import (MonocularEyeSampleEvent, FixationStartEvent, FixationEndEvent,
                                                SaccadeEndEvent, SaccadeStartEvent, BlinkEndEvent, BlinkStartEvent)
 
-# builtin mouse device
-yamlFile = __file__.replace('__init__.py', 'supported_config_settings.yaml')

--- a/psychopy/iohub/devices/eyetracker/hw/pupil_labs/pupil_core/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/pupil_labs/pupil_core/__init__.py
@@ -9,6 +9,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
+import psyhopy.iohub.util as _util
 
 try:
     from psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core import (
@@ -20,6 +21,9 @@ except (ModuleNotFoundError, ImportError, NameError):
         "Pupil Labs eyetracker support requires the package "
         "'psychopy-eyetracker-pupil-labs' to be installed. Please install this "
         "package and restart the session to enable support.")
+
+# get configuration from plugin
+yamlFile = _util.getSupportedConfigSettings(pupil_core)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/pupil_labs/pupil_core/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/pupil_labs/pupil_core/__init__.py
@@ -9,7 +9,6 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
-import psyhopy.iohub.util as _util
 
 try:
     import psychopy_eyetracker_pupil_labs.pupil_labs.pupil_core as __plugin__
@@ -25,8 +24,6 @@ except (ModuleNotFoundError, ImportError, NameError):
         "'psychopy-eyetracker-pupil-labs' to be installed. Please install this "
         "package and restart the session to enable support.")
 
-# get configuration from plugin
-yamlFile = _util.getSupportedConfigSettings(pupil_core)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/__init__.py
@@ -4,7 +4,6 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
-import psyhopy.iohub.util as _util
 
 try:
     from psychopy_eyetracker_sr_research.sr_research.eyelink import (
@@ -24,9 +23,6 @@ except (ModuleNotFoundError, ImportError, NameError):
         "SR Research eyetracker support requires the package "
         "'psychopy-eyetracker-sr-research' to be installed. Please install "
         "this package and restart the session to enable support.")
-
-# get configuration from plugin
-yamlFile = _util.getSupportedConfigSettings(eyelink)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/sr_research/eyelink/__init__.py
@@ -4,6 +4,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
+import psyhopy.iohub.util as _util
 
 try:
     from psychopy_eyetracker_sr_research.sr_research.eyelink import (
@@ -21,6 +22,9 @@ except (ModuleNotFoundError, ImportError, NameError):
         "SR Research eyetracker support requires the package "
         "'psychopy-eyetracker-sr-research' to be installed. Please install "
         "this package and restart the session to enable support.")
+
+# get configuration from plugin
+yamlFile = _util.getSupportedConfigSettings(eyelink)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
@@ -4,7 +4,9 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
+import psyhopy.iohub.util as _util
 
+yamlFile = None
 try:
     from psychopy_eyetracker_tobii.tobii import *
 except (ModuleNotFoundError, ImportError, NameError):
@@ -12,6 +14,9 @@ except (ModuleNotFoundError, ImportError, NameError):
         "The Tobii eyetracker requires package 'psychopy-eyetracker-tobii' to "
         "be installed. Please install this package and restart the session to "
         "enable support.")
+
+# get configuration from plugin
+yamlFile = _util.getSupportedConfigSettings(tobii)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
@@ -4,20 +4,15 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import psychopy.logging as logging
-import psyhopy.iohub.util as _util
 
 yamlFile = None
 try:
-    from psychopy_eyetracker_tobii.tobii import __file__
     from psychopy_eyetracker_tobii.tobii import *
 except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "The Tobii eyetracker requires package 'psychopy-eyetracker-tobii' to "
         "be installed. Please install this package and restart the session to "
         "enable support.")
-
-# get configuration from plugin
-yamlFile = _util.getSupportedConfigSettings(tobii)
 
 if __name__ == "__main__":
     pass

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -13,6 +13,7 @@ import datetime
 from ..errors import print2err, printExceptionDetailsToStdErr
 import re
 import collections.abc
+import pathlib
 import psychopy.logging as logging
 import psychopy.plugins as plugins
 
@@ -135,6 +136,33 @@ def module_directory(local_function):
     mp = module_path(local_function)
     moduleDirectory, mname = os.path.split(mp)
     return moduleDirectory
+
+
+def getSupportedConfigSettings(module_name):
+    """Get the supported configuration settings for a device.
+
+    Parameters
+    ----------
+    module_name : str
+        The name of the module to get the path for. Must be a package that defines
+        `__init__.py`.
+    
+    Returns
+    -------
+    str
+        The path to the module.
+
+    """
+    fileName = 'supported_config_settings_{0}.yaml'.format(device_class_name.lower())
+    yamlFile = pathlib.Path(module_name.__file__).parent / fileName
+
+    # check if exists
+    if not yamlFile.exists():
+        raise FileNotFoundError(
+            'Could not find supported_config_settings.yaml for {0}.'.format(
+                module_name))
+
+    return yamlFile
 
 
 def isIterable(o):

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -138,31 +138,45 @@ def module_directory(local_function):
     return moduleDirectory
 
 
-def getSupportedConfigSettings(module_name):
+def getSupportedConfigSettings(moduleName, deviceClassName=None):
     """Get the supported configuration settings for a device.
+
+    These are usually stored as YAML files within the module directory that 
+    defines the device class.
 
     Parameters
     ----------
-    module_name : str
+    moduleName : str
         The name of the module to get the path for. Must be a package that defines
         `__init__.py`.
+    deviceClassName : str, optional
+        The name of the specific device class to get the path for. If not provided, 
+        the default configuration file will be searched for in the module 
+        directory.
     
     Returns
     -------
     str
-        The path to the module.
+        The path to the supported configuration settings file in YAML format.
 
     """
-    fileName = 'supported_config_settings_{0}.yaml'.format(device_class_name.lower())
-    yamlFile = pathlib.Path(module_name.__file__).parent / fileName
-
-    # check if exists
-    if not yamlFile.exists():
+    if deviceClassName is not None:
+        # file name for yaml file name convention for multiple files
+        fileName = 'supported_config_settings_{0}.yaml'.format(
+            deviceClassName.lower())
+        yamlFile = pathlib.Path(moduleName.__file__).parent / fileName
+        if not yamlFile.exists():
+            raise FileNotFoundError(
+                "No config file found in module dir {0}".format(moduleName))
+        return str(yamlFile)
+        
+    # file name for yaml file name convention for single file
+    yamlFile = pathlib.Path('supported_config_settings.yaml')
+    if not yamlFile.exists():  # nothing is found
         raise FileNotFoundError(
-            'Could not find supported_config_settings.yaml for {0}.'.format(
-                module_name))
+            "No config file found in module dir {0}".format(moduleName))
 
-    return yamlFile
+    return str(yamlFile)
 
 
 def isIterable(o):

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -160,21 +160,28 @@ def getSupportedConfigSettings(moduleName, deviceClassName=None):
         The path to the supported configuration settings file in YAML format.
 
     """
+    yamlRoot = pathlib.Path(moduleName.__file__).parent
     if deviceClassName is not None:
         # file name for yaml file name convention for multiple files
         fileName = 'supported_config_settings_{0}.yaml'.format(
             deviceClassName.lower())
-        yamlFile = pathlib.Path(moduleName.__file__).parent / fileName
+        yamlFile = yamlRoot / pathlib.Path(moduleName.__file__).parent / fileName
         if not yamlFile.exists():
             raise FileNotFoundError(
                 "No config file found in module dir {0}".format(moduleName))
+        logging.debug(
+            "Found ioHub device configuration file: {0}".format(yamlFile))
+
         return str(yamlFile)
         
     # file name for yaml file name convention for single file
-    yamlFile = pathlib.Path('supported_config_settings.yaml')
+    yamlFile = yamlRoot / pathlib.Path('supported_config_settings.yaml')
     if not yamlFile.exists():  # nothing is found
         raise FileNotFoundError(
             "No config file found in module dir {0}".format(moduleName))
+    
+    logging.debug(
+        "Found ioHub device configuration file: {0}".format(yamlFile))
 
     return str(yamlFile)
 


### PR DESCRIPTION
This gets ioHub configurations from plugin package directories without importing `__file__` which overwrites the `__file__` of the existing module with possible unintended consequences. 