### PR TITLE
FF: Catch JSON decode error in plugins dialog on Mac

### DIFF
--- a/psychopy/app/plugin_manager/plugins.py
+++ b/psychopy/app/plugin_manager/plugins.py
@@ -493,7 +493,10 @@ class PluginBrowserList(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
 
     def populate(self):
         # Get all plugin details
-        items = getAllPluginDetails()
+        try:
+            items = getAllPluginDetails()
+        except json.decoder.JSONDecodeError:
+            return
         # Start off assuming no headings
         self.badItemLbl.Hide()
         # Put installed packages at top of list


### PR DESCRIPTION
Unclear under what circumstances this happens (other than being on Mac), but either way we should be able to handle this without error