### PR TITLE
ENH: Improvements to attributeSetter decorator

### DIFF
--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -259,7 +259,7 @@ class _baseTest():
         m.getPressed(getTime=True)
 
     def test_isPressedIn(self):
-        m = event.Mouse(self.win, newPos=(0,0))
+        m = event.Mouse(win=self.win, newPos=(0,0))
         s = ShapeStim(self.win, vertices=[[10,10],[10,-10],[-10,-10],[-10,10]], autoLog=False)
         if not s.contains(m.getPos()):
             pytest.skip()  # or can't test

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -98,6 +98,20 @@ class attributeSetter:
 
         return newValue
 
+    def __set_name__(self, cls, name):
+        """
+        When assigned to a class, also create setWhatever/getWhatever methods.
+        """
+        # make PascalCase variation of name
+        pascalName = CaseSwitcher.camel2pascal(name)
+        # assign setter
+        setattr(cls, "set" + pascalName, self.func)
+        # create getter
+        def getter(obj):
+            return getattr(obj, name)
+        # assign getter
+        setattr(cls, "get" + pascalName, getter)
+
     def __repr__(self):
         return repr(self.__getattribute__)
 

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -8,6 +8,7 @@
 """
 Functions and classes related to attribute handling
 """
+from pathlib import Path
 
 import numpy
 import inspect
