### PR TITLE
FF: Fix timing on photodiode validator

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -504,6 +504,7 @@ class BaseComponent:
         buff.setIndentLevel(+1, relative=True)
         code = (f"# keep track of stop time/frame for later\n"
                 f"{params['name']}.tStop = t  # not accounting for scr refresh\n"
+                f"{params['name']}.tStopRefresh = tThisFlipGlobal  # on global time\n"
                 f"{params['name']}.frameNStop = frameN  # exact frame index\n"
                 )
         if self.params['saveStartStop']:

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -329,7 +329,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
         code = (
             "# validate {name} start time\n"
             "if {name}.status == STARTED and %(name)s.status == STARTED:\n"
-            "    %(name)s.tStart, %(name)s.tStartValid = %(name)s.validate(state=True, t={name}.tStart)\n"
+            "    %(name)s.tStart, %(name)s.tStartValid = %(name)s.validate(state=True, t={name}.tStartRefresh)\n"
             "    if %(name)s.tStart is not None:\n"
             "        %(name)s.status = FINISHED\n"
         )
@@ -349,7 +349,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
         code = (
             "# validate {name} stop time\n"
             "if {name}.status == FINISHED and %(name)s.status == STARTED:\n"
-            "    %(name)s.tStop, %(name)s.tStopValid = %(name)s.validate(state=False, t={name}.tStop)\n"
+            "    %(name)s.tStop, %(name)s.tStopValid = %(name)s.validate(state=False, t={name}.tStopRefresh)\n"
             "    if %(name)s.tStop is not None:\n"
             "        %(name)s.status = FINISHED\n"
         )

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -377,8 +377,12 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         state = pixels.mean() > (255 - self.getThreshold())
         # if state has changed, make an event
         if state != self.state[0]:
+            if self.win._frameTimes:
+                frameT = logging.defaultClock.getTime() - self.win._frameTimes[-1]
+            else:
+                frameT = 0
             resp = PhotodiodeResponse(
-                t=self.clock.getTime(),
+                t=self.clock.getTime() - frameT,
                 value=state,
                 channel=0,
                 threshold=self._threshold

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -378,7 +378,7 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         # if state has changed, make an event
         if state != self.state[0]:
             resp = PhotodiodeResponse(
-                t=self.clock.getTime() + self.win.monitorFramePeriod,
+                t=self.clock.getTime(),
                 value=state,
                 channel=0,
                 threshold=self._threshold
@@ -397,7 +397,8 @@ class ScreenBufferSampler(BasePhotodiodeGroup):
         return []
 
     def resetTimer(self, clock=logging.defaultClock):
-        self.clock.reset(clock.getTime())
+        self.clock._timeAtLastReset = clock._timeAtLastReset
+        self.clock._epochTimeAtLastReset = clock._epochTimeAtLastReset
 
     @property
     def pos(self):


### PR DESCRIPTION
Was using tStart/tStop rather than tStartRefresh/tStopRefresh, meaning if within a trial loop it was comparing the photodiode's (synced to global) clock to the stimulus's (synced to Routine) clock and returning FALSE when actually the times were within validity range.