### PR TITLE
BF: Fix handling of code expressions in sound component stop values

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -13,6 +13,7 @@ from xml.etree.ElementTree import Element
 from psychopy import prefs
 from psychopy.constants import FOREVER
 from ..params import Param
+from psychopy.experiment.utils import canBeNumeric
 from psychopy.experiment.utils import CodeGenerationException
 from psychopy.experiment.utils import unescapedDollarSign_re
 from psychopy.experiment.params import getCodeFromParamStr
@@ -1349,14 +1350,3 @@ class BaseVisualComponent(BaseComponent):
                     "\n"
                 )
                 indented -= 1
-
-
-def canBeNumeric(inStr):
-    """Determines whether the input can be converted to a float
-    (using a try: float(instr))
-    """
-    try:
-        float(inStr)
-        return True
-    except Exception:
-        return False

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -10,6 +10,7 @@ Distributed under the terms of the GNU General Public License (GPL).
 from pathlib import Path
 from psychopy.experiment.components import BaseDeviceComponent, Param, getInitVals, \
     _translate
+from psychopy.experiment.utils import canBeNumeric
 from psychopy.tools.audiotools import knownNoteNames
 
 
@@ -139,7 +140,7 @@ class SoundComponent(BaseDeviceComponent):
     def writeInitCode(self, buff):
         # replaces variable params with sensible defaults
         inits = getInitVals(self.params)
-        if '$' in str(inits['stopVal'].val):
+        if not canBeNumeric(inits['stopVal'].val):
             inits['stopVal'].val = -1
         else:
             if inits['stopVal'].val in ['', None, 'None']:
@@ -177,7 +178,7 @@ class SoundComponent(BaseDeviceComponent):
     def writeInitCodeJS(self, buff):
         # replaces variable params with sensible defaults
         inits = getInitVals(self.params)
-        if '$' in inits['stopVal'].val:
+        if not canBeNumeric(inits['stopVal'].val):
             inits['stopVal'].val = -1
         elif inits['stopVal'].val in ['', None, 'None']:
             inits['stopVal'].val = -1

--- a/psychopy/experiment/utils.py
+++ b/psychopy/experiment/utils.py
@@ -32,3 +32,13 @@ class CodeGenerationException(Exception):
     def __str__(self):
         return "{}: ".format(self.source, self.message)
 
+
+def canBeNumeric(inStr):
+    """Determines whether the input can be converted to a float
+    (using a try: float(instr))
+    """
+    try:
+        float(inStr)
+        return True
+    except Exception:
+        return False


### PR DESCRIPTION
## PsychoPy Versions

2023.2.3, dev

## What OSes is your PsychoPy running on?

Ubuntu-20.4

## Bug Description

There is an issue in the sound component where code expressions for the stop value without preceding `$` were causing errors. This does not happen with start value, only with the stop property, but both are marked with `$`.

![sound-component-stopVal-bug](https://github.com/psychopy/psychopy/assets/1878434/7b4311d0-f209-45cc-9420-4d9f6daa807b)

Traceback error example:
```
Traceback (most recent call last):
  File "~/src/psychopy/psychopy/app/builder/builder.py", line 1392, in pilotFile
    self.app.runner.panel.pilotLocal(event)
  File "~/src/psychopy/psychopy/app/runner/runner.py", line 653, in pilotLocal
    self.runLocal(evt, args=["--pilot"], focusOnExit=focusOnExit)
  File "~/src/psychopy/psychopy/app/runner/runner.py", line 635, in runLocal
    generateScript(
  File "~/src/psychopy/psychopy/scripts/psyexpCompile.py", line 87, in generateScript
    compileScript(infile=exp, version=None, outfile=outfile)
  File "~/src/psychopy/psychopy/scripts/psyexpCompile.py", line 225, in compileScript
    _makeTarget(thisExp, outfile, targetOutput)
  File "~/src/psychopy/psychopy/scripts/psyexpCompile.py", line 205, in _makeTarget
    script = thisExp.writeScript(outfile, target=targetOutput)
  File "~/src/psychopy/psychopy/experiment/_experiment.py", line 327, in writeScript
    self_copy.flow.writeBody(script)
  File "~/src/psychopy/psychopy/experiment/flow.py", line 301, in writeBody
    entry.writeInitCode(script)
  File "~/src/psychopy/psychopy/experiment/routines/_base.py", line 482, in writeInitCode
    thisCompon.writeInitCode(buff)
  File "~/src/psychopy/psychopy/experiment/components/sound/__init__.py", line 147, in writeInitCode
    elif float(inits['stopVal'].val) > 2:
ValueError: could not convert string to float: 'sound_time'
```

## Solution

- Fix handling of code expressions in sound component stop values by using `canBeNumeric()` to check the value correctly.
- This change also moves `canBeNumeric()` to a more central location: `experiment.utils`.