### PR TITLE
FF: Added zeroconf as MacOS dependancy

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -408,7 +408,10 @@ class EyeTracker(EyeTrackerDevice):
         cal_run = calibration.runCalibration()
         calibration.window.close()
 
-        calibration._unregisterEventMonitors()
+        # NOTE - The following line has been commented out to prevent ioHub from 
+        # losing keyboard input after the window is closed. The new keyboard 
+        # input system does not require this call anymore.
+        # calibration._unregisterEventMonitors()
         calibration.clearAllEventBuffers()
 
         if cal_run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
     "pyobjc-core; platform_system == \"Darwin\"",
     "pyobjc-framework-Quartz < 8.0; platform_system == \"Darwin\"",
     "pyobjc; platform_system == \"Darwin\"",
+    "zeroconf"; platform_system == \"Darwin\"",
     "python-xlib; platform_system == \"Linux\"",
     'tables<3.9; python_version < "3.9"',
     'tables; python_version >= "3.9"',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "pyobjc-core; platform_system == \"Darwin\"",
     "pyobjc-framework-Quartz < 8.0; platform_system == \"Darwin\"",
     "pyobjc; platform_system == \"Darwin\"",
-    "zeroconf"; platform_system == \"Darwin\"",
+    "zeroconf; platform_system == \"Darwin\"",
     "python-xlib; platform_system == \"Linux\"",
     'tables<3.9; python_version < "3.9"',
     'tables; python_version >= "3.9"',


### PR DESCRIPTION
Allows Pupil Labs' plugin to be installed on MacOS stand alone due to py2app idiosyncrasies interfering with the packaging system on that platform.