### PR TITLE
DOCS: Conform translation guide to workshop

### DIFF
--- a/docs/source/developers/localization.rst
+++ b/docs/source/developers/localization.rst
@@ -11,46 +11,85 @@ As a translator, you will likely introduce many new people to |PsychoPy|, and yo
 .. note:: 
   Translations here do **not** refer to what the participant in a study sees, nor what is seen in documentation (help files, etc.). 
 
+|
+
 What you need to *know* already
-------------------------------
+---------------------------------
 
 In order to translate the |PsychoPy| app to another language, you need a thorough understanding of at least three things:
 
-* `PsychoPy <https://www.psychopy.org/>`_ itself, as an experiment designer yourself
+* |psychopyWebpage| itself, as an experiment designer yourself
 * the English language
 * the language you want to translate into (e.g., Korean)
 
 You will also need an understanding of two more things. But in contrast to the above, these can be learned in less than a day.
 
-* how to contribute to the |PsychoPy| project using `Git <https://git-scm.com/>`_, usually via `GitHub <https://github.com/>`_
-* how to use the free app `Poedit <https://poedit.net/>`_ 
+* how to contribute to the |PsychoPy| project using |gitWebpage| via |githubWebpage|
+* how to use the free app |poeditWebpage| 
  
-To help you along with `Git <https://git-scm.com/>`_ and `GitHub <https://github.com/>`_, you should read through :ref:`the instructions on how to do so<usingRepos>`. However, we explain how to use `Poedit <https://poedit.net/>`_ in the tutorial directly below.
+To help you along with |gitWebpage| and |githubWebpage|, you should read through :ref:`the instructions on how to do so<usingRepos>`. However, we explain how to use |poeditWebpage| in the tutorial directly below.
+
+.. note::
+  For a more step-by-step tutorial for translators, please see the materials from our 3-hour translator workshop. You can go to the |translatorWorkshopSlides|, or the |translatorWorkshopWebpage|. The information is identical in both.
+
+.. |psychopyWebpage| raw:: html
+
+  <a href="https://www.psychopy.org/" target="_blank">PsychoPy</a>
+
+.. |gitWebpage| raw:: html
+
+  <a href="https://git-scm.com/" target="_blank">Git</a>
+
+.. |githubWebpage| raw:: html
+
+  <a href="https://github.com/" target="_blank">GitHub</a>
+
+.. |poeditWebpage| raw:: html
+
+  <a href="https://poedit.net/" target="_blank">Poedit</a>
+
+.. |translatorWorkshopSlides| raw:: html
+
+  <a href="https://workshops.psychopy.org/slides/translators/#1" target="_blank">workshop slides</a>
+
+.. |translatorWorkshopWebpage| raw:: html
+
+  <a href="https://workshops.psychopy.org/translators/index.html" target="_blank">workshop webpage</a>
+
+|
 
 What you need to *have already done* before you begin
------------------------------------
+----------------------------------------------------------
 
 Importantly, everything in the rest of this tutorial assumes you have already done the following: 
 
-* forked the `psychopy repository on GitHub <https://github.com/psychopy/psychopy>`_ to your own *GitHub* account
-* created a new branch based on the *Release* branch, but renamed according to what you are going to do (e.g., ``feature-translate-spanish``)
-* then clone that branch to your own computer
+* forked the |psychopyOnGithub| to your own *GitHub* account
+* cloned the repository to your own computer
 
 Again, see :ref:`the instructions on how to contribute to PsychoPy<usingRepos>` if you are unclear on how to do any or all of this.
 
+.. warning::
+  If you are **also** working on things other than translations, consider creating a new branch based on the *release* branch, but rename it according to what you are going to do (e.g., ``translate-spanish``). This will help you keep things organised in your own workspace. But if you are only doing translations, then just stay on the *release* branch.
+
+.. |psychopyOnGithub| raw:: html
+
+  <a href="https://github.com/psychopy/psychopy" target="_blank">PsychoPy repository on GitHub</a>
+
+|
+
 Finding the file you need for your translation
