### PR TITLE
Installed plugins were not being found on Linux/MacOS

### DIFF
--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -71,15 +71,15 @@ template = """#!/usr/bin/env python
 import os
 import sys
 
-__version__ = '2024.1.4'
-__license__ = 'GPL v3'
-__author__ = 'Open Science Tools Ltd'
-__author_email__ = 'support@opensciencetools.org'
-__maintainer_email__ = 'support@opensciencetools.org'
-__url__ = 'https://www.psychopy.org/'
-__download_url__ = 'https://github.com/psychopy/psychopy/releases/'
-__git_sha__ = 'n/a'
-__build_platform__ = 'n/a'
+__version__ = '{version}'
+__license__ = '{license}'
+__author__ = '{author}'
+__author_email__ = '{author_email}'
+__maintainer_email__ = '{maintainer_email}'
+__url__ = '{url}'
+__download_url__ = '{download_url}'
+__git_sha__ = '{shaStr}'
+__build_platform__ = '{platform}'
 
 __all__ = ["gui", "misc", "visual", "core",
            "event", "data", "sound", "microphone"]

--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -71,15 +71,15 @@ template = """#!/usr/bin/env python
 import os
 import sys
 
-__version__ = '{version}'
-__license__ = '{license}'
-__author__ = '{author}'
-__author_email__ = '{author_email}'
-__maintainer_email__ = '{maintainer_email}'
-__url__ = '{url}'
-__download_url__ = '{download_url}'
-__git_sha__ = '{shaStr}'
-__build_platform__ = '{platform}'
+__version__ = '2024.1.4'
+__license__ = 'GPL v3'
+__author__ = 'Open Science Tools Ltd'
+__author_email__ = 'support@opensciencetools.org'
+__maintainer_email__ = 'support@opensciencetools.org'
+__url__ = 'https://www.psychopy.org/'
+__download_url__ = 'https://github.com/psychopy/psychopy/releases/'
+__git_sha__ = 'n/a'
+__build_platform__ = 'n/a'
 
 __all__ = ["gui", "misc", "visual", "core",
            "event", "data", "sound", "microphone"]
@@ -111,13 +111,50 @@ if 'installing' not in locals():
         sys.path.append(str(_userPackagePath))  # user site-packages
         sys.path.append(str(_userScripts))  # user scripts
 
-    # add paths from individual plugins/packages (installed by plugins manager)
+    # Add paths from individual plugins/packages (installed by plugins manager),
+    # this is to support legacy plugins that don't use the customized user 
+    # site-packages location. This will be removed in the future.
     import pathlib as _pathlib
     for _pathName in _pathlib.Path(prefs.paths['packages']).glob("*"):
         if _pathName.is_dir():
             sys.path.append(str(_pathName))
 
