### PR TITLE
BF: Mute audio on movie control

### DIFF
--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -541,8 +541,10 @@ class MovieStreamThreadFFPyPlayer(threading.Thread):
                     self._player.set_mute(bool(cmdVal))
                     needsWait = True
                 elif cmdOpCode == 'play':
+                    self._player.set_mute(False)
                     self._player.set_pause(False)
                 elif cmdOpCode == 'pause':
+                    self._player.set_mute(True)
                     self._player.set_pause(True)
                 elif cmdOpCode == 'seek':
                     seekToPts, seekRel = cmdVal
@@ -552,6 +554,7 @@ class MovieStreamThreadFFPyPlayer(threading.Thread):
                         accurate=True)
                     time.sleep(0.1)  # long wait for seeking
                 elif cmdOpCode == 'stop':  # stop playback, return to start
+                    self._player.set_mute(True)
                     self._player.seek(
                         -1.0,  # seek to beginning
                         relative=False,


### PR DESCRIPTION
Make an additional mute call to silence audio during playback control. Helps deal with audio playing at inappropriate times.