### PR TITLE
BF: Fixed error setting `autoLog` attribute for 3D stimuli classes

### DIFF
--- a/psychopy/visual/stim3d.py
+++ b/psychopy/visual/stim3d.py
@@ -1812,7 +1812,7 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
         super(BaseRigidBodyStim, self).__init__()
 
         self.win = win
-
+        self.autoLog = autoLog
         self.colorSpace = colorSpace
         self.contrast = contrast
         self.opacity = opacity
@@ -1822,8 +1822,6 @@ class BaseRigidBodyStim(ColorMixin, WindowMixin):
         self.material = None
 
         self._vao = None
-
-        self.autoLog = autoLog
 
     @property
     def thePose(self):


### PR DESCRIPTION
Fixes the error when creating 3D stimuli caused by attribute `autoLog` is not being defined, yet is accessed by attribute setters.