### PR TITLE
BF: Fix _set function to handle input length

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1942,7 +1942,7 @@ class BaseVisualStim(MinimalStim, WindowMixin, LegacyVisualMixin):
         """
         # format the input value as float vectors
         if type(val) in [tuple, list, numpy.ndarray]:
-            val = val2array(val)
+            val = val2array(val, length=len(val))
 
         # Set attribute with operation and log
         setAttribute(self, attrib, val, log, op)


### PR DESCRIPTION
When I added a custom mask to visual.NoiseStim(), there was an error from val2array() function, saying "expected 2, but got (the length of the mask)". I traced the issue to the _set() function in basevisual.py, as it sends val to val2array() without specifying the length, so it's still using the default value length=2. I added length=len(val) and it fixed the issue for me.