### PR TITLE
ENH: When calling registerMethods, also register @Property methods

### DIFF
--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -274,7 +274,7 @@ class CameraComponent(BaseComponent):
         self.params['mic'] = Param(
             mic, valType='str', inputType="choice", categ="Basic",
             allowedVals=list(range(len(micDevices))),
-            allowedLabels=[d.title() for d in list(micDevices)],
+            allowedLabels=[d['device_name'].title() for d in micDevices],
             hint=msg,
             label=_translate("Audio device")
         )
@@ -444,6 +444,65 @@ class CameraComponent(BaseComponent):
         #     "false": "hide",  # permitted: hide, show, enable, disable
         # })
 
+    def writeDeviceCode(self, buff):
+        """
+        Code to setup the CameraDevice for this component.
+
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        """
+        inits = getInitVals(self.params)
+
+        # --- setup mic ---
+
+        # substitute default if device not found
+        if inits['mic'].val not in micDeviceIndices:
+            inits['mic'].val = None
+        # substitute sample rate value for numeric equivalent
+        inits['micSampleRate'] = micSampleRates[inits['micSampleRate'].val]
+        # substitute channel value for numeric equivalent
+        inits['micChannels'] = {'mono': 1, 'stereo': 2, 'auto': None}[
+            self.params['micChannels'].val]
+        # get device name
+        inits['micDeviceName'] = getDeviceName("mic", inits['mic'].val)
+        # initialise mic device
+        code = (
+            "# initialise microphone\n"
+            "if deviceManager.getDevice('%(micDeviceName)s') is None:\n"
+            "    deviceManager.addDevice(\n"
+            "        deviceClass='microphone',\n"
+            "        deviceName='%(micDeviceName)s',\n"
+            "        index=%(mic)s,\n"
+            "        channels=%(micChannels)s, \n"
+            "        sampleRateHz=%(micSampleRate)s, \n"
+            "        maxRecordingSize=%(micMaxRecSize)s\n"
+            "    )\n"
+        )
+        buff.writeOnceIndentedLines(code % inits)
+
+        # --- setup camera ---
+        # get camera name
+        inits['cameraDeviceName'] = getDeviceName("cam", inits['device'].val)
+        # initialise camera device
+        code = (
+            "# initialise camera\n"
+            "if deviceManager.getDevice('%(cameraDeviceName)s') is None:\n"
+            "    cam = deviceManager.addDevice(\n"
+            "        deviceClass='camera',\n"
+            "        deviceName='%(cameraDeviceName)s',\n"
+            "        cameraLib=%(cameraLib)s, \n"
+            "        device=%(device)s, \n"
+            "        mic=%(micDeviceName)s, \n"
+            "        frameRate=%(frameRate)s, \n"
+            "        frameSize=%(resolution)s\n"
+            "    )\n"
+            "    cam.open()\n"
+            "\n"
+        )
+        buff.writeOnceIndentedLines(code % inits)
+
     def writeRoutineStartCode(self, buff):
         pass
 
@@ -476,32 +535,17 @@ class CameraComponent(BaseComponent):
         inits['micChannels'] = {'mono': 1, 'stereo': 2, 'auto': None}[
             self.params['micChannels'].val]
         # Get device names
-        inits['micDeviceName'] = getDeviceName(inits['mic'].val)
-        inits['micDeviceVarName'] = getDeviceVarName(inits['mic'].val)
+        inits['micDeviceName'] = getDeviceName("mic", inits['mic'].val)
+        inits['cameraDeviceName'] = getDeviceName("cam", inits['device'].val)
+
         # Create Microphone object
