### PR TITLE
DOCS: Fix redirect link on recruiting online page

### DIFF
--- a/docs/source/online/onlineParticipants.rst
+++ b/docs/source/online/onlineParticipants.rst
@@ -5,4 +5,10 @@
 Recruiting participants and daisy-chaining with other platforms
 -------------------------------------------------------------
 
-We have now moved our updated documentation on daisy-chaining participants to <a href="https://pavlovia.org/">Pavlovia/a>. Click <a href="https://pavlovia.org/docs/experiments/recruiting">here/a> to find out more.
+We have now moved our updated documentation on daisy-chaining participants to `Pavlovia <https://pavlovia.org/>`_. Click `here <https://pavlovia.org/docs/experiments/recruiting>`_ to find out more.
+
+
+
+
+
+


### PR DESCRIPTION
URL formatting was using HTML instead of RST