### PR TITLE
DOCS: Guidance on subclassing lazy-imported classes

### DIFF
--- a/docs/source/api/visual/aperture.rst
+++ b/docs/source/api/visual/aperture.rst
@@ -2,7 +2,9 @@
 :class:`Aperture`
 ------------------------------------
 
-Stimulus class to restrict a stimulus visibility area to a basic shape or list of vertices. This is a lazy-imported class, therefore import using full path `psychopy.visual.aperture.Aperture` when inheriting from it.
+Stimulus class to restrict a stimulus visibility area to a basic shape or list of vertices.
+This is a lazy-imported class, therefore import using full path
+`from psychopy.visual.aperture import Aperture` when inheriting from it.
 
 Attributes
 =============

--- a/docs/source/api/visual/aperture.rst
+++ b/docs/source/api/visual/aperture.rst
@@ -2,6 +2,8 @@
 :class:`Aperture`
 ------------------------------------
 
+Stimulus class to restrict a stimulus visibility area to a basic shape or list of vertices. This is a lazy-imported class, therefore import using full path `psychopy.visual.aperture.Aperture` when inheriting from it.
+
 Attributes
 =============
 
@@ -21,6 +23,9 @@ Attributes
     Aperture.units
     Aperture.name
     Aperture.autoLog
+
+Details
+=======
 
 .. autoclass:: psychopy.visual.Aperture
     :members:

--- a/docs/source/api/visual/circle.rst
+++ b/docs/source/api/visual/circle.rst
@@ -1,7 +1,7 @@
 :class:`psychopy.visual.Circle`
 ------------------------------
 
-Stimulus class for drawing circles.
+Stimulus class for drawing circles. This is a lazy-imported class, therefore import using full path `psychopy.visual.circle.Circle` when inheriting from it.
 
 Overview
 ========

--- a/docs/source/api/visual/circle.rst
+++ b/docs/source/api/visual/circle.rst
@@ -3,7 +3,7 @@
 
 Stimulus class for drawing circles. This is a lazy-imported class, therefore import using full path `psychopy.visual.circle.Circle` when inheriting from it.
 
-Overview
+Attributes
 ========
 
 .. currentmodule:: psychopy.visual.circle

--- a/docs/source/api/visual/circle.rst
+++ b/docs/source/api/visual/circle.rst
@@ -1,7 +1,9 @@
 :class:`psychopy.visual.Circle`
 ------------------------------
 
-Stimulus class for drawing circles. This is a lazy-imported class, therefore import using full path `psychopy.visual.circle.Circle` when inheriting from it.
+Stimulus class for drawing circles. This is a lazy-imported class,
+therefore import using full path `from psychopy.visual.circle import Circle`
+when inheriting from it.
 
 Attributes
 ========

--- a/docs/source/api/visual/moviestim.rst
+++ b/docs/source/api/visual/moviestim.rst
@@ -1,6 +1,9 @@
 
 :class:`MovieStim`
 ------------------------------------------------------------------------
+Class for presenting movie clips as stimuli. This is a lazy-imported
+class, therefore import using full path
+`from psychopy.visual.movies import MovieStim` when inheriting from it.
 
 Attributes
 =============

--- a/docs/source/api/visual/progressbar.rst
+++ b/docs/source/api/visual/progressbar.rst
@@ -1,7 +1,7 @@
 :class:`psychopy.visual.Progress`
 -------------------------------
 
-Stimulus class for drawing progress bars.
+Stimulus class for drawing progress bars. This is a lazy-imported class, therefore import using full path `psychopy.visual.progress.Progress` when inheriting from it.
 
 Overview
 ========

--- a/docs/source/api/visual/progressbar.rst
+++ b/docs/source/api/visual/progressbar.rst
@@ -1,7 +1,9 @@
 :class:`psychopy.visual.Progress`
 -------------------------------
 
-Stimulus class for drawing progress bars. This is a lazy-imported class, therefore import using full path `psychopy.visual.progress.Progress` when inheriting from it.
+Stimulus class for drawing progress bars. This is a lazy-imported class,
+therefore import using full path `from psychopy.visual.progress import Progress`
+when inheriting from it.
 
 Overview
 ========

--- a/docs/source/api/visual/slider.rst
+++ b/docs/source/api/visual/slider.rst
@@ -2,6 +2,8 @@
 :class:`Slider`
 ------------------------------------
 
+A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale. This is a lazy-imported class, therefore import using full path `psychopy.visual.slider.Slider` when inheriting from it.
+
 Attributes
 =============
 