-        micInitCode = (
-            "# create a microphone object for device: %(micDeviceName)s\n"
-            "%(micDeviceVarName)s = sound.microphone.Microphone(\n"
-            "    device=%(mic)s, \n"
-            "    channels=%(micChannels)s, \n"
-            "    sampleRateHz=%(micSampleRate)s, \n"
-            "    maxRecordingSize=%(micMaxRecSize)s\n"
-            ")\n"
-        )
-        cameraInitCode = (
+        code = (
+            "# create a camera object\n"
             "%(name)s = camera.Camera(\n"
-            "    name='%(name)s', \n"
-            "    cameraLib=%(cameraLib)s, \n"
-            "    device=%(device)s, \n"
-            "    mic=%(micDeviceVarName)s, \n"
-            "    frameRate=%(frameRate)s, \n"
-            "    frameSize=%(resolution)s\n"
+            "    device='%(cameraDeviceName)s', \n"
+            "    mic='%(micDeviceName)s', \n"
             ")\n"
-            "# Switch on %(name)s\n"
-            "%(name)s.open()\n"
-            "\n"
         )
-        code = micInitCode + cameraInitCode
         buff.writeIndentedLines(code % inits)
 
     def writeInitCodeJS(self, buff):
@@ -627,21 +671,27 @@ class CameraComponent(BaseComponent):
         buff.writeIndentedLines(code % self.params)
 
 
-def getDeviceName(index):
+def getDeviceName(deviceClass, index):
     """
     Get device name from a given index
 
     Parameters
     ----------
+    deviceClass : str
+        Microphone ("mic") or camera ("cam")
     index : int or None
         Index of the device to use
     """
-    # Alias None
-    if index not in micDeviceIndices:
-        index = None
-    # Get device name
-    i = micDeviceIndices.index(index)
-    name = micDeviceNames[i]
+    if deviceClass == "mic":
+        name = "defaultMicrophone"
+        for dev in syst.getAudioCaptureDevices():
+            if dev['index'] == index:
+                name = dev['name']
+    else:
+        name = "defaultCamera"
+        for i, dev in enumerate(syst.getCameras()):
+            if i == index:
+                name = dev[0]['device_name']
 
     return name
 

--- a/psychopy/experiment/components/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/components/photodiodeValidator/__init__.py
@@ -30,7 +30,7 @@ class PhotodiodeValidatorComponent(BaseComponent):
             # layout
             findDiode=True, diodePos="(1, 1)", diodeSize="(0.1, 0.1)", diodeUnits="norm",
             # device
-            backend="bbtk-tpad", port="", number="1",
+            backend="bbtk-tpad", port="", channel="1",
             # data
             saveValid=True,
     ):
@@ -180,11 +180,11 @@ class PhotodiodeValidatorComponent(BaseComponent):
                 "Serial port which the photodiode is connected to."
             )
         )
-        self.params['number'] = Param(
-            number, valType="code", inputType="single", categ="Device",
-            label=_translate("Device number"),
+        self.params['channel'] = Param(
+            channel, valType="code", inputType="single", categ="Device",
+            label=_translate("Photodiode channel"),
             hint=_translate(
-                "If relevant, a device number attached to the photodiode, to distinguish it from other photodiodes on "
+                "If relevant, a channel number attached to the photodiode, to distinguish it from other photodiodes on "
                 "the same port."
             )
         )
@@ -242,7 +242,7 @@ class PhotodiodeValidatorComponent(BaseComponent):
             code = (
                 "# find threshold for photodiode\n"
                 "if %(deviceName)s.getThreshold() is None:\n"
-                "    %(deviceName)s.findThreshold(win)\n"
+                "    %(deviceName)s.findThreshold(win, channel=%(channel)s)\n"
             )
             buff.writeOnceIndentedLines(code % inits)
         # find pos if indicated
@@ -250,7 +250,7 @@ class PhotodiodeValidatorComponent(BaseComponent):
             code = (
                 "# find position and size of photodiode\n"
                 "if %(deviceName)s.pos is None and %(deviceName)s.size is None and %(deviceName)s.units is None:\n"
-                "    %(deviceName)s.findPhotodiode(win)\n"
+                "    %(deviceName)s.findPhotodiode(win, channel=%(channel)s)\n"
             )
             buff.writeOnceIndentedLines(code % inits)
 
@@ -268,7 +268,7 @@ class PhotodiodeValidatorComponent(BaseComponent):
 
         if self.params['threshold'] and not self.params['findThreshold']:
             code = (
-                "%(diodeName)s.setThreshold(%(threshold)s)\n"
+                "%(diodeName)s.setThreshold(%(threshold)s, channels=[%(channel)s])\n"
             )
             buff.writeIndentedLines(code % inits)
         # find/set diode position
@@ -294,7 +294,7 @@ class PhotodiodeValidatorComponent(BaseComponent):
         code = (
             "# validator object for %(name)s\n"
             "%(name)s = phd.PhotodiodeValidator(\n"
-            "    win, %(name)sDiode,\n"
+            "    win, %(name)sDiode, %(channel)s,\n"
             "    variability=%(variability)s,\n"
             "    report=%(report)s,\n"
             ")\n"

--- a/psychopy/experiment/components/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/components/photodiodeValidator/__init__.py
@@ -198,71 +198,98 @@ class PhotodiodeValidatorComponent(BaseComponent):
             )
         )
 
