### PR TITLE
BF: don't sys.exit if argparse finds unknown args

### DIFF
--- a/psychopy/piloting.py
+++ b/psychopy/piloting.py
@@ -53,8 +53,9 @@ def setPilotModeFromArgs():
     parser.add_argument('--pilot', action='store_true', dest='pilot')
     parser.add_argument('--d', action='store_true', dest='pilot')
     # set mode
+    known_args, unknownArgs = parser.parse_known_args()
     setPilotMode(
-        parser.parse_args().pilot
+        known_args.pilot
     )
 
     return getPilotMode()


### PR DESCRIPTION
argparse.parse_args() does a sys_exit if it finds unknown args, even if `exit_on_error=False` which is too agressive for our needs

Instead, use parse_known_args and then select the known args set