--- a/docs/source/api/visual/slider.rst
+++ b/docs/source/api/visual/slider.rst
@@ -2,7 +2,9 @@
 :class:`Slider`
 ------------------------------------
 
-A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale. This is a lazy-imported class, therefore import using full path `psychopy.visual.slider.Slider` when inheriting from it.
+A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale.
+This is a lazy-imported class, therefore import using full path
+`from psychopy.visual.slider import Slider` when inheriting from it.
 
 Attributes
 =============

--- a/docs/source/api/visual/textbox.rst
+++ b/docs/source/api/visual/textbox.rst
@@ -5,7 +5,8 @@
 
     TextBox is deprecated. Please use :class:`~psychopy.visual.TextBox2` instead which supports similar
     editable high-performance rendering of text but also supports non-monospaced
-    fonts and a wider range of formatting and alignment options.
+    fonts and a wider range of formatting and alignment options. This is a lazy-imported class, therefore
+    import using full path `from psychopy.visual.textbox import TextBox` when inheriting from it.
 
 Attributes
 ==========

--- a/psychopy/visual/bufferimage.py
+++ b/psychopy/visual/bufferimage.py
@@ -37,7 +37,10 @@ import numpy
 
 
 class BufferImageStim(ImageStim):
-    """Take a "screen-shot", save as an ImageStim (RBGA object).
+    """Take a "screen-shot", save as an ImageStim (RBGA object). This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.bufferimage import BufferImageStim` when
+    inheriting from it.
 
     The screen-shot is a single collage image composed of static elements
     that you can treat as being a single stimulus. The screen-shot can be of

--- a/psychopy/visual/custommouse.py
+++ b/psychopy/visual/custommouse.py
@@ -25,7 +25,8 @@ class CustomMouse(MinimalStim):
     """Class for more control over the mouse,
     including the pointer graphic and bounding box.
     This is a lazy-imported class, therefore import using
-    full path `psychopy.visual.custommouse.CustomMouse` when inheriting from it.
+    full path `from psychopy.visual.custommouse import CustomMouse`
+    when inheriting from it.
 
     Seems to work with pyglet or pygame. Not completely tested.
 

--- a/psychopy/visual/custommouse.py
+++ b/psychopy/visual/custommouse.py
@@ -24,6 +24,8 @@ import numpy
 class CustomMouse(MinimalStim):
     """Class for more control over the mouse,
     including the pointer graphic and bounding box.
+    This is a lazy-imported class, therefore import using
+    full path `psychopy.visual.custommouse.CustomMouse` when inheriting from it.
 
     Seems to work with pyglet or pygame. Not completely tested.
 

--- a/psychopy/visual/dot.py
+++ b/psychopy/visual/dot.py
@@ -49,7 +49,9 @@ _2pi = 2 * np.pi
 
 class DotStim(BaseVisualStim, ColorMixin, ContainerMixin):
     """This stimulus class defines a field of dots with an update rule that
-    determines how they change on every call to the .draw() method.
+    determines how they change on every call to the .draw() method. This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.dot import DotStim` when inheriting from it.
 
     This single class can be used to generate a wide variety of dot motion
     types. For a review of possible types and their pros and cons see Scase,

--- a/psychopy/visual/dropdown.py
+++ b/psychopy/visual/dropdown.py
@@ -7,7 +7,9 @@ class DropDownCtrl(ButtonStim):
     """
     Class to create a "Drop Down" control, similar to a HTML <select> tag. Consists of a psychopy.visual.ButtonStim
     which, when clicked on, shows a psychopy.visual.Slider with style "choice", which closes again when a value is
-    selected.
+    selected. This is a lazy-imported class, therefore import using full path
+    `from psychopy.visual.dropdown import DropDownCtrl` when inheriting from it.
+
 
     win : psychopy.visual.Window
         Window to draw the control to

--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -39,9 +39,10 @@ import numpy
 
 class ElementArrayStim(MinimalStim, TextureMixin, ColorMixin):
     """This stimulus class defines a field of elements whose behaviour can
-    be independently controlled. Suitable for creating 'global form' stimuli
-    or more detailed random dot stimuli. This is a lazy-imported class, therefore
-    import using full path `psychopy.visual.elementarray.ElementArrayStim` when
+    be independently controlled. Suitable for creating 'global form'
+    stimuli or more detailed random dot stimuli. This is a lazy-imported
+    class, therefore import using full path 
+    `from psychopy.visual.elementarray import ElementArrayStim` when
     inheriting from it.
 
     This stimulus can draw thousands of elements without dropping a frame,

