### PR TITLE
EN: PsychoPy launcher improvements

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -11,6 +11,7 @@
 __all__ = [
     'startApp',
     'quitApp',
+    'restartApp',
     'getAppInstance',
     'getAppFrame',
     'isAppStarted']
@@ -153,6 +154,33 @@ def quitApp():
 
     # remove the session lock
     setSessionLock(False)
+
+
+def restartApp():
+    """Restart the PsychoPy application instance.
+
+    This will write a file named '.restart' to the user preferences directory
+    and quit the application. The presence of this file will indicate to the 
+    launcher parent process that the app should restart.
+
+    The app restarts with the same arguments as the original launch. This is
+    useful for updating the application or plugins without requiring the user
+    to manually restart the app.
+
+    The user will be prompted to save any unsaved work before the app restarts.
+
+    """
+    if not isAppStarted():
+        return
+    
+    # write a restart file to the user preferences directory
+    from psychopy.preferences import prefs
+    restartFilePath = os.path.join(prefs.paths['userPrefsDir'], '.restart')
+    
+    with open(restartFilePath, 'w') as restartFile:
+        restartFile.write('')
+
+    quitApp()
 
 
 def getAppInstance():

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -25,7 +25,7 @@ from .frametracker import openFrames
 _psychopyAppInstance = None
 
 
-def startApp(showSplash=True, testMode=False, safeMode=False):
+def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     """Start the PsychoPy GUI.
 
     This function is idempotent, where additional calls after the app starts
@@ -52,6 +52,10 @@ def startApp(showSplash=True, testMode=False, safeMode=False):
     safeMode : bool
         Start PsychoPy in safe-mode. If `True`, the GUI application will launch
         with without loading plugins.
+    startView : str, None
+        Name of the view to start the app with. Valid values are 'coder',
+        'builder' or 'runner'. If `None`, the app will start with the default
+        view.
 
     """
     global _psychopyAppInstance
@@ -110,6 +114,20 @@ def startApp(showSplash=True, testMode=False, safeMode=False):
         # After this point, errors will appear in a dialog box. Messages will
         # continue to be written to the dialog.
         sys.excepthook = exceptionCallback
+
+        # open the frames if requested
+        if startView is not None:
+            frame = getAppFrame(startView)  # opens if not yet loaded
+
+            # raise frames to the top
+            if frame is not None:
+                if hasattr(frame, 'Raise'):
+                    frame.Raise()
+                else:
+                    logging.warning(
+                        'Frame has no `Raise()` method. Cannot raise it.')
+            else:
+                logging.error('Frame cannot be opened.')
 
         # Allow the UI to refresh itself. Don't do this during testing where the
         # UI is exercised programmatically.
@@ -266,6 +284,8 @@ def getAppFrame(frameName):
             _psychopyAppInstance.showRunner()
         else:
             raise AttributeError('Cannot load frame. Method not available.')
+        
+        frameRef = getattr(_psychopyAppInstance, frameName, None)
 
     return frameRef
 

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -58,6 +58,9 @@ def startApp(showSplash=True, testMode=False, safeMode=False):
 
     if isAppStarted():  # do nothing it the app is already loaded
         return  # NOP
+    
+    # set the session lock
+    setSessionLock(True)
 
     # Make sure logging is started before loading the bulk of the main
     # application UI to catch as many errors as possible. After the app is
@@ -130,6 +133,9 @@ def quitApp():
     else:
         raise AttributeError('Object `_psychopyApp` has no attribute `quit`.')
 
+    # remove the session lock
+    setSessionLock(False)
+
 
 def getAppInstance():
     """Get a reference to the `PsychoPyApp` object.
@@ -177,6 +183,50 @@ def isAppStarted():
 
     """
     return _psychopyAppInstance is not None
+
+
+def getSessionLock():
+    """Check if the session is locked.
+
+    Returns
+    -------
+    bool
+        `True` if the session is locked, `False` otherwise.
+
+    """
+    from psychopy.preferences import prefs
+    lockFilePath = os.path.join(prefs.paths['userPrefsDir'], 'session.lock')
+    return os.path.exists(lockFilePath)
+
+
+def setSessionLock(state):
+    """Set the session lock state.
+
+    This writes a session lock file to the user preferences directory. The
+    presence of this file will indicate that an active PsychoPy session is
+    running. This is used to prevent multiple instances of PsychoPy from running
+    simultaneously, but also to detect if the app was closed unexpectedly.
+
+    Setting the state will either create or remove the lock file. If the file
+    is deleted during a session, the app will restart automatically when the 
+    user quits PsychoPy.
+
+    Parameters
+    ----------
+    state : bool
+        `True` to lock the session, `False` to unlock.
+
+    """
+    from psychopy.preferences import prefs
+    lockFilePath = os.path.join(prefs.paths['userPrefsDir'], 'session.lock')
+
+    if state:
+        if not os.path.exists(lockFilePath):
+            with open(lockFilePath, 'w') as lockFile:
+                lockFile.write('')  # empty file
+    else:
+        if os.path.exists(lockFilePath):
+            os.remove(lockFilePath)
 
 
 def getAppFrame(frameName):

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -56,13 +56,20 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     startView : str, None
         Name of the view to start the app with. Valid values are 'coder',
         'builder' or 'runner'. If `None`, the app will start with the default