-    def writeInitCode(self, buff):
-        inits = getInitVals(self.params)
-        # initialise diode
-        if self.params['backend'] == "bbtk-tpad":
-            # construct tpad and diode names
-            inits['padName'] = "tpad" + inits['port'].val
-            inits['diodeName'] = "diode" + inits['number'].val + inits['port'].val
-            # add TPad (only once per pad)
-            code = (
-                "# initialise TPad on %(port)s\n"
-                "%(padName)s = tpad.TPad(name='%(padName)s', port=%(port)s)\n"
-            )
-            buff.writeOnceIndentedLines(code % inits)
-            # get diode (only once per diode)
-            code = (
-                "# initialise photodiode %(number)s on port %(port)s\n"
-                "%(diodeName)s = %(padName)s.photodiodes[%(number)s]\n"
-            )
-            buff.writeOnceIndentedLines(code % inits)
-            # find/set threshold
-            if self.params['findThreshold']:
-                code = (
-                    "if %(diodeName)s.getThreshold() is None:\n"
-                    "    %(diodeName)s.findThreshold(win)\n"
-                )
-                buff.writeOnceIndentedLines(code % inits)
-            elif self.params['threshold']:
-                code = (
-                    "%(diodeName)s.setThreshold(%(threshold)s)\n"
-                )
-                buff.writeIndentedLines(code % inits)
-            # find/set diode position
-            if self.params['findDiode']:
-                code = (
-                    "if %(diodeName)s.pos is None and %(diodeName)s.size is None and %(diodeName)s.units is None:\n"
-                    "    %(diodeName)s.findPhotodiode(win)\n"
-                )
-                buff.writeOnceIndentedLines(code % inits)
-            else:
-                code = ""
-                # set units (unless None)
-                if self.params['units']:
-                    code += (
-                        "%(diodeName)s.units = %(units)s\n"
-                    )
-                # set pos (unless None)
-                if self.params['pos']:
-                    code += (
-                        "%(diodeName)s.pos = %(pos)s\n"
-                    )
-                # set size (unless None)
-                if self.params['size']:
-                    code += (
-                        "%(diodeName)s.size = %(size)s\n"
-                    )
-                buff.writeIndentedLines(code % inits)
+    def _makeDeviceName(self):
+        # get port
+        port = self.params['port'].val
+        # construct string
+        name = f"photodiode{port}"
 
-            # store diode by this component's name
-            code = (
-                "# diode object for %(name)s\n"
-                "%(name)sDiode = %(diodeName)s\n"
-            )
-            buff.writeIndentedLines(code % inits)
+        return name
+
+    def writeDeviceCode(self, buff):
+        """
+        Code to setup the CameraDevice for this component.
+
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        """
+        inits = getInitVals(self.params)
+
+        # make device name
+        inits['deviceName'] = self._makeDeviceName()
+        # make deviceClass string
+        if self.params['backend'] == "bbtk-tpad":
+            inits['deviceClass'] = "psychopy_bbtk.tpad.TPadPhotodiodeGroup"
         else:
             raise NotImplementedError(f"Backend %(backend)s is not supported." % self.params)
