### PR TITLE
BF: Fixed Mouse.visible attribute not applying requested state

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -554,7 +554,7 @@ def xydist(p1=(0.0, 0.0), p2=(0.0, 0.0)):
     return numpy.sqrt(pow(p1[0] - p2[0], 2) + pow(p1[1] - p2[1], 2))
 
 
-class Mouse():
+class Mouse:
     """Easy way to track what your mouse is doing.
 
     It needn't be a class, but since Joystick works better
@@ -578,7 +578,7 @@ class Mouse():
                  newPos=None,
                  win=None):
         super(Mouse, self).__init__()
-        self.visible = visible
+        self._visible = visible
         self.lastPos = None
         self.prevPos = None  # used for motion detection and timing
         if win:
@@ -799,7 +799,8 @@ class Mouse():
         mouseWheelRel = numpy.array([0.0, 0.0])
         return rel
 
-    def getVisible(self):
+    @property
+    def visible(self):
         """Gets the visibility of the mouse (1 or 0)
         """
         if usePygame:
@@ -807,6 +808,24 @@ class Mouse():
         else:
             print("Getting the mouse visibility is not supported under"
                   " pyglet, but you can set it anyway")
+    
+    @visible.setter
+    def visible(self, visible):
+        """Sets the visibility of the mouse to 1 or 0
+
+        NB when the mouse is not visible its absolute position is held
+        at (0, 0) to prevent it from going off the screen and getting lost!
+        You can still use getRel() in that case.
+        """
+        self.setVisible(visible)
+
+    def getVisible(self):
+        """Gets the visibility of the mouse (1 or 0)
+        """
+        if usePygame:
+            return mouse.get_visible()
+        
+        return self._visible
 
     def setVisible(self, visible):
         """Sets the visibility of the mouse to 1 or 0
@@ -815,18 +834,22 @@ class Mouse():
         at (0, 0) to prevent it from going off the screen and getting lost!
         You can still use getRel() in that case.
         """
-        if self.win:  # use default window if we don't have one
-            self.win.setMouseVisible(visible)
-        elif usePygame:
-            mouse.set_visible(visible)
-        else:  # try communicating with window directly?
+        if self.win is not None:  # use default window if we don't have one
             from psychopy.visual import openWindows
-            if psychopy.core.openWindows:
-                w = psychopy.core.openWindows[0]()  # type: psychopy.visual.Window
+            if openWindows:
+                w = openWindows[0]()  # type: psychopy.visual.Window
             else:
-                logging.warning("Called event.Mouse.getPos() for the mouse with no Window being opened")
+                logging.warning(
+                    "Called event.Mouse.getPos() for the mouse with no Window " 
+                    "being opened")
                 return None
             w.setMouseVisible(visible)
+        elif usePygame:
+            mouse.set_visible(visible)
+        else:
+            self.win.setMouseVisible(visible)
+
+        self._visible = visible  # set internal state
 
     def clickReset(self, buttons=(0, 1, 2)):
         """Reset a 3-item list of core.Clocks use in timing button clicks.

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -834,7 +834,11 @@ class Mouse:
         at (0, 0) to prevent it from going off the screen and getting lost!
         You can still use getRel() in that case.
         """
-        if self.win is not None:  # use default window if we don't have one
+        if self.win:  # use default window if we don't have one
+            self.win.setMouseVisible(visible)
+        elif usePygame:
+            mouse.set_visible(visible)
+        else:
             from psychopy.visual import openWindows
             if openWindows:
                 w = openWindows[0]()  # type: psychopy.visual.Window
@@ -844,11 +848,7 @@ class Mouse:
                     "being opened")
                 return None
             w.setMouseVisible(visible)
-        elif usePygame:
-            mouse.set_visible(visible)
-        else:
-            self.win.setMouseVisible(visible)
-
+            
         self._visible = visible  # set internal state
 
     def clickReset(self, buttons=(0, 1, 2)):

--- a/psychopy/hardware/mouse/__init__.py
+++ b/psychopy/hardware/mouse/__init__.py
@@ -799,6 +799,16 @@ class Mouse(AttributeGetSetMixin):
     @property
     def velocity(self):
         """The velocity of the mouse cursor on-screen in window units (`float`).
+
+        The velocity is calculated as the relative change in position of the
+        mouse cursor between motion events divided by the time elapsed between
+        the events.
+
+        Returns
+        -------
+        float
+            Velocity of the mouse cursor in window units per second.
+
         """
         if self._velocityNeedsUpdate:
             tdelta = self.motionAbsTime - \

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -398,9 +398,6 @@ class PygletBackend(BaseBackend):
         if flipThisFrame:
             self.winHandle.flip()
 
-    def setMouseVisibility(self, visibility):
-        self.winHandle.set_mouse_visible(visibility)
-
     def setCurrent(self):
         """Sets this window to be the current rendering target.
 
@@ -720,6 +717,42 @@ class PygletBackend(BaseBackend):
     # --------------------------------------------------------------------------
     # Mouse event handlers and utilities
     #
+    @property
+    def mouseVisible(self):
+        """Get the visibility of the mouse cursor.
+
+        Returns
+        -------
+        bool
+            `True` if the mouse cursor is visible.
+
+        """
+
+        return self.winHandle._mouse_visible
+
+    @mouseVisible.setter
+    def mouseVisible(self, visibility):
+        """Set the visibility of the mouse cursor.
+
+        Parameters
+        ----------
+        visibility : bool
+            If `True`, the mouse cursor is visible.
+
+        """
+        self.winHandle.set_mouse_visible(visibility)
+
+    def setMouseVisibility(self, visibility):
+        """Set the visibility of the mouse cursor.
+
+        Parameters
+        ----------
+        visibility : bool
+            If `True`, the mouse cursor is visible.
+
+        """
+        self.winHandle.set_mouse_visible(visibility)
+
     def onMouseButton(self, *args, **kwargs):
         """Event handler for any mouse button event (pressed and released).
 


### PR DESCRIPTION
Fixes the issue where mouse visibility cannot be set using `Mouse.visible=True` due to the attribute not having a correct setter method.