--- a/psychopy/visual/elementarray.py
+++ b/psychopy/visual/elementarray.py
@@ -40,7 +40,9 @@ import numpy
 class ElementArrayStim(MinimalStim, TextureMixin, ColorMixin):
     """This stimulus class defines a field of elements whose behaviour can
     be independently controlled. Suitable for creating 'global form' stimuli
-    or more detailed random dot stimuli.
+    or more detailed random dot stimuli. This is a lazy-imported class, therefore
+    import using full path `psychopy.visual.elementarray.ElementArrayStim` when
+    inheriting from it.
 
     This stimulus can draw thousands of elements without dropping a frame,
     but in order to achieve this performance, uses several OpenGL extensions

--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -35,7 +35,9 @@ import numpy
 class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
                   ContainerMixin):
     """Stimulus object for drawing arbitrary bitmaps that can repeat (cycle) in
-    either dimension.
+    either dimension. This is a lazy-imported class, therefore import using 
+    full path `from psychopy.visual.grating import GratingStim` when inheriting
+    from it.
 
     One of the main stimuli for PsychoPy.
 

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -21,7 +21,10 @@ from psychopy.tools.attributetools import attributeSetter, setAttribute
 
 
 class Line(ShapeStim):
-    """Creates a Line between two points.
+    """Creates a Line between two points. This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.line import Line` when
+    inheriting from it.
 
     `Line` accepts all input parameters, that :class:`~psychopy.visual.ShapeStim`
     accepts, except for `vertices`, `closeShape` and `fillColor`.

--- a/psychopy/visual/movie2.py
+++ b/psychopy/visual/movie2.py
@@ -176,7 +176,9 @@ class MovieStim2(BaseVisualStim, ContainerMixin):
     """A stimulus class for playing movies (mpeg, avi, etc...) in PsychoPy
     that does not require avbin. Instead it requires the cv2 python package
     for OpenCV. The VLC media player also needs to be installed on the
-    psychopy computer.
+    psychopy computer. This is a lazy-imported class, therefore import using
+    full path `from psychopy.visual.movie2 import MovieStim2` when
+    inheriting from it.
 
     **Example**::
 

--- a/psychopy/visual/movie3.py
+++ b/psychopy/visual/movie3.py
@@ -49,7 +49,9 @@ import pyglet.gl as GL
 
 
 class MovieStim3(BaseVisualStim, ContainerMixin, TextureMixin):
-    """A stimulus class for playing movies.
+    """A stimulus class for playing movies. This is a lazy-imported class,
+    therefore import using full path 
+    `from psychopy.visual.movie3 import MovieStim3` when inheriting from it.
 
     This class uses MoviePy and FFMPEG as a backend for loading and decoding
     video data from files.

--- a/psychopy/visual/nnlvs.py
+++ b/psychopy/visual/nnlvs.py
@@ -65,7 +65,10 @@ vshdModels = {
 
 class VisualSystemHD(window.Window):
     """Class provides support for NordicNeuralLab's VisualSystemHD(tm) fMRI
-    display hardware.
+    display hardware. This is a lazy-imported class, therefore import using
+    full path `from psychopy.visual.nnlvs import VisualSystemHD` when
+    inheriting from it.
+
 
     Use this class in-place of the `Window` class for use with the VSHD
     hardware. Ensure that the VSHD headset display output is configured in

--- a/psychopy/visual/panorama.py
+++ b/psychopy/visual/panorama.py
@@ -11,7 +11,11 @@ from ..tools.attributetools import attributeSetter, setAttribute
 
 class PanoramicImageStim(ImageStim):
     """Map an image to the inside of a sphere and allow view to be changed via
-    latitude and longitude coordinates (between -1 and 1).
+    latitude and longitude coordinates (between -1 and 1). This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.panorama import PanoramicImageStim` when inheriting
+    from it.
+
 
     Parameters
     ----------

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -13,7 +13,9 @@ import numpy as np
 
 
 class Pie(BaseShapeStim):
-    """Creates a pie shape which is a circle with a wedge cut-out.
+    """Creates a pie shape which is a circle with a wedge cut-out. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.pie import Pie` when inheriting from it.
 
     This shape is sometimes referred to as a Pac-Man shape which is often
     used for creating Kanizsa figures. However, the shape can be adapted for

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -16,7 +16,9 @@ import numpy as np
 
 
 class Polygon(BaseShapeStim):
-    """Creates a regular polygon (triangles, pentagons, ...).
+    """Creates a regular polygon (triangles, pentagons, ...). This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.polygon import Polygon` when inheriting from it.
 
     This class is a special case of a :class:`~psychopy.visual.ShapeStim` that
     accepts the same parameters except `closeShape` and `vertices`.

