### PR TITLE
Speed-up of MovieStim (noticeable for larger videos)

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -20,7 +20,7 @@ from psychopy.tools.filetools import pathToString, defaultStim
 from psychopy.visual.basevisual import (
     BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin
 )
-from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED
+from psychopy.constants import FINISHED, NOT_STARTED, PAUSED, PLAYING, STOPPED, INVALID
 
 from .players import getMoviePlayer
 from .metadata import MovieMetadata, NULL_MOVIE_METADATA
@@ -320,6 +320,17 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
     # --------------------------------------------------------------------------
     # Video playback controls and status
     #
+
+    @property
+    def status(self):
+        if self._player is not None:
+            return self._player.status
+        
+        return INVALID
+    
+    @status.setter
+    def status(self, value):
+        pass
 
     @property
     def isPlaying(self):
@@ -752,12 +763,10 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
             GL.GL_PIXEL_UNPACK_BUFFER,
             GL.GL_WRITE_ONLY)
 
-        bufferArray = np.ctypeslib.as_array(
-            ctypes.cast(bufferPtr, ctypes.POINTER(GL.GLubyte)),
-            shape=(nBufferBytes,))
-
         # copy data
-        bufferArray[:] = self._recentFrame.colorData[:]
+        ctypes.memmove(bufferPtr,
+            self._recentFrame.colorData.ctypes.data,
+            nBufferBytes)
 
         # Very important that we unmap the buffer data after copying, but
         # keep the buffer bound for setting the texture.

--- a/psychopy/visual/movies/frame.py
+++ b/psychopy/visual/movies/frame.py
@@ -62,7 +62,8 @@ class MovieFrame:
         "_audioSamples",
         "_audioChannels",
         "_movieLib",
-        "_userData"
+        "_userData",
+        "_keepAlive"
     ]
 
     def __init__(self,
@@ -76,7 +77,8 @@ class MovieFrame:
                  audioSamples=None,
                  metadata=None,
                  movieLib=u"",
-                 userData=None):
+                 userData=None,
+                 keepAlive=None):
 
         self.frameIndex = frameIndex
         self.absTime = absTime
@@ -89,6 +91,7 @@ class MovieFrame:
         self._metadata = metadata
         self.movieLib = movieLib
         self.userData = userData
+        self._keepAlive = keepAlive
 
     def __repr__(self):
         return (f"MovieFrame(frameIndex={self.frameIndex}, "

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -1303,7 +1303,7 @@ class FFPyPlayer(BaseMoviePlayer):
     # --------------------------------------------------------------------------
     # Methods for getting video frames from the encoder
     #
-
+    
     def _enqueueFrame(self):
         """Grab the latest frame from the stream.
 
@@ -1336,7 +1336,7 @@ class FFPyPlayer(BaseMoviePlayer):
         self._streamTime = streamStatus.streamTime  # stream time for the camera
 
         # if we have a new frame, update the frame information
-        videoBuffer = frameImage.to_bytearray()[0]
+        videoBuffer = frameImage.to_memoryview()[0].memview
         videoFrameArray = np.frombuffer(videoBuffer, dtype=np.uint8)
 
         # provide the last frame
@@ -1350,7 +1350,8 @@ class FFPyPlayer(BaseMoviePlayer):
             audioSamples=None,
             metadata=self.metadata,
             movieLib=u'ffpyplayer',
-            userData=None)
+            userData=None,
+            keepAlive=frameImage)
 
         return True
 


### PR DESCRIPTION
These were some lower-hanging fruit I noticed when others were trying to play 4k videos via MovieStim.

1. MovieStim's `.play` was being called every `.draw()`, since the MovieStim's state never changed (but the `_player` did)
2. Copying the frame's bytearray was expensive, so use the memoryview and keep the frame alive until the frame is copied to the PBO

(1) saves about 8ms per call on my Windows laptop, and (2) saves about 10ms per call.

The switch to `memmove(...)` was more of a clarity thing, happy to keep/drop...

I also noticed the glTexSubImage2D blocking on my AMD linux laptop, but that might be something more driver-related.


