### PR TITLE
BF: Static component was preventing Movie from starting

### DIFF
--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -105,7 +105,7 @@ class StaticComponent(BaseComponent):
     def writeFrameCodeJS(self, buff):
         # Start test
         self.writeStartTestCodeJS(buff)
-        buff.writeIndentedLines("ISI.status = PsychoJS.Status.STARTED;\n")
+        buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.STARTED;\n" % self.params)
         self.writeParamUpdates(buff, target="PsychoJS")
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("}\n")
@@ -150,7 +150,7 @@ class StaticComponent(BaseComponent):
                 buff.writeIndentedLines(code % self.params)
                 buff.setIndentLevel(-1, relative=True)
                 buff.writeIndentedLines("}\n")
-        buff.writeIndentedLines("ISI.status = PsychoJS.Status.FINISHED;\n")
+        buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.FINISHED;\n" % self.params)
         # Escape stop code indent
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("}\n")

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -242,7 +242,7 @@ class StaticComponent(BaseComponent):
                     code = (
                         f"console.log('register and start downloading resources specified by component %(name)s');\n"
                         f"await psychoJS.serverManager.prepareResources(%({fieldName})s);\n"
-                        f"%(name)s.status = PsychoJS.Status.STARTED;\n"
+                        f"{self.params['name']}.status = PsychoJS.Status.STARTED;\n"
                     )
                     buff.writeIndentedLines(code % prms)
                 # Set values


### PR DESCRIPTION
Because it (the Static component) was setting the movie's status to STARTED rather than its own, so when the start code for the movie happened it wasn't being started because the code thinks it's already started.