### PR TITLE
Fixed bug in preferences.py

### DIFF
--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -41,7 +41,7 @@ class Preferences:
 
         import psychopy
         psychopy.prefs.hardware['audioLib'] = ['ptb', 'pyo','pygame']
-        print(prefs)
+        print(psychopy.prefs)
         # prints the location of the user prefs file and all the current vals
 
     Use the instance of `prefs`, as above, rather than the `Preferences` class


### PR DESCRIPTION
Fixed bug where it printed an object that didn't exist. I'm sure this was a typo and was meant to be "psychopy.prefs", not "prefs"