### PR TITLE
FF: Fix bug when syncing right after creating new project

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -864,8 +864,8 @@ class PavloviaProject(dict):
                 repo = self.newRepo(infoStream)
                 if repo is None:
                     return 0
-            # If first commit, do initial push
-            if not bool(self.project.attributes['default_branch']):
+            # If first commit (besides repo creation), do initial push
+            if len(self.project.commits.list()) < 2:
                 self.firstPush(infoStream=infoStream)
             # Pull and push
             self.pull(infoStream)


### PR DESCRIPTION
Checking whether a remote is bare by using the `default_branch` attribute meant that the remote still read as bare after creating a project until the next time the repo refreshed (which is a slow process), leading to a git sync error if you try to sync again too soon after the initial sync, querying the number of commits is safer as this is immediately available after calling `firstPush`