### PR TITLE
NF/RF: Allow more components to find their device backends from plugins

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -825,6 +825,9 @@ class Experiment:
                         # if not componentNode.get('choiceLabelsAboveLine'):
                         #    # this rating scale was created using older version
                         #    component.params['choiceLabelsAboveLine'].val=True
+                    # if component depends on backends, load them
+                    if hasattr(component, "loadBackends"):
+                        component.loadBackends()
                     # populate the component with its various params
                     for paramNode in componentNode:
                         recognised = self._getXMLparam(
@@ -853,6 +856,9 @@ class Experiment:
                 else:
                     # Otherwise treat as unknown
                     routine = allRoutines['UnknownRoutine'](exp=self, name=routineNode.get('name'))
+                # if routine depends on backends, load them
+                if hasattr(routine, "loadBackends"):
+                    routine.loadBackends()
                 # Apply all params
                 for paramNode in routineNode:
                     if paramNode.tag == "Param":

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -863,7 +863,9 @@ class Experiment:
                 for paramNode in routineNode:
                     if paramNode.tag == "Param":
                         for key, val in paramNode.items():
-                            setattr(routine.params[paramNode.get("name")], key, val)
+                            name = paramNode.get("name")
+                            if name in routine.params:
+                                setattr(routine.params[name], key, val)
                 # Add routine to experiment
                 self.addStandaloneRoutine(routine.name, routine)
         # for each component that uses a Static for updates, we need to set

--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -295,9 +295,13 @@ def getInitVals(params, target="PsychoPy"):
                                        .format(inits[name]))
                     inits[name].valType = 'code'
 
-        if name == "deviceName" and not params[name]:
-            # if deviceName exists but is blank, use component name
-            inits[name].val = params['name'].val
+        if name == "deviceName":
+            if not params[name]:
+                # if deviceName exists but is blank, use component name
+                inits[name].val = inits['name'].val
+            # make a code version of device name
+            inits['deviceNameCode'] = copy.copy(inits[name])
+            inits['deviceNameCode'].valType = "code"
 
         if not hasattr(inits[name], 'updates'):  # might be settings parameter instead
             continue

--- a/psychopy/experiment/components/buttonBox/__init__.py
+++ b/psychopy/experiment/components/buttonBox/__init__.py
@@ -1,58 +1,10 @@
 from pathlib import Path
 from psychopy.experiment.components import BaseComponent, Param, getInitVals
+from psychopy.experiment.plugins import PluginDevicesMixin, DeviceBackend
 from psychopy.localization import _translate
 
 
-class ButtonBoxBackend:
-    def __init_subclass__(cls, key, label=None):
-        """
-        Initialise a new backend for ButtonBoxComponent.
-
-        Parameters
-        ----------
-        key : str
-            Name of this backend - will be used in allowedVals for the deviceBackend parameter of ButtonBoxComponent.
-            This will be used for indexing, so shouldn't be localized (translated)!
-        label : str
-            Label for this backend - will be used in allowedLabels for the deviceBackend parameter of
-            ButtonBoxComponent.
-        """
-        # if not given a label, use key
-        if label is None:
-            label = key
-        # store key and label in class
-        cls.key = key
-        cls.label = label
-        # add class to list of backends for ButtonBoxComponent
-        ButtonBoxComponent.backends.append(cls)
-
-    def getParams(self):
-        """
-        Get parameters from this backend to add to each new instance of ButtonBoxComponent
-
-        Returns
-        -------
-        dict[str:Param]
-            Dict of Param objects, which will be added to any Button Box Component's params, along
-            with a dependency to only show them when this backend is selected
-        list[str]
-            List of param names, defining the order in which params should appear
-        list[dict[str:str]]
-            List of dependency dicts, defining any additional dependencies required by this backend
-        """
-        raise NotImplementedError()
-
-    def addRequirements(self):
-        """
-        Add any required module/package imports for this backend
-        """
-        raise NotImplementedError()
-
-    def writeDeviceCode(self, buff):
-        raise NotImplementedError()
-
-
-class ButtonBoxComponent(BaseComponent):
+class ButtonBoxComponent(BaseComponent, PluginDevicesMixin):
     """
 
     """
@@ -60,20 +12,18 @@ class ButtonBoxComponent(BaseComponent):
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'buttonBox.png'
     tooltip = _translate('Button Box: Get input from a button box')
