### PR TITLE
FF: Don't show README if no experiment, even if README file exists

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -967,6 +967,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
             self.readmeFrame.setFile(self.readmeFilename)
         else:
             self.readmeFrame.setFile(None)
+            show = False
         self.readmeFrame.ctrl.load()
 
         # Show/hide frame as appropriate


### PR DESCRIPTION
Fixes bug where the README file for `psychopy.app` was shown when experiment was untitled.psyexp