### PR TITLE
NF: Allow speech-to-text engine configuration from Builder

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -69,6 +69,7 @@ class MicrophoneComponent(BaseComponent):
                  transcribe=False, transcribeBackend="Whisper",
                  transcribeLang="en-US", transcribeWords="",
                  transcribeWhisperModel="base",
+                 transcribeWhisperDevice="auto",
                  #legacy
                  stereo=None, channel=None):
         super(MicrophoneComponent, self).__init__(
@@ -164,7 +165,16 @@ class MicrophoneComponent(BaseComponent):
             label=_translate("Transcribe audio")
         )
 
-        for depParam in ['transcribeBackend', 'transcribeLang', 'transcribeWords', 'transcribeWhisperModel']:
+        # whisper specific params
+        whisperParams = [
+            'transcribeBackend', 
+            'transcribeLang', 
+            'transcribeWords', 
+            'transcribeWhisperModel',
+            'transcribeWhisperDevice'
+        ]
+
+        for depParam in whisperParams:
             self.depends.append({
                 "dependsOn": "transcribe",
                 "condition": "==True",
@@ -223,6 +233,24 @@ class MicrophoneComponent(BaseComponent):
             "false": "hide",  # permitted: hide, show, enable, disable
         })
 
+        # settings for whisper we might want, we'll need to get these from the
+        # plugin itself at some point
+        self.params['transcribeWhisperDevice'] = Param(
+            transcribeWhisperDevice, valType='code', inputType='choice', 
+            categ='Transcription',
+            allowedVals=["auto", "gpu", "cpu"],
+            hint=_translate(
+                "Which device to use for transcription?"),
+            label=_translate("Whisper device")
+        )
+        self.depends.append({
+            "dependsOn": "transcribeBackend",
+            "condition": "=='Whisper'",
+            "param": "transcribeWhisperDevice",
+            "true": "show",  # what to do with param if condition is True
+            "false": "hide",  # permitted: hide, show, enable, disable
+        })
+
     def writeStartCode(self, buff):
         inits = getInitVals(self.params)
         # Use filename with a suffix to store recordings
@@ -268,6 +296,22 @@ class MicrophoneComponent(BaseComponent):
             "    sampleRateHz=%(sampleRate)s, maxRecordingSize=%(maxSize)s\n"
             ")\n"
         )
+
+        # check if the user wants to do transcription
+        if inits['transcribe'].val:
+            code += (
+                "# Setup speech-to-text transcriber for audio recordings\n"
+                "from psychopy.sound.transcribe import setupTranscriber\n"
+                "setupTranscriber(\n"
+                "    '%(transcribeBackend)s'")
+        
+        # handle advanced config options
+        if inits['transcribeBackend'].val == 'Whisper':
+            code += (
+                ",\n    config={'device': '%(transcribeWhisperDevice)s'})\n")
+        else:
+            code += (")\n")
+
         buff.writeOnceIndentedLines(code % inits)
 
     def writeInitCode(self, buff):

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -13,15 +13,14 @@ __all__ = [
     'transcribe',
     'TRANSCR_LANG_DEFAULT',
     'BaseTranscriber',
-    # 'WhisperTranscriber',
     'recognizerEngineValues',
     'recognizeSphinx',
     'recognizeGoogle',
-    'recognizeWhisper',
     'getAllTranscriberInterfaces',
     'getTranscriberInterface',
     'setupTranscriber',
-    'getActiveTranscriberName',
+    'getActiveTranscriber',
+    'getActiveTranscriberEngine',
     'submit'
 ]
 
@@ -795,7 +794,23 @@ def setupTranscriber(engine, config=None):
     _activeTranscriber = transcriber(config)  # init the transcriber
 
 
