### PR TITLE
BF: JS code translation errored when a whole snippet was commented out

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -506,22 +506,16 @@ def transformPsychoJsCode(psychoJsCode, addons, namespace=[]):
 
         """
 
-    lines = psychoJsCode.splitlines()
-
-    # remove the initial variable declarations, unless it is for _pj:
-    if lines[0].find('var _pj;') == 0:
-        transformedPsychoJSCode = 'var _pj;\n'
-        startIndex = 1
-    else:
-        startIndex = 0
-
-    for index in range(startIndex, len(lines)):
+    for index, thisLine in enumerate(psychoJsCode.splitlines()):
         include = True
-
+        # remove the initial variable declarations, unless it is for _pj:
+        if index == 0 and thisLine.find('var _pj;') == 0:
+            transformedPsychoJSCode = 'var _pj;\n'
+            continue
         # Remove var defs if variable is defined earlier in experiment
-        if lines[index].startswith("var "):
+        if thisLine.startswith("var "):
             # Get var names
-            varNames = lines[index][4:-1].split(", ")
+            varNames = thisLine[4:-1].split(", ")
             validVarNames = []
             for varName in varNames:
                 if namespace is not None and varName not in namespace:
@@ -531,11 +525,11 @@ def transformPsychoJsCode(psychoJsCode, addons, namespace=[]):
             if not len(validVarNames):
                 include = False
             # Recombine line
-            lines[index] = f"var {', '.join(validVarNames)};"
+            thisLine = f"var {', '.join(validVarNames)};"
 
         # Append line
         if include:
-            transformedPsychoJSCode += lines[index]
+            transformedPsychoJSCode += thisLine
             transformedPsychoJSCode += '\n'
 
     return transformedPsychoJSCode


### PR DESCRIPTION
Reason being that comments aren't processed by the transpiler, so when we do the post-transpile check for variable defs in the first line we got an index error as there was no first line. Fix is to just do this check within the for loop, but only at the first index (so no values = no iterations loop = no indexing = no index error)