-        view.
+        view or the view specifed with the `PSYCHOPYSTARTVIEW` environment
+        variable.
 
     """
     global _psychopyAppInstance
 
     if isAppStarted():  # do nothing it the app is already loaded
         return  # NOP
+
+    # process environment variables
+    if os.environ.get('PSYCHOPYSTARTVIEW', None) is not None:
+        startView = str(os.environ['PSYCHOPYSTARTVIEW']).lower()
+        if startView not in ('coder', 'builder', 'runner'):
+            startView = None  # silently drop invalid values and use default 
     
     # set the session lock
     setSessionLock(True)

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -1033,6 +1033,11 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__
 
+        # remove the session lock file
+        lockFilePath = os.path.join(prefs.paths['userPrefsDir'], 'session.lock')
+        if os.path.exists(lockFilePath):
+            os.remove(lockFilePath)
+
         if not self.testMode:
             sys.exit()
 

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -243,6 +243,9 @@ class Job:
         # self._process = wx.Process(None, -1)
         # self._process.Redirect()  # redirect streams from subprocess
 
+        if env is None:
+            env = os.environ  # use the same environment as the parent process
+
         # start the sub-process
         command = self._command
 

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -398,20 +398,37 @@ Options:
         startArgs)
     startCmd = [execPath, '-c', startCmdStr]
 
-    # run command in a subprocess and block until it finishes
-    psychopyProc = subprocess.Popen(startCmd, env=env)
-    print("PsychoPy: Application started (PID: {})".format(psychopyProc.pid))
-    output, err = psychopyProc.communicate()  
-    exitCode = psychopyProc.wait()
+    # if the restart file is found, the app will restart
+    while 1:
+        try:
+            # run command in a subprocess and block until it finishes
+            psychopyProc = subprocess.Popen(startCmd, env=env)
+            print("PsychoPy: Application started (PID: {})".format(
+                psychopyProc.pid))
+            output, err = psychopyProc.communicate()  
+            exitCode = psychopyProc.wait()
 
-    # print output from the subprocess (if any)
-    if output is not None:
-        print(output, file=sys.stdout)
-    if err is not None:
-        print(err, file=sys.stderr)
+            # print output from the subprocess (if any)
+            if output is not None:
+                print(output, file=sys.stdout)
+            if err is not None:
+                print(err, file=sys.stderr)
 
-    print("PsychoPy: Application terminated (exit code {})" .format(exitCode))
+            print("PsychoPy: Application terminated (exit code {})" .format(
+                exitCode))
+            
+        except KeyboardInterrupt:
+            print("PsychoPy: Application interrupted.")
+            break
 
+        # check for the restart file
+        restartFile = os.path.join(getUserPrefsDir(), '.restart')
+        if os.path.exists(restartFile):
+            print("PsychoPy: Restarting the application.")
+            os.remove(restartFile)
+        else:
+            break
+    
     sys.exit(exitCode)  # forwarded exit code from the subprocess
 
 

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -377,10 +377,6 @@ Options:
         if PYTHONW != 'True':
             env['PYTHONW'] = 'True'
 
-    # run the pre-startup tasks if not ignored
-    if '--skip-pkg-tasks' not in sys.argv:
-        runStartupPackageTasks(env)
-
     # construct executable path depending on the platform
     execPath = sys.executable
     if PYTHONW is not None:
@@ -400,6 +396,10 @@ Options:
 
     # if the restart file is found, the app will restart
     while 1:
+        # run the pre-startup tasks if not ignored
+        if '--skip-pkg-tasks' not in sys.argv:
+            runStartupPackageTasks(env)
+
         try:
             # run command in a subprocess and block until it finishes
             psychopyProc = subprocess.Popen(startCmd, env=env)

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -6,17 +6,18 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 import sys
+import subprocess
 
 # fix macOS locale-bug on startup: sets locale to LC_ALL (must be defined!)
-import psychopy.locale_setup  # noqa
-
+# import psychopy.locale_setup  # noqa
 
 # NB the PsychoPyApp classes moved to _psychopyApp.py as of version 1.78.00
 # to allow for better upgrading possibilities from the mac app bundle. this
 # file now used solely as a launcher for the app, not as the app itself.
 
-
 def start_app():
+    """Start the GUI application.
+    """
     from psychopy.app import startApp, quitApp
     from psychopy.preferences import prefs
 
@@ -28,17 +29,135 @@ def start_app():
     quitApp()
 
 
+def getUserPrefsDir():
+    """Get the user preferences directory.
+
+    Returns
+    -------
+    str
+        The user preferences directory path.
+
+    """
+    # TODO - try and make this work without any psychopy imports
+    from psychopy.preferences import prefs
+    return prefs.paths['userPrefsDir']
+
+
+def runStartupPackageTasks(env=None):
+    """Run startup package tasks.
+
+    This checks for a file called 'pip_tasks.list' in the user preferences
+    directory. If the file exists, it will install the modules listed in it.
+
+    The format of the file is a list of pip commands, one per line. Each line
+    should start with a valid pip command, followed by any flags or options.
+
+    Parameters
+    ----------
+    env : dict, optional
+        The environment variables to use when running the tasks. Should be the 
+        same as the enviornment variables used to start the app. These are set
+        to the current environment if not provided. The default is None.
+
+    """
+    import os
+
+    # get the current environment if not provided
+    if env is None:
+        env = os.environ
+
+    # preload install tasks are writen to a file in the user prefs directory
+    installFile = os.path.join(getUserPrefsDir(), 'pip_tasks.list')
+
+    # if the file exists, install each module listed in it
+    if os.path.exists(installFile):
+        print("PsychoPy: Found 'pip_tasks.list' file.")
+        pipTaskList = []
+        with open(installFile) as f:
+            for line in f:
+                cmdVals = line.strip().split()  # clean up the line
+                
+                # check if the line starts with a valid command
+                if cmdVals[0] not in ['install', 'uninstall']:
+                    print("Invalid command in 'pip_tasks.list' file: {}".format(
+                        cmdVals[0]))
+                    continue
+
+                pipTaskList.append(cmdVals)
+
+        # for valid commands, install the modules
+        if pipTaskList:
+            print('PsychoPy: Running pre-startup package tasks...')
+            # construct executable path depending on the platform
+            execPath = sys.executable
+
+            for cmd in pipTaskList:
+                failed = False
+                # run the pip commands
+                extraCmd = []  # extra commands for pip
+                if cmd[0] == 'install':
+                    if '--user' not in cmd:
+                        extraCmd.append('--user')
+                elif cmd[0] == 'uninstall':
+                    if '--yes' not in cmd:
+                        extraCmd = ['--yes']
+                
+                # run the pip command
+                pipCmd = [execPath, '-m', 'pip'] + cmd + extraCmd
+
+                # run command in a subprocess and block until it finishes
+                pipProc = subprocess.Popen(pipCmd, env=env)
+                output, err = pipProc.communicate()  
+                exitCode = pipProc.wait()  # block until done
+
+                if output is not None:
+                    print(output, file=sys.stdout)
+                
+                if err is not None:
+                    print(err, file=sys.stderr)
+                
+        # delete the file after installing all modules
+        os.remove(installFile)
+
+        msg = ("PsychoPy: Completed pre-startup package tasks, see above for "
+               "warnings and errors.")
+        print(msg)
+
+    # else:
+    #     print("PsychoPy: No pre-startup package tasks to run.")
+
+
 def main():
+    """Main entry point for the PsychoPy application.
+
+    This function is the main entry point for the PsychoPy application. It
+    handles the command line arguments and starts the application in a
+    subprocess.
+
+    It also handles any pre-startup tasks that need to be run before the app
+    starts, but within the same environment.
+
+    """
+    # Setup the environment variables for running the app
+    import os
+    env = os.environ
+
+    if '--no-pkg-dir' not in sys.argv:
+        userBaseDir = os.path.join(getUserPrefsDir(), 'packages')
+        env['PYTHONUSERBASE'] = userBaseDir
+        env['PYTHONNOUSERSITE'] = '1'  # isolate user packages for plugins
+
     if '-x' in sys.argv:
         # run a .py script from the command line using StandAlone python
         targetScript = sys.argv[sys.argv.index('-x') + 1]
         from psychopy import core
-        import os
-        core.shellCall([sys.executable, os.path.abspath(targetScript)])
+        core.shellCall(
+            [sys.executable, os.path.abspath(targetScript)], 
+            env=env)
         sys.exit()
     if '-v' in sys.argv or '--version' in sys.argv:
         from psychopy import __version__
-        msg = ('PsychoPy3, version %s (c)Jonathan Peirce 2018, GNU GPL license'
+        msg = ('PsychoPy3, version %s (c) Jonathan Peirce 2018, GNU GPL license'
                % __version__)
         print(msg)
         sys.exit()
@@ -56,46 +175,58 @@ depends on the type of the [file]:
  Experiment design 'file.psyexp' -- opens builder
 
 Options:
-    -c, --coder, coder       opens coder view only
+    -c, --coder, coder       pens coder view only
     -b, --builder, builder   opens builder view only
     -x script.py             execute script.py using StandAlone python
 
-    -v, --version    prints version and exits
-    -h, --help       prints this help and exit
+    -v, --version            prints version and exits
+    -h, --help               prints this help and exit
 
-    --firstrun       launches configuration wizard
-    --no-splash      suppresses splash screen
+    --firstrun               launches configuration wizard
+    --no-splash              suppresses splash screen
+    --skip-pkg-tasks         skip pip tasks on startup this session
+    --no-pkg-dir             use default user site-packages directory
 
 """)
         sys.exit()
 
