### PR TITLE
Fix numpy deprecation

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -541,20 +541,17 @@ class Color:
         # Treat 1x1 arrays as a float
         if isinstance(value, np.ndarray):
             if value.size == 1:
-                value = float(value)
-        # Clip value(s) to within range
-        if isinstance(value, np.ndarray):
-            value = np.clip(value, 0, 1)
+                value = float(value[0])
         else:
-            # If coercible to float, do so
             try:
-                value = float(value)
+                value = float(value)  # If coercible to float, do so
             except (TypeError, ValueError) as err:
                 raise TypeError(
-                    "Could not set alpha as value `{}` of type `{}`".format(value, type(value).__name__)
+                    "Could not set alpha as value `{}` of type `{}`".format(
+                        value, type(value).__name__
+                    )
                 )
-            value = min(value, 1)
-            value = max(value, 0)
+        value = np.clip(value, 0, 1)  # Clip value(s) to within range
         # Set value
         self._alpha = value
         # Clear render cache

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -142,8 +142,7 @@ class Monitor:
         thisGamma = self.getGamma()
         # run the test just on this
         array = np.array
-        return (thisGamma is None or
-                np.alltrue(array(thisGamma) == array([1, 1, 1])))
+        return (thisGamma is None or np.all(array(thisGamma) == array([1, 1, 1])))
 
 # functions to set params of current calibration
     def setSizePix(self, pixels):
@@ -285,8 +284,7 @@ class Monitor:
         """Returns just the gamma value (not the whole grid)
         """
         gridInCurrent = 'gammaGrid' in self.currentCalib
-        if (gridInCurrent and
-                not np.alltrue(self.getGammaGrid()[1:, 2] == 1)):
+        if (gridInCurrent and not np.all(self.getGammaGrid()[1:, 2] == 1)):
             return self.getGammaGrid()[1:, 2]
         elif 'gamma' in self.currentCalib:
             return self.currentCalib['gamma']

--- a/psychopy/tests/test_hardware/test_CRS_bitsShaders.py
+++ b/psychopy/tests/test_hardware/test_CRS_bitsShaders.py
@@ -96,10 +96,10 @@ def test_bitsShaders():
             win.flip()
             fr = np.array(win._getFrame(buffer='front').transpose(Image.ROTATE_270))
             if not systemtools.isVM_CI():
-                assert np.alltrue(thisExpected['lowR'] == fr[0:10, -1, 0])
-                assert np.alltrue(thisExpected['lowG'] == fr[0:10, -1, 1])
-                assert np.alltrue(thisExpected['highR'] == fr[250:256, -1, 0])
-                assert np.alltrue(thisExpected['highG'] == fr[250:256, -1, 1])
+                assert np.all(thisExpected['lowR'] == fr[0:10, -1, 0])
+                assert np.all(thisExpected['lowG'] == fr[0:10, -1, 1])
+                assert np.all(thisExpected['highR'] == fr[250:256, -1, 0])
+                assert np.all(thisExpected['highG'] == fr[250:256, -1, 1])
 
                 print('R', repr(fr[0:10,-1,0]), repr(fr[250:256,-1,0]))
                 print('G', repr(fr[0:10,-1,1]), repr(fr[250:256,-1,0]))

--- a/psychopy/tools/mathtools.py
+++ b/psychopy/tools/mathtools.py
@@ -2525,7 +2525,7 @@ def alignTo(v, t, out=None, dtype=None):
     qr[nonparallel, :3] = cross(v2d[nonparallel], b[nonparallel], dtype=dtype)
     qr[nonparallel, 3] = cosHalfAngle[nonparallel]
 
-    if np.alltrue(nonparallel):  # don't bother handling special cases
+    if np.all(nonparallel):  # don't bother handling special cases
         return toReturn + 0.0
 
     # deal with cases where the vectors are facing exact opposite directions
@@ -2533,13 +2533,13 @@ def alignTo(v, t, out=None, dtype=None):
     rx = np.logical_and(~ry, ~nonparallel)
 
     getLength = lambda x, y: np.sqrt(x * x + y * y)
-    if not np.alltrue(rx):
+    if not np.all(rx):
         invLength = getLength(v2d[ry, 0], v2d[ry, 2])
         invLength = np.where(invLength > 0.0, 1.0 / invLength, invLength)  # avoid x / 0
         qr[ry, 0] = -v2d[ry, 2] * invLength
         qr[ry, 2] = v2d[ry, 0] * invLength
 
-    if not np.alltrue(ry):  # skip if all the same edge case
+    if not np.all(ry):  # skip if all the same edge case
         invLength = getLength(v2d[rx, 1], v2d[rx, 2])
         invLength = np.where(invLength > 0.0, 1.0 / invLength, invLength)
         qr[rx, 1] = v2d[rx, 2] * invLength

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -774,7 +774,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         display.
         Also note that this position is in scale units, not in coordinates"""
         rating = self._granularRating(rating)
-        if ('markerPos' not in self.__dict__ or not np.alltrue(
+        if ('markerPos' not in self.__dict__ or not np.all(
                 self.__dict__['markerPos'] == rating)):
             self.__dict__['markerPos'] = rating
             self._updateMarkerPos = True


### PR DESCRIPTION
Found through a strict pytest run:

```
    @alpha.setter
    def alpha(self, value):
        # Treat 1x1 arrays as a float
        if isinstance(value, np.ndarray):
            if value.size == 1:
>               value = float(value)
E               DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)
```

I also slightly simplified the validation logic by clipping to the acceptable range *after* the conversion to a `float`.