@@ -164,8 +165,12 @@ def setAttribute(self, attrib, value, log=None,
 
         # Apply operation except for the case when new or old value
         # are None or string-like
-        if (value is not None and type(value)!=str
-                and oldValue is not None and type(oldValue)!=str):
+        if (
+                value is not None
+                and not isinstance(value, (str, Path))
+                and oldValue is not None
+                and not isinstance(oldValue, (str, Path))
+        ):
             value = numpy.array(value, float)
 
             # Calculate new value using operation

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -52,6 +52,10 @@ class attributeSetter:
         If attribute value is queried before being set, get its default value from the method
         signature. If it has none, will return the attributeSetter object itself.
         """
+        # from class, treat as method
+        if obj is None:
+            return self
+        # from object, treat as attribute
         if self.func.__name__ in obj.__dict__:
             # if value has been set, return it
             return obj.__dict__[self.func.__name__]
@@ -219,8 +223,8 @@ def logAttrib(obj, log, attrib, value=None):
 
 class AttributeGetSetMixin:
     """
-    For all attributeSetter and property/setter methods, makes a get and set method whose names are the attribute name,
-    in PascalCase, preceeded by "set" or "get"
+    For all attributeSetter and property/setter methods, makes a get and set method whose names
+    are the attribute name, in PascalCase, preceeded by "set" or "get"
     """
     def __init_subclass__(cls, **kwargs):
         # iterate through methods

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -104,11 +104,16 @@ class attributeSetter:
         """
         # make PascalCase variation of name
         pascalName = CaseSwitcher.camel2pascal(name)
+        # create setter
+        def setter(obj, value, operation='', log=None):
+            setAttribute(obj, name, value, operation=operation, log=log)
+        setter.__doc__ = self.func.__doc__
         # assign setter
-        setattr(cls, "set" + pascalName, self.func)
+        setattr(cls, "set" + pascalName, setter)
         # create getter
         def getter(obj):
             return getattr(obj, name)
+        getter.__doc__ = self.func.__doc__
         # assign getter
         setattr(cls, "get" + pascalName, getter)
 

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -34,7 +34,7 @@ class attributeSetter:
             Some attribute in a visual stim. If not set yet, will be None.
             '''
             # set the value in the object's dict
-            self.__dict__['someAttrib']
+            self.__dict__['someAttrib'] = value
     ```
     """
 
@@ -47,7 +47,7 @@ class attributeSetter:
         else:
             self.__doc__ = func.__doc__
     
-    def __get__(self, obj, owner):
+    def __get__(self, obj, cls):
         """
         If attribute value is queried before being set, get its default value from the method
         signature. If it has none, will return the attributeSetter object itself.

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -456,8 +456,8 @@ class BaseColorMixin:
         else:
             logging.error(f"'{value}' is not a valid color space")
 
-    @property
-    def contrast(self):
+    @attributeSetter
+    def contrast(self, value=1):
         """A value that is simply multiplied by the color.
 
         Value should be: a float between -1 (negative) and 1 (unchanged).
@@ -483,31 +483,13 @@ class BaseColorMixin:
 
         """
         if hasattr(self, '_foreColor'):
-            return self._foreColor.contrast
-
-    @contrast.setter
-    def contrast(self, value):
-        if hasattr(self, '_foreColor'):
             self._foreColor.contrast = value
         if hasattr(self, '_fillColor'):
             self._fillColor.contrast = value
         if hasattr(self, '_borderColor'):
             self._borderColor.contrast = value
 
-    def setContrast(self, newContrast, operation='', log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
-        """
-        if newContrast is not None:
-            self.contrast = newContrast
-        if operation in ['', '=']:
-            self.contrast = newContrast
-        elif operation in ['+']:
-            self.contrast += newContrast
-        elif operation in ['-']:
-            self.contrast -= newContrast
-        else:
-            logging.error(f"Operation '{operation}' not recognised.")
+        self.__dict__['contrast'] = value
 
     def _getDesiredRGB(self, rgb, colorSpace, contrast):
         """ Convert color to RGB while adding contrast.
@@ -1284,7 +1266,7 @@ class TextureMixin:
             setAttribute(self, 'mask', self.mask, log=False)
 
     @attributeSetter
-    def maskParams(self, value):
+    def maskParams(self, value=None):
         """Various types of input. Default to `None`.
 
         This is used to pass additional parameters to the mask if those are

--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -267,61 +267,47 @@ class LegacyForeColorMixin:
     """
     Mixin class to give an object all of the legacy functions for setting foreground color
     """
-    def setDKL(self, color, operation=''):
-        """DEPRECATED since v1.60.05: Please use the `color` attribute
+    @attributeSetter
+    def DKL(self, value="black"):
         """
-        self.setForeColor(color, 'dkl', operation)
+        DEPRECATED: Legacy property for setting the foreground color of a stimulus in DKL, instead
+        use `obj._foreColor.dkl`
+        """
+        self.foreColor = Color(value, 'dkl')
 
-    def setLMS(self, color, operation=''):
-        """DEPRECATED since v1.60.05: Please use the `color` attribute
+    @attributeSetter
+    def LMS(self, value="black"):
         """
-        self.setForeColor(color, 'lms', operation)
+        DEPRECATED: Legacy property for setting the foreground color of a stimulus in LMS, instead
+        use `obj._foreColor.lms`
+        """
+        self.foreColor = Color(value, 'lms')
 
-    @property
-    def foreRGB(self):
+    @attributeSetter
+    def foreRGB(self, value="black"):
         """
-        DEPRECATED: Legacy property for setting the foreground color of a stimulus in RGB, instead use `obj._foreColor.rgb`
+        DEPRECATED: Legacy property for setting the foreground color of a stimulus in RGB, instead
+        use `obj._foreColor.rgb`
         """
-        return self._foreColor.rgb
-
-    @foreRGB.setter
-    def foreRGB(self, value):
         self.foreColor = Color(value, 'rgb')
 
-    @property
-    def RGB(self):
+    @attributeSetter
+    def RGB(self, value="black"):
         """
-        DEPRECATED: Legacy property for setting the foreground color of a stimulus in RGB, instead use `obj._foreColor.rgb`
+        DEPRECATED: Legacy property for setting the foreground color of a stimulus in RGB, instead
+        use `obj._foreColor.rgb`
         """
-        return self.foreRGB
+        self.foreColor = Color(value, 'rgb')
 
-    @RGB.setter
-    def RGB(self, value):
-        self.foreRGB = value
-
-    def setRGB(self, color, operation='', log=None):
+    @attributeSetter
+    def foreColorSpace(self, value="rgb"):
         """
-        DEPRECATED: Legacy setter for foreground RGB, instead set `obj._foreColor.rgb`
+        Deprecated, please use colorSpace instead.
         """
-        self.setForeColor(color, 'rgb', operation, log)
-
-    def setForeRGB(self, color, operation='', log=None):
-        """
-        DEPRECATED: Legacy setter for foreground RGB, instead set `obj._foreColor.rgb`
-        """
-        self.setForeColor(color, 'rgb', operation, log)
-
-    @property
-    def foreColorSpace(self):
-        """Deprecated, please use colorSpace to set color space for the entire
-        object.
-        """
-        return self.colorSpace
-
-    @foreColorSpace.setter
-    def foreColorSpace(self, value):
         logging.warning(
-            "Setting color space by attribute rather than by object is deprecated. Value of foreColorSpace has been assigned to colorSpace.")
+            "Attribute foreColorSpace is deprecated. Value has been assigned to colorSpace "
+            "instead."
+        )
         self.colorSpace = value
 
 
@@ -329,63 +315,48 @@ class LegacyFillColorMixin:
     """
     Mixin class to give an object all of the legacy functions for setting fill color
     """
-    @property
-    def fillRGB(self):
+    @attributeSetter
+    def fillRGB(self, value="white"):
         """
-        DEPRECATED: Legacy property for setting the fill color of a stimulus in RGB, instead use `obj._fillColor.rgb`
+        DEPRECATED: Legacy property for setting the fill color of a stimulus in RGB, instead use
+        `obj._fillColor.rgb`
         """
-        return self._fillColor.rgb
-
-    @fillRGB.setter
-    def fillRGB(self, value):
+        logging.warning(
+            "Attribute fillRGB is deprecated. Value has been assigned to fillColor instead."
+        )
         self.fillColor = Color(value, 'rgb')
 
-    @property
-    def backRGB(self):
+    @attributeSetter
+    def backRGB(self, value="white"):
         """
-        DEPRECATED: Legacy property for setting the fill color of a stimulus in RGB, instead use `obj._fillColor.rgb`
+        DEPRECATED: Legacy property for setting the fill color of a stimulus in RGB, instead use
+        `obj._fillColor.rgb`
         """
-        return self.fillRGB
+        logging.warning(
+            "Attribute backRGB is deprecated. Value has been assigned to fillColor instead."
+        )
+        self.fillColor = Color(value, 'rgb')
 
-    @backRGB.setter
-    def backRGB(self, value):
-        self.fillRGB = value
-
-    def setFillRGB(self, color, operation='', log=None):
+    @attributeSetter
+    def fillColorSpace(self, value="rgb"):
         """
-        DEPRECATED: Legacy setter for fill RGB, instead set `obj._fillColor.rgb`
+        Deprecated, please use colorSpace instead.
         """
-        self.setFillColor(color, 'rgb', operation, log)
-
-    def setBackRGB(self, color, operation='', log=None):
-        """
-        DEPRECATED: Legacy setter for fill RGB, instead set `obj._fillColor.rgb`
-        """
-        self.setFillColor(color, 'rgb', operation, log)
-
-    @property
-    def fillColorSpace(self):
-        """Deprecated, please use colorSpace to set color space for the entire
-        object.
-        """
-        return self.colorSpace
-
-    @fillColorSpace.setter
-    def fillColorSpace(self, value):
-        logging.warning("Setting color space by attribute rather than by object is deprecated. Value of fillColorSpace has been assigned to colorSpace.")
+        logging.warning(
+            "Attribute fillColorSpace is deprecated. Value has been assigned to colorSpace "
+            "instead."
+        )
         self.colorSpace = value
 
-    @property
-    def backColorSpace(self):
-        """Deprecated, please use colorSpace to set color space for the entire
-        object.
+    @attributeSetter
+    def backColorSpace(self, value="rgb"):
         """
-        return self.colorSpace
-
-    @backColorSpace.setter
-    def backColorSpace(self, value):
+        Deprecated, please use colorSpace instead.
+        """
         logging.warning(
-            "Setting color space by attribute rather than by object is deprecated. Value of backColorSpace has been assigned to colorSpace.")
+            "Attribute backColorSpace is deprecated. Value has been assigned to colorSpace "
+            "instead."
+        )
         self.colorSpace = value
 
 
@@ -393,64 +364,48 @@ class LegacyBorderColorMixin:
     """
     Mixin class to give an object all of the legacy functions for setting border color
     """
-    @property
-    def borderRGB(self):
+    @attributeSetter
+    def borderRGB(self, value="black"):
         """
-        DEPRECATED: Legacy property for setting the border color of a stimulus in RGB, instead use `obj._borderColor.rgb`
+        DEPRECATED: Legacy property for setting the border color of a stimulus in RGB, instead
+        use `obj._borderColor.rgb`
         """
-        return self._borderColor.rgb
-
-    @borderRGB.setter
-    def borderRGB(self, value):
+        logging.warning(
+            "Attribute borderRGB is deprecated. Value has been assigned to borderColor instead."
+        )
         self.borderColor = Color(value, 'rgb')
 
-    @property
-    def lineRGB(self):
+    @attributeSetter
+    def lineRGB(self, value="black"):
         """
-        DEPRECATED: Legacy property for setting the border color of a stimulus in RGB, instead use `obj._borderColor.rgb`
+        DEPRECATED: Legacy property for setting the border color of a stimulus in RGB, instead use
+        `obj._borderColor.rgb`
         """
-        return self.borderRGB
-
-    @lineRGB.setter
-    def lineRGB(self, value):
-        self.borderRGB = value
-
-    def setBorderRGB(self, color, operation='', log=None):
-        """
-        DEPRECATED: Legacy setter for border RGB, instead set `obj._borderColor.rgb`
-        """
-        self.setBorderColor(color, 'rgb', operation, log)
-
-    def setLineRGB(self, color, operation='', log=None):
-        """
-        DEPRECATED: Legacy setter for border RGB, instead set `obj._borderColor.rgb`
-        """
-        self.setBorderColor(color, 'rgb', operation, log)
-
-    @property
-    def borderColorSpace(self):
-        """Deprecated, please use colorSpace to set color space for the entire
-        object
-        """
-        return self.colorSpace
-
-    @borderColorSpace.setter
-    def borderColorSpace(self, value):
         logging.warning(
-            "Setting color space by attribute rather than by object is deprecated. Value of borderColorSpace has been assigned to colorSpace.")
+            "Attribute lineRGB is deprecated. Value has been assigned to borderColor instead."
+        )
+        self.borderColor = Color(value, 'rgb')
+
+    @attributeSetter
+    def borderColorSpace(self, value="rgb"):
+        """
+        Deprecated, please use colorSpace instead.
+        """
+        logging.warning(
+            "Attribute borderColorSpace is deprecated. Value has been assigned to colorSpace "
+            "instead."
+        )
         self.colorSpace = value
 
-    @property
-    def lineColorSpace(self):
-        """Deprecated, please use colorSpace to set color space for the entire
-        object
+    @attributeSetter
+    def lineColorSpace(self, value="rgb"):
         """
-        return self.colorSpace
-
-    @lineColorSpace.setter
-    def lineColorSpace(self, value):
+        Deprecated, please use colorSpace instead.
+        """
         logging.warning(
-            "Setting color space by attribute rather than by object is deprecated. Value of lineColorSpace has been assigned to colorSpace.")
+            "Attribute lineColorSpace is deprecated. Value has been assigned to colorSpace "
+            "instead."
+        )
         self.colorSpace = value
 
 
@@ -458,6 +413,7 @@ class LegacyColorMixin(LegacyForeColorMixin, LegacyFillColorMixin, LegacyBorderC
     """
     Mixin class to give an object all of the legacy functions for setting all colors (fore, fill and border
     """
+    pass
 
 
 class BaseColorMixin:
@@ -1311,12 +1267,6 @@ class TextureMixin:
             value, id=self._maskID, pixFormat=GL.GL_ALPHA, dataType=dataType,
             stim=self, res=self.texRes, maskParams=self.maskParams,
             wrapping=False)
-
-    def setMask(self, value, log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message.
-        """
-        setAttribute(self, 'mask', value, log)
 
     @attributeSetter
     def texRes(self, value):

--- a/psychopy/visual/bufferimage.py
+++ b/psychopy/visual/bufferimage.py
@@ -160,8 +160,12 @@ class BufferImageStim(ImageStim):
             pos *= win.size / 2.
 
         size = region.size / win.size / 2.
+        # convert image to a numpy array in rgb1
+        img = numpy.array(region, float) / 255
+        img = numpy.flipud(img)
+        # build a regular ImageStim with the captured data
         super(BufferImageStim, self).__init__(
-            win, image=region, units='pix', mask=mask, pos=pos,
+            win, image=img, units='pix', mask=mask, pos=pos,
             size=size, interpolate=interpolate, name=name, autoLog=False)
         self.size = region.size
 

--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -274,7 +274,7 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
             logging.exp("Created {} = {}".format(self.name, self))
 
     @attributeSetter
-    def sf(self, value):
+    def sf(self, value=1):
         """Spatial frequency of the grating texture.
 
         Should be a :ref:`x,y-pair <attrib-xy>` or :ref:`scalar <attrib-scalar>`
@@ -303,7 +303,7 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
         self._needUpdate = True
 
     @attributeSetter
-    def phase(self, value):
+    def phase(self, value=(0.0, 0.0)):
         """Phase of the stimulus in each dimension of the texture.
 
         Should be an :ref:`x,y-pair <attrib-xy>` or :ref:`scalar
@@ -320,7 +320,7 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
         self._needUpdate = True
 
     @attributeSetter
-    def tex(self, value):
+    def tex(self, value="sin"):
         """Texture to used on the stimulus as a grating (aka carrier).
 
         This can be one of various options:
@@ -346,7 +346,7 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
         self._needTextureUpdate = False
 
     @attributeSetter
-    def blendmode(self, value):
+    def blendmode(self, value='avg'):
         """The OpenGL mode in which the stimulus is draw
 
         Can the 'avg' or 'add'. Average (avg) places the new stimulus over the
@@ -357,26 +357,6 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
         """
         self.__dict__['blendmode'] = value
         self._needUpdate = True
-
-    def setSF(self, value, operation='', log=None):
-        """DEPRECATED. Use 'stim.parameter = value' syntax instead
-        """
-        self._set('sf', value, operation, log=log)
-
-    def setPhase(self, value, operation='', log=None):
-        """DEPRECATED. Use 'stim.parameter = value' syntax instead
-        """
-        self._set('phase', value, operation, log=log)
-
-    def setTex(self, value, log=None):
-        """DEPRECATED. Use 'stim.parameter = value' syntax instead
-        """
-        self.tex = value
-
-    def setBlendmode(self, value, log=None):
-        """DEPRECATED. Use 'stim.parameter = value' syntax instead
-        """
-        self._set('blendmode', value, log=log)
 
     def draw(self, win=None):
         """Draw the stimulus in its relevant window.
@@ -499,3 +479,6 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
             self._cycles = self.sf
         else:
             self._cycles = self.sf * self.size
+
+# alias the all caps version of setSf
+GratingStim.setSF = GratingStim.setSf

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -367,12 +367,6 @@ class ImageStim(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin,
 
         self._needTextureUpdate = False
 
-    def setImage(self, value, log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message.
-        """
-        setAttribute(self, 'image', value, log)
-
     @property
     def aspectRatio(self):
         """

--- a/psychopy/visual/slider.py
+++ b/psychopy/visual/slider.py
@@ -750,7 +750,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         self.rating = val
 
     @attributeSetter
-    def ticks(self, value):
+    def ticks(self, value=(1, 2, 3, 4, 5)):
         if isinstance(value, (list, tuple, np.ndarray)):
             # make sure all values are numeric
             for i, subval in enumerate(value):
@@ -768,7 +768,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         self.__dict__['ticks'] = value
 
     @attributeSetter
-    def markerPos(self, rating):
+    def markerPos(self, rating=None):
         """The position on the scale where the marker should be. Note that
         this does not alter the value of the reported rating, only its visible
         display.
@@ -800,24 +800,6 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         """Get the RT for most recent rating (or None if no response yet)
         """
         return self.rt
-
-    def getMarkerPos(self):
-        """Get the current marker position (or None if no response yet)
-        """
-        return self.markerPos
-
-    def setMarkerPos(self, rating):
-        """Set the current marker position (or None if no response yet)
-
-        Parameters
-        ----------
-        rating : int or float
-            The rating on the scale where we want to set the marker
-        """
-        if self._updateMarkerPos:
-            self.marker.pos = self._ratingToPos(rating)
-            self.markerPos = rating
-            self._updateMarkerPos = False
 
     def draw(self):
         """Draw the Slider, with all its constituent elements on this frame
@@ -867,7 +849,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
             self.contrast = 1.0
 
     @attributeSetter
-    def contrast(self, contrast):
+    def contrast(self, contrast=1):
         """Set all elements of the Slider (labels, ticks, line) to a contrast
 
         Parameters
@@ -1109,7 +1091,7 @@ class Slider(MinimalStim, WindowMixin, ColorMixin):
         return style
 
     @attributeSetter
-    def styleTweaks(self, styleTweaks):
+    def styleTweaks(self, styleTweaks=[]):
         """Sets some predefined style tweaks or use these to create your own.
 
         If you fancy creating and including your own style tweaks that would be great!

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -355,7 +355,7 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
         setAttribute(self, 'font', font, log)
 
     @attributeSetter
-    def text(self, text):
+    def text(self, text=None):
         """The text to be rendered. Use \\\\n to make new lines.
 
         Issues: May be slow, and pyglet has a memory leak when setting text.
@@ -387,12 +387,6 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
 
         self._needSetText = False
         return self.__dict__['text']
-
-    def setText(self, text=None, log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message.
-        """
-        setAttribute(self, 'text', text, log)
 
     def _setTextShaders(self, value=None):
         """Set the text to be rendered using the current font
@@ -733,7 +727,7 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
         # update list if necss and then call it
         if win.winType in ["pyglet", "glfw"]:
             if self._needSetText:
-                self.setText()
+                self.setText(None)
 
             # unbind the mask texture regardless
             GL.glActiveTexture(GL.GL_TEXTURE1)

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -522,26 +522,14 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
         """If set to True then the text will be flipped left-to-right.  The
         flip is relative to the original, not relative to the current state.
         """
-        self.__dict__['flipHoriz'] = value
-
-    def setFlipHoriz(self, newVal=True, log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message.
-        """
-        setAttribute(self, 'flipHoriz', newVal, log)
+        self.__dict__['flipHoriz'] = bool(value)
 
     @attributeSetter
     def flipVert(self, value):
         """If set to True then the text will be flipped top-to-bottom.  The
         flip is relative to the original, not relative to the current state.
         """
-        self.__dict__['flipVert'] = value
-
-    def setFlipVert(self, newVal=True, log=None):
-        """Usually you can use 'stim.attribute = value' syntax instead,
-        but use this method if you need to suppress the log message
-        """
-        setAttribute(self, 'flipVert', newVal, log)
+        self.__dict__['flipVert'] = bool(value)
 
     def setFlip(self, direction, log=None):
         """(used by Builder to simplify the dialog)


### PR DESCRIPTION
Intention being to make it easier for plugin developers to use.

- Adding an attributeSetter attribute now automatically creates `setWhatever`/`getWhatever` functions, reducing `setWhatever is not defined` errors coming out of Builder because xyz developer forgot to create that function
- Querying the value of an attributeSetter attribute before it's been set will now return the decorated function's default value rather than the __getattribute__ method handle, making error messages much clearer and reducing the chance of getting `attributeSetter has no attribute xyz` because you forgot to set something in __init__
- While I was in the neighbourhood I expanded the documentation to help see how to use it

Tested the speed and it doesn't seem any slower, which makes sense as there's not really any extra overhead once the attribute is set once - the only things which take any time are setting the get/set methods (which only happens once, on class import) and generating the method sig to get default (which only happens if the value hasn't been set)