### PR TITLE
ENH/RF: Changes to allow individual items in a list param to be code ($)

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -713,7 +713,7 @@ class FileListCtrl(wx.ListBox, _ValidatorMixin, _HideMixin, _FileMixin):
         if stringEntry:
             self.InsertItems([stringEntry], 0)
 
-    def GetValue(self):
+    def getValue(self):
         return self.Items
 
 

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -526,11 +526,11 @@ class Experiment:
             val = val.replace("&#10;", "\n")
 
         # custom settings (to be used when
-        if valType == 'fixedList':  # convert the string to a list
+        if valType in ('list', 'fileList', 'fixedList'):  # convert the string to a list
             try:
-                params[name].val = eval('list({})'.format(val))
-            except NameError:  # if val is a single string it will look like variable
-                params[name].val = [val]
+                params[name].val = eval('{}'.format(val))
+            except:  # if val is a single string it will look like variable
+                pass
         elif name == 'storeResponseTime':
             return  # deprecated in v1.70.00 because it was redundant
         elif name == 'nVertices':  # up to 1.85 there was no shape param

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -381,6 +381,10 @@ def dollarSyntax(val, valType):
 
         return outVal, outTypes
 
+    # if val isn't a string, just return as is
+    if not isinstance(val, str):
+        return val, valType
+
     # copy val
     activeVal = str(val)
     # remove any string contents

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -391,7 +391,7 @@ class Partial(functools.partial):
 
 def dollarSyntax(val, valType):
     """
-
+    Parse dollar syntax to identify whether a parameter value indicates that it is code.
 
     Parameters
     ----------

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -255,14 +255,28 @@ class Param():
             else:
                 # Otherwise, treat as string
                 return repr(val)
-        elif self.valType == 'list':
-            valid, val = self.dollarSyntax()
-            val = toList(val)
-            return "{}".format(val)
         elif self.valType == 'fixedList':
             return "{}".format(self.val)
-        elif self.valType == 'fileList':
-            return "{}".format(self.val)
+        elif self.valType in ('list', 'fileList'):
+            val = self.val
+            # convert to list if needed
+            if not len(val):
+                val = []
+            if isinstance(val, str):
+                if val[0] in ("[", "(") and val[-1] in ("]", ")"):
+                    val = val[1:-1].split(",")
+            # work out dollar syntax
+            val, valType = dollarSyntax(val, self.valType)
+            # add each value according to dollar syntax
+            code = "["
+            for subval, subtype in zip(val, valType):
+                if subtype == "code":
+                    code += str(subval)
+                else:
+                    code += repr(str(subval))
+                code += ", "
+            code += "]"
+            return code
         elif self.valType == 'bool':
             if utils.scriptTarget == "PsychoJS":
                 return ("%s" % self.val).lower()  # make True -> "true"

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -242,7 +242,6 @@ class Param():
                 # Otherwise, treat as string
                 return repr(val)
         elif self.valType == 'list':
-            valid, val = self.dollarSyntax()
             val = toList(val)
             return "{}".format(val)
         elif valType == 'fixedList':
@@ -325,44 +324,7 @@ class Param():
         return element
 
     def dollarSyntax(self):
-        """
-        Interpret string according to dollar syntax, return:
-        1: Whether syntax is valid (True/False)
-        2: Whether code is wanted (True/False)
-        3: The value, stripped of any unnecessary $
-        """
-        val = self.val
-        if self.valType in ['extendedStr','str', 'file', 'table', 'color', 'list']:
-            # How to handle dollar signs in a string param
-            self.codeWanted = str(val).startswith("$")
-
-            if not re.search(r"\$", str(val)):
-                # Return if there are no $
-                return True, val
-            if self.codeWanted:
-                # If value begins with an unescaped $, remove the first char and treat the rest as code
-                val = val[1:]
-                inComment = "".join(re.findall(r"\#.*", val))
-                inQuotes = "".join(re.findall("[\'\"][^\"|^\']*[\'\"]", val))
-                if not re.findall(r"\$", val):
-                    # Return if there are no further dollar signs
-                    return True, val
-                if len(re.findall(r"\$", val)) == len(re.findall(r"\$", inComment)):
-                    # Return if all $ are commented out
-                    return True, val
-                if len(re.findall(r"\$", val)) - len(re.findall(r"\$", inComment)) == len(re.findall(r"\$", inQuotes)):
-                    # Return if all non-commended $ are in strings
-                    return True, val
-            else:
-                # If value does not begin with an unescaped $, treat it as a string
-                if not re.findall(r"(?<!\\)\$", val):
-                    # Return if all $ are escaped (\$)
-                    return True, val
-        else:
-            # If valType does not interact with $, return True
-            return True, val
-        # Return false if method has not returned yet
-        return False, val
+        return dollarSyntax(self.val, self.valType)
 
     __nonzero__ = __bool__  # for python2 compatibility
 

--- a/psychopy/experiment/utils.py
+++ b/psychopy/experiment/utils.py
@@ -17,6 +17,7 @@ unescapedDollarSign_re = re.compile(r"^\$|[^\\]\$")  # detect "code wanted"
 valid_var_re = re.compile(r"^[a-zA-Z_][\w]*$")  # filter for legal var names
 nonalphanumeric_re = re.compile(r'\W')  # will match all bad var name chars
 list_like_re = re.compile(r"(?<!\\),")  # will match for strings which could be a list
+unescaped_re = r"(?<!\\)"  # append a character or regex string to check for it unescaped
 
 
 class CodeGenerationException(Exception):

--- a/psychopy/tests/test_experiment/test_params.py
+++ b/psychopy/tests/test_experiment/test_params.py
@@ -295,56 +295,56 @@ def test_dollar_sign_syntax():
     cases = [
         # Valid dollar and redundant dollar
         {'val': f"$hello $there",
-         'ans': f"hello {_d}there",
-         'valid': False},
+         'ans': f"hello there",
+         'valType': "code"},
         # Valid dollar and scaped dollar
         {'val': "$hello \\$there",
          'ans': r"hello \\\$there",
-         'valid': False},
+         'valType': "code"},
         # Just redundant dollar
         {'val': "hello $there",
-         'ans': f"hello {_d}there",
-         'valid': False},
+         'ans': f"hello there",
+         'valType': "code"},
         # Just escaped dollar
         {'val': "\\$hello there",
          'ans': r"\\\$hello there",
-         'valid': True},
+         'valType': "str"},
         # Dollar in comment
         {'val': "#$hello there",
          'ans': r"#\$hello there",
-         'valid': False},
+         'valType': "str"},
         # Comment after dollar
         {'val': "$#hello there",
          'ans': r"#hello there",
-         'valid': True},
+         'valType': "code"},
         # Dollar and comment
         {'val': "$hello #there",
          'ans': r"hello #there",
-         'valid': True},
+         'valType': "code"},
         # Valid dollar and redundtant dollar in comment
         {'val': "$hello #$there",
          'ans': r"hello #\$there",
-         'valid': True},
+         'valType': "code"},
         # Valid dollar and escaped dollar in escaped d quotes
         {'val': "$hello \"\\$there\"",
          'ans': f"hello {_q}" + r"\\\$" + f"there{_q}",
-         'valid': True},
+         'valType': "code"},
         # Valid dollar and escaped dollar in escaped s quotes
         {'val': "$hello \'\\$there\'",
          'ans': f"hello {_q}" + r"\\\$" + f"there{_q}",
-         'valid': True},
+         'valType': "code"},
     ]
     # Run dollar syntax on each case
     for case in cases:
         # Make str param from val
         param = Param(case['val'], "str")
         # Run dollar syntax method
-        valid, ans = param.dollarSyntax()
+        ans, valType = param.dollarSyntax()
         # Is the output correct?
         assert re.fullmatch(case['ans'], ans), (
             f"Dollar syntax for {repr(param)} should return `{case['ans']}`, but instead returns `{ans}`"
         )
-        assert valid == case['valid'], (
-            f"Dollar syntax function should consider validity of {repr(param)} to be {case['valid']}, but instead "
-            f"received {valid}"
+        assert valType == case['valType'], (
+            f"Dollar syntax for {repr(param)} should return valType `{case['valType']}`, but instead returns valType "
+            f"`{valType}`"
         )


### PR DESCRIPTION
Bit nervous about this as there's a lot of change, but if we're to be able to process $ in individual items in a `list` type Param then I think it's necessary.

TLDR on what's changed:
- Functions to parse dollar syntax and stringify params are now modular, so they can be called on values rather than having to use the Param's attributes
- Param can now detect whether its value is an array and, if so, will parse dollar syntax and do stringifying on *each value* rather than on the whole thing
- This means that (and this is why this was requested) the FileListCtrl in Resource Manager Component can have an individual item within it be code, so you can have "image.png" alongside "$cond" and both will work
