### PR TITLE
TESTS: get tests working again on macos

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -14,9 +14,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
       matrix:
-        os: [macos-latest]
+        os: [macos-11]
         python-version: ["3.8", "3.10"]
 
     steps:

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest]
-        python-version: [3.8]
+        python-version: [3.8, 3.10]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -36,12 +36,12 @@ jobs:
         pip install attrdict3  # used by wxpython setup
         python ./building/plat_custom_installs.py
 
-        pip install pdm
-        pdm config python.use_venv false  # don't need/want venv in a vm!
-        pdm install  # fetch dependendices in lock file
-        pdm add -G tests
-        pdm install -G tests
-        pdm build
+        # pip install pdm
+        # pdm config python.use_venv false  # don't need/want venv in a vm!
+        # pdm install  # fetch dependendices in lock file
+        # pdm add -G tests
+        # pdm install -G tests
+        # pdm build
         # install with pip both the main and [tests] group
         pip install . --prefer-binary  # install with pip
         pip install '.[tests]' --prefer-binary  # optional dependency group

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest]
-        python-version: [3.8, 3.10]
+        python-version: ["3.8", "3.10"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
failing during install of HDF5 but that's because the github runner has switched to using ARM architecture instead of intel