### PR TITLE
FF: Save as was entering loop on first time save

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -827,6 +827,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
                 self.exp.setExpName(newShortName)
             # actually save
             self.filename = newPath
+            self.fileExists = True
             self.fileSave(event=None, filename=newPath)
             self.project = pavlovia.getProject(filename)
             returnVal = 1


### PR DESCRIPTION
The logic in `save` is basically "if file doesn't exist, do save as instead", but `save as` calls `save` in order to make the file, so it was looping forever. Forcing `fileExists` to be `True` before calling `save` in `save as` avoids this.