### PR TITLE
FF: Avoid creating the same device twice if we can

### DIFF
--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -71,6 +71,13 @@ class DeviceManager:
         if liaison is not None:
             DeviceManager.liaison = liaison
 
+        # make sure we have at least one response device
+        if "defaultKeyboard" not in self.devices:
+            self.addDevice(
+                deviceClass="psychopy.hardware.keyboard.KeyboardDevice",
+                deviceName="defaultKeyboard"
+            )
+
     # --- utility ---
 
     def _getSerialPortsInUse(self):

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -241,6 +241,13 @@ class DeviceManager:
                 DeviceManager.addDeviceAlias(deviceName, thisAlias)
 
             return True
+
+        # don't add alias if there's no device to alias!
+        if DeviceManager.getDevice(deviceName) is None:
+            raise KeyError(
+                f"Cannot add alias for {deviceName} as no device by this name has been added."
+            )
+
         # store same device by new handle
         DeviceManager.devices[alias] = DeviceManager.getDevice(deviceName)
 

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -239,6 +239,8 @@ class DeviceManager:
         if isinstance(alias, (list, tuple)):
             for thisAlias in alias:
                 DeviceManager.addDeviceAlias(deviceName, thisAlias)
+
+            return True
         # store same device by new handle
         DeviceManager.devices[alias] = DeviceManager.getDevice(deviceName)
 

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -71,13 +71,6 @@ class DeviceManager:
         if liaison is not None:
             DeviceManager.liaison = liaison
 
-        # make sure we have at least one response device
-        if "defaultKeyboard" not in self.devices:
-            self.addDevice(
-                deviceClass="psychopy.hardware.keyboard.KeyboardDevice",
-                deviceName="defaultKeyboard"
-            )
-
     # --- utility ---
 
     def _getSerialPortsInUse(self):

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -997,6 +997,12 @@ class Session:
         thisExp.name = key
         # Mark ExperimentHandler as current
         self.currentExperiment = thisExp
+        # Make sure we have at least one response device
+        if "defaultKeyboard" not in DeviceManager.devices:
+            DeviceManager.addDevice(
+                deviceClass="psychopy.hardware.keyboard.KeyboardDevice",
+                deviceName="defaultKeyboard"
+            )
         # Hide Window message
         self.win.hideMessage()
         # Setup window for this experiment

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -1007,8 +1007,6 @@ class Session:
         self.win.stashAutoDraw()
         # Setup logging
         self.experiments[key].run.__globals__['logFile'] = self.logFile
-        # Setup devices
-        self.setupDevicesFromExperiment(key, expInfo=expInfo, thisExp=thisExp)
         # Log start
         logging.info(_translate(
             "Running experiment via Session: name={key}, expInfo={expInfo}"


### PR DESCRIPTION
Because Session still runs the setupDevices function but just doesn't use it, devices which can't be initialised twice (Camera and Microphone for example) sometimes crash when setting up via Session