### PR TITLE
BF: show start parameter for stop only eyetracker components

### DIFF
--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -54,14 +54,6 @@ class EyetrackerRecordComponent(BaseComponent):
               }
          )
 
-        self.depends.append(
-             {"dependsOn": "actionType",  # must be param name
-              "condition": "=='Stop Only'",  # val to check for
-              "param": "start",  # param property to alter
-              "true": "hide",  # what to do with param if condition is True
-              "false": "show",  # permitted: hide, show, enable, disable
-              }
-         )
 
         # TODO: Display actionType control after component name.
         #       Currently, adding params before start / stop time


### PR DESCRIPTION
Currently the Stop Only action type causes experiments to crash. This is because the stop recording component never has its status set to START in the compiled python code. It does make sense to have a Start time because in theory you might want to Stop following a stimulus or something like that. This edit means that the stop recording component is set to start and therefore the recording is stopped.