### PR TITLE
BF: disable Coder save buttons when currentDoc is None on open

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1318,6 +1318,11 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
 
         self.theme = colors.theme
 
+        # disable save buttons if currentDoc is None
+        if self.currentDoc is None:
+            self.ribbon.buttons['save'].Disable()
+            self.ribbon.buttons['saveas'].Disable()
+
     @property
     def useAutoComp(self):
         """Show autocomplete while typing."""


### PR DESCRIPTION
Previously, it was possible to start a Coder window with no active document, click one of the save buttons, and then encounter an error.

A fix was added to quit early out of the fileSave method if this was the case, but this builds on that by disabling the save buttons if we're not in a valid state to save.

Related to GH-6157