### PR TITLE
ENH: Hide components/routines from future versions

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -36,6 +36,7 @@ from ..pavlovia_ui.user import UserFrame
 from ..pavlovia_ui.functions import logInPavlovia
 from ...experiment import getAllElements, getAllCategories
 from ...experiment.routines import Routine, BaseStandaloneRoutine
+from psychopy.tools.versionchooser import parseVersionSafely, psychopyVersion
 
 try:
     import markdown_it as md
@@ -3142,6 +3143,13 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
             anyShown = False
             for name, btn in self.objectHandles[cat].items():
                 shown = True
+                # Get element button refers to
+                if isinstance(btn, self.ComponentButton):
+                    emt = btn.component
+                elif isinstance(btn, self.RoutineButton):
+                    emt = btn.routine
+                else:
+                    emt = None
                 # Check whether button is hidden by filter
                 for v in view:
                     if v not in btn.element.targets:
@@ -3149,6 +3157,11 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
                 # Check whether button is hidden by prefs
                 if name in prefs.builder['hiddenComponents'] + alwaysHidden:
                     shown = False
+                # Check whether button refers to a future comp/rt
+                if hasattr(emt, "version"):
+                    ver = parseVersionSafely(emt.version)
+                    if ver > psychopyVersion:
+                        shown = False
                 # Show/hide button
                 btn.Show(shown)
                 # Count state towards category

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -19,6 +19,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
     iconFile = Path(__file__).parent / 'photodiode_validator.png'
     tooltip = _translate('')
     deviceClasses = []
+    version = "2024.2.0"
 
     def __init__(
             self,

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -16,7 +16,7 @@ from subprocess import CalledProcessError
 import psychopy  # for currently loaded version
 from psychopy import prefs
 # the following will all have been imported so import here and reload later
-from psychopy import logging, tools, web, constants, preferences
+from psychopy import logging, tools, web, constants, preferences, __version__
 from pkg_resources import parse_version
 from importlib import reload
 from packaging.version import Version, InvalidVersion, VERSION_PATTERN
@@ -41,6 +41,8 @@ for n in range(13):
     v = Version(f"3.{n}")
     av = max([key for key in versionMap if key <= v])
     versionMap[v] = versionMap[av]
+# parse current psychopy version
+psychopyVersion = Version(__version__)
 
 
 def parseVersionSafely(version, fallback=Version("0")):


### PR DESCRIPTION
Motivation for this is to hide "PhotodiodeValidatorRoutine" as it only works with one (unreleased) device. Adding to "hidden components" in prefs only hides it for new users / users who reset their prefs, this way means it remains hidden until the release pointed to by its `.version` attribute (set it to 2024.2.0)