### PR TITLE
ENH: Redirect log to its own Runner tab

### DIFF
--- a/psychopy/alerts/_alerts.py
+++ b/psychopy/alerts/_alerts.py
@@ -169,14 +169,17 @@ def alert(code=None, obj=object, strFields=None, trace=None):
     #                                         msg=msg.msg,
     #                                         trace=msg.trace))
 
-    # if a psychopy warning instead of a file-like stderr then pass a raw str
-    if hasattr(sys.stderr, 'receiveAlert'):
-        sys.stderr.receiveAlert(msg)
-    else:
-        # For tests detecting output - change when error handler set up
-        sys.stderr.write(msgAsStr)
-        for handler in _activeAlertHandlers:
-            handler.receiveAlert(msg)
+    # write to any linked handlers
+    written = False
+    for handler in _activeAlertHandlers:
+        written = True
+        handler.receiveAlert(msg)
+    # if no handlers were written to, send to stdout as a fallback
+    if not written:
+        if hasattr(sys.stderr, 'receiveAlert'):
+            sys.stderr.receiveAlert(msg)
+        else:
+            sys.stderr.write(msgAsStr)
 
 
 # Create catalog

--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -155,15 +155,7 @@ class LogFile():
 
         """
         super(LogFile, self).__init__()
-        # work out if this is a filename or a stream to write to
-        if isinstance(f, Path):
-            f = str(f)
-        if f is None:
-            self.stream = 'stdout'
-        elif hasattr(f, 'write'):
-            self.stream = f
-        elif isinstance(f, str):
-            self.stream = codecs.open(f, filemode, encoding)
+        self.setStream(f, filemode=filemode, encoding=encoding)
         self.level = level
         if logger is None:
             logger = root
@@ -180,6 +172,18 @@ class LogFile():
         self.logger = logger
 
         self.logger.addTarget(self)
+
+    def setStream(self, f, filemode='a', encoding='utf-8'):
+        # work out if this is a filename or a stream to write to
+        if isinstance(f, Path):
+            f = str(f)
+
+        if f is None:
+            self.stream = 'stdout'
+        elif hasattr(f, 'write'):
+            self.stream = f
+        elif isinstance(f, str):
+            self.stream = codecs.open(f, filemode, encoding)
 
     def setLevel(self, level):
         """Set a new minimal level for the log file/stream


### PR DESCRIPTION
Makes the WARNING spam we get sometimes a little less annoying as you can at least navigate away from the tab rather than having to scroll past it