### PR TITLE
BF: When Routine only has an estimated duration, draw the end routine line but don't mark as non-slip

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2320,7 +2320,11 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
         dc.SetId(id)
         # get max time & check if we have a hard stop
         tMax, hardStop = self.getMaxTime()
-        if hardStop or self.routine.settings.params.get("durationEstim", False):
+        # if routine has an estimated stop, it's not a hard stop but we shold draw the line anyway
+        if self.routine.settings.params.get("durationEstim", False):
+            hardStop = True
+
+        if hardStop:
             # if hard stop, draw orange final line
             dc.SetPen(
                 wx.Pen(colors.app['rt_comp_force'], width=4)

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2668,8 +2668,11 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
                     self.redrawRoutine()  # need to refresh timings section
                     self.Refresh()  # then redraw visible
                     self.frame.flowPanel.canvas.draw()
-            # Redraw if timings have changed
-            if component.getStartAndDuration() != initialTimings:
+            # Redraw if timings have changed (or always, if comp was RoutineSettings)
+            if (
+                component.getStartAndDuration() != initialTimings
+                or component.type == "RoutineSettingsComponent"
+            ):
                 self.redrawRoutine()  # need to refresh timings section
                 self.Refresh()  # then redraw visible
                 self.frame.flowPanel.canvas.draw()

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2320,7 +2320,7 @@ class RoutineCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
         dc.SetId(id)
         # get max time & check if we have a hard stop
         tMax, hardStop = self.getMaxTime()
-        if hardStop:
+        if hardStop or self.routine.settings.params.get("durationEstim", False):
             # if hard stop, draw orange final line
             dc.SetPen(
                 wx.Pen(colors.app['rt_comp_force'], width=4)

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -875,7 +875,6 @@ class BaseComponent:
             # deduce duration (s) if possible. Duration used because component
             # time icon needs width
             if canBeNumeric(self.params['durationEstim'].val):
-                numericStop = True
                 duration = float(self.params['durationEstim'].val)
             elif self.params['stopVal'].val in ['', '-1', 'None']:
                 duration = FOREVER  # infinite duration

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -890,7 +890,7 @@ class Routine(list):
                 maxTime = max(maxTime, thisT)
         # if max set by routine, override calculated max
         rtDur, numericStop = self.settings.getDuration()
-        if numericStop and rtDur != FOREVER:
+        if rtDur != FOREVER:
             maxTime = rtDur
         # if there are no components, default to 10s
         if maxTime == 0:


### PR DESCRIPTION
When a Routine had an expected duration, it was being marked as a hard stop (so the line gets drawn), but doing so also meant we were subtracting from the Routine timer rather than calling reset, breaking timing in the subsequent Routine. This fix keeps `hardStop = False` but draws the line anyway