+    # Configure the environment to use our custom site-packages location for
+    # user-installed packages. In the future, this will be configured outside of
+    # the running environment, but for now, we need to do it here.
+    useDefaultSite = False
+    if 'PSYCHOPYNOPACKAGES' in os.environ:
+        # Custom environment variable for people using PsychoPy as a library,
+        # who don't want to use the custom site-packages location. If set to 1,
+        # this will disable the custom site-packages location. Packages will be
+        # installed in the default, system dependent user's site-packages 
+        # location.
+        useDefaultSite = os.environ['PSYCHOPYNOPACKAGES'] == '1'
+
+    if not useDefaultSite:
+        env = os.environ.copy()
+        if 'PYTHONPATH' in env:  # append to existing PYTHONPATH
+            if prefs.paths['packages'] not in env['PYTHONPATH']:
+                env['PYTHONPATH'] = os.pathsep.join(
+                    [env['PYTHONPATH']] + [prefs.paths['packages']])
+        else:
+            env['PYTHONPATH'] = prefs.paths['packages']  # set PYTHONPATH
+
+        # set user site packages
+        env['PYTHONUSERBASE'] = prefs.paths['packages']
+        env['PYTHONNOUSERSITE'] = '1'  # isolate user packages
+
+        # update environment, pass this to sub-processes (e.g. pip)
+        os.environ.update(env)
+
+        # make sure site knows about our custom user site-packages
+        import site
+        site.USER_SITE = prefs.paths['packages']  # custom user site-packages
+        site.ENABLE_USER_SITE = True
+        site.main()
+
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
+
 
 if sys.version_info.major < 3:
     raise ImportError("psychopy does not support Python2 installations. "
@@ -130,6 +167,7 @@ try:
     import readline
 except ImportError:
     pass  # all that will happen is the stderr/stdout might get redirected
+
 
 """
 

--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -140,7 +140,7 @@ if 'installing' not in locals():
         os.environ.update(env)
 
         # make sure site knows about our custom user site-packages
-        site.USER_SITE = prefs.paths['packages']  # custom user site-packages
+        site.USER_SITE = prefs.paths['userPackages']
         site.ENABLE_USER_SITE = True
         site.main()
 

--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -101,23 +101,7 @@ if __git_sha__ == 'n/a':
 # update preferences and the user paths
 if 'installing' not in locals():
     from psychopy.preferences import prefs
-    for _pathName in prefs.general['paths']:
-        sys.path.append(_pathName)
-    
-    # add paths from main plugins/packages (installed by plugins manager)
-    _userPackagePath = prefs.paths['userPackages']
-    _userScripts = prefs.paths['userScripts']
-    if _userPackagePath.is_dir():
-        sys.path.append(str(_userPackagePath))  # user site-packages
-        sys.path.append(str(_userScripts))  # user scripts
-
-    # Add paths from individual plugins/packages (installed by plugins manager),
-    # this is to support legacy plugins that don't use the customized user 
-    # site-packages location. This will be removed in the future.
-    import pathlib as _pathlib
-    for _pathName in _pathlib.Path(prefs.paths['packages']).glob("*"):
-        if _pathName.is_dir():
-            sys.path.append(str(_pathName))
+    import site
 
     # Configure the environment to use our custom site-packages location for
     # user-installed packages. In the future, this will be configured outside of
@@ -131,14 +115,22 @@ if 'installing' not in locals():
         # location.
         useDefaultSite = os.environ['PSYCHOPYNOPACKAGES'] == '1'
 
+    # configure environment for custom site-packages location
     if not useDefaultSite:
         env = os.environ.copy()
-        if 'PYTHONPATH' in env:  # append to existing PYTHONPATH
-            if prefs.paths['packages'] not in env['PYTHONPATH']:
-                env['PYTHONPATH'] = os.pathsep.join(
-                    [env['PYTHONPATH']] + [prefs.paths['packages']])
+        if 'PYTHONPATH' in env:  # append entries to existing PYTHONPATH
+            _userSitePackages = str(prefs.paths['userPackages'])
+            if _userSitePackages not in env['PYTHONPATH']:
+                env['PYTHONPATH'] = os.pathsep.join([
+                    env['PYTHONPATH'], _userSitePackages])
+            _userPackages = str(prefs.paths['packages'])
+            if _userPackages not in env['PYTHONPATH']:
+                env['PYTHONPATH'] = os.pathsep.join([
+                    env['PYTHONPATH'], _userPackages]) 
         else:
-            env['PYTHONPATH'] = prefs.paths['packages']  # set PYTHONPATH
+            env['PYTHONPATH'] = os.pathsep.join([
+                str(prefs.paths['userPackages']), 
+                str(prefs.paths['packages'])])
 
         # set user site packages
         env['PYTHONUSERBASE'] = prefs.paths['packages']
@@ -148,10 +140,37 @@ if 'installing' not in locals():
         os.environ.update(env)
 
         # make sure site knows about our custom user site-packages
-        import site
         site.USER_SITE = prefs.paths['packages']  # custom user site-packages
         site.ENABLE_USER_SITE = True
         site.main()
+
+        # add paths from main plugins/packages (installed by plugins manager)
+        site.addsitedir(prefs.paths['userPackages'])  # user site-packages
+        site.addsitedir(prefs.paths['userInclude'])  # user include
+        site.addsitedir(prefs.paths['packages'])  # base package dir
+
+        _envPath = os.environ.get('PATH', None)
+        if _envPath is not None:
+            # add user include path to system PATH (for C extensions)
+            if str(prefs.paths['userInclude']) not in _envPath:
+                os.environ['PATH'] = os.pathsep.join([
+                    os.environ['PATH'], str(prefs.paths['userInclude'])])
+            # add scripts path for user packages to system PATH
+            if str(prefs.paths['userScripts']) not in _envPath:
+                os.environ['PATH'] = os.pathsep.join([
+                    os.environ['PATH'], str(prefs.paths['userScripts'])])
+    
+    # add paths from general preferences
+    for _pathName in prefs.general['paths']:
+        sys.path.append(_pathName)
+    
+    # Add paths from individual plugins/packages (installed by plugins manager),
+    # this is to support legacy plugins that don't use the customized user 
+    # site-packages location. This will be removed in the future.
+    import pathlib as _pathlib
+    for _pathName in _pathlib.Path(prefs.paths['packages']).glob("*"):
+        if _pathName.is_dir():
+            sys.path.append(str(_pathName))
 
     from psychopy.tools.versionchooser import useVersion, ensureMinimal
 

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -60,8 +60,6 @@ if 'installing' not in locals():
         if _pathName.is_dir():
             sys.path.append(str(_pathName))
 
-    from psychopy.tools.versionchooser import useVersion, ensureMinimal
-
     # Configure the environment to use our custom site-packages location for
     # user-installed packages. In the future, this will be configured outside of
     # the running environment, but for now, we need to do it here.
@@ -95,6 +93,8 @@ if 'installing' not in locals():
         site.USER_SITE = prefs.paths['packages']  # custom user site-packages
         site.ENABLE_USER_SITE = True
         site.main()
+
+    from psychopy.tools.versionchooser import useVersion, ensureMinimal
 
 
 if sys.version_info.major < 3:

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -81,7 +81,7 @@ if 'installing' not in locals():
         os.environ.update(env)
 
         # make sure site knows about our custom user site-packages
-        site.USER_SITE = prefs.paths['packages']  # custom user site-packages
+        site.USER_SITE = prefs.paths['userPackages']
         site.ENABLE_USER_SITE = True
         site.main()
 

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -77,8 +77,9 @@ if 'installing' not in locals():
     if not useDefaultSite:
         env = os.environ.copy()
         if 'PYTHONPATH' in env:  # append to existing PYTHONPATH
-            env['PYTHONPATH'] = os.pathsep.join(
-                [env['PYTHONPATH']] + [prefs.paths['packages']])
+            if prefs.paths['packages'] not in env['PYTHONPATH']:
+                env['PYTHONPATH'] = os.pathsep.join(
+                    [env['PYTHONPATH']] + [prefs.paths['packages']])
         else:
             env['PYTHONPATH'] = prefs.paths['packages']  # set PYTHONPATH
 

--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -37,6 +37,7 @@ import os.path
 
 import wx
 import os
+import sys
 from subprocess import Popen, PIPE
 from threading import Thread, Event
 from queue import Queue, Empty
@@ -246,6 +247,22 @@ class Job:
         # start the sub-process
         command = self._command
 
+        # # subprocess inherits the environment of the parent process
+        if env is None:  
+            scriptEnv = os.environ.copy()
+        else:
+            scriptEnv = env
+
+        # remove some environment variables that can cause issues
+        if 'PYTHONSTARTUP' in scriptEnv:
+            del scriptEnv['PYTHONSTARTUP']
+
+        # Set encoding for text mode pipes, needs to be explicitly set or we 
+        # crash on windows
+        scriptEnv['PYTHONIOENCODING'] = 'utf-8'
+        if sys.platform == 'win32':
+            scriptEnv['PYTHONLEGACYWINDOWSSTDIO'] = 'utf-8'
+
         try:
             self._process = Popen(
                 args=command,
@@ -257,10 +274,11 @@ class Job:
                 preexec_fn=None,
                 shell=False,
                 cwd=cwd,
-                env=env,
-                universal_newlines=True,  # gives us back a string instead of bytes
+                env=scriptEnv,
+                # universal_newlines=True,  # gives us back a string instead of bytes
                 creationflags=0,
-                text=True
+                text=False,
+                encoding='utf-8'
             )
         except FileNotFoundError:
             return -1  # negative PID means failure

--- a/psychopy/app/plugin_manager/packages.py
+++ b/psychopy/app/plugin_manager/packages.py
@@ -1,6 +1,7 @@
 import webbrowser
 
 import wx
+import os
 import sys
 import subprocess as sp
 from pypi_search import search as pypi
@@ -101,11 +102,15 @@ class PIPTerminalPanel(wx.Panel):
 
     def runCommand(self, cmd):
         """Run the command."""
+
+        env = os.environ.copy()
+
         emts = [self.preface, cmd]
         output = sp.Popen(' '.join(emts),
                           stdout=sp.PIPE,
                           stderr=sp.PIPE,
                           shell=True,
+                          env=env,
                           universal_newlines=True)
         stdout, stderr = output.communicate()
         sys.stdout.write(stdout)

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -168,8 +168,8 @@ class Preferences:
         # root site-packages directory for user-installed packages and add it
         userBasePath = Path(self.paths['userPrefsDir']) / 'packages'
 
-        # Package paths for custom user site-packages, these should be compiant
-        # with platform specify conventions.
+        # Package paths for custom user site-packages, these should be compliant
+        # with platform specific conventions.
         prefixTail = os.path.basename(sys.prefix)
         if sys.platform == 'win32':
             pyDirName = "Python" + sys.winver.replace(".", "")

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -166,41 +166,41 @@ class Preferences:
                     raise
 
         # root site-packages directory for user-installed packages and add it
-        userBasePath = Path(self.paths['userPrefsDir']) / 'packages'
+        userPkgRoot = Path(self.paths['packages'])
 
         # Package paths for custom user site-packages, these should be compliant
         # with platform specific conventions.
-        prefixTail = os.path.basename(sys.prefix)
         if sys.platform == 'win32':
             pyDirName = "Python" + sys.winver.replace(".", "")
-            userPackagePath = userBasePath / pyDirName / "site-packages"
-            userIncludePath = userBasePath / pyDirName / "Include"
-            userScriptsPath = userBasePath / pyDirName / "Scripts"
+            userPackages = userPkgRoot / pyDirName / "site-packages"
+            userInclude = userPkgRoot / pyDirName / "Include"
+            userScripts = userPkgRoot / pyDirName / "Scripts"
         elif sys.platform == 'darwin' and sys._framework:  # macos + framework
             pyVersion = sys.version_info
             pyDirName = "python{}.{}".format(pyVersion[0], pyVersion[1])
-            userPackagePath = userBasePath / "lib" / "python" / "site-packages"
-            userIncludePath = userBasePath / "include" / pyDirName
-            userScriptsPath = userBasePath / "bin"
+            userPackages = userPkgRoot / "lib" / "python" / "site-packages"
+            userInclude = userPkgRoot / "include" / pyDirName
+            userScripts = userPkgRoot / "bin"
         else:  # posix (including linux and macos without framework)
             pyVersion = sys.version_info
             pyDirName = "python{}.{}".format(pyVersion[0], pyVersion[1])
-            userPackagePath = userBasePath / "lib" / pyDirName / "site-packages"
-            userIncludePath = userBasePath / "include" / pyDirName
-            userScriptsPath = userBasePath / "bin"
+            userPackages = userPkgRoot / "lib" / pyDirName / "site-packages"
+            userInclude = userPkgRoot / "include" / pyDirName
+            userScripts = userPkgRoot / "bin"
 
         # populate directory structure for user-installed packages
-        if not userPackagePath.is_dir():
-            userPackagePath.mkdir(parents=True)
-        if not userIncludePath.is_dir():
-            userIncludePath.mkdir(parents=True)
-        if not userScriptsPath.is_dir():
-            userScriptsPath.mkdir(parents=True)
+        if not userPackages.is_dir():
+            userPackages.mkdir(parents=True)
+        if not userInclude.is_dir():
+            userInclude.mkdir(parents=True)
+        if not userScripts.is_dir():
+            userScripts.mkdir(parents=True)
 
         # add paths from plugins/packages (installed by plugins manager)
-        self.paths['userPackages'] = userBasePath
-        self.paths['userScripts'] = userScriptsPath
-        
+        self.paths['userPackages'] = userPackages
+        self.paths['userInclude'] = userInclude
+        self.paths['userScripts'] = userScripts
+
         # Get dir for base and user themes
         baseThemeDir = Path(self.paths['appDir']) / "themes" / "spec"
         userThemeDir = Path(self.paths['themes'])

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -47,8 +47,8 @@ if not site.USER_SITE in sys.path:
     site.addsitedir(site.getusersitepackages()) 
 
 # add packages dir to import path
-if prefs.paths['packages'] not in pkg_resources.working_set.entries:
-    pkg_resources.working_set.add_entry(prefs.paths['packages'])
+# if prefs.paths['packages'] not in pkg_resources.working_set.entries:
+#     pkg_resources.working_set.add_entry(prefs.paths['packages'])
 
 # cache list of packages to speed up checks
 _installedPackageCache = []
@@ -198,13 +198,17 @@ def installPackage(package, target=None, upgrade=False, forceReinstall=False,
     cmd.append('--no-color')  # no color for console, not supported
     cmd.append('--no-warn-conflicts')  # silence non-fatal errors
 
+    # get the environment for the subprocess
+    env = os.environ.copy()
+
     # run command in subprocess
     output = sp.Popen(
         cmd,
         stdout=sp.PIPE,
         stderr=sp.PIPE,
         shell=False,
-        universal_newlines=True)
+        universal_newlines=True,
+        env=env)
     stdout, stderr = output.communicate()  # blocks until process exits
 
     sys.stdout.write(stdout)
@@ -437,7 +441,6 @@ def uninstallPackage(package):
 
         # setup the environment to use the user's site-packages
         env = os.environ.copy()
-        env["PYTHONUSERBASE"] = site.USER_BASE
 
         # run command in subprocess
         output = sp.Popen(


### PR DESCRIPTION
This PR fixes various bugs around plugin installation and discovery. Mainly, we ensure that the directory structure of the package folder is compliant with the scheme for user site packages on a given platform. We also configure environment variables to allow sub-processes to access the user package directory. 

WIP:
* ~Enable PIP installations on MacOS again and see if it works now~
* ~Update build script with new `psychopy.__init__.py` contents~