### PR TITLE
ENH: Speed-up MovieStim (noticeable for larger videos)

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -675,7 +675,7 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         """
         # get the size of the movie frame and compute the buffer size
         vidWidth, vidHeight = self._player.getMetadata().size
-        nBufferBytes = vidWidth * vidHeight * 3
+        nBufferBytes = vidWidth * vidHeight * 4
 
         # Create the pixel buffer object which will serve as the texture memory
         # store. Pixel data will be copied to this buffer each frame.
@@ -696,14 +696,12 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         GL.glTexImage2D(
             GL.GL_TEXTURE_2D,
             0,
-            GL.GL_RGB8,
+            GL.GL_RGBA8,
             vidWidth, vidHeight,  # frame dims in pixels
             0,
-            GL.GL_RGB,
+            GL.GL_BGRA,
             GL.GL_UNSIGNED_BYTE,
             None)
-
-        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
 
         # setup texture filtering
         if self.interpolate:
@@ -732,7 +730,7 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         # get the size of the movie frame and compute the buffer size
         vidWidth, vidHeight = self._player.getMetadata().size
 
-        nBufferBytes = vidWidth * vidHeight * 3
+        nBufferBytes = vidWidth * vidHeight * 4
 
         # bind pixel unpack buffer
         GL.glBindBuffer(GL.GL_PIXEL_UNPACK_BUFFER, self._pixbuffId)
@@ -769,12 +767,11 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         GL.glBindTexture(GL.GL_TEXTURE_2D, self._textureId)
 
         # copy the PBO to the texture
-        GL.glPixelStorei(GL.GL_UNPACK_ALIGNMENT, 1)
         GL.glTexSubImage2D(
             GL.GL_TEXTURE_2D, 0, 0, 0,
             vidWidth, vidHeight,
-            GL.GL_RGB,
-            GL.GL_UNSIGNED_BYTE,
+            GL.GL_BGRA,
+            GL.GL_UNSIGNED_INT_8_8_8_8_REV,
             0)  # point to the presently bound buffer
 
         # update texture filtering only if needed

--- a/psychopy/visual/movies/frame.py
+++ b/psychopy/visual/movies/frame.py
@@ -62,7 +62,8 @@ class MovieFrame:
         "_audioSamples",
         "_audioChannels",
         "_movieLib",
-        "_userData"
+        "_userData",
+        '_keepAlive'
     ]
 
     def __init__(self,
@@ -76,7 +77,8 @@ class MovieFrame:
                  audioSamples=None,
                  metadata=None,
                  movieLib=u"",
-                 userData=None):
+                 userData=None,
+                 keepAlive=None):
 
         self.frameIndex = frameIndex
         self.absTime = absTime
@@ -89,6 +91,7 @@ class MovieFrame:
         self._metadata = metadata
         self.movieLib = movieLib
         self.userData = userData
+        self._keepAlive = keepAlive
 
     def __repr__(self):
         return (f"MovieFrame(frameIndex={self.frameIndex}, "

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -1336,7 +1336,7 @@ class FFPyPlayer(BaseMoviePlayer):
         self._streamTime = streamStatus.streamTime  # stream time for the camera
 
         # if we have a new frame, update the frame information
-        videoBuffer = frameImage.to_bytearray()[0]
+        videoBuffer = frameImage.to_memoryview()[0].memview
         videoFrameArray = np.frombuffer(videoBuffer, dtype=np.uint8)
 
         # provide the last frame
@@ -1350,7 +1350,8 @@ class FFPyPlayer(BaseMoviePlayer):
             audioSamples=None,
             metadata=self.metadata,
             movieLib=u'ffpyplayer',
-            userData=None)
+            userData=None,
+            keepAlive=frameImage)
 
         return True
 

--- a/psychopy/visual/movies/players/ffpyplayer_player.py
+++ b/psychopy/visual/movies/players/ffpyplayer_player.py
@@ -737,6 +737,8 @@ class FFPyPlayer(BaseMoviePlayer):
 
         self._lastPlayerOpts = DEFAULT_FF_OPTS.copy()
 
+        self._lastPlayerOpts['out_fmt'] = 'bgra'
+
         # options from the parent
         if self.parent.loop:  # infinite loop
             self._lastPlayerOpts['loop'] = 0


### PR DESCRIPTION
See https://github.com/psychopy/psychopy/pull/6439 for context. With my AMD+Ubuntu 22.04 laptop and [this sample video](https://github.com/psychopy/psychopy/pull/6439#issuecomment-2100781642), I get an overall reduction in `MovieStim.draw()` time (starting from [this patch](https://github.com/psychopy/psychopy/pull/6448)) from ~34ms to ~4ms (i.e. ~40ms -> 4ms across both sets of patches). I haven't tested on other systems yet, but will try on a Windows 11 + Intel and Ubuntu 20.04 + AMD desktop today.