### PR TITLE
BF: Let experiments run without git installed

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -7,7 +7,6 @@
 
 """Dialog classes for the Builder, including ParamCtrls
 """
-import functools
 import sys
 
 import os
@@ -256,7 +255,7 @@ class ParamCtrls():
         #         parent, val, order=['Field', 'Default'])
         if hasattr(self.valueCtrl, 'SetToolTip'):
             self.valueCtrl.SetToolTip(wx.ToolTip(_translate(param.hint)))
-        if not isinstance(param.allowedVals, functools.partial) and len(param.allowedVals) == 1 or param.readOnly:
+        if not callable(param.allowedVals) and len(param.allowedVals) == 1 or param.readOnly:
             self.valueCtrl.Disable()  # visible but can't be changed
 
         # add a Validator to the valueCtrl

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -5,7 +5,6 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2022 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 import ast
-import functools
 import os
 import subprocess
 import sys
@@ -343,14 +342,14 @@ class ChoiceCtrl(wx.Choice, _ValidatorMixin, _HideMixin):
         self.SetStringSelection(val)
 
     def populate(self):
-        if isinstance(self._choices, functools.partial):
+        if callable(self._choices):
             # if choices are given as a partial, execute it now to get values
             choices = self._choices()
         else:
             # otherwise, treat it as a list
             choices = list(self._choices)
 
-        if isinstance(self._labels, functools.partial):
+        if callable(self._labels):
             # if labels are given as a partial, execute it now to get values
             labels = self._labels()
         elif self._labels:

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -893,6 +893,7 @@ class SettingsComponent:
             copyFileWithMD5(srcFile['abs'], dstAbs)
 
     def writeInitCodeJS(self, buff, version, localDateTime, modular=True):
+        from psychopy.tools import versionchooser as versions
         # create resources folder
         if self.exp.htmlFolder:
             self.prepareResourcesJS()

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -9,7 +9,6 @@ import re
 from psychopy import logging, plugins
 from psychopy.experiment.components import Param, _translate
 from psychopy.experiment.routines.eyetracker_calibrate import EyetrackerCalibrationRoutine
-import psychopy.tools.versionchooser as versions
 from psychopy.experiment import utils as exputils
 from psychopy.monitors import Monitor
 from psychopy.iohub import util as ioUtil
@@ -19,7 +18,6 @@ from psychopy.tools.filetools import genDelimiter
 # for creating html output folders:
 import shutil
 import hashlib
-from pkg_resources import parse_version
 import ast  # for doing literal eval to convert '["a","b"]' to a list
 
 try:
@@ -167,12 +165,16 @@ class SettingsComponent:
             hint=_translate("The info to present in a dialog box. Right-click"
                             " to check syntax and preview the dialog box."),
             label=_translate("Experiment info"))
+        def getVersions():
+            import psychopy.tools.versionchooser as versions
+            available = versions._versionFilter(versions.versionOptions(), wx_version)
+            available += ['']
+            available += versions._versionFilter(versions.availableVersions(), wx_version)
+            return available
         self.params['Use version'] = Param(
             useVersion, valType='str', inputType="choice",
             # search for options locally only by default, otherwise sluggish
-            allowedVals=versions._versionFilter(versions.versionOptions(), wx_version)
-                        + ['']
-                        + versions._versionFilter(versions.availableVersions(), wx_version),
+            allowedVals=getVersions,
             hint=_translate("The version of PsychoPy to use when running "
                             "the experiment."),
             label=_translate("Use PsychoPy version"), categ='Basic')


### PR DESCRIPTION
Git was previously needed to query available versions when making a SettingsComponent, instead we should only do this query when trying to open the UseVersion control.