-def getActiveTranscriberName():
+def getActiveTranscriber():
+    """Get the currently active transcriber interface instance.
+
+    Should return a subclass of `BaseTranscriber` upon a successful call to
+    `setupTranscriber()`, otherwise `None` is returned.
+
+    Returns
+    -------
+    Subclass of `BaseTranscriber` or None
+        Active transcriber interface instance, or `None` if none is active.
+
+    """
+    global _activeTranscriber
+    return _activeTranscriber
+
+
+def getActiveTranscriberEngine():
     """Get the name currently active transcriber interface.
 
     Should return a string upon a successful call to `setupTranscriber()`, 
@@ -807,18 +822,19 @@ def getActiveTranscriberName():
         Name of the active transcriber interface, or `None` if none is active.
 
     """
-    global _activeTranscriber
-    if _activeTranscriber is None:
+    activeTranscriber = getActiveTranscriber()
+    if activeTranscriber is None:
         return None
 
-    return _activeTranscriber.engine
+    return activeTranscriber.engine
 
 
 def submit(audioClip, config=None):
     """Submit an audio clip for transcription.
 
     This will begin the transcription process using the currently loaded 
-    transcriber and return when completed.
+    transcriber and return when completed. Unlike `transcribe`, not calling 
+    `setupTranscriber` before calling this function will raise an exception.
 
     Parameters
     ----------
@@ -840,7 +856,7 @@ def submit(audioClip, config=None):
 
     """
     global _activeTranscriber
-    if getActiveTranscriberName() is None:
+    if getActiveTranscriberEngine() is None:
         raise TranscriberNotSetupError(
             "No transcriber interface has been setup, call `setupTranscriber` "
             "before calling `submit`.")

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -18,7 +18,8 @@ __all__ = [
     'recognizeSphinx',
     'recognizeGoogle',
     'recognizeWhisper',
-    'getAllTranscribers'
+    'getAllTranscribers',
+    'getTranscriber'
 ]
 
 import json
@@ -677,6 +678,39 @@ def getAllTranscribers(engineKeys=False):
             toReturn[interface._engine] = interface
 
     return toReturn
+
+
+def getTranscriber(engine):
+    """Get a transcriber interface by name.
+
+    Parameters
+    ----------
+    engine : str
+        Name of the transcriber interface to get.
+
+    Returns
+    -------
+    Subclass of `BaseTranscriber`
+        Transcriber interface.
+
+    Examples
+    --------
+    Get a transcriber interface and initalize it::
+
+        whisperInterface = getTranscriber('WhisperTranscriber')
+        # initialize it
+        transcriber = whisperInterface({'device': 'cuda'})
+    
+    """
+    transcribers = getAllTranscribers(engineKeys=True)
+
+    try:
+        transcriber = transcribers[engine]
+    except KeyError:
+        raise ValueError(
+            f"Transcriber with engine name `{engine}` not found.")
+
+    return transcribe
 
 
 def transcribe(audioClip, engine='whisper', language='en-US', expectedWords=None,

--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -377,7 +377,21 @@ class BaseTranscriber:
             Transcription result object.
 
         """
-        return NULL_TRANSCRIPTION_RESULT
+        self._lastResult = NULL_TRANSCRIPTION_RESULT  # dummy value
+
+        return self._lastResult
+
+    def unload(self):
+        """Unload the transcriber interface.
+
+        This method is called when the transcriber interface is no longer
+        needed. This is useful for freeing up resources used by the transcriber
+        interface.
+
+        This might not be available on all transcriber interfaces.
+
+        """
+        pass
 
 
 class PocketSphinxTranscriber(BaseTranscriber):
@@ -823,10 +837,10 @@ def submit(audioClip, config=None):
     -------
     TranscriptionResult
         Result of the transcription.
-    
+
     """
     global _activeTranscriber
-    if _activeTranscriber is None:
+    if getActiveTranscriberName() is None:
         raise TranscriberNotSetupError(
             "No transcriber interface has been setup, call `setupTranscriber` "
             "before calling `submit`.")


### PR DESCRIPTION
This commit allows the speech-to-text engine to be initialized and configured prior to calling `transcribe`. This should reduce overhead during the first call the the function. Added the new `submit` function which replaces `transcribe` in anticipation for multi-threading. 