### PR TITLE
BF: Sound was being set each repeat even if parameter was constant

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -164,12 +164,9 @@ class SoundComponent(BaseDeviceComponent):
         buff.writeIndented("%(name)s.setVolume(%(volume)s)\n" % inits)
 
     def writeRoutineStartCode(self, buff):
-        if self.params['stopVal'].val in [None, 'None', '']:
-            buff.writeIndentedLines("%(name)s.setSound(%(sound)s, hamming=%(hamming)s)\n"
-                                    "%(name)s.setVolume(%(volume)s, log=False)\n" % self.params)
-        else:
-            buff.writeIndentedLines("%(name)s.setSound(%(sound)s, secs=%(stopVal)s, hamming=%(hamming)s)\n"
-                                    "%(name)s.setVolume(%(volume)s, log=False)\n" % self.params)
+        # write base code
+        BaseDeviceComponent.writeRoutineStartCode(self, buff)
+        # seek back to 0
         code = (
             "%(name)s.seek(0)\n"
         )


### PR DESCRIPTION
Putting this in as a draft while we figure out why it was like that in the first place & whether it still needs to be.

Testing with the attached file seems fine:
[testSound.psyexp.zip](https://github.com/psychopy/psychopy/files/14864336/testSound.psyexp.zip)
