### PR TITLE
BF: Fixed error if camera thread object is `None`

### DIFF
--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -2196,6 +2196,9 @@ class Camera:
     def stop(self):
         """Stop recording frames and audio (if available).
         """
+        if self._captureThread is None:  # do nothing if not open
+            return
+
         if not self._captureThread.isOpen():
             raise RuntimeError("Cannot stop recording, stream is not open.")
 
@@ -2217,6 +2220,9 @@ class Camera:
         to save the frames to disk.
 
         """
+        if self._captureThread is None:  # nop
+            return
+
         if not self._captureThread.isOpen():
             raise RuntimeError("Cannot close stream, stream is not open.")
         


### PR DESCRIPTION
Fixes an error, usually when exiting, that is raised if the camera thread attribute is `None`. This can happen if `close` is called in succession without a call to `open()` between them.