### PR TITLE
BF: Handle when Static component has no start time

### DIFF
--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -98,56 +98,58 @@ class StaticComponent(BaseComponent):
 
     def writeFrameCodeJS(self, buff):
         # Start test
-        self.writeStartTestCodeJS(buff)
-        buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.STARTED;\n" % self.params)
-        self.writeParamUpdates(buff, target="PsychoJS")
-        buff.setIndentLevel(-1, relative=True)
-        buff.writeIndentedLines("}\n")
+        indent = self.writeStartTestCodeJS(buff)
+        if indent:
+            buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.STARTED;\n" % self.params)
+            self.writeParamUpdates(buff, target="PsychoJS")
+            buff.setIndentLevel(-indent, relative=True)
+            buff.writeIndentedLines("}")
 
         # Stop test, with stop actions
-        self.writeStopTestCodeJS(buff)
-        for update in self.updatesList:
+        indent = self.writeStopTestCodeJS(buff)
+        if indent:
+            for update in self.updatesList:
 
-            # Get params for update
-            compName = update['compName']
-            fieldName = update['fieldName']
-            # routine = self.exp.routines[update['routine']]
-            if hasattr(compName, 'params'):
-                prms = compName.params  # it's already a compon so get params
-            else:
-                # it's a name so get compon and then get params
-                prms = self.exp.getComponentFromName(str(compName)).params
-            if prms[fieldName].valType == "file":
-                # Check resource manager status
-                code = (
-                    f"if (psychoJS.serverManager.getResourceStatus({prms[fieldName]}) === core.ServerManager.ResourceStatus.DOWNLOADED) {{\n"
-                )
-                buff.writeIndentedLines(code % self.params)
-                # Print confirmation
-                buff.setIndentLevel(+1, relative=True)
-                code = (
-                    "console.log('finished downloading resources specified by component %(name)s');\n"
-                )
-                buff.writeIndentedLines(code % self.params)
-                # else...
-                buff.setIndentLevel(-1, relative=True)
-                code = (
-                    "} else {\n"
-                )
-                buff.writeIndentedLines(code % self.params)
-                # Print warning if not downloaded
-                buff.setIndentLevel(+1, relative=True)
-                code = (
-                    f"console.log('resource specified in %(name)s took longer than expected to download');\n"
-                    f"await waitForResources(resources = {prms[fieldName]})"
-                )
-                buff.writeIndentedLines(code % self.params)
-                buff.setIndentLevel(-1, relative=True)
-                buff.writeIndentedLines("}\n")
-        buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.FINISHED;\n" % self.params)
-        # Escape stop code indent
-        buff.setIndentLevel(-1, relative=True)
-        buff.writeIndentedLines("}\n")
+                # Get params for update
+                compName = update['compName']
+                fieldName = update['fieldName']
+                # routine = self.exp.routines[update['routine']]
+                if hasattr(compName, 'params'):
+                    prms = compName.params  # it's already a compon so get params
+                else:
+                    # it's a name so get compon and then get params
+                    prms = self.exp.getComponentFromName(str(compName)).params
+                if prms[fieldName].valType == "file":
+                    # Check resource manager status
+                    code = (
+                        f"if (psychoJS.serverManager.getResourceStatus({prms[fieldName]}) === core.ServerManager.ResourceStatus.DOWNLOADED) {{\n"
+                    )
+                    buff.writeIndentedLines(code % self.params)
+                    # Print confirmation
+                    buff.setIndentLevel(+1, relative=True)
+                    code = (
+                        "console.log('finished downloading resources specified by component %(name)s');\n"
+                    )
+                    buff.writeIndentedLines(code % self.params)
+                    # else...
+                    buff.setIndentLevel(-1, relative=True)
+                    code = (
+                        "} else {\n"
+                    )
+                    buff.writeIndentedLines(code % self.params)
+                    # Print warning if not downloaded
+                    buff.setIndentLevel(+1, relative=True)
+                    code = (
+                        f"console.log('resource specified in %(name)s took longer than expected to download');\n"
+                        f"await waitForResources(resources = {prms[fieldName]})"
+                    )
+                    buff.writeIndentedLines(code % self.params)
+                    buff.setIndentLevel(-1, relative=True)
+                    buff.writeIndentedLines("}\n")
+            buff.writeIndentedLines("%(name)s.status = PsychoJS.Status.FINISHED;\n" % self.params)
+            # Escape stop code indent
+            buff.setIndentLevel(-indent, relative=True)
+            buff.writeIndentedLines("}\n")
 
     def writeStartTestCode(self, buff):
         """This will be executed as the final component in the routine


### PR DESCRIPTION
Write start/stop code inside of an `if` statement so it only gets written (including the dedent and close `}`) if the statement was opened in the first place