### PR TITLE
BF: edit messages.mo entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.so
 *.egg
 .eggs
-messages.mo
+psychopy/app/locale/*/LC_MESSAGE/messages.mo
 
 # Python files #
 ################

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.so
 *.egg
 .eggs
-psychopy/app/locale/*/LC_MESSAGE/messages.mo
+psychopy/app/locale/**/LC_MESSAGE/messages.mo
 
 # Python files #
 ################


### PR DESCRIPTION
I left out a path originally. Currently, it's not blocking translators' .mo files from being staged... Alas, I read that the double-asterisk allows for multiple directories. So the final version pulled in should have the two asterisks under `locale`... I think :)