### PR TITLE
BF: Catch error when package info is missing

### DIFF
--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -574,15 +574,27 @@ def getPypiInfo(packageName, silence=False):
             dlg.ShowModal()
         return
 
-    return {
-        'name': data['info'].get('Name', packageName),
-        'author': data['info'].get('author', 'Unknown'),
-        'authorEmail': data['info'].get('author_email', 'Unknown'),
-        'license': data['info'].get('license', 'Unknown'),
-        'summary': data['info'].get('summary', ''),
-        'desc': data['info'].get('description', ''),
-        'releases': list(data['releases']),
-    }
+    if 'info' not in data:
+        # handle case where the data cannot be retrived
+        return {
+            'name': packageName,
+            'author': 'Unknown',
+            'authorEmail': 'Unknown',
+            'license': 'Unknown',
+            'summary': '',
+            'desc': 'Failed to get package info from PyPI.',
+            'releases': [],
+        }
+    else:
+        return {
+            'name': data['info'].get('Name', packageName),
+            'author': data['info'].get('author', 'Unknown'),
+            'authorEmail': data['info'].get('author_email', 'Unknown'),
+            'license': data['info'].get('license', 'Unknown'),
+            'summary': data['info'].get('summary', ''),
+            'desc': data['info'].get('description', ''),
+            'releases': list(data['releases']),
+        }
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes error in the package tab when selecting items. If the data for the package is malformed, this substitutes default values.