### PR TITLE
Fixed units for mouse gaze calibration targets (pix -> height)

### DIFF
--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -99,7 +99,7 @@ class EyetrackerCalibration:
         if isinstance(textColor, str) and textColor.lower() == 'auto':
             textColor = None
 
-        if tracker == 'eyetracker.hw.sr_research.eyelink.EyeTracker':
+        if tracker.endswith('sr_research.eyelink.EyeTracker'):
             # As EyeLink
             asDict = {
                 'target_attributes': dict(target),
@@ -108,6 +108,8 @@ class EyetrackerCalibration:
                 'pacing_speed': self.targetDelay,
                 'randomize': self.randomisePos,
                 'text_color': textColor,
+                'unit_type': self.units,
+                'color_type': self.colorSpace,
                 'screen_background_color': getattr(self.win._color, self.colorSpace)
             }
         elif tracker == 'eyetracker.hw.tobii.EyeTracker':

--- a/psychopy/iohub/devices/eyetracker/calibration/procedure.py
+++ b/psychopy/iohub/devices/eyetracker/calibration/procedure.py
@@ -157,10 +157,10 @@ class BaseCalibrationProcedure:
         def setDefaultCalibrationTarget():
             # convert sizes to stimulus units
             radiusPix = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2
-            radiusObj = layout.Size(radiusPix, units="pix", win=self.window)
+            radiusObj = layout.Size(radiusPix, units=unit_type, win=self.window)
             radius = getattr(radiusObj, unit_type)[1]
             innerRadiusPix = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2
-            innerRadiusObj = layout.Size(innerRadiusPix, units="pix", win=self.window)
+            innerRadiusObj = layout.Size(innerRadiusPix, units=unit_type, win=self.window)
             innerRadius = getattr(innerRadiusObj, unit_type)[1]
             # make target
             self.targetStim = visual.TargetStim(


### PR DESCRIPTION
Units for mousegaze calibration targets were set to pixels instead of height units so they appeared very small. This has now been changed, calibration targets should now be of appropriate size.