### PR TITLE
Fix nreversals doc issue

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -84,6 +84,8 @@ class StairHandler(_BaseTrialHandler):
                 reversals to perform, `nReversals`, is less than the
                 length of this list, PsychoPy will automatically increase
                 the minimum number of reversals and emit a warning.
+                This minimum number of reversals is always set to be
+                greater than 0.
 
             stepSizes:
                 The size of steps as a single value or a list (or array).


### PR DESCRIPTION
This PR addresses issue #3174 by updating documentation.

## Description
`nreversals` cannot be 0, despite no information about this on the documentation.

## Changes
added a line to `nreversals` documentation specifying that this parameter is always set to be greater than 0.
