### PR TITLE
FF: Fix time printing in log and data file

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -267,11 +267,14 @@ class MonotonicClock:
             format = "%Y-%m-%d_%H:%M:%S.%f%z"
         # get time since last reset
         t = getTime() - self._timeAtLastReset
+        # get last reset time from epoch
+        lastReset = self._epochTimeAtLastReset
         if not applyZero:
-            # if not applying zero, add epoch start time
+            # if not applying zero, add epoch start time to t rather than supplying it
             t += self._epochTimeAtLastReset
+            lastReset = 0
 
-        return Timestamp(t, format, lastReset=self._epochTimeAtLastReset)
+        return Timestamp(t, format, lastReset=lastReset)
 
     def getLastResetTime(self):
         """

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -368,26 +368,25 @@ class ExperimentHandler(_ComparisonMixin):
         """
         self.addData("notes", value)
 
-    def timestampOnFlip(self, win, name):
+    def timestampOnFlip(self, win, name, format=float):
         """Add a timestamp (in the future) to the current row
 
         Parameters
         ----------
 
         win : psychopy.visual.Window
-
             The window object that we'll base the timestamp flip on
-
         name : str
-
             The name of the column in the datafile being written,
             such as 'myStim.stopped'
+        format : str, class or None
+            Format in which to return time, see clock.Timestamp.resolve() for more info. Defaults to `float`.
         """
         # make sure the name is used when writing the datafile
         if name not in self.dataNames:
             self.dataNames.append(name)
-        #
-        win.timeOnFlip(self.thisEntry, name)
+        # tell win to record timestamp on flip
+        win.timeOnFlip(self.thisEntry, name, format=format)
 
     @property
     def status(self):

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -149,7 +149,7 @@ class RoutineSettingsComponent(BaseComponent):
         # Store Routine start time (UTC)
         if self.params['saveStartStop']:
             code = (
-                "thisExp.addData('%(name)s.started', globalClock.getTime())\n"
+                "thisExp.addData('%(name)s.started', globalClock.getTime(format='float'))\n"
             )
             buff.writeIndentedLines(code % params)
         # Skip Routine if condition is met
@@ -290,7 +290,7 @@ class RoutineSettingsComponent(BaseComponent):
         # Store Routine start time (UTC)
         if self.params['saveStartStop']:
             code = (
-                "thisExp.addData('%(name)s.stopped', globalClock.getTime())\n"
+                "thisExp.addData('%(name)s.stopped', globalClock.getTime(format='float'))\n"
             )
             buff.writeIndentedLines(code % params)
         # Restore window appearance after this Routine (if changed)

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -196,7 +196,7 @@ class TrialHandler(_BaseLoopHandler):
         buff.setIndentLevel(1, relative=True)
         code = (
             "currentLoop = %(name)s\n"
-            "thisExp.timestampOnFlip(win, 'thisRow.t')\n"
+            "thisExp.timestampOnFlip(win, 'thisRow.t', format=globalClock.format)\n"
         )
         buff.writeIndentedLines(code % self.params)
 
@@ -526,7 +526,7 @@ class StairHandler(_BaseLoopHandler):
         buff.setIndentLevel(1, relative=True)
         code = (
             "currentLoop = %(name)s\n"
-            "thisExp.timestampOnFlip(win, 'thisRow.t')\n"
+            "thisExp.timestampOnFlip(win, 'thisRow.t', format=globalClock.format)\n"
         )
         buff.writeIndentedLines(code % self.params)
         buff.writeIndented("level = %s\n" % self.thisName)
@@ -657,7 +657,7 @@ class MultiStairHandler(_BaseLoopHandler):
         buff.setIndentLevel(1, relative=True)
         code = (
             "currentLoop = %(name)s\n"
-            "thisExp.timestampOnFlip(win, 'thisRow.t')\n"
+            "thisExp.timestampOnFlip(win, 'thisRow.t', format=globalClock.format)\n"
         )
         buff.writeIndentedLines(code % self.params)
         # uncluttered namespace

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -898,7 +898,7 @@ class Window():
                              'args': args,
                              'kwargs': kwargs})
 
-    def timeOnFlip(self, obj, attrib):
+    def timeOnFlip(self, obj, attrib, format=float):
         """Retrieves the time on the next flip and assigns it to the `attrib`
         for this `obj`.
 
@@ -908,6 +908,8 @@ class Window():
             A mutable object (usually a dict of class instance).
         attrib : str
             Key or attribute of `obj` to assign the flip time to.
+        format : str, class or None
+            Format in which to return time, see clock.Timestamp.resolve() for more info. Defaults to `float`.
 
         Examples
         --------
@@ -916,7 +918,7 @@ class Window():
             win.getTimeOnFlip(myTimingDict, 'tStartRefresh')
 
         """
-        self.callOnFlip(self._assignFlipTime, obj, attrib)
+        self.callOnFlip(self._assignFlipTime, obj, attrib, format)
 
     def getFutureFlipTime(self, targetTime=0, clock=None):
         """The expected time of the next screen refresh. This is currently
@@ -957,7 +959,7 @@ class Window():
 
         return output
 
-    def _assignFlipTime(self, obj, attrib):
+    def _assignFlipTime(self, obj, attrib, format=float):
         """Helper function to assign the time of last flip to the obj.attrib
 
         Parameters
@@ -966,12 +968,15 @@ class Window():
             A mutable object (usually a dict of class instance).
         attrib : str
             Key or attribute of ``obj`` to assign the flip time to.
+        format : str, class or None
+            Format in which to return time, see clock.Timestamp.resolve() for more info. Defaults to `float`.
 
         """
+        frameTime = self._frameTime.resolve(format=format)
         if hasattr(obj, attrib):
-            setattr(obj, attrib, self._frameTime)
+            setattr(obj, attrib, frameTime)
         elif isinstance(obj, dict):
-            obj[attrib] = self._frameTime
+            obj[attrib] = frameTime
         else:
             raise TypeError("Window.getTimeOnFlip() should be called with an "
                             "object and its attribute or a dict and its key. "


### PR DESCRIPTION
Because ISO format needs to be from epoch to be meaningful, if a Timestamp was created from an ISO string, it was always from epoch, even if `getTime(applyZero=True`. The Timestamp itself needs to know when last reset was so that `resolve` can account for it when outputting to float/str.