### PR TITLE
FF: Fix Keyboard getKeys getting events for press and release

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -439,9 +439,11 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             # start off assuming we want the key
             wanted = True
             # if we're waiting on release, only store if it has a duration
+            wasRelease = hasattr(resp, "duration") and resp.duration is not None
             if waitRelease:
-                if not getattr(resp, "duration") or resp.duration is None:
-                    wanted = False
+                wanted = wanted and wasRelease
+            else:
+                wanted = wanted and not wasRelease
             # if we're looking for a key list, only store if it's in the list
             if keyList:
                 if resp.value not in keyList:


### PR DESCRIPTION
Because keys weren't filtered for press/release when waitRelease=False, keypresses were registering on release as well as on press