### PR TITLE
ENH: Changes to wording of If finished... and Save remaining cap

### DIFF
--- a/psychopy/experiment/routines/counterbalance/__init__.py
+++ b/psychopy/experiment/routines/counterbalance/__init__.py
@@ -111,7 +111,7 @@ class CounterbalanceRoutine(BaseStandaloneRoutine):
             onFinished, valType="str", inputType="choice", categ="Basic",
             allowedVals=["raise", "reset", "ignore"],
             allowedLabels=[_translate("Raise error"), _translate("Reset participant caps"),
-                           _translate("Just set .finished = True")],
+                           _translate("Just set as finished")],
             label=_translate("If finished..."),
             hint=_translate(
                 "What to do when all groups are finished? Raise an error, reset the count or just continue with "
@@ -134,7 +134,7 @@ class CounterbalanceRoutine(BaseStandaloneRoutine):
 
         self.params['saveRemaining'] = Param(
             saveRemaining, valType="bool", inputType="bool", categ="Data",
-            label=_translate("Save remaning cap"),
+            label=_translate("Save remaining cap"),
             hint=_translate(
                 "Save the remaining cap for the chosen group this repeat to the data file?"
             )


### PR DESCRIPTION
- Changed `Just set .finished` to `Just set as finished` to make it sound more natural
- Fixed spelling of remaining