### PR TITLE
BF: Add `__file__` import for eyetracker extensions

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/gazepoint/gp3/__init__.py
@@ -6,7 +6,10 @@
 import psychopy.logging as logging
 
 try:
-    from psychopy_eyetracker_gazepoint.gp3 import *
+    from psychopy_eyetracker_gazepoint.gp3 import (
+        __file__,
+        EyeTracker
+    )
 except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "The Gazepoint eyetracker requires package " 

--- a/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/tobii/__init__.py
@@ -7,7 +7,10 @@ import psychopy.logging as logging
 
 yamlFile = None
 try:
-    from psychopy_eyetracker_tobii.tobii import *
+    from psychopy_eyetracker_tobii.tobii import (
+        __file__,
+        EyeTracker
+    )
 except (ModuleNotFoundError, ImportError, NameError):
     logging.error(
         "The Tobii eyetracker requires package 'psychopy-eyetracker-tobii' to "

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -168,7 +168,8 @@ def getSupportedConfigSettings(moduleName, deviceClassName=None):
         yamlFile = yamlRoot / pathlib.Path(moduleName.__file__).parent / fileName
         if not yamlFile.exists():
             raise FileNotFoundError(
-                "No config file found in module dir {0}".format(moduleName))
+                "No config file found in module dir for: {0}".format(
+                    moduleName))
         logging.debug(
             "Found ioHub device configuration file: {0}".format(yamlFile))
 


### PR DESCRIPTION
This adds the import of `__file__` from eyetracker extensions, this allows ioHub to resolve their paths to find YAML config files. This needed to be added to Tobii and Gazepoint stubs. 

Fixes #6207 