### PR TITLE
ENH: Give Components and Standalone Routines translated labels

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2661,7 +2661,10 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             self.component = comp
             self.category = cat
             # construct label
-            label = name
+            if comp.label is not None:
+                label = comp.label
+            else:
+                label = name
             # remove "Component" from the end
             for redundant in ['component', 'Component', "ButtonBox"]:
                 label = label.replace(redundant, "")
@@ -2794,7 +2797,10 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             self.routine = rt
             self.category = cat
             # construct label
-            label = name
+            if rt.label is not None:
+                label = rt.label
+            else:
+                label = name
             # remove "Routine" from the end
             for redundant in ['routine', 'Routine', "ButtonBox"]:
                 label = label.replace(redundant, "")

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -31,6 +31,7 @@ class BaseComponent:
     targets = []
     plugin = None
     iconFile = Path(__file__).parent / "unknown" / "unknown.png"
+    label = None
     tooltip = ""
     # what version was this Component added in?
     version = "0.0.0"

--- a/psychopy/experiment/components/aperture/__init__.py
+++ b/psychopy/experiment/components/aperture/__init__.py
@@ -23,6 +23,7 @@ class ApertureComponent(PolygonComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'aperture.png'
+    label = _translate("Aperture")
     tooltip = _translate('Aperture: restrict the drawing of stimuli to a given '
                          'region')
 

--- a/psychopy/experiment/components/brush/__init__.py
+++ b/psychopy/experiment/components/brush/__init__.py
@@ -15,6 +15,7 @@ class BrushComponent(BaseVisualComponent):
     categories = ['Responses']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'brush.png'
+    label = _translate("Brush")
     tooltip = _translate('Brush: a drawing tool')
 
     def __init__(self, exp, parentName, name='brush',

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -21,6 +21,7 @@ class ButtonComponent(BaseVisualComponent):
     targets = ['PsychoPy', 'PsychoJS']
     version = "2021.1.0"
     iconFile = Path(__file__).parent / 'button.png'
+    label = _translate("Button")
     tooltip = _translate('Button: A clickable textbox')
     beta = True
 

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -43,6 +43,7 @@ class CameraComponent(BaseComponent):
     targets = ["PsychoPy", "PsychoJS"]
     version = "2022.2.0"
     iconFile = Path(__file__).parent / 'webcam.png'
+    label = _translate("Camera")
     tooltip = _translate('Webcam: Record video from a webcam.')
     beta = True
 

--- a/psychopy/experiment/components/code/__init__.py
+++ b/psychopy/experiment/components/code/__init__.py
@@ -17,6 +17,7 @@ class CodeComponent(BaseComponent):
     categories = ['Custom']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'code.png'
+    label = _translate("Code")
     tooltip = _translate('Code: insert python commands into an experiment')
 
     def __init__(self, exp, parentName, name='code',

--- a/psychopy/experiment/components/dots/__init__.py
+++ b/psychopy/experiment/components/dots/__init__.py
@@ -16,6 +16,7 @@ class DotsComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'dots.png'
+    label = _translate("Dots")
     tooltip = _translate('Dots: Random Dot Kinematogram')
 
     def __init__(self, exp, parentName, name='dots',

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -20,6 +20,7 @@ class EyetrackerRecordComponent(BaseComponent):
     targets = ['PsychoPy']
     version = "2021.2.0"
     iconFile = Path(__file__).parent / 'eyetracker_record.png'
+    label = _translate("Eyetracker Record")
     tooltip = _translate('Start and / or Stop recording data from the eye tracker')
     beta = True
 

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -22,6 +22,7 @@ class FormComponent(BaseVisualComponent):
     targets = ['PsychoPy', 'PsychoJS']
     version = "2020.2.0"
     iconFile = Path(__file__).parent / 'form.png'
+    label = _translate("Form")
     tooltip = _translate('Form: a Psychopy survey tool')
     beta = True
 

--- a/psychopy/experiment/components/grating/__init__.py
+++ b/psychopy/experiment/components/grating/__init__.py
@@ -16,6 +16,7 @@ class GratingComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'grating.png'
+    label = _translate("Grating")
     tooltip = _translate('Grating: present cyclic textures, prebuilt or from a '
                          'file')
 

--- a/psychopy/experiment/components/image/__init__.py
+++ b/psychopy/experiment/components/image/__init__.py
@@ -16,6 +16,7 @@ class ImageComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'image.png'
+    label = _translate("Image")
     tooltip = _translate('Image: present images (bmp, jpg, tif...)')
 
     def __init__(self, exp, parentName, name='image', image='', mask='',

--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -17,6 +17,7 @@ class JoyButtonsComponent(BaseComponent):
     categories = ['Responses']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'joyButtons.png'
+    label = _translate("Joy Buttons")
     tooltip = _translate('JoyButtons: check and record joystick/gamepad button presses')
 
     def __init__(self, exp, parentName, name='button_resp',

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -19,6 +19,7 @@ class JoystickComponent(BaseComponent):
     categories = ['Responses']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'joystick.png'
+    label = _translate("Joystick")
     tooltip = _translate('Joystick: query joystick position and buttons')
 
     def __init__(self, exp, parentName, name='joystick',

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -21,6 +21,7 @@ class KeyboardComponent(BaseComponent):
     categories = ['Responses']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'keyboard.png'
+    label = _translate("Keyboard")
     tooltip = _translate('Keyboard: check and record keypresses')
 
     def __init__(self, exp, parentName, name='key_resp',

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -56,6 +56,7 @@ class MicrophoneComponent(BaseComponent):
     targets = ['PsychoPy', 'PsychoJS']
     version = "2021.2.0"
     iconFile = Path(__file__).parent / 'microphone.png'
+    label = _translate("Microphone")
     tooltip = _translate('Microphone: basic sound capture (fixed onset & '
                          'duration), okay for spoken words')
 

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -17,6 +17,7 @@ class MouseComponent(BaseComponent):
     categories = ['Responses']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'mouse.png'
+    label = _translate("Mouse")
     tooltip = _translate('Mouse: query mouse position and buttons')
 
     def __init__(self, exp, parentName, name='mouse',

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -17,6 +17,7 @@ class MovieComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'movie.png'
+    label = _translate("Movie")
     tooltip = _translate('Movie: play movie files')
 
     def __init__(self, exp, parentName, name='movie', movie='',

--- a/psychopy/experiment/components/panorama/__init__.py
+++ b/psychopy/experiment/components/panorama/__init__.py
@@ -16,6 +16,7 @@ class PanoramaComponent(BaseVisualComponent):
     targets = ['PsychoPy']
     version = "2023.1.0"
     iconFile = Path(__file__).parent / 'panorama.png'
+    label = _translate("Panorama")
     tooltip = _translate('Panorama: Present a panoramic image (such as from a phone camera in Panorama mode) on '
                          'screen.')
     beta = True

--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -16,6 +16,7 @@ class ParallelOutComponent(BaseComponent):
     categories = ['I/O', 'EEG']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'parallel.png'
+    label = _translate("Parallel Out")
     tooltip = _translate('Parallel out: send signals from the parallel port')
 
     def __init__(self, exp, parentName, name='p_port',

--- a/psychopy/experiment/components/patch/__init__.py
+++ b/psychopy/experiment/components/patch/__init__.py
@@ -15,6 +15,7 @@ class PatchComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'patch.png'
+    label = _translate("Patch")
     tooltip = _translate('Patch: present images (bmp, jpg, tif...) or textures '
                          'like gratings')
 

--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -17,6 +17,7 @@ class PolygonComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'polygon.png'
+    label = _translate("Polygon")
     tooltip = _translate('Polygon: any regular polygon (line, triangle, square'
                          '...circle)')
 

--- a/psychopy/experiment/components/progress/__init__.py
+++ b/psychopy/experiment/components/progress/__init__.py
@@ -13,6 +13,7 @@ class ProgressComponent(BaseVisualComponent):
     targets = ['PsychoPy', 'PsychoJS']
     version = "2023.2.0"
     iconFile = Path(__file__).parent / 'progress.png'
+    label = _translate("Progress")
     tooltip = _translate('Progress: Present a progress bar, with values ranging from 0 to 1.')
     beta = True
 

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -18,6 +18,7 @@ class RatingScaleComponent(BaseComponent):
     categories = ['Responses']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'ratingscale.png'
+    label = _translate("Rating Scale")
     tooltip = _translate('Rating scale: obtain numerical or categorical '
                          'responses')
 

--- a/psychopy/experiment/components/resourceManager/__init__.py
+++ b/psychopy/experiment/components/resourceManager/__init__.py
@@ -11,6 +11,7 @@ class ResourceManagerComponent(BaseComponent):
     categories = ['Custom']
     targets = ['PsychoJS']
     iconFile = Path(__file__).parent / "resource_manager.png"
+    label = _translate("Resource Manager")
     tooltip = _translate("Pre-load some resources into memory so that components using them can start without having "
                          "to load first")
     beta = True

--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -17,6 +17,7 @@ class RegionOfInterestComponent(PolygonComponent):
     targets = ['PsychoPy']
     version = "2021.2.0"
     iconFile = Path(__file__).parent / 'eyetracker_roi.png'
+    label = _translate("Region Of Interest")
     tooltip = _translate('Region Of Interest: Define a region of interest for use with eyetrackers')
     beta = True
 

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -12,6 +12,7 @@ class RoutineSettingsComponent(BaseComponent):
     categories = ['Other']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'routineSettings.png'
+    label = _translate("Routine Settings")
     tooltip = _translate('Settings for this Routine.')
     version = "2023.2.0"
 

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -17,6 +17,7 @@ class SerialOutComponent(BaseComponent):
     targets = ['PsychoPy']
     version = "2022.2.0"
     iconFile = Path(__file__).parent / 'serial.png'
+    label = _translate("Serial Out")
     tooltip = _translate('Serial out: send signals from a serial port')
     beta = True
 

--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -40,6 +40,7 @@ class SliderComponent(BaseVisualComponent):
     categories = ['Responses']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'slider.png'
+    label = _translate("Slider")
     tooltip = _translate('Slider: A simple, flexible object for getting ratings')
 
     def __init__(self, exp, parentName,

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -17,6 +17,7 @@ class SoundComponent(BaseComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'sound.png'
+    label = _translate("Sound")
     tooltip = _translate('Sound: play recorded files or generated sounds', )
 
     def __init__(self, exp, parentName, name='sound_1', sound='A', volume=1,

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -23,6 +23,7 @@ class StaticComponent(BaseComponent):
     categories = ['Custom']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'static.png'
+    label = _translate("Static")
     tooltip = _translate('Static: Static screen period (e.g. an ISI). '
                          'Useful for pre-loading stimuli.')
 

--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -17,6 +17,7 @@ class TextComponent(BaseVisualComponent):
     categories = ['Stimuli']
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'text.png'
+    label = _translate("Text")
     tooltip = _translate('Text: present text stimuli')
 
     def __init__(self, exp, parentName, name='text',

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -18,6 +18,7 @@ class TextboxComponent(BaseVisualComponent):
     targets = ['PsychoPy', 'PsychoJS']
     version = "2020.2.0"
     iconFile = Path(__file__).parent / 'textbox.png'
+    label = _translate("Textbox")
     tooltip = _translate('Textbox: present text stimuli but cooler')
     beta = True
 

--- a/psychopy/experiment/components/unknown/__init__.py
+++ b/psychopy/experiment/components/unknown/__init__.py
@@ -17,6 +17,7 @@ class UnknownComponent(BaseComponent):
     categories = ['Other']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'unknown.png'
+    label = _translate("Unknown")
     tooltip = _translate('Unknown: A component that is not known by the current '
                          'installed version of PsychoPy\n(most likely from the '
                          'future)')

--- a/psychopy/experiment/components/unknownPlugin/__init__.py
+++ b/psychopy/experiment/components/unknownPlugin/__init__.py
@@ -17,6 +17,7 @@ class UnknownPluginComponent(BaseComponent):
     categories = ['Other']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'unknownPlugin.png'
+    label = _translate("Unknown Plugin")
     tooltip = _translate('Unknown: A component which comes from a plugin which you do not have installed & activated.')
 
     def __init__(self, exp, parentName, name='', compType="UnknownPluginComponent"):

--- a/psychopy/experiment/components/variable/__init__.py
+++ b/psychopy/experiment/components/variable/__init__.py
@@ -18,6 +18,7 @@ class VariableComponent(BaseComponent):
     categories = ['Custom']
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'variable.png'
+    label = _translate("Variable")
     tooltip = _translate('Variable: create a new variable')
 
     def __init__(self, exp, parentName,

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -23,6 +23,7 @@ class BaseStandaloneRoutine:
     categories = ['Custom']
     targets = []
     iconFile = Path(__file__).parent / "unknown" / "unknown.png"
+    label = None
     tooltip = ""
     limit = float('inf')
     # what version was this Routine added in?

--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -10,6 +10,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
     targets = ["PsychoPy"]
     version = "2021.2.0"
     iconFile = Path(__file__).parent / "eyetracker_calib.png"
+    label = _translate("Eyetracker Calibration")
     tooltip = _translate("Calibration routine for eyetrackers")
     beta = True
 

--- a/psychopy/experiment/routines/eyetracker_validate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_validate/__init__.py
@@ -14,6 +14,7 @@ class EyetrackerValidationRoutine(BaseStandaloneRoutine):
     targets = ["PsychoPy"]
     version = "2021.2.0"
     iconFile = Path(__file__).parent / "eyetracker_valid.png"
+    label = _translate("Eyetracker Validation")
     tooltip = _translate("Validation routine for eyetrackers")
     beta = True
 

--- a/psychopy/experiment/routines/pavlovia_survey/__init__.py
+++ b/psychopy/experiment/routines/pavlovia_survey/__init__.py
@@ -10,6 +10,7 @@ class PavloviaSurveyRoutine(BaseStandaloneRoutine):
     targets = ["PsychoJS"]
     version = "2023.1.0"
     iconFile = Path(__file__).parent / "survey.png"
+    label = _translate("Pavlovia Survey")
     tooltip = _translate("Run a SurveyJS survey in Pavlovia")
     beta = False
 

--- a/psychopy/experiment/routines/unknown/__init__.py
+++ b/psychopy/experiment/routines/unknown/__init__.py
@@ -1,12 +1,14 @@
 from .. import BaseStandaloneRoutine
 from pathlib import Path
+from psychopy.localization import _translate
 
 
 class UnknownRoutine(BaseStandaloneRoutine):
     categories = ['Other']
     targets = []
     iconFile = Path(__file__).parent / "unknown.png"
-    tooltip = "Unknown routine"
+    label = _translate("Unknown")
+    tooltip = _translate("Unknown routine")
 
     def __init__(self, exp, name=''):
         BaseStandaloneRoutine.__init__(self, exp, name=name)


### PR DESCRIPTION
Adds a "label" attribute to BaseComponent and BaseStandaloneRoutine, which defaults to None. It can then be set by subclassing components to be a translated string, or left as None. If None, then Builder generates label as normal, if set, it uses the translated label.

Not a pressing issue but only took a mo and seemed like low hanging fruit for improving accessibility! 