### PR TITLE
BF: default logging level from exp to warning

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -116,7 +116,7 @@ class SettingsComponent:
                  winSize=(1024, 768), screen=1, monitor='testMonitor', winBackend='pyglet',
                  showMouse=False, saveLogFile=True, showExpInfo=True,
                  expInfo="{'participant':'f\"{randint(0, 999999):06.0f}\"', 'session':'001'}",
-                 units='height', logging='exp',
+                 units='height', logging='warning',
                  color='$[0,0,0]', colorSpace='rgb', enableEscape=True,
                  backgroundImg="", backgroundFit="none",
                  blendMode='avg',


### PR DESCRIPTION
Current logging level is exp which cause a lot of spam in the stdout window. Changing to warning reduces the amount of clutter