### PR TITLE
BF: Fixed missing ref for `backend` in `setDevice`

### DIFF
--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -227,11 +227,15 @@ def setDevice(dev, kind=None):
     if dev is None:
         # if given None, do nothing
         return
+    
+    global backend  # pull from module namespace
     if not hasattr(backend, 'defaultOutput'):
         raise IOError("Attempting to SetDevice (audio) but not supported by "
                       "the current audio library ({!r})".format(audioLib))
+    
     if hasattr(dev, 'name'):
         dev = dev['name']
+
     if kind is None:
         backend.defaultInput = backend.defaultOutput = dev
     elif kind == 'input':


### PR DESCRIPTION
Fixes the missing global declaration which raises a name error.