+        # initialise diode device
+        code = (
+            "# initialise photodiode\n"
+            "%(deviceName)s = deviceManager.getDevice('%(deviceName)s')\n"
+            "if %(deviceName)s is None:\n"
+            "    %(deviceName)s = deviceManager.addDevice(\n"
+            "        deviceClass='%(deviceClass)s',\n"
+            "        deviceName='%(deviceName)s',\n"
+            "        pad=%(port)s,\n"
+            "        channels=2\n"
+            "    )\n"
+        )
+        buff.writeOnceIndentedLines(code % inits)
+        # find threshold if indicated
+        if self.params['findThreshold']:
+            code = (
+                "# find threshold for photodiode\n"
+                "if %(deviceName)s.getThreshold() is None:\n"
+                "    %(deviceName)s.findThreshold(win)\n"
+            )
+            buff.writeOnceIndentedLines(code % inits)
+        # find pos if indicated
+        if self.params['findDiode']:
+            code = (
+                "# find position and size of photodiode\n"
+                "if %(deviceName)s.pos is None and %(deviceName)s.size is None and %(deviceName)s.units is None:\n"
+                "    %(deviceName)s.findPhotodiode(win)\n"
+            )
+            buff.writeOnceIndentedLines(code % inits)
+
+
+    def writeInitCode(self, buff):
+        inits = getInitVals(self.params)
+        # make device name
+        inits['deviceName'] = self._makeDeviceName()
+        # get diode
+        code = (
+            "# diode object for %(name)s\n"
+            "%(name)sDiode = deviceManager.getDevice('%(deviceName)s')\n"
+        )
+        buff.writeIndentedLines(code % inits)
+
+        if self.params['threshold'] and not self.params['findThreshold']:
+            code = (
+                "%(diodeName)s.setThreshold(%(threshold)s)\n"
+            )
+            buff.writeIndentedLines(code % inits)
+        # find/set diode position
+        if not self.params['findDiode']:
+            code = ""
+            # set units (unless None)
+            if self.params['units']:
+                code += (
+                    "%(diodeName)s.units = %(units)s\n"
+                )
+            # set pos (unless None)
+            if self.params['pos']:
+                code += (
+                    "%(diodeName)s.pos = %(pos)s\n"
+                )
+            # set size (unless None)
+            if self.params['size']:
+                code += (
+                    "%(diodeName)s.size = %(size)s\n"
+                )
+            buff.writeIndentedLines(code % inits)
         # create validator object
         code = (
             "# validator object for %(name)s\n"

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -8,6 +8,7 @@ from xml.etree.ElementTree import Element
 import re
 from psychopy import logging, plugins
 from psychopy.experiment.components import Param, _translate
+from psychopy.experiment.routines import Routine
 from psychopy.experiment.routines.eyetracker_calibrate import EyetrackerCalibrationRoutine
 from psychopy.experiment import utils as exputils
 from psychopy.monitors import Monitor
@@ -1562,6 +1563,12 @@ class SettingsComponent:
             "    )\n"
         )
         buff.writeIndentedLines(code % inits)
