### PR TITLE
FF: Catch JSON decode error in plugins dialog on Mac

### DIFF
--- a/psychopy/app/plugin_manager/plugins.py
+++ b/psychopy/app/plugin_manager/plugins.py
@@ -1196,7 +1196,13 @@ def getAllPluginDetails():
             resp = requests.get(srcURL)
             if resp.status_code == 404:
                 return None
-            return resp.text
+            value = resp.text
+            # confirm json is valid
+            try:
+                json.loads(value)
+                return value
+            except json.decoder.JSONDecodeError:
+                return None
         except requests.exceptions.ConnectionError:
             return None
         


### PR DESCRIPTION
If we get a value from psychopy.org but that value isn't a valid JSON string, act as if we didn't get a value (so the rest of the error handling catches it)