### PR TITLE
FF: Fix failures to get app handle early in setup

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -154,6 +154,19 @@ def getAppInstance():
     return _psychopyAppInstance  # use a function here to protect the reference
 
 
+def setAppInstance(obj):
+    """
+    Define a reference to the current PsychoPyApp object.
+
+    Parameters
+    ----------
+    obj : psychopy.app._psychopyApp.PsychoPyApp
+        Current instance of the PsychoPy app
+    """
+    global _psychopyAppInstance
+    _psychopyAppInstance = obj
+
+
 def isAppStarted():
     """Check if the GUI portion of PsychoPy is running.
 

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -173,6 +173,9 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             profile.enable()
             t0 = time.time()
 
+        from . import setAppInstance
+        setAppInstance(self)
+
         self._appLoaded = False  # set to true when all frames are created
         self.builder = None
         self.coder = None

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -112,9 +112,11 @@ def login(tokenOrUsername, rememberMe=True):
         user = currentSession.user
         prefs.appData['projects']['pavloviaUser'] = user['username']
     # update Pavlovia button(s)
-    if app.getAppInstance():
-        for btn in app.getAppInstance().pavloviaButtons['user'] + app.getAppInstance().pavloviaButtons['project']:
+    appInstance = app.getAppInstance()
+    if appInstance:
+        for btn in appInstance.pavloviaButtons['user'] + appInstance.pavloviaButtons['project']:
             btn.updateInfo()
+
 
 def logout():
     """Log the current user out of pavlovia.


### PR DESCRIPTION
Means that app doesn't have to have *finished* setting up to be accessible as a reference, it just has to have a handle. Meaning processes called during app initialisation can still refer to the app by handle.