### PR TITLE
RF: Supply end message from Builder rather than relying on JS default

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -118,7 +118,8 @@ class SettingsComponent:
             plCompanionPort=8080,
             plCompanionRecordingEnabled=True,
             keyboardBackend="ioHub",
-            filename=None, exportHTML='on Sync', endMessage=''
+            filename=None, exportHTML='on Sync',
+            endMessage=_translate("Thank you for your patience.")
     ):
         self.type = 'Settings'
         self.exp = exp  # so we can access the experiment if necess

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -395,11 +395,18 @@ class Flow(list):
                     loopStack.remove(thisEntry.loop)
             script.writeIndentedLines(code)
         # quit when all routines are finished
-        script.writeIndented("flowScheduler.add(quitPsychoJS, %(End Message)s, true);\n" % self.exp.settings.params)
+        code = (
+            "flowScheduler.add(quitPsychoJS, %(End Message)s, true);\n"
+        )
+        script.writeIndentedLines(code % self.exp.settings.params)
         # handled all the flow entries
-        code = ("\n// quit if user presses Cancel in dialog box:\n"
-                "dialogCancelScheduler.add(quitPsychoJS, '', false);\n\n")
-        script.writeIndentedLines(code)
+        code = (
+            "\n"
+            "// quit if user presses Cancel in dialog box:\n"
+            "dialogCancelScheduler.add(quitPsychoJS, %(End Message)s, false);\n"
+            "\n"
+        )
+        script.writeIndentedLines(code % self.exp.settings.params)
 
         # Write resource list
         resourceFiles = []


### PR DESCRIPTION
In draft as this needs the accompanying change in PsychoJS (otherwise the end message becomes "Thank you for your patience." twice)