### PR TITLE
BF: fix inconsistent data outside trial loop

### DIFF
--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -462,6 +462,3 @@ class JoyButtonsComponent(BaseComponent):
                     "    %s.addData('%s.rt', %s.rt)\n" %
                     (currLoop.params['name'], name, name))
             buff.writeIndentedLines(code)
-
-        if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -581,6 +581,3 @@ class JoystickComponent(BaseComponent):
 
         # get parent to write code too (e.g. store onset/offset times)
         super().writeRoutineEndCode(buff)
-
-        if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -502,9 +502,6 @@ class KeyboardComponent(BaseComponent):
         # get parent to write code too (e.g. store onset/offset times)
         super().writeRoutineEndCode(buff)
 
-        if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)
-
     def writeRoutineEndCodeJS(self, buff):
         # some shortcuts
         name = self.params['name']

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -678,9 +678,6 @@ class MouseComponent(BaseComponent):
         # get parent to write code too (e.g. store onset/offset times)
         super().writeRoutineEndCode(buff)
 
-        if currLoop.params['name'].val == self.exp._expHandler.name:
-            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)
-
     def writeRoutineEndCodeJS(self, buff):
         """Write code at end of routine"""
         # some shortcuts

--- a/psychopy/experiment/components/ratingScale/__init__.py
+++ b/psychopy/experiment/components/ratingScale/__init__.py
@@ -352,9 +352,6 @@ class RatingScaleComponent(BaseComponent):
                     code = "%s.addData('%s.history', %s.getHistory())\n"
                     buff.writeIndented(code % (currLoop.params['name'],
                                                name, name))
-                if currLoop.params['name'].val == self.exp._expHandler.name:
-                    buff.writeIndented("%s.nextEntry()\n" %
-                                       self.exp._expHandler.name)
             else:
                 buff.writeIndented("# RatingScaleComponent: unknown loop "
                                    "type, not saving any data.\n")

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -147,6 +147,15 @@ class BaseStandaloneRoutine:
         return
 
     def writeRoutineEndCode(self, buff):
+        # what loop are we in (or thisExp)?
+        if len(self.exp.flow._loopList):
+            currLoop = self.exp.flow._loopList[-1]  # last (outer-most) loop
+        else:
+            currLoop = self.exp._expHandler
+
+        if currLoop.params['name'].val == self.exp._expHandler.name:
+            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)
+
         # reset routineTimer at the *very end* of all non-nonSlip routines
         code = ('# the Routine "%s" was not non-slip safe, so reset '
                 'the non-slip timer\n'
@@ -683,6 +692,15 @@ class Routine(list):
     def writeRoutineEndCode(self, buff):
         # can we use non-slip timing?
         maxTime, useNonSlip = self.getMaxTime()
+
+        # what loop are we in (or thisExp)?
+        if len(self.exp.flow._loopList):
+            currLoop = self.exp.flow._loopList[-1]  # last (outer-most) loop
+        else:
+            currLoop = self.exp._expHandler
+
+        if currLoop.params['name'].val == self.exp._expHandler.name:
+            buff.writeIndented("%s.nextEntry()\n" % self.exp._expHandler.name)
 
         # reset routineTimer at the *very end* of all non-nonSlip routines
         if not useNonSlip:


### PR DESCRIPTION
Possible solution to  #6002. Instead of having the input components write the call to  `nextEntry` if they do not occur within a trial loop, this is done by the routine. This way there is always a line of data for routines outside of a trial loop, regardless of which components are in there. Routines within a loop are not affected. 