--- a/psychopy/visual/radial.py
+++ b/psychopy/visual/radial.py
@@ -39,7 +39,10 @@ from numpy import pi
 
 
 class RadialStim(GratingStim):
-    """Stimulus object for drawing radial stimuli.
+    """Stimulus object for drawing radial stimuli. This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.radial import RadialStim` when
+    inheriting from it.
 
     Examples: annulus, rotating wedge, checkerboard.
 

--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -23,6 +23,8 @@ from psychopy.constants import FINISHED, STARTED, NOT_STARTED
 
 class RatingScale(MinimalStim):
     """A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale.
+    This is a lazy-imported class, therefore import using full path 
+    `psychopy.visual.ratingscale.RatingScale` when inheriting from it.
 
     A RatingScale instance is a re-usable visual object having a ``draw()``
     method, with customizable appearance and response options. ``draw()``

--- a/psychopy/visual/ratingscale.py
+++ b/psychopy/visual/ratingscale.py
@@ -24,7 +24,8 @@ from psychopy.constants import FINISHED, STARTED, NOT_STARTED
 class RatingScale(MinimalStim):
     """A class for obtaining ratings, e.g., on a 1-to-7 or categorical scale.
     This is a lazy-imported class, therefore import using full path 
-    `psychopy.visual.ratingscale.RatingScale` when inheriting from it.
+    `from psychopy.visual.ratingscale import RatingScale` when inheriting
+    from it.
 
     A RatingScale instance is a re-usable visual object having a ``draw()``
     method, with customizable appearance and response options. ``draw()``

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -17,7 +17,9 @@ from psychopy.tools.attributetools import attributeSetter, setAttribute
 
 class Rect(BaseShapeStim):
     """Creates a rectangle of given width and height as a special case of a
-    :class:`~psychopy.visual.ShapeStim`.
+    :class:`~psychopy.visual.ShapeStim`. This is a lazy-imported class,
+    therefore import using full path `from psychopy.visual.rect import Rect`
+    when inheriting from it.
 
     Parameters
     ----------

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -185,7 +185,10 @@ class LibOVRError(Exception):
 
 class Rift(window.Window):
     """Class provides a display and peripheral interface for the Oculus Rift
-    (see: https://www.oculus.com/) head-mounted display.
+    (see: https://www.oculus.com/) head-mounted display. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.rift import Rift` when inheriting from it.
+
 
     Requires PsychXR 0.2.4 to be installed. Setting the `winType='glfw'` is
     preferred for VR applications.

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -95,6 +95,10 @@ knownShapes['square'] = knownShapes['rectangle']
 
 class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
     """Create geometric (vector) shapes by defining vertex locations.
+    This is a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.shape import BaseShapeStim` when inheriting
+    from it.
+    
 
     Shapes can be outlines or filled, set lineColor and fillColor to
     a color name, or None. They can also be rotated (stim.setOri(__)),
@@ -379,6 +383,9 @@ class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
 
 class ShapeStim(BaseShapeStim):
     """A class for arbitrary shapes defined as lists of vertices (x,y).
+    This is a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.shape import ShapeStim` when inheriting
+    from it.
 
     Shapes can be lines, polygons (concave, convex, self-crossing), or have
     holes or multiple regions.

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -45,7 +45,8 @@ import numpy
 class SimpleImageStim(MinimalStim, WindowMixin):
     """A simple stimulus for loading images from a file and presenting at
     exactly the resolution and color in the file (subject to gamma correction
-    if set).
+    if set). This is a lazy-imported class, therefore import using full path 
+    `psychopy.visual.simpleimage.SimpleImageStim` when inheriting from it.
 
     Unlike the ImageStim, this type of stimulus cannot be rescaled, rotated or
     masked (although flipping horizontally or vertically is possible). Drawing

--- a/psychopy/visual/simpleimage.py
+++ b/psychopy/visual/simpleimage.py
@@ -46,7 +46,8 @@ class SimpleImageStim(MinimalStim, WindowMixin):
     """A simple stimulus for loading images from a file and presenting at
     exactly the resolution and color in the file (subject to gamma correction
     if set). This is a lazy-imported class, therefore import using full path 
-    `psychopy.visual.simpleimage.SimpleImageStim` when inheriting from it.
+    `from psychopy.visual.simpleimage import SimpleImageStim` when inheriting
+    from it.
 
     Unlike the ImageStim, this type of stimulus cannot be rescaled, rotated or
     masked (although flipping horizontally or vertically is possible). Drawing

--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -28,7 +28,10 @@ import pyglet.gl as GL
 
 
 class LightSource:
-    """Class for representing a light source in a scene.
+    """Class for representing a light source in a scene. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import LightSource` when inheriting from it.
+
 
     Only point and directional lighting is supported by this object for now. The
     ambient color of the light source contributes to the scene ambient color
