### PR TITLE
BF: Make `engine` param lower case

### DIFF
--- a/psychopy/sound/transcribe.py
+++ b/psychopy/sound/transcribe.py
@@ -740,7 +740,7 @@ def getTranscriberInterface(engine):
     --------
     Get a transcriber interface and initalize it::
 
-        whisperInterface = getTranscriber('WhisperTranscriber')
+        whisperInterface = getTranscriberInterface('whisper')
         # initialize it
         transcriber = whisperInterface({'device': 'cuda'})
     
@@ -776,6 +776,8 @@ def setupTranscriber(engine, config=None):
         Options to configure the speech-to-text engine during initialization.
     
     """
+    engine = engine.lower()  # make lower case
+
     global _activeTranscriber
     if _activeTranscriber is not None:
         oldInterface = _activeTranscriber.engine


### PR DESCRIPTION
Forces the engine param to be lowercase. This ensures that the interface can specify it in various ways.