### PR TITLE
ENH: Device selection for multiple sounds (ptb library)

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -137,7 +137,7 @@ class _SoundBase(AttributeGetSetMixin):
 
         return device
 
-    def setSound(self, value, secs=0.5, octave=4, hamming=True, log=True):
+    def setSound(self, value, device, secs=0.5, octave=4, hamming=True, log=True):
         """Set the sound to be played.
 
         Often this is not needed by the user - it is called implicitly during


### PR DESCRIPTION
I implemented the option to select different output devices for multiple streams using the ptb library. The ptb library already had this functionality, but until now the psychopy code did not pass the device ID correctly. As a result, the sound was not output on the selected device. This will now work correctly and the sound will be played through the corresponding device/output for multiple simultaneous sounds on different devices.