### PR TITLE
FF: Add path to plugin directory on library import

### DIFF
--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -50,6 +50,13 @@ if 'installing' not in locals():
         if _pathName.is_dir():
             sys.path.append(str(_pathName))
 
+    # add paths from plugins/packages (installed by plugins manager)
+    _userPackagePath = prefs.paths['userPackages']
+    _userScripts = prefs.paths['userScripts']
+    if _userPackagePath.is_dir():
+        sys.path.append(str(_userPackagePath))  # user site-packages
+        sys.path.append(str(_userScripts))  # user scripts
+    
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
 
 if sys.version_info.major < 3:

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -164,7 +164,30 @@ class Preferences:
             except OSError as err:
                 if err.errno != errno.EEXIST:
                     raise
+        
+        # root site-packages directory for user-installed packages and add it
+        pyVer = 'Python{}{}'.format(
+            sys.version_info.major, sys.version_info.minor)
+        prefixRootDir = Path(
+            self.paths['userPrefsDir']) / 'packages' / pyVer
 
+        # populate directory structure for user-installed packages
+        if not prefixRootDir.is_dir():
+            prefixRootDir.mkdir()
+        
+        userSiteDir = prefixRootDir / 'site-packages'
+        if not userSiteDir.is_dir():
+            userSiteDir.mkdir()
+
+        # Scripts directory for user-installed packages
+        userScriptsDir = prefixRootDir / 'Scripts'
+        if not userScriptsDir.is_dir():
+            userScriptsDir.mkdir()
+
+        # add paths from plugins/packages (installed by plugins manager)
+        self.paths['userPackages'] = userSiteDir
+        self.paths['userScripts'] = userScriptsDir
+        
         # Get dir for base and user themes
         baseThemeDir = Path(self.paths['appDir']) / "themes" / "spec"
         userThemeDir = Path(self.paths['themes'])


### PR DESCRIPTION
This PR adds code which ensures that the user's plugin directory is added to paths on import of PsychoPy's library. This allows extension plugins to be importable without making an explicit call to activate them. Regular plugins still need to be activated after the app is loaded.