### PR TITLE
FF: Fix Builder behaviour when file is unsaved

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -927,8 +927,9 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
             )
 
         # Set file
-        self.readmeFrame.setFile(self.readmeFilename)
-        self.readmeFrame.ctrl.load()
+        if self.fileExists:
+            self.readmeFrame.setFile(self.readmeFilename)
+            self.readmeFrame.ctrl.load()
 
         # Show/hide frame as appropriate
         if show is None:
@@ -3347,6 +3348,8 @@ class ReadmeFrame(wx.Frame, handlers.ThemeMixin):
         """Sets the readme file found with current builder experiment"""
         self.filename = filename
         self.expName = self.parent.exp.getExpName()
+        if not self.expName:
+            self.expName = "untitled"
         # check we can read
         if filename is None:  # check if we can write to the directory
             return False
@@ -3380,7 +3383,7 @@ class ReadmeFrame(wx.Frame, handlers.ThemeMixin):
         f.close()
         self._fileLastModTime = os.path.getmtime(filename)
         self.ctrl.setValue(readmeText)
-        self.SetTitle("%s readme (%s)" % (self.expName, filename))
+        self.SetTitle("readme (%s)" % self.expName)
 
     def refresh(self, evt=None):
         if hasattr(self, 'filename'):

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1476,7 +1476,10 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
     def compileScript(self, event=None):
         """Defines compile script button behavior"""
         # save so we have a file to work off
-        self.fileSave()
+        saved = self.fileSave()
+        # if save cancelled, return now
+        if not saved:
+            return
         # construct filename for py file
         fullPath = self.filename.parent / (self.filename.stem + '.py')
         # write script

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -929,7 +929,9 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # Set file
         if self.fileExists:
             self.readmeFrame.setFile(self.readmeFilename)
-            self.readmeFrame.ctrl.load()
+        else:
+            self.readmeFrame.setFile(None)
+        self.readmeFrame.ctrl.load()
 
         # Show/hide frame as appropriate
         if show is None:
@@ -3346,7 +3348,7 @@ class ReadmeFrame(wx.Frame, handlers.ThemeMixin):
 
     def setFile(self, filename):
         """Sets the readme file found with current builder experiment"""
-        self.filename = filename
+        self.filename = self.ctrl.file = filename
         self.expName = self.parent.exp.getExpName()
         if not self.expName:
             self.expName = "untitled"

--- a/psychopy/app/utils.py
+++ b/psychopy/app/utils.py
@@ -591,11 +591,20 @@ class MarkdownCtrl(wx.Panel, handlers.ThemeMixin):
 
     def save(self, evt=None):
         if self.file is None:
-            return
-        # Write current contents to file
+            # if no file, open dialog to choose one
+            dlg = wx.FileDialog(
+                self, message=_translate("Save file as..."), defaultDir=str(Path.home()),
+                style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
+                wildcard="Markdown file (*.md)|*.md|Text file (*.txt)|*.txt|Any file (*.*)|*.*")
+            if dlg.ShowModal() == wx.ID_OK:
+                self.file = dlg.GetPath()
+                self.load()
+            else:
+                return
+        # write current contents to file
         with open(self.file, "w") as f:
             f.write(self.rawTextCtrl.GetValue())
-        # Disable save button
+        # disable save button
         self.saveBtn.Disable()
 
     def onEdit(self, evt=None):


### PR DESCRIPTION
Prevents it from assuming the file path is in the psychopy library