+    # special envionment variables for the app
+    PYTHONW = None
     if (('| packaged by conda-forge |' in sys.version or '|Anaconda' in sys.version)
-        and sys.platform == 'darwin' and sys.version_info >= (3,9)):
-
-        # On macOS with Anaconda, GUI applications need to be run using
-        # `pythonw`. Since we have no way to determine whether this is currently
-        # the case, we run this script again -- ensuring we're definitely using
-        # pythonw.
-        import os
-        env = os.environ
+            and sys.platform == 'darwin' and sys.version_info >= (3,9)):
         PYTHONW = env.get('PYTHONW', 'False')
-
         if PYTHONW != 'True':
-            from psychopy import core
-            cmd = [sys.executable + 'w', __file__]
-            if '--no-splash' in sys.argv:
-                cmd.append('--no-splash')
+            env['PYTHONW'] = 'True'
 
-            stdout, stderr = core.shellCall(cmd,
-                                            env=dict(env, PYTHONW='True'),
-                                            stderr=True)
-            print(stdout, file=sys.stdout)
-            print(stderr, file=sys.stderr)
-            sys.exit()
-        else:
-            start_app()
-    else:
-        start_app()
+    # run the pre-startup tasks if not ignored
+    if '--skip-pkg-tasks' not in sys.argv:
+        runStartupPackageTasks(env)
+
+    # construct executable path depending on the platform
+    execPath = sys.executable
+    if PYTHONW is not None:
+        execPath = execPath + 'w'  # macOS
+
+    # construct the command to run the app in a subprocess
+    cmd = [execPath, '-c', 'from psychopy.app import startApp;startApp()']
+
+    # run command in a subprocess and block until it finishes
+    psychopyProc = subprocess.Popen(cmd, env=env)
+
+    print("PsychoPy: Application started (PID: {})".format(psychopyProc.pid))
+
+    output, err = psychopyProc.communicate()  
+    exitCode = psychopyProc.wait()
+
+    # print output from the subprocess (if any)
+    if output is not None:
+        print(output, file=sys.stdout)
+    if err is not None:
+        print(err, file=sys.stderr)
+
+    print("PsychoPy: Application terminated (exit code {})" .format(exitCode))
+
+    sys.exit(exitCode)  # forwarded exit code from the subprocess
 
 
 if __name__ == '__main__':

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -265,6 +265,8 @@ def main():
             pipCmd = [x.strip() for x in inputCmd]
             if '--user' not in pipCmd:    # add --user flag if not present
                 pipCmd.append('--user')
