### PR TITLE
BF: Use Version couldn't compile when Python path contains a space

### DIFF
--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -64,7 +64,7 @@ def generateScript(experimentPath, exp, target="PsychoPy"):
             exp.saveToXML(filename=exp.filename)
         # generate command to run compile from requested version
         cmd = [
-            pythonExec, '-m', compiler, str(exp.legacyFilename), '-o', experimentPath
+            pythonExec, '-m', compiler, repr(exp.legacyFilename), '-o', experimentPath
         ]
         # run command
         cmd.extend(['-v', version])

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -64,7 +64,7 @@ def generateScript(experimentPath, exp, target="PsychoPy"):
             exp.saveToXML(filename=exp.filename)
         # generate command to run compile from requested version
         cmd = [
-            pythonExec, '-m', compiler, repr(exp.legacyFilename), '-o', experimentPath
+            repr(pythonExec), '-m', compiler, repr(exp.legacyFilename), '-o', experimentPath
         ]
         # run command
         cmd.extend(['-v', version])


### PR DESCRIPTION
I *think* the fix is as simple as just putting the Python path in quotes when calling the command, but I need to test this on Mac so keeping as draft until I can confirm. 