### PR TITLE
BF: Selecting audio device in builder and coder (fixes #6142)

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -588,7 +588,7 @@ class PreferencesDlg(wx.Dialog):
                         options = self.audioDevNames
                         try:
                             default = self.audioDevNames.index(
-                                self.audioDevDefault)
+                                self.audioDevDefault[0])
                         except ValueError:
                             default = 0
                     else:
@@ -663,8 +663,8 @@ class PreferencesDlg(wx.Dialog):
                     self.app.theme = self.prefsCfg[sectionName][prefName] = self.themeList[thisPref]
                     continue
                 elif prefName == 'audioDevice':
-                    self.prefsCfg[sectionName][prefName] = \
-                        self.audioDevNames[thisPref]
+                    self.audioDevDefault = [self.audioDevNames[thisPref]]
+                    self.prefsCfg[sectionName][prefName] = self.audioDevDefault
                     continue
                 elif prefName == 'locale':
                     # '' corresponds to system locale


### PR DESCRIPTION
## PsychoPy Versions

2023.2.3, release, dev

Apparently in 2022.2.5 version it worked. The bug was introduced afterwards.

## What OSes is your PsychoPy running on?

Ubuntu-20.4, Windows 10

## Bug Description

This patch fixes an issue where selecting an audio device in PsychoPy Builder preferences is not being saved correctly. There is no way to change the audio device but to manually edit the user configuration.

This same issue has been described here before:

- https://github.com/psychopy/psychopy/issues/6142
- https://discourse.psychopy.org/t/how-to-change-audiodevice-in-hardware-preferences/30982

This was closed believing it is fixed in 2024.1.0/dev, but it is not.

## Solution

- The `audioDevice` preference must be a `list` for the PsychoPy's internal settings validation to pass. This fixes the Apply and OK buttons.
- Additionally, it ensures `self.audioDevDefault` is updated to reflect the newly selected audio device, allowing the Apply button to function correctly.

This change allows the audio device to be correctly selected, saved, and utilized in experiments.