+            if '--prefer-binary' not in pipCmd:  # usually do
+                pipCmd.append('--prefer-binary')
         except (ValueError, IndexError):
             print("Error: Missing package name.")
             sys.exit()

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -211,7 +211,6 @@ def main():
 
         # Package paths for custom user site-packages, these should be compiant
         # with platform specify conventions.
-        prefixTail = os.path.basename(sys.prefix)
         if sys.platform == 'win32':  # windows 
             pyDirName = "Python" + sys.winver.replace(".", "")
             userPackagePath = os.path.join(


### PR DESCRIPTION
This PR makes several enhancements to the PsychoPy launcher: 

* The main PsychoPy app is now started in a sub-process with the correct environment for plugins to work without hacks to `pkg_resources` and `site` modules at runtime. Should be more compatible with py2app on Mac
* Packages can be installed/upgraded/removed prior to starting the main application so they aren't installed into a running environment. Likely possible to do in-place upgrades of PsychoPy in the future.
* PsychoPy is capable of self-restart after crashes or if initiated by the user: no more unrecoverable splash screen crashes
* Session lock file for determining if the app crashed in a previous session to allow for recovery tasks on the next startup

WIP or Planned features:
* Safe mode for recovering from startup crashes which disables plugins
* Hardware enumeration on startup in subprocess to avoid loading PTB and others with the GUI. Save hardware mapping to JSON in user preferences directory for populating dialog fields
* Command line options for clearing plugin cache, etc.