-    # list of backends - starts with generic serial, plugins (lke psychopy-bbtk or psychopy-cedrus) will add to this
-    backends = []
 
     def __init__(
             self, exp, parentName,
             # basic
-            name='buttonBox', nButtons=1,
+            name='buttonBox',
             startType='time (s)', startVal=0.0,
             stopType='duration (s)', stopVal=1.0,
             startEstim='', durationEstim='',
             forceEndRoutine=True,
             # device
             deviceName="",
-            deviceBackend="serial",
+            deviceBackend="keyboard",
             # data
             registerOn=True,
             store='first',
@@ -196,44 +146,6 @@ class ButtonBoxComponent(BaseComponent):
             direct=False
         )
 
-    def loadBackends(self):
-        from psychopy.plugins import activatePlugins
-        activatePlugins()
-        # add params from backends
-        for backend in self.backends:
-            # get params using backend's method
-            params, order = backend.getParams(self)
-            # add order
-            self.order.extend(order)
-            # add any params
-            for key, param in params.items():
-                if key in self.params:
-                    # if this param already exists (i.e. from saved data), get the saved val
-                    param.val = self.params[key].val
-                    param.updates = self.params[key].updates
-                # add param
-                self.params[key] = param
-
-            # add dependencies so that backend params are only shown for this backend
-            for name in params:
-                self.depends.append(
-                    {
-                        "dependsOn": "deviceBackend",  # if...
-                        "condition": f"== '{backend.key}'",  # meets...
-                        "param": name,  # then...
-                        "true": "show",  # should...
-                        "false": "hide",  # otherwise...
-                    }
-                )
-            # add requirements
-            backend.addRequirements(self)
-
-    def writeDeviceCode(self, buff):
-        # write init code from backend
-        for backend in self.backends:
-            if backend.key == self.params['deviceBackend']:
-                backend.writeDeviceCode(self, buff)
-
     def writeInitCode(self, buff):
         inits = getInitVals(self.params)
         # code to create object
@@ -348,11 +260,16 @@ class ButtonBoxComponent(BaseComponent):
         buff.writeIndentedLines(code % params)
 
 
-class KeyboardButtonBoxBackend(ButtonBoxBackend, key="keyboard", label=_translate("Keyboard")):
+class KeyboardButtonBoxBackend(DeviceBackend):
     """
-    Adds a basic serial connection backend for ButtonBoxComponent, as well as acting as an example for implementing
-    other ButtonBoxBackends.
+    Adds a basic keyboard emulation backend for ButtonBoxComponent, as well as acting as an example
+    for implementing other ButtonBoxBackends.
     """
+
+    key = "keyboard"
+    label = _translate("Keyboard")
+    component = ButtonBoxComponent
+
     def getParams(self: ButtonBoxComponent):
         # define order
         order = [

--- a/psychopy/experiment/components/buttonBox/__init__.py
+++ b/psychopy/experiment/components/buttonBox/__init__.py
@@ -131,14 +131,10 @@ class ButtonBoxComponent(BaseComponent, PluginDevicesMixin):
                 "same device for multiple components, be sure to use the same name here."
             )
         )
