### PR TITLE
FF: Fix encoding error when getting experiment data as JSON

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -681,7 +681,7 @@ class ExperimentHandler(_ComparisonMixin):
             'threshold': priorityThreshold,
         }
 
-        return json.dumps(context, indent=True, allow_nan=False)
+        return json.dumps(context, indent=True, allow_nan=False, default=str)
         
     def close(self):
         if self.dataFileName not in ['', None]:


### PR DESCRIPTION
Needed to be told to use `str()` by default rather than failing when receiving a non-string value