+        # write any device setup code required by a component
+        for rt in self.exp.flow:
+            if isinstance(rt, Routine):
+                for comp in rt:
+                    if hasattr(comp, "writeDeviceCode"):
+                        comp.writeDeviceCode(buff)
 
         code = (
             "# return True if completed successfully\n"

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1911,8 +1911,8 @@ class SettingsComponent:
             "    win.flip()\n"
             "    win.close()\n"
             "# shut down eyetracker, if there is one\n"
-            "if deviceManager.getEyetracker('eyetracker') is not None:\n"
-            "    deviceManager.removeEyetracker('eyetracker')\n"
+            "if deviceManager.getDevice('eyetracker') is not None:\n"
+            "    deviceManager.removeDevice('eyetracker')\n"
         )
         if self.params['Save log file'].val:
             code += (

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -65,6 +65,7 @@ from psychopy.constants import NOT_STARTED
 from psychopy.hardware import DeviceManager
 from psychopy.visual.movies.frame import MovieFrame, NULL_MOVIE_FRAME_INFO
 from psychopy.sound.microphone import Microphone, MicrophoneDevice
+from psychopy.tools import systemtools as st
 import psychopy.tools.movietools as movietools
 import psychopy.logging as logging
 from psychopy.localization import _translate
@@ -1891,6 +1892,19 @@ class Camera:
             raise ValueError("Invalid value for parameter `cameraLib`")
 
     @staticmethod
+    def getAvailableDevices():
+        devices = []
+        for dev in st.getCameras():
+            for spec in dev:
+                devices.append({
+                    'device': spec['index'],
+                    'frameRate': spec['frameRate'],
+                    'frameSize': spec['frameSize'],
+                })
+
+        return devices
+
+    @staticmethod
     def getCameraDescriptions(collapse=False):
         """Get a mapping or list of camera descriptions.
 
@@ -2418,6 +2432,9 @@ class Camera:
                     self._mic.close()
                 except AttributeError:
                     pass
+
+
+DeviceManager.registerAlias("camera", "psychopy.hardware.camera.Camera")
 
 
 # ------------------------------------------------------------------------------

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -62,8 +62,9 @@ import time
 import numpy as np
 
 from psychopy.constants import NOT_STARTED
+from psychopy.hardware import DeviceManager
 from psychopy.visual.movies.frame import MovieFrame, NULL_MOVIE_FRAME_INFO
-from psychopy.sound.microphone import Microphone
+from psychopy.sound.microphone import Microphone, MicrophoneDevice
 import psychopy.tools.movietools as movietools
 import psychopy.logging as logging
 from psychopy.localization import _translate
@@ -1707,9 +1708,16 @@ class Camera:
         #         "`'cv'` or `'photo'`.")
         # self._mode = mode
 
-        if not isinstance(mic, Microphone):
-            TypeError(
-                "Expected type for parameter `mic`, expected `Microphone`.")
+        _requestedMic = mic
+        # if not given a Microphone or MicrophoneDevice, get it from DeviceManager
+        if not isinstance(mic, (Microphone, MicrophoneDevice)):
+            mic = DeviceManager.getDevice(mic)
+        # if not known by name, try index
+        if mic is None:
+            mic = DeviceManager.getDeviceBy("index", mic, deviceClass="microphone")
+        # if not known by name or index, raise error
+        if mic is None:
+            raise SystemError(f"Could not find microphone {_requestedMic}")
 
         # current camera frame since the start of recording
         self._player = None  # media player instance

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -220,6 +220,34 @@ class DeviceManager:
         return DeviceManager.devices.get(deviceName, None)
 
     @staticmethod
+    def getDeviceBy(attr, value, deviceClass="*"):
+        """
+        Get a device by the value of a particular attribute. e.g. get a Microphone device by its index.
+
+        Parameters
+        ----------
+        attr : str
+            Name of the attribute to query each device for
+        value : *
+            Value which the attribute should return for the device to be a match
+        deviceClass : str
+            Filter search only to devices of a particular class (optional)
+
+        Returns
+        -------
+        BaseDevice
+            Device matching given parameters, or None if none found
+        """
+        # get devices by class
+        devices = DeviceManager.getInitialisedDevices(deviceClass=deviceClass)
+        # try each matching device
+        for dev in devices:
+            if hasattr(dev, attr):
+                # if device matches attribute, return it
+                if getattr(dev, attr) == value:
+                    return dev
+
+    @staticmethod
     def getInitialisedDevices(deviceClass="*"):
         """
         Get all devices of a given type which have been `add`ed to this DeviceManager

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -296,8 +296,8 @@ class DeviceManager:
         cls = DeviceManager._resolveClassString(deviceClass)
         # make sure cass has a getAvailableDevices method
         assert hasattr(cls, "getAvailableDevices"), (
-            "Could not get available devices of type `{deviceClass}` as device class does not have a "
-            "`getAvailableDevices` method."
+            f"Could not get available devices of type `{deviceClass}` as device class does not have a "
+            f"`getAvailableDevices` method."
         )
         # use class method
         return cls.getAvailableDevices()

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -125,7 +125,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
             was able to detect.
         """
         # keyboard to check for escape
-        kb = keyboard.Keyboard(name="photodiodeValidatorKeyboard")
+        kb = keyboard.Keyboard(deviceName="photodiodeValidatorKeyboard")
         # stash autodraw
         win.stashAutoDraw()
         # import visual here - if they're using this function, it's already in the stack
@@ -219,7 +219,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
 
     def findThreshold(self, win):
         # keyboard to check for escape/continue
-        kb = keyboard.Keyboard(name="photodiodeValidatorKeyboard")
+        kb = keyboard.Keyboard(deviceName="photodiodeValidatorKeyboard")
         # stash autodraw
         win.stashAutoDraw()
         # import visual here - if they're using this function, it's already in the stack

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -6,13 +6,14 @@ from psychopy.hardware import keyboard
 
 
 class PhotodiodeResponse:
-    def __init__(self, t, value, threshold=None):
+    def __init__(self, t, value, channel=0, threshold=None):
         self.t = t
         self.value = value
+        self.channel = channel
         self.threshold = threshold
 
     def __repr__(self):
-        return f"<PhotodiodeResponse: t={self.t}, value={self.value}, threshold={self.threshold}>"
+        return f"<PhotodiodeResponse: t={self.t}, value={self.value}, channel={self.channel}, threshold={self.threshold}>"
 
     def getJSON(self):
         message = {
@@ -21,6 +22,7 @@ class PhotodiodeResponse:
             'data': {
                 't': self.t,
                 'value': self.value,
+                'channel': self.channel,
                 'threshold': self.threshold
             }
         }
@@ -28,10 +30,12 @@ class PhotodiodeResponse:
         return json.dumps(message)
 
 
-class BasePhotodiode(base.BaseDevice):
-    def __init__(self, parent, threshold=None, pos=None, size=None, units=None):
-        # get serial parent from port (if photodiode manages its own parent, this needs to be handled by the subclass)
+class BasePhotodiodeGroup(base.BaseDevice):
+    def __init__(self, parent, channels=1, threshold=None, pos=None, size=None, units=None):
+        # store ref to parent device which drives the diode group
         self.parent = parent
+        # store number of channels
+        self.channels = channels
         # attribute in which to store current state
         self.state = False
         # list in which to store messages in chronological order

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -37,7 +37,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
         # store number of channels
         self.channels = channels
         # attribute in which to store current state
-        self.state = False
+        self.state = [False] * channels
         # list in which to store messages in chronological order
         self.responses = []
         # list of listener objects
@@ -65,7 +65,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
         """
         self.listeners.append(listener)
 
-    def getResponses(self, state=None, clear=True):
+    def getResponses(self, state=None, channel=None, clear=True):
         """
         Get responses which match a given on/off state.
 
@@ -88,7 +88,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
         # check messages in chronological order
         for resp in self.responses.copy():
             # does this message meet the criterion?
-            if state is None or resp.value == state:
+            if (state is None or resp.value == state) and (channel is None or resp.channel == channel):
                 # if clear, remove the response
                 if clear:
                     i = self.responses.index(resp)
@@ -104,14 +104,14 @@ class BasePhotodiodeGroup(base.BaseDevice):
             "{msgType}. Try parsing the message first using {ownType}.parseMessage()"
         ).format(ownType=type(self).__name__, msgType=type(message).__name__)
         # update current state
-        self.state = message.value
+        self.state[message.channel] = message.value
         # add message to responses
         self.responses.append(message)
         # relay message to listener
         for listener in self.listeners:
             listener.receiveMessage(message)
 
-    def findPhotodiode(self, win):
+    def findPhotodiode(self, win, channel):
         """
         Draws rectangles on the screen and records photodiode responses to recursively find the location of the diode.
 
@@ -186,20 +186,20 @@ class BasePhotodiodeGroup(base.BaseDevice):
                 if kb.getKeys(['escape']):
                     return
                 # poll photodiode
-                if self.state:
+                if self.getState(channel):
                     # if it detected this rectangle, recur
                     return scanQuadrants()
             # if none of these have returned, rect is too small to cover the whole photodiode, so return
             return
 
         # reset state
-        self.state = None
+        self.state = [None] * self.channels
         self.parent.dispatchMessages()
         self.clearResponses()
         # recursively shrink rect around the photodiode
         scanQuadrants()
         # clear all the events created by this process
-        self.state = None
+        self.state = [None] * self.channels
         self.parent.dispatchMessages()
         self.clearResponses()
         # reinstate autodraw
@@ -217,7 +217,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
             layout.Position(self.size, units="norm", win=win),
         )
 