-----------------------------
+--------------------------------------------------
 
-|PsychoPy| uses `GNU gettext <https://www.gnu.org/software/gettext/>`_ and `wxPython <https://docs.wxpython.org/wx.Locale.html>`_ to allow for translations into other languages. But the only thing you as translator need to understand here is that in order to add any particular translation to |PsychoPy|, you need to work on a particular ``messages.po`` file.
+|PsychoPy| uses |gettextWebpage| and |wxPythonWebpage| to allow for translations into other languages. But the only thing you as translator need to understand here is that in order to add any particular translation to |PsychoPy|, you need to work on a particular ``messages.po`` file.
 
-This ``messages.po`` file for any given language is stored within a unique subdirectory within the following directory in the repository:
+The ``messages.po`` file for any given language is stored within a unique subdirectory within the following directory in the repository:
 
 ``THE/PATH/ON/YOUR/COMPUTER/TO/psychopy/app/locale/``
 
-The list of subdirectory names you see at that location are `locale names <https://www.gnu.org/software/gettext/manual/gettext.html#Locale-Names>`_ from the ``ll_CC`` system in `gettext <https://www.gnu.org/software/gettext/>`_. The naming convention works as follows:
+The list of subdirectory names you see at that location are |localeNames| from the ``ll_CC`` system in |gettextWebpage|. The naming convention works as follows:
 
-* For any given language, the first pair of letters, ``ll``, is replaced by an `ISO 639 pair <https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes>`_ of lowercase letters that identify that language
-* For any given country, the second pair of letters, ``CC``, is replaced by an `ISO 3166 pair <https://www.gnu.org/software/gettext/manual/gettext.html#Country-Codes>`_ of uppercase letters that identify a country.
+* For any given language, the first pair of letters, ``ll``, is replaced by an |iso639pairs| of lowercase letters that identify that language
+* For any given country, the second pair of letters, ``CC``, is replaced by an |iso3166pairs| of uppercase letters that identify a country.
   
 For example, for German, ``ll_CC`` becomes ``de_DE``, and refers to the German language (``de``, for *deutsch*) as it is used in the country of Germany (``DE``, *Deutschland*). Together, they index the dialect known as *High German* (the standard dialect used in Germany).
 
