### PR TITLE
PKG: Changed python dependency in conda env to >=3.8

### DIFF
--- a/conda/psychopy-env.yml
+++ b/conda/psychopy-env.yml
@@ -2,7 +2,7 @@ name: psychopy
 channels:
 - conda-forge
 dependencies:
-- python=3.8
+- python>=3.8
 - psychopy
 - pip
 - pip:


### PR DESCRIPTION
The conda environment file appears to create conflicting dependency requirements, was able to fix by changing `python=3.8` to `python>=3.8`. See issue #6256. Not entirely sure if this is a bug on my end, but I was able to reproduce it on two separate computers. Opened the pull request just in case folks decide its best to make the change.