### PR TITLE
BF: Error when AUI perspective loads if window size is negative

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1292,7 +1292,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
             self.paneManager.GetPane('SourceAsst').Caption(_translate("Source Assistant"))
             self.paneManager.GetPane('Editor').Caption(_translate("Editor"))
         else:
-            self.SetMinSize(wx.Size(480, 640))  # min size for whole window
+            self.SetMinSize(wx.Size(640, 480))  # min size for whole window
             self.SetSize(wx.Size(1024, 800))
             self.Fit()
         # Update panes PsychopyToolbar

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1286,13 +1286,17 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.outputWindow.write("v%s\n" % self.app.version)
 
         # Manage perspective
+        self.SetMinSize(wx.Size(640, 480))  # min size for whole window
         if (self.appData['auiPerspective'] and
                 'Shelf' in self.appData['auiPerspective']):
-            self.paneManager.LoadPerspective(self.appData['auiPerspective'])
+            try:
+                self.paneManager.LoadPerspective(self.appData['auiPerspective'])
+            except Exception as err:
+                logging.error("Error loading perspective: %s" % err)
+                self.SetSize(wx.Size(1024, 800))
             self.paneManager.GetPane('SourceAsst').Caption(_translate("Source Assistant"))
             self.paneManager.GetPane('Editor').Caption(_translate("Editor"))
         else:
-            self.SetMinSize(wx.Size(640, 480))  # min size for whole window
             self.SetSize(wx.Size(1024, 800))
             self.Fit()
         # Update panes PsychopyToolbar

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1293,7 +1293,9 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
                 self.paneManager.LoadPerspective(self.appData['auiPerspective'])
             except Exception as err:
                 logging.error("Error loading perspective: %s" % err)
+                # defaults for the window if the perspective fails
                 self.SetSize(wx.Size(1024, 800))
+                self.Fit()
             self.paneManager.GetPane('SourceAsst').Caption(_translate("Source Assistant"))
             self.paneManager.GetPane('Editor').Caption(_translate("Editor"))
         else:


### PR DESCRIPTION
This bug comes up when resizing the coder window. Since there is no `SetMinSize` call, the window can be resized to (-1. -1). The app will raise an unhandled exception, and the AUI perspective will be invalid. The coder window cannot be resized since it will always raise an error when the user attempts to resize it. If the app is closed, the invalid AUI layout will be saved and loaded next startup. This will crash the app since it is invalid, preventing the app from making it past the splash screen.

This fixes the issue by ensuring `SetMinSize()` is always called to prevent the window from being size too small in the first place. The second modification catches the error and manually sets up the window. This should generalize to other AUI perspective errors, allowing the app to get a fresh, default layout on any error.