-    def findThreshold(self, win):
+    def findThreshold(self, win, channel):
         # keyboard to check for escape/continue
         kb = keyboard.Keyboard(deviceName="photodiodeValidatorKeyboard")
         # stash autodraw
@@ -272,7 +272,8 @@ class BasePhotodiodeGroup(base.BaseDevice):
         label.color = (-0.8, -0.8, -0.8)
         label.draw()
         win.flip()
-        if self.getState():
+        state = self.getState(channel)
+        if state:
             raise PhotodiodeValidationError(
                 "Photodiode did not recognise a black screen even when its threshold was at maximum. This means either "
                 "the screen is too bright or the photodiode is too sensitive."
@@ -284,7 +285,8 @@ class BasePhotodiodeGroup(base.BaseDevice):
         label.color = (0.8, 0.8, 0.8)
         label.draw()
         win.flip()
-        if not self.getState():
+        state = self.getState(channel)
+        if not state:
             raise PhotodiodeValidationError(
                 "Photodiode did not recognise a white screen even when its threshold was at minimum. This means either "
                 "the screen is too dark or the photodiode is not sensitive enough."
@@ -316,7 +318,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
             if kb.getKeys(['escape']):
                 return int(current)
             # if state is still True, move threshold up and try again
-            if self.getState():
+            if self.getState(channel):
                 current = (current + 0) / 2
                 _bisectThreshold(current)
             # try white
@@ -326,7 +328,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
             label.draw()
             win.flip()
             # if state is still False, move threshold down and try again
-            if not self.getState():
+            if not self.getState(channel):
                 current = (current + 255) / 2
                 _bisectThreshold(current)
 
@@ -334,7 +336,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
             return int(current)
 
         # reset state
-        self.state = None
+        self.state = [None] * self.channels
         self.parent.dispatchMessages()
         self.clearResponses()
         # bisect thresholds, starting at 127 (exact middle)
@@ -343,7 +345,7 @@ class BasePhotodiodeGroup(base.BaseDevice):
         # clear bg rect
         bg.setAutoDraw(False)
         # clear all the events created by this process
-        self.state = None
+        self.state = [None] * self.channels
         self.parent.dispatchMessages()
         self.clearResponses()
         # reinstate autodraw
@@ -363,11 +365,11 @@ class BasePhotodiodeGroup(base.BaseDevice):
         if hasattr(self, "_threshold"):
             return self._threshold
 
-    def getState(self):
+    def getState(self, channel):
         # dispatch messages from parent
         self.parent.dispatchMessages()
         # return state after update
-        return self.state
+        return self.state[channel]
 
     def parseMessage(self, message):
         raise NotImplementedError()
@@ -380,7 +382,7 @@ class PhotodiodeValidationError(BaseException):
 class PhotodiodeValidator:
 
     def __init__(
-            self, win, diode,
+            self, win, diode, channel,
             variability=1/60,
             report="log",
             autoLog=False):
@@ -390,6 +392,7 @@ class PhotodiodeValidator:
         self.win = win
         # store diode handle
         self.diode = diode
+        self.channel = channel
         # store method of reporting
         self.report = report
         # set acceptable variability
@@ -448,7 +451,7 @@ class PhotodiodeValidator:
             True if photodiode state matched requested state, False otherwise.
         """
         # get and clear responses
-        messages = self.diode.getResponses(state=state, clear=True)
+        messages = self.diode.getResponses(state=state, channel=self.channel, clear=True)
         # if there have been no responses yet, return empty handed
         if not messages:
             return None, None

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -646,6 +646,18 @@ class Session:
         # get expInfo from ExperimentHandler object
         return self.currentExperiment.extraInfo
 
+    @property
+    def win(self):
+        """
+        Window associated with this Session. Defined as a property so as to be accessible from Liaison
+        if needed.
+        """
+        return self._win
+
+    @win.setter
+    def win(self, value):
+        self._win = value
+
     def setupWindowFromExperiment(self, key, expInfo=None, blocking=True):
         """
         Setup the window for this Session via the 'setupWindow` method from one of this

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -313,7 +313,6 @@ class RecordingBuffer:
 class Microphone:
     def __init__(
             self,
-            deviceName=None,
             device=None,
             sampleRateHz=None,
             channels=None,
@@ -322,11 +321,16 @@ class Microphone:
             policyWhenFull='warn',
             audioLatencyMode=None,
             audioRunMode=0):
-
-        if deviceName not in DeviceManager.devices:
-            # if no matching device is in DeviceManager, make a new one
+        # look for device if initialised
+        self.device = DeviceManager.getDevice(device)
+        # if no matching name, try matching index
+        if self.device is None:
+            self.device = DeviceManager.getDeviceBy("index", device)
+        # if still no match, make a new device
+        if self.device is None:
             self.device = DeviceManager.addDevice(
-                deviceClass="psychopy.sound.MicrophoneDevice", deviceName=deviceName,
+                deviceClass="psychopy.sound.MicrophoneDevice", deviceName=device,
+                index=device,
                 sampleRateHz=sampleRateHz,
                 channels=channels,
                 streamBufferSecs=streamBufferSecs,
@@ -335,9 +339,6 @@ class Microphone:
                 audioLatencyMode=audioLatencyMode,
                 audioRunMode=audioRunMode
             )
-        else:
-            # otherwise, use the existing device
-            self.device = DeviceManager.getDevice(deviceName)
 
     @property
     def recording(self):
@@ -437,7 +438,7 @@ class MicrophoneDevice(BaseDevice):
 
     Parameters
     ----------
-    device : int or `~psychopy.sound.AudioDevice`
+    index : int or `~psychopy.sound.AudioDevice`
         Audio capture device to use. You may specify the device either by index
         (`int`) or descriptor (`AudioDevice`).
     sampleRateHz : int
@@ -508,7 +509,7 @@ class MicrophoneDevice(BaseDevice):
     enforceWASAPI = True
 
     def __init__(self,
-                 device=None,
+                 index=None,
                  sampleRateHz=None,
                  channels=None,
                  streamBufferSecs=2.0,
@@ -555,10 +556,10 @@ class MicrophoneDevice(BaseDevice):
             return useDevice
 
         # get information about the selected device
-        if isinstance(device, AudioDeviceInfo):
-            self._device = device
-        elif isinstance(device, (int, float, str)):
-            self._device = _getDeviceByIndex(device)
+        if isinstance(index, AudioDeviceInfo):
+            self._device = index
+        elif isinstance(index, (int, float, str)):
+            self._device = _getDeviceByIndex(index)
         else:
             # get default device, first enumerated usually
             devices = MicrophoneDevice.getDevices()
@@ -863,6 +864,10 @@ class MicrophoneDevice(BaseDevice):
         """``True`` if stream recording has been started (`bool`). Alias of
         `isStarted`."""
         return self.isStarted
+
+    @property
+    def index(self):
+        return self._device.deviceIndex
 
     def start(self, when=None, waitForStart=0, stopTime=None):
         """Start an audio recording.

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -711,9 +711,9 @@ class MicrophoneDevice(BaseDevice):
     @staticmethod
     def getAvailableDevices():
         devices = []
-        for key, val in st.getAudioCaptureDevices().items():
+        for val in st.getAudioCaptureDevices():
             device = {
-                'device': val.get('index', None),
+                'index': val.get('index', None),
                 'sampleRateHz': val.get('defaultSampleRate', None),
                 'channels': val.get('inputChannels', None),
             }


### PR DESCRIPTION
Means that Liaison can use Python handles as inputs to methods, which is needed for e.g. supplying the Session's `.win` attribute as the first input to `DeviceManager.getDevice("tpad_photodiodes").findPhotodiode(`

(also includes all commits from #5982)