### PR TITLE
BF: Fixed JSON encoding error when opening plugin dialog

### DIFF
--- a/psychopy/app/plugin_manager/plugins.py
+++ b/psychopy/app/plugin_manager/plugins.py
@@ -1222,6 +1222,13 @@ def getAllPluginDetails():
             return None
         # otherwise get as a string
         value = resp.text
+
+        if value is None or value == "":
+            return None
+
+        # make sure we are using UTF-8 encoding
+        value = value.encode('utf-8', 'ignore').decode('utf-8')
+
         # attempt to parse JSON
         try:
             database = json.loads(value)


### PR DESCRIPTION
Fixes another JSON decoding error when trying to read text from the `plugins.json` file. This one is different from the one @TEParsons fixed. Solution is to force the downloaded file text into UTF-8.

The work around in current installations is to open the `~/psychopy3/cache/appCache/plugins/plugins.json` file in Notepad or something and save it as UTF-8.