@@ -401,7 +404,9 @@ class LightSource:
 
 
 class SceneSkybox:
-    """Class to render scene skyboxes.
+    """Class to render scene skyboxes. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import SceneSkybox` when inheriting from it.
 
     A skybox provides background imagery to serve as a visual reference for the
     scene. Background images are projected onto faces of a cube centered about
@@ -587,6 +592,9 @@ class SceneSkybox:
 
 class BlinnPhongMaterial:
     """Class representing a material using the Blinn-Phong lighting model.
+    This is a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import BlinnPhongMaterial` when inheriting
+    from it.
 
     This class stores material information to modify the appearance of drawn
     primitives with respect to lighting, such as color (diffuse, specular,
@@ -1153,7 +1161,10 @@ class BlinnPhongMaterial:
 
 
 class RigidBodyPose:
-    """Class for representing rigid body poses.
+    """Class for representing rigid body poses. This is a lazy-imported
+    class, therefore import using full path
+    `from psychopy.visual.stim3d import RigidBodyPose` when inheriting
+    from it.
 
     This class is an abstract representation of a rigid body pose, where the
     position of the body in a scene is represented by a vector/coordinate and
@@ -1683,7 +1694,10 @@ class RigidBodyPose:
 
 
 class BoundingBox:
-    """Class for representing object bounding boxes.
+    """Class for representing object bounding boxes. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import BoundingBox` when inheriting from it.
+
 
     A bounding box is a construct which represents a 3D rectangular volume about
     some pose, defined by its minimum and maximum extents in the reference frame
@@ -2088,7 +2102,10 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
 
 
 class SphereStim(BaseRigidBodyStim):
-    """Class for drawing a UV sphere.
+    """Class for drawing a UV sphere. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import SphereStim` when inheriting from it.
+
 
     The resolution of the sphere mesh can be controlled by setting `sectors`
     and `stacks` which controls the number of latitudinal and longitudinal
@@ -2223,7 +2240,10 @@ class SphereStim(BaseRigidBodyStim):
 
 
 class BoxStim(BaseRigidBodyStim):
-    """Class for drawing 3D boxes.
+    """Class for drawing 3D boxes. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import BoxStim` when inheriting from it.
+
 
     Draws a rectangular box with dimensions specified by `size` (length, width,
     height) in scene units.
@@ -2330,7 +2350,10 @@ class BoxStim(BaseRigidBodyStim):
 
 
 class PlaneStim(BaseRigidBodyStim):
-    """Class for drawing planes.
+    """Class for drawing planes. This is a 
+    lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import PlaneStim` when inheriting from it.
+
 
     Draws a plane with dimensions specified by `size` (length, width) in scene
     units.
@@ -2432,6 +2455,9 @@ class PlaneStim(BaseRigidBodyStim):
 
 class ObjMeshStim(BaseRigidBodyStim):
     """Class for loading and presenting 3D stimuli in the Wavefront OBJ format.
+    This is a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.stim3d import ObjMeshStim` when inheriting from it.
+
 
     Calling the `draw` method will render the mesh to the current buffer. The
     render target (FBO or back buffer) must have a depth buffer attached to it

--- a/psychopy/visual/vlcmoviestim.py
+++ b/psychopy/visual/vlcmoviestim.py
@@ -51,7 +51,10 @@ reportNDroppedFrames = 10
 
 class VlcMovieStim(BaseVisualStim, ContainerMixin):
     """A stimulus class for playing movies in various formats (mpeg, avi,
-    etc...) in PsychoPy using the VLC media player as a decoder.
+    etc...) in PsychoPy using the VLC media player as a decoder. This is
+    a lazy-imported class, therefore import using full path 
+    `from psychopy.visual.vlcmoviestim import VlcMovieStim` when inheriting
+    from it.
 
     This movie class is very efficient and better suited for playing
     high-resolution videos (720p+) than the other movie classes. However, audio


### PR DESCRIPTION
This solves issue  #5039. All lazy imported class have the following information added to the documentation, e.g.
"This is a lazy-imported class, therefore import using full path `from psychopy.visual.aperture import Aperture` when inheriting from it."