### PR TITLE
BF: Fixed iohub keyboard input loss after eyetracker calibration

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -408,7 +408,10 @@ class EyeTracker(EyeTrackerDevice):
         cal_run = calibration.runCalibration()
         calibration.window.close()
 
-        calibration._unregisterEventMonitors()
+        # NOTE - The following line has been commented out to prevent ioHub from 
+        # losing keyboard input after the window is closed. The new keyboard 
+        # input system does not require this call anymore.
+        # calibration._unregisterEventMonitors()
         calibration.clearAllEventBuffers()
 
         if cal_run:


### PR DESCRIPTION
Removes the `calibration._unregisterEventMonitors()` call which unhooks input monitoring and makes the experiment unresponsive after eyetracker calibration is complete.