### PR TITLE
Docs: Fix translation .po file error

### DIFF
--- a/psychopy/app/locale/zh_CN/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/zh_CN/LC_MESSAGE/messages.po
@@ -7113,7 +7113,7 @@ msgstr "扫描所有端口"
 
 #: ../monitors/MonitorCenter.py:401
 msgid "Get Photometer"
-msgstr 获取光度计""
+msgstr "获取光度计"
 
 #: ../monitors/MonitorCenter.py:407
 msgid "Gamma Calibration..."


### PR DESCRIPTION
A typo error will failing compiling to .mo.