### PR TITLE
NF: Added `writePreCode` to base component class

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -252,6 +252,12 @@ class BaseComponent:
         # each routine
         pass
 
+    def writePreCode(self, buff):
+        """Write any code that a component needs that should be done before 
+        the session's `run` method is called.
+        """
+        pass
+
     def writeFrameCode(self, buff):
         """Write the code that will be called every frame
         """


### PR DESCRIPTION
Adds the `writePreCode` to the base component class for writing code to execute before the experiment begins. This is required to do things like configuring eye trackers and such.