### PR TITLE
RF: Better fallback behaviour if mic params are unsupported

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -130,7 +130,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         # numericise index if needed
         if isinstance(index, str):
             try:
-                index = float(index)
+                index = int(index)
             except ValueError:
                 pass
 

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -127,7 +127,18 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         from psychopy.hardware import DeviceManager
 
-        def _getDefaultDevice():
+        # numericise index if needed
+        if isinstance(index, str):
+            try:
+                index = float(index)
+            except ValueError:
+                pass
+
+        # get information about the selected device
+        if isinstance(index, AudioDeviceInfo):
+            # if already an AudioDeviceInfo object, great!
+            self._device = index
+        elif index in (-1, None):
             # get all devices
             _devices = MicrophoneDevice.getDevices()
             # if there are none, error
@@ -137,65 +148,26 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
                     "connected."
                 ))
 
-            return _devices[0]
-
-        def _getDeviceByIndex(deviceIndex):
-            """Subroutine to get a device by index. Used to handle the case
-            where the user specifies a device by index.
-
-            Parameters
-            ----------
-            deviceIndex : int, float or str
-                Index of the device to get.
-
-            Returns
-            -------
-            AudioDeviceInfo
-                Audio device information object.
-
-            """
-            # convert to `int` first, sometimes strings can specify the enum
-            # value from builder
-            deviceIndex = int(deviceIndex)
-            # get all audio devices
-            devices_ = MicrophoneDevice.getDevices()
-
-            # get information about the selected device
-            devicesByIndex = {d.deviceIndex: d for d in devices_}
-            if deviceIndex in devicesByIndex:
-                useDevice = devicesByIndex[deviceIndex]
-            else:
-                logging.warn(_translate(
-                    "Could not find audio recording device at index {}, using default."
-                ).format(deviceIndex))
-                useDevice = _getDefaultDevice()
-
-            return useDevice
-
-        # get information about the selected device
-        if isinstance(index, AudioDeviceInfo):
-            # if already an AudioDeviceInfo object, great!
-            self._device = index
-        elif index in (None, "none", "None", "NONE", -1, "default", "Default", "DEFAULT"):
-            # if some variant of None, they've asked for default
-            self._device = _getDefaultDevice()
-        elif isinstance(index, int) or (isinstance(index, str) and index.isnumeric()):
-            # if given an integer (or something like it), it's an index
-            self._device = _getDeviceByIndex(int(index))
+            self._device = _devices[0]
         elif isinstance(index, str):
             # if given a str that's a name from DeviceManager, get info from device
             device = DeviceManager.getDevice(index)
             if isinstance(device, MicrophoneDevice):
-                self._device = _getDeviceByIndex(device.deviceIndex)
+                self._device = device._device
             else:
-                # fallback to default
-                self._device = _getDefaultDevice()
+                raise KeyError(
+                    f"Could not find MicrophoneDevice named {index}"
+                )
         else:
-            # default device as the ultimate fallback
-            self._device = _getDefaultDevice()
+            # get best match
+            self._device = self.findBestDevice(
+                index=index,
+                sampleRateHz=sampleRateHz,
+                channels=channels
+            )
 
-        logging.info('Using audio device #{} ({}) for audio capture'.format(
-            self._device.deviceIndex, self._device.deviceName))
+        logging.info('Using audio device #{} ({}) for audio capture. Full spec: {}'.format(
+            self._device.deviceIndex, self._device.deviceName, self._device))
 
         # error if specified device is not suitable for capture
         if not self._device.isCapture:
@@ -229,10 +201,6 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         logging.debug('Set recording channels to {} ({})'.format(
             self._channels, 'stereo' if self._channels > 1 else 'mono'))
 
-        if self._channels > self._device.inputChannels:
-            raise AudioInvalidDeviceError(
-                'Invalid number of channels for audio input specified.')
-
         # internal recording buffer size in seconds
         assert isinstance(streamBufferSecs, (float, int))
         self._streamBufferSecs = float(streamBufferSecs)
@@ -249,8 +217,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
                 device_id=self._device.deviceIndex,
                 latency_class=self._audioLatencyMode,
                 mode=self._mode,
-                freq=self._sampleRateHz,
-                channels=self._channels)
+                freq=self._device.defaultSampleRate,
+                channels=self._device.inputChannels)
             logging.debug('Stream opened')
         else:
             logging.debug(
@@ -298,6 +266,36 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         logging.debug('Audio capture device #{} ready'.format(
             self._device.deviceIndex))
+
+    def findBestDevice(self, index, sampleRateHz, channels):
+        fallbackDevice = None
+        chosenDevice = None
+        for profile in self.getDevices():
+            # if same index, keep as fallback
+            if profile.deviceIndex == index:
+                fallbackDevice = profile
+            # if same everything, we got it!
+            if all((
+                profile.deviceIndex == index,
+                profile.defaultSampleRate == sampleRateHz,
+                profile.inputChannels == channels,
+            )):
+                chosenDevice = profile
+        if chosenDevice is None:
+            logging.warning(
+                f"Could not find exact match for specified parameters (index={index}, sampleRateHz="
+                f"{sampleRateHz}, channels={channels}), falling back to best approximation ("
+                f"index={fallbackDevice.deviceIndex}, "
+                f"sampleRateHz={fallbackDevice.defaultSampleRate}, "
+                f"channels={fallbackDevice.inputChannels})"
+            )
+            chosenDevice = fallbackDevice
+        if chosenDevice is None:
+            raise KeyError(
+                f"Could not find any device with index {index}"
+            )
+
+        return chosenDevice
 
     def isSameDevice(self, other):
         """
@@ -354,9 +352,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         allDevs = [allDevs] if isinstance(allDevs, dict) else allDevs
 
         # create list of descriptors only for capture devices
-        inputDevices = [desc for desc in [
-            AudioDeviceInfo.createFromPTBDesc(dev) for dev in allDevs]
-                     if desc.isCapture]
+        devObjs = [AudioDeviceInfo.createFromPTBDesc(dev) for dev in allDevs]
+        inputDevices = [desc for desc in devObjs if desc.isCapture]
 
         return inputDevices
 


### PR DESCRIPTION
Rethink of the logic behind Microphone failing, allowing it to fallback to "close enough" Mic profiles (while printing a warning) rather than going ahead with parameters as requested and then failing. Very cautious about this one as it's a big change, definitely needs @mdcutone 's approval before pulling in.