### PR TITLE
RF: Make all device objects "quasi-singletons" (only one per device)

### DIFF
--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -54,6 +54,25 @@ class BaseDevice:
     """
     Base class for device interfaces, includes support for DeviceManager and adding listeners.
     """
+    def __new__(cls, *args, **kwargs):
+        from psychopy.hardware.manager import DeviceManager
+        import inspect
+        # convert args to kwargs
+        argNames = inspect.getfullargspec(cls.__init__).args
+        for i, arg in enumerate(args):
+            kwargs[argNames[i]] = arg
+        # iterate through existing devices
+        for other in DeviceManager.devices.values():
+            # skip devices of different class
+            if not isinstance(other, cls):
+                continue
+            # if device already represented, use existing object
+            if other.isSameDevice(kwargs):
+                return other
+
+        # if first object to represent this device, make as normal
+        return super(BaseDevice, cls).__new__(cls)
+
     def __init_subclass__(cls, aliases=None):
         from psychopy.hardware.manager import DeviceManager
         import inspect

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -248,20 +248,6 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
     _iohubKeyboard = None
     _ptbOffset = 0.0
 
-    _instance = None
-
-    def __new__(cls, *args, **kwargs):
-        # KeyboardDevice needs to function as a "singleton" as there is only one HID input and
-        # multiple devices would compete for presses
-        if cls._instance is None:
-            cls._instance = super(KeyboardDevice, cls).__new__(cls)
-        return cls._instance
-
-    def __del__(self):
-        # if one instance is deleted, reset the singleton instance so that the next
-        # initialisation recreates it
-        KeyboardDevice._instance = None
-
     def __init__(self, device=-1, bufferSize=10000, waitForStart=False, clock=None, backend=None,
                  muteOutsidePsychopy=True):
         """Create the device (default keyboard or select one)


### PR DESCRIPTION
e.g. if you do:
```
dev1 = MicrophoneDevice(index=1)
dev2 = MicrophoneDevice(index=2)
dev3 = MicrophoneDevice(index=1)
```

dev3 and dev1 would be the same object (`dev1 is dev3`) rather than just two objects of the same class with the same index (`dev1 == dev3`). 

### Advantages:
- Gets around issues with initialising the same device twice - if two objects point to the same device, the second isn't initialised
- Easy to implement now that we have a DeviceManager as we know what device objects exist and device objects have a method to query whether two of them point to the same device

### Disadvantages
- It's a big change quite close to release
- Would mean that changing attributes on one device object would change the same attribute on all objects pointing to that device
    - This may not be a problem now that we distinguish between `Something` and `SomethingDevice`, as the main issue this would cause would be setting boilerplate-y stuff like status
    - In some cases this may actually be desirable, e.g. you call `setThreshold` on a PhotodiodeGroup, it sets the threshold and stores the value - if all handles pointing to that device were the same object, then they all now know this device's threshold