-        def getBackendVals():
-            return [getattr(cls, 'key', cls.__name__) for cls in self.backends]
-        def getBackendLabels():
-            return [getattr(cls, 'label', cls.__name__) for cls in self.backends]
         self.params['deviceBackend'] = Param(
             deviceBackend, valType="str", inputType="choice", categ="Device",
-            allowedVals=getBackendVals,
-            allowedLabels=getBackendLabels,
+            allowedVals=self.getBackendKeys,
+            allowedLabels=self.getBackendLabels,
             label=_translate("Device backend"),
             hint=_translate(
                 "What kind of button box is it? What package/plugin should be used to talk to it?"

--- a/psychopy/experiment/plugins.py
+++ b/psychopy/experiment/plugins.py
@@ -1,0 +1,107 @@
+class PluginDevicesMixin:
+    """
+    Mixin for Components and Routines which adds behaviour to get parameters and values from
+    plugins and use them to create different devices for different plugin backends.
+    """
+
+    # list of backends for this component - each should be a subclass of DeviceBackend
+    backends = []
+
+    def loadBackends(self):
+        from psychopy.plugins import activatePlugins
+        activatePlugins()
+        # add params from backends
+        for backend in self.backends:
+            # get params using backend's method
+            params, order = backend.getParams(self)
+            # add order
+            self.order.extend(order)
+            # add any params
+            for key, param in params.items():
+                if key in self.params:
+                    # if this param already exists (i.e. from saved data), get the saved val
+                    param.val = self.params[key].val
+                    param.updates = self.params[key].updates
+                # add param
+                self.params[key] = param
+
+            # add dependencies so that backend params are only shown for this backend
+            for name in params:
+                self.depends.append(
+                    {
+                        "dependsOn": "deviceBackend",  # if...
+                        "condition": f"== '{backend.key}'",  # meets...
+                        "param": name,  # then...
+                        "true": "show",  # should...
+                        "false": "hide",  # otherwise...
+                    }
+                )
+            # add requirements
+            backend.addRequirements(self)
+
+    def getBackendKeys(self):
+        keys = []
+        for backend in self.backends:
+            keys.append(backend.key)
+
+    def getBackendLabels(self):
+        labels = []
+        for backend in self.backends:
+            labels.append(backend.label)
+
+    def writeDeviceCode(self, buff):
+        # write init code from backend
+        for backend in self.backends:
+            if backend.key == self.params['deviceBackend']:
+                backend.writeDeviceCode(self, buff)
+
+
+class DeviceBackend:
+    # which component is this backend for?
+    component = PluginDevicesMixin
+    # what value should Builder use for this backend?
+    key = ""
+    # what label should be displayed by Builder for this backend?
+    label = ""
+
+    def __init_subclass__(cls):
+        """
+        Initialise a new backend for ButtonBoxComponent.
+
+        Parameters
+        ----------
+        key : str
+            Name of this backend - will be used in allowedVals for the deviceBackend parameter of ButtonBoxComponent.
+            This will be used for indexing, so shouldn't be localized (translated)!
+        label : str
+            Label for this backend - will be used in allowedLabels for the deviceBackend parameter of
+            ButtonBoxComponent.
+        """
+        # add class to list of backends for ButtonBoxComponent
+        cls.component.backends.append(cls)
+
+    def getParams(self):
+        """
+        Get parameters from this backend to add to each new instance of ButtonBoxComponent
+
+        Returns
+        -------
+        dict[str:Param]
+            Dict of Param objects, which will be added to any Button Box Component's params, along
+            with a dependency to only show them when this backend is selected
+        list[str]
+            List of param names, defining the order in which params should appear
+        """
+        raise NotImplementedError()
+
+    def addRequirements(self):
+        """
+        Add any required module/package imports for this backend
+        """
+        raise NotImplementedError()
+
+    def writeDeviceCode(self, buff):
+        """
+        Write the code to create a device for this backend
+        """
+        raise NotImplementedError()

--- a/psychopy/experiment/plugins.py
+++ b/psychopy/experiment/plugins.py
@@ -4,8 +4,9 @@ class PluginDevicesMixin:
     plugins and use them to create different devices for different plugin backends.
     """
 
-    # list of backends for this component - each should be a subclass of DeviceBackend
-    backends = []
+    def __init_subclass__(cls):
+        # list of backends for this component - each should be a subclass of DeviceBackend
+        cls.backends = []
 
     def loadBackends(self):
         from psychopy.plugins import activatePlugins

--- a/psychopy/experiment/plugins.py
+++ b/psychopy/experiment/plugins.py
@@ -45,10 +45,14 @@ class PluginDevicesMixin:
         for backend in self.backends:
             keys.append(backend.key)
 
+        return keys
+
     def getBackendLabels(self):
         labels = []
         for backend in self.backends:
             labels.append(backend.label)
+
+        return labels
 
     def writeDeviceCode(self, buff):
         # write init code from backend

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -3,7 +3,7 @@
 
 from pathlib import Path
 from psychopy.experiment import Param
-from psychopy.experiment.plugins import PluginDevicesMixin
+from psychopy.experiment.plugins import PluginDevicesMixin, DeviceBackend
 from psychopy.experiment.components import getInitVals
 from psychopy.experiment.routines import Routine, BaseValidatorRoutine
 from psychopy.localization import _translate
@@ -413,3 +413,39 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
 
         return stims
 
+
+class ScreenBufferPhotodiodeValidatorBackend(DeviceBackend):
+    """
+    Adds a basic screen buffer emulation backend for PhotodiodeValidator, as well as acting as an
+    example for implementing other photodiode device backends.
+    """
+
+    key = "screenbuffer"
+    label = _translate("Screen Buffer (Debug)")
+    component = PhotodiodeValidatorRoutine
+
+    def getParams(self: PhotodiodeValidatorRoutine):
+        # define order
+        order = [
+        ]
+        # define params
+        params = {}
+
+        return params, order
+
+    def addRequirements(self):
+        # no requirements needed - so just return
+        return
+
+    def writeDeviceCode(self: PhotodiodeValidatorRoutine, buff):
+        # get inits
+        inits = getInitVals(self.params)
+        # make ButtonGroup object
+        code = (
+            "deviceManager.addDevice(\n"
+            "    deviceClass='psychopy.hardware.photodiode.ScreenBufferSampler',\n"
+            "    deviceName=%(deviceName)s,\n"
+            "    win=win,\n"
+            ")\n"
+        )
+        buff.writeOnceIndentedLines(code % inits)

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -150,8 +150,8 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine):
         ]
         self.params['backend'] = Param(
             backend, valType="code", inputType="choice", categ="Device",
-            allowedVals=["bbtk-tpad"],
-            allowedLabels=["Black Box Toolkit (BBTK) TPad"],
+            allowedVals=["bbtk-tpad", "debug"],
+            allowedLabels=["Black Box Toolkit (BBTK) TPad", "Screen Buffer (Debug Mode)"],
             label=_translate("Photodiode type"),
             hint=_translate(
                 "Type of photodiode to use."
@@ -215,6 +215,8 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine):
         # make deviceClass string
         if self.params['backend'] == "bbtk-tpad":
             inits['deviceClass'] = "psychopy_bbtk.tpad.TPadPhotodiodeGroup"
+        elif self.params['backend'] == "debug":
+            inits['deviceClass'] = "psychopy.hardware.photodiode.ScreenBufferSampler"
         else:
             raise NotImplementedError(f"Backend %(backend)s is not supported." % self.params)
         # initialise diode device
@@ -225,8 +227,17 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine):
             "    %(deviceName)s = deviceManager.addDevice(\n"
             "        deviceClass='%(deviceClass)s',\n"
             "        deviceName='%(deviceName)s',\n"
+        )
+        if self.params['backend'] == "bbtk-tpad":
+            code += (
             "        pad=%(port)s,\n"
             "        channels=2\n"
+            )
+        elif self.params['backend'] == "debug":
+            code += (
+            "        win=win\n"
+            )
+        code += (
             "    )\n"
         )
         buff.writeOnceIndentedLines(code % inits)

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -151,7 +151,12 @@ class DeviceManager:
         pkgName = ".".join(parts[:-1])
         clsName = parts[-1]
         # import package
-        pkg = importlib.import_module(pkgName)
+        try:
+            pkg = importlib.import_module(pkgName)
+        except:
+            raise ModuleNotFoundError(
+                f"Could not find module: {pkgName}"
+            )
         # get class
         cls = getattr(pkg, clsName)
 

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -420,35 +420,69 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
 
     @property
     def pos(self):
-        return getattr(self._pos, self.units)
+        if self.units and hasattr(self._pos, self.units):
+            return getattr(self._pos, self.units)
 
     @pos.setter
     def pos(self, value):
-        self._pos = layout.Position(
-            value, self.units, win=self.win
-        )
+        # retain None so value is identifiable as not set
+        if value is None:
+            self._pos = None
+            return
+        # make sure we have a Position object
+        if not isinstance(value, layout.Position):
+            value = layout.Position(
+                value, self.units, win=self.win
+            )
+        # set
+        self._pos = value
 
     @property
     def size(self):
-        return getattr(self._size, self.units)
+        if self.units and hasattr(self._size, self.units):
+            return getattr(self._size, self.units)
 
     @size.setter
     def size(self, value):
-        self._size = layout.Size(
-            value, self.units, win=self.win
-        )
+        # retain None so value is identifiable as not set
+        if value is None:
+            self._size = None
+            return
+        # make sure we have a Size object
+        if not isinstance(value, layout.Size):
+            value = layout.Size(
+                value, self.units, win=self.win
+            )
+        # set
+        self._size = value
 
     @property
     def units(self):
         units = None
         if hasattr(self, "_units"):
             units = self._units
-        if units is None:
-            return self.win.units
+
+        return units
 
     @units.setter
     def units(self, value):
         self._units = value
+
+    def findPhotodiode(self, win=None, channel=0):
+        if win is None:
+            win = self.win
+        # there's no physical photodiode, so just pick a reasonable place for it
+        self._pos = layout.Position((0.95, -0.95), units="norm", win=win)
+        self._size = layout.Size((0.05, 0.05), units="norm", win=win)
+        self.units = "norm"
+
+        return self._pos, self._size
+
+    def findThreshold(self, win=None, channel=0):
+        # there's no physical photodiode, so just pick a reasonable threshold
+        self.setThreshold(127)
+
+        return self.getThreshold()
 
 
 class PhotodiodeValidator:

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -388,12 +388,12 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         h = int(h)
         # read front buffer luminances for specified area
         pixels = self.win._getPixels(
-            buffer="back",
+            buffer="front",
             rect=(left, bottom, w, h),
             makeLum=True
         )
         # work out whether it's brighter than threshold
-        state = pixels.mean() > (255 - self._threshold)
+        state = pixels.mean() > (255 - self.getThreshold())
         # if state has changed, make an event
         if state != self.state[0]:
             resp = PhotodiodeResponse(

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -381,11 +381,14 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         """
         # get rect
         left, bottom = self._pos.pix + self.win.size / 2
-        w, h = (10, 10)
+        w, h = self._size.pix
         left = int(left - w / 2)
         bottom = int(bottom - h / 2)
+        w = int(w)
+        h = int(h)
         # read front buffer luminances for specified area
         pixels = self.win._getPixels(
+            buffer="back",
             rect=(left, bottom, w, h),
             makeLum=True
         )

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -384,12 +384,13 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         w, h = (10, 10)
         left = int(left - w / 2)
         bottom = int(bottom - h / 2)
-        # get GL context
-        gl = self.win.backend.GL
-        # todo: read front buffer for specified area
-        # todo: work out whether it's brighter than threshold
-        brightness = sum(pixels) / (h*w*3)
-        state = brightness > (255 - self._threshold)
+        # read front buffer luminances for specified area
+        pixels = self.win._getPixels(
+            rect=(left, bottom, w, h),
+            makeLum=True
+        )
+        # work out whether it's brighter than threshold
+        state = pixels.mean() > (255 - self._threshold)
         # if state has changed, make an event
         if state != self.state[0]:
             resp = PhotodiodeResponse(

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -388,7 +388,7 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         h = int(h)
         # read front buffer luminances for specified area
         pixels = self.win._getPixels(
-            buffer="front",
+            buffer="back",
             rect=(left, bottom, w, h),
             makeLum=True
         )

--- a/psychopy/tests/test_experiment/test_component_compile_python.py
+++ b/psychopy/tests/test_experiment/test_component_compile_python.py
@@ -130,6 +130,9 @@ class TestComponentCompilerPython():
     def add_components(self, compName):
         """Add components to routine"""
         thisComp = self.allComp[compName](parentName='trial', exp=self.exp)
+        if hasattr(thisComp, "loadBackends"):
+            # load backend params if needed
+            thisComp.loadBackends()
         if compName == 'StaticComponent':
             # Create another component to trigger param updates for static
             textStim = self.allComp['TextComponent'](parentName='trial', exp=self.exp)

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -2383,9 +2383,9 @@ class Window():
 
         Parameters
         ----------
-        rect : tuple, optional
-            The region of the window to capture in normalized coordinates
-            (left, top, width, height). If `None`, the whole window is captured.
+        rect : tuple[int], optional
+            The region of the window to capture in pixel coordinates (left,
+            bottom, width, height). If `None`, the whole window is captured.
         buffer : str, optional
             Buffer to capture.
         includeAlpha : bool, optional
@@ -2428,12 +2428,8 @@ class Window():
                              "'front' or 'back'".format(buffer))
 
         if rect:
-            x, y = self.size
             # box corners in pix
-            left = int((rect[0] / 2. + 0.5) * x)
-            bottom = int((rect[3] / 2. + 0.5) * y)
-            w = int((rect[2] / 2. + 0.5) * x) - left
-            h = int((rect[1] / 2. + 0.5) * y) - bottom
+            left, bottom, w, h = rect
         else:
             left = bottom = 0
             w, h = self.size


### PR DESCRIPTION
Adds a photodiode backend which, rather than querying an actual device, queries the screen buffer for pixel values. Useful for building experiments when not connected to the physical device.