### PR TITLE
BF: Check MovieStim's underlying player status when handling autoplay

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -308,7 +308,7 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         self._selectWindow(self.win if win is None else win)
 
         # handle autoplay
-        if self._autoStart and self.status == NOT_STARTED:
+        if self._autoStart and self.isNotStarted:
             self.play()
 
         # update the video frame and draw it to a quad


### PR DESCRIPTION
In a non-Builder context, the MovieStim's state is not updated, and `.play()` would subsequently be called on every `.draw()` call. On a test 4K video, this change saves ~6ms per call to `.draw()`.

See https://github.com/psychopy/psychopy/pull/6439 for context.