@@ -63,17 +102,43 @@ If your language is **not** listed and you need to add it (or even if you are un
 
 If the appropriate language subdirectory is already listed, then proceed to the next section.
 
+.. |wxPythonWebpage| raw:: html
+
+  <a href="https://docs.wxpython.org/wx.Locale.html" target="_blank">wxPython</a>
+
+.. |localeNames| raw:: html
+
+  <a href="https://www.gnu.org/software/gettext/manual/gettext.html#Locale-Names" target="_blank">locale names</a>
+
+.. |gettextWebpage| raw:: html
+
+  <a href="https://www.gnu.org/software/gettext/" target="_blank">gettext</a>
+
+.. |iso639pairs| raw:: html
+
+  <a href="https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes" target="_blank">ISO 639 pair</a>
+
+.. |iso3166pairs| raw:: html
+
+  <a href="https://www.gnu.org/software/gettext/manual/gettext.html#Country-Codes" target="_blank">ISO 3166 pair</a>
+
 .. _translateProcess:
+
+|
 
 The translation process in *Poedit*
 --------------------------------------
 
-Open the relevant ``ll_CC`` directory. You will see a subdirectory titled ``LC_MESSAGE``. Inside that directory are two files. The one you work on as a translator is the ``.po`` file: ``messages.po``. The other file is ``messages.mo``, an un-editable binary file which *Poedit* will generate for you when you request it (see below), and is actually the file that |PsychoPy| will use during operation.
+Open the relevant ``ll_CC`` directory. You will see a subdirectory titled ``LC_MESSAGE``. Inside that subdirectory are two files. The one you work on as a translator is the ``.po`` file: ``messages.po``. The other file is ``messages.mo``, an un-editable binary file that actually turns out to be the file that |PsychoPy| will use during operation. This file is compiled during major and minor releases of |PsychoPy|, however. So you should not do it yourself within *Poedit*.
 
-There are a number of tools you can use to edit the ``messages.po`` file, but the rest of this tutorial assumes that you are using the free app `Poedit <https://poedit.net/>`_. It is cross-platform, and very user-friendly. If you haven't done so already, `download it <https://poedit.net/download>`_ and install it in order to continue.
+There are a number of tools you can use to edit the ``messages.po`` file, but the rest of this tutorial assumes that you are using the free app |poeditWebpage|. It is cross-platform, and very user-friendly. If you haven't done so already, |poeditDownloadPage| and install it in order to continue.
 
 .. note:: 
   How to translate the *start-up tips* in |PsychoPy| is covered below under the section titled *Step 3b: Translating Start-up Tips*. It involves a somewhat different process. First however, please read through the section directly below.
+
+.. |poeditDownloadPage| raw:: html
+
+  <a href="https://poedit.net/download" target="_blank">download Poedit</a>
 
 |
 
@@ -92,36 +157,39 @@ Start *Poedit*
   * Under the tab labled ``Translation properties``
     
     * ``Project name and version``: Type in *PsychoPy* followed by the |PsychoPy| version you are working on (usually the most recently released version of |PsychoPy|)
-    * ``Language``: Scroll to and select the appropriate ``ll`` or ``ll_CC`` language (see above).
-    * ``Charset``: Set this to *UTF-8*.   
-
+    * ``Language``: Scroll to and select the appropriate language or language variety (language + country; see above)
+    * ``Charset``: Set this to *UTF-8*.
   * Under the tab labeled ``Sources Paths``
     
     * ``Base path``: Set this to the path on your computer that leads to the ``psychopy`` directory *within* the cloned repository on your computer. Assuming you forked and cloned the *psychopy* repository in the usual way, this path would appear as follows on your computer: ``..THE/PATH/ON/YOUR/COMPUTER/TO/psychopy/psychopy``   
-
   * Under the tab labeled ``Sources Keywords``
 
     * ``Additional keywords``: Make sure that the keyword ``_translate`` is listed in that box. If not, type it in.   
-
 * Save your work (``File`` > ``Save``)   
 
-Start your preferred text editor (e.g., *Visual Studio Code*, *PyCharm*)
+Start your preferred text editor (e.g., *TextEdit*, *Visual Studio Code*, *PyCharm*)
 
 * Go to ``psychopy/app/localization/mappings.txt`` in the repository
 
   * Find or type in the appropriate ``ll_CC`` code at the appropriate line (entries are listed alphabetically)
-  * Add the 3-letter Microsoft code that refers to the language. These can be found in the rightmost column (`Language code`) on Microsoft's list of `Language Idenfiers and and Locales <https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms903928(v=msdn.10)?redirectedfrom=MSDN>`_.
-  * At the far right, be sure that there is a label for the language that should be familiar to people who read that language, followed by the name of the language in English, but in parentheses. The purpose is to highlight the name of the language as written in the non-English language itself. For example:
+  * Add the 3-letter Microsoft code that refers to the language. These can be found in the rightmost column (`Language code`) on |msListOfLangIDsAndLocales|.
+  * At the far right, be sure that there is a label for the language (and possibly country) that should be familiar to people who read that language, followed by the same in English, but in parentheses. The purpose is to highlight the name of the language as written in the non-English language itself. For example:
   
-    *  " ``español (Spanish)``" (not "``Spanish``")   
-    *  " ``עִברִית (Hebrew)``" (not "``Hebrew``")   
-
+    *  " ``español, España (Spanish, Spain)``" (not just "``Spanish``")   
+    *  " ``עִברִית (Hebrew)``" (not just "``Hebrew``")   
 * Save the altered ``mappings.txt`` file in your editor
+
+.. note:: 
+  In some language varieties, like the example of Spanish above, you might find it appropriate to include the country of the locale as well. This is important for Spanish since there are varieties that differ significantly (e.g., Argentinean Spanish, Mexican Spanish). But notice that writing *Hebrew, Israel* would probably not be necessary since there is practially only one variety of the language that anyone would ever expect to see in a software program.
+
+.. |msListOfLangIDsAndLocales| raw:: html
+
+  <a href="https://learn.microsoft.com/en-us/previous-versions/windows/embedded/ms903928(v=msdn.10)?redirectedfrom=MSDN" target="_blank">Microsoft's list of Language Idenfiers and and Locales</a>
 
 |
 
 Step 2: Generate a list of strings to translate
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  
 * In *Poedit*, go to the ``Translation`` menu and select ``Update from Source Code``. As long as you added ``_translate`` to the keywords (see above), you should subsequently see a list of strings that need translating in your language. An example is shown below (from Swedish, which does not yet have any translations).
 
@@ -133,7 +201,7 @@ Step 2: Generate a list of strings to translate
 |
 
 Step 3a: Translate the strings
-^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     
 * From the list, select a string that you want to translate.
 * Once selected, you should see it appear as English in the ``Source text`` box below the list.
@@ -148,36 +216,45 @@ Step 3a: Translate the strings
 
 * If you think your translation might have room for improvement, toggle the ``Needs Work`` button to the right of the ``Translation`` header
 * You can also add notes by clicking the ``Add Comment`` button to the lower-right of the app window if you have the sidebar visible.
-* Save your work (``File`` > ``Save``).
-* When you ready to push your work to your forked repository on *GitHub*, compile the ``.mo`` file (``File`` > ``Compile to MO..``).
+* Save your work (``File > Save``).
+
+|
 
 Some important notes
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 * Technical terms should not be translated: ``Builder``, ``Coder``, |PsychoPy|, ``Flow``, ``Routine``, and so on. (See the Japanese translation for guidance.)
-* If there are formatting arguments in the original string (``%s``, ``%(first)i``), the same number of arguments must also appear in the translation (but their order is not constrained to be the original order). If they are named (e.g., ``%(first)i``), that part should not be translated--here ``first`` is a python name.
+* If there are formatting arguments in the original string (``%s``, ``%(first)i``), the same number of arguments must also appear in the translation, though their position in the translation would be dictated by the word-order rules of the language being translated into). If they are named (e.g., ``%(first)i``), that part should not be translated -- here ``first`` is a python name.
 * Sometimes, you will not understand what a particular function does in |PsychoPy|, and you may be unable to translate it. There are a few possible things you can do in this situation. 
   
   * Ask
   
-    * Go to the `forum <https://discourse.psychopy.org/>`_. There are friendly, useful experts there.   
-
+    * Go to the |psychopyForum|. There are friendly, useful experts there. 
+    
+      * Click ``+ New Topic``
+      * Choose *Development* as the ``category``
+      * Type in ``translation`` as an ``optional tag``
+      * Type in your question in English, of course
+      * The reasons for the category and the tag is to alert the people more involved with the underlying code of |PsychoPy|
   * Determine it yourself
   
     * Place your mouse over the relevant string in the ``Source text`` box and right-click it (control-click on a Mac). You can see where the string is defined under ``Code Occurrences`` with the file(s), followed by a colon, ``:``, then the respective line number. You can then go into that file (or those files) to determine the function. Naturally, you need to understand *Python* quite well to take this approach.   
-
   * Do nothing
     
-    * If still in doubt, just leave out the translation until you do understand. There is nothing wrong with this approach. It is, by far, preferable to mis-translating a string.   
+    * If still in doubt, just leave out the translation until you do understand. There is nothing wrong with this approach. It is, by far, preferable to mis-translating a string. Use the ``Needs Work`` or ``Add Comment`` in *Poedit*, if you feel it is appropriate.   
+
+.. |psychopyForum| raw:: html
+
+  <a href="https://discourse.psychopy.org/" target="_blank">PsychoPy Forum on discourse.org</a>
 
 |
 
 Step 3b: Translating the *Start-up Tips*
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Instead of being directly translated in a ``.po`` file, the *start-up tips* are stored in a ``.txt`` file, one per language. That ``.txt`` file is then referred to in the ``.po`` file for your language. This is explained next.
+Instead of being translated as a set of strings in a ``.po`` file, all of the *start-up tips* in US-English are stored in a separate, single ``.txt`` file called ``tips.txt``. This file is then generated as a  string under ``Source text - English`` in the ``.po`` file. If there are translations of these tips for another language, they are stored in separate ``.txt`` file in the same directory, but with a different name (e.g., ``tips_es_ES.txt``). This new file is then listed as the translation for ``tips.txt`` in *Poedit*. This is explained next.
 
-The default *Start-up Tips* file (in English) is named ``tips.txt`` and is located in the following directory ``psychopy/app/Resources/``.
+The default *Start-up Tips* file (in US-English) is named ``tips.txt`` and is located in the following directory ``psychopy/app/Resources/``.
 
  To create the same file for another language, do the following:
 
@@ -188,14 +265,14 @@ The default *Start-up Tips* file (in English) is named ``tips.txt`` and is locat
 * Translate the English-language tips by replacing them entirely with those of the language you are working on
 
 .. note:: 
-  This may be a little bit obvious, but it would probably be a good idea *not* to delete any English entry in the new ``.txt`` file before you have completely translated it. It would be more strategic to insert the relevant translation below the English entry, and then delete the English entry only when the translation is complete.
+  This may be a little bit obvious, but it would be a good idea *not* to delete any English entry in the new ``.txt`` file before you have completely translated it, or decided it is not appropriate. If you are going to translate one of the tips, it would be wise to insert the relevant translation below the English entry, and then delete the English entry only when the translation on the new line is complete.
 
 |
 
 * Save your work
 * Open *Poedit*
-* Find the source text ``tips.txt``
-* Where you would normally provide a translation for it, simply provide the name of the ``.txt`` file that you just created. See the screenshot below for the case of Japanese.
+* Find the string ``tips.txt``  under ``Source text - English`` (the easiest way is ``Edit > Find > Find: tips.txt``)
+* Where you would normally provide a translation for it, simply provide the name of the new ``.txt`` file that you just created. See the screenshot below for the case of Japanese.
 
 .. image:: /images/poeditTipsIntoJapanese.png
   :width: 80%
@@ -210,35 +287,47 @@ The default *Start-up Tips* file (in English) is named ``tips.txt`` and is locat
 |
 
 Step 4: The git commit and the pull request
-----------------------------
-* Commit both the ``.po`` file and the compiled ``.mo`` file to your repository on *GitHub* (not just one or the other)
-* Include in the commit any other changed files (e.g., ``tips_[ll_CC].txt``, ``localization/mappings.txt``)
-* From *GitHub*, make your pull request to the *release* branch of the |PsychoPy| repository as outlined in :ref:`how to contribute to PsychoPy<usingRepos>`
+---------------------------------------------
+* Commit the files that you have changed
+  
+  * Usually, this is at least the ``.po`` file 
+  * But it could comprise or include other relevant files (e.g., ``tips_[ll_CC].txt``, ``localization/mappings.txt``)
+  * Use the prefix ``DOCS:`` in your commit message 
+* Push the commit to your repository on *GitHub* (aka *origin*)
+* From *origin* on GitHub, make your pull request to the *release* branch of the |PsychoPy| repository as outlined in :ref:`how to contribute to PsychoPy<usingRepos>`
 
 .. _newLangSubdirect:
 
 |
 
-If necessary: Creating a new language subdirectory
---------------------------------------
+If necessary, create a new language subdirectory
+----------------------------------------------------
 
-The default list of languages we have provided is clearly not exhaustive. (`Current estimates <https://www.linguisticsociety.org/content/how-many-languages-are-there-world>`_ are that there are between 6,000 and 8,000 human languages in the world, depending on how you define *language*!) So you may indeed find it necessary to create a new directory containing the ``.po`` file necessary to enable |PsychoPy| to operate in the language you want to translate into.
+The default list of languages we have provided is clearly not exhaustive. (|estimatedWorldLanguages| suggest that there are between 6,000 and 8,000 human languages in the world, depending on how you define *language*!) So you may indeed find it necessary to create a new directory containing the ``.po`` file necessary to enable |PsychoPy| to operate in the language you want to translate into.
 
-If this is the case, feel free to add your language. Below is an explanation of the easiest way to do this, followed by finding the most appropriate label for your new subdirectory.
+If this is the case, feel free to add your language or language variety. Below is an explanation of the easiest way to do this, followed by finding the most appropriate label for your new subdirectory.
+
+.. |estimatedWorldLanguages| raw:: html
+
+  <a href="https://www.linguisticsociety.org/content/how-many-languages-are-there-world" target="_blank">Current estimates on the number of languages in the world</a>
+
+|
 
 The easiest way to do this
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
 
 The easiest way to get started is to copy and paste one of the other ``ll_CC`` directories, then rename it. Then you can make adjustments to the ``messages.po`` file inside. How to do this is covered up above in the section called *The translation process in Poedit*.
 
-The immediate question, however, is what to rename it **as**. This may require some forethought involving linguistic and cultural appropriateness.
+The immediate question, however, is what to rename it **to**. This may require some forethought involving linguistic and cultural appropriateness.
+
+|
 
 What to name the new directory
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Whichever ``ll_CC`` label you use, please be as inclusive as you possibly can, within reason. Naturally, you are the expert here since you actually know the language, its dialects, and any political implications involved. Make sure, however, that you are highly proficient in whichever one you choose.
+Whichever ``ll_CC`` label you use, please be as inclusive as you possibly can, within reason. Naturally, you are the expert here since you actually know the language, its varieties, and any political implications involved. Make sure, however, that you are highly proficient in whichever one you choose.
 
-If in doubt, please feel free to discuss this with the |PsychoPy| team directly, or on the forum under the *Development* category. The same is true if you cannot find your language at all in the `language list at gettext <https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes>`_: Please talk with the |PsychoPy| team to find a solution.
+If in doubt, please feel free to discuss this with the |PsychoPy| team directly, or on the forum under the *Development* category. The same is true if you cannot find your language at all in the |listOfLanguagesAtGettext|: Please talk with the |PsychoPy| team to find a solution.
 
 * Chinese
 
@@ -254,7 +343,11 @@ If in doubt, please feel free to discuss this with the |PsychoPy| team directly,
 
 * English
 
-  * Another example is English. The default variety of English for |PsychoPy| is American English (``en_US``). One could include a translation for British English (``en_GB``), but the effort required of such a translation with such minor (mostly spelling) differences seems hardly worth it.
+  * Another example is English. The default variety of English for |PsychoPy| is American English (``en_US``). One could include a translation for British English (``en_GB``), but the effort required of such a translation with such minor (mostly spelling) differences hardly seems worth it.
+
+.. |listOfLanguagesAtGettext| raw:: html
+
+  <a href="https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes" target="_blank">list of languages at Gettext</a>
 
 |
 


### PR DESCRIPTION
@peircej This makes the [translation guide](https://psychopy.org/developers/localization.html) in the documentation more consistent decisions more recently made for the [translation workshop](https://workshops.psychopy.org/translators/index.html). It also adds a few tweaks, like opening links in a new tab, etc.