### PR TITLE
ENH: Improvements to start/stop behaviour of Eyetracker Record Components

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -522,13 +522,16 @@ class StartStopCtrls(wx.GridBagSizer):
             self.estimLabel.Show(visible)
         if hasattr(self, "label"):
             self.label.Show(visible)
+        # show/hide dollars
+        if hasattr(self, "dollar"):
+            self.dollar.Show(visible)
         # Set value to None if hidden (specific to start/stop)
         if not visible:
             if "startVal" in self.ctrls:
                 self.ctrls["startVal"].Value = ""
             if "stopVal" in self.ctrls:
                 self.ctrls["stopVal"].Value = ""
-        # Layout
+        # layout
         self.parent.Layout()
 
     def updateCodeFont(self, evt=None):

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -514,10 +514,10 @@ class StartStopCtrls(wx.GridBagSizer):
         return all(ctrl.IsShown() for ctrl in self.ctrls.values())
 
     def setVisible(self, visible=True):
-        # Show/hide controls
+        # show/hide controls
         for ctrl in self.ctrls.values():
             ctrl.Show(visible)
-        # Show/hide labels
+        # show/hide labels
         if hasattr(self, "estimLabel"):
             self.estimLabel.Show(visible)
         if hasattr(self, "label"):
@@ -525,7 +525,7 @@ class StartStopCtrls(wx.GridBagSizer):
         # show/hide dollars
         if hasattr(self, "dollar"):
             self.dollar.Show(visible)
-        # Set value to None if hidden (specific to start/stop)
+        # set value to None if hidden (specific to start/stop)
         if not visible:
             if "startVal" in self.ctrls:
                 self.ctrls["startVal"].Value = ""

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -97,6 +97,12 @@ class EyetrackerRecordComponent(BaseComponent):
         if self.params['actionType'].val in ("Start and Stop", "Start Only"):
             # if we're starting the recording, write usual start code
             indented = self.writeStartTestCode(buff)
+            # start recording
+            code = (
+                "%(name)s.startRecording()\n"
+            )
+            buff.writeIndentedLines(code % self.params)
+            # dedent
             buff.setIndentLevel(-indented, relative=True)
         else:
             # otherwise, assume already started
@@ -109,6 +115,12 @@ class EyetrackerRecordComponent(BaseComponent):
         if self.params['actionType'].val in ("Start and Stop", "Stop Only"):
             # if we're stopping the recording, write usual stop code
             indented = self.writeStopTestCode(buff)
+            # stop recording
+            code = (
+                "%(name)s.stopRecording()\n"
+            )
+            buff.writeIndentedLines(code % self.params)
+            # dedent
             buff.setIndentLevel(-indented, relative=True)
 
     def writeRoutineEndCode(self, buff):

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -109,6 +109,10 @@ class EyetrackerRecordComponent(BaseComponent):
             code = (
                 "if %(name)s.status == NOT_STARTED:\n"
                 "    %(name)s.status = STARTED\n"
+                "    %(name)s.frameNStart = frameN\n"
+                "    %(name)s.tStart = t\n"
+                "    %(name)s.tStartRefresh = tThisFlipGlobal\n"
+                "    win.timeOnFlip(%(name)s, 'tStartRefresh')\n"
             )
             buff.writeIndentedLines(code % self.params)
         

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -112,7 +112,6 @@ class EyetrackerRecordComponent(BaseComponent):
                 "    %(name)s.frameNStart = frameN\n"
                 "    %(name)s.tStart = t\n"
                 "    %(name)s.tStartRefresh = tThisFlipGlobal\n"
-                "    win.timeOnFlip(%(name)s, 'tStartRefresh')\n"
             )
             buff.writeIndentedLines(code % self.params)
         
@@ -126,6 +125,16 @@ class EyetrackerRecordComponent(BaseComponent):
             buff.writeIndentedLines(code % self.params)
             # dedent
             buff.setIndentLevel(-indented, relative=True)
+        else:
+            # otherwise, assume immediately stopped
+            code = (
+                "if %(name)s.status == STARTED:\n"
+                "    %(name)s.status = FINISHED\n"
+                "    %(name)s.tStop = t\n"
+                "    %(name)s.tStopRefresh = tThisFlipGlobal\n"
+                "    %(name)s.frameNStop = frameN\n"
+            )
+            buff.writeIndentedLines(code % self.params)
 
     def writeRoutineEndCode(self, buff):
         inits = self.params

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -90,27 +90,26 @@ class EyetrackerRecordComponent(BaseComponent):
     def writeFrameCode(self, buff):
         """Write the code that will be called every frame
         """
-        # Alert user if eyetracking isn't setup
+        # alert user if eyetracking isn't setup
         if self.exp.eyetracking == "None":
             alert(code=4505)
 
-        inits = self.params
-        buff.writeIndentedLines("# *%s* updates\n" % self.params['name'])
-
-        # test for whether we're just starting to record
-        # writes an if statement to determine whether to draw etc
-        indented = self.writeStartTestCode(buff)
-        buff.setIndentLevel(-indented, relative=True)
-
-        # test for stop (only if there was some setting for duration or stop)
-        org_val = self.params['stopVal'].val
-        if self.params['actionType'].val.find('Start Only') >= 0:
-            self.params['stopVal'].val = 0
-
-        indented = self.writeStopTestCode(buff)
-        buff.setIndentLevel(-indented, relative=True)
-
-        self.params['stopVal'].val = org_val
+        if self.params['actionType'].val in ("Start and Stop", "Start Only"):
+            # if we're starting the recording, write usual start code
+            indented = self.writeStartTestCode(buff)
+            buff.setIndentLevel(-indented, relative=True)
+        else:
+            # otherwise, assume already started
+            code = (
+                "if %(name)s.status == NOT_STARTED:\n"
+                "    %(name)s.status = STARTED\n"
+            )
+            buff.writeIndentedLines(code % self.params)
+        
+        if self.params['actionType'].val in ("Start and Stop", "Stop Only"):
+            # if we're stopping the recording, write usual stop code
+            indented = self.writeStopTestCode(buff)
+            buff.setIndentLevel(-indented, relative=True)
 
     def writeRoutineEndCode(self, buff):
         inits = self.params

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -12,37 +12,36 @@ class EyetrackerControl(AttributeGetSetMixin):
     def __init__(self, tracker, actionType="Start and Stop"):
         self.tracker = tracker
         self.actionType = actionType
-        self._status = NOT_STARTED
-
-    @property
-    def status(self):
-        return self._status
-
-    @status.setter
-    def status(self, value):
-        old = self._status
-        new = self._status = value
-        # Skip if there's no change
-        if new == old:
+        self.status = NOT_STARTED
+        
+    def startRecording(self):
+        """
+        Start the eyetracker recording. If it's already recording, this will do nothing.
+        """
+        # if already recording, do nothing
+        if EyetrackerControl.currentlyRecording:
             return
-        # Start recording if set to STARTED
-        if new in (STARTED,):
-            if old in (NOT_STARTED, STOPPED, FINISHED):
-                # If was previously at a full stop, clear events before starting again
-                if self.actionType.find('Start') >= 0 and EyetrackerControl.currentlyRecording is False:
-                    logging.exp("eyetracker.clearEvents()")
-                    self.tracker.clearEvents()
-            # Start recording
-            if self.actionType.find('Start') >= 0 and not EyetrackerControl.currentlyRecording:
-                self.tracker.setRecordingState(True)
-                logging.exp("eyetracker.setRecordingState(True)")
-                EyetrackerControl.currentlyRecording = True
-        # Stop recording if set to any stop constants
-        if new in (NOT_STARTED, PAUSED, STOPPED, FINISHED):
-            if self.actionType.find('Stop') >= 0 and EyetrackerControl.currentlyRecording:
-                self.tracker.setRecordingState(False)
-                logging.exp("eyetracker.setRecordingState(False)")
-                EyetrackerControl.currentlyRecording = False
+        # clear events
+        logging.exp("eyetracker.clearEvents()")
+        self.tracker.clearEvents()
+        # start
+        self.tracker.setRecordingState(True)
+        logging.exp("eyetracker.setRecordingState(True)")
+        # store recording state
+        EyetrackerControl.currentlyRecording = True
+    
+    def stopRecording(self):
+        """
+        Stop the eyetracker recording. If it's already stopped (or hasn't started), this will do nothing.
+        """
+        # if not recording, do nothing
+        if not EyetrackerControl.currentlyRecording:
+            return
+        # stop
+        self.tracker.setRecordingState(False)
+        logging.exp("eyetracker.setRecordingState(False)")
+        # store recording state
+        EyetrackerControl.currentlyRecording = False
 
     @property
     def pos(self):


### PR DESCRIPTION
Attempt to fix the problem identified in #6456 

The problem:
- An EyetrackerRecordComponent set to "Stop only" doesn't have a start time, so was never marked with `.status = STARTED`
- Marking it with `.status = STARTED` calls a property/setter pair which actually starts the eyetracker, this is generally inadvisable as sometimes we want to just tell Builder it's started (i.e. when there's a new *Component* but not a new *device*, we want to mark the Component as `STARTED` but don't want to start the device again)
- This meant the eyetracker was never stopped so crashed when the experiment finished

The solution(s):
- Instead of `.status = STARTED` starting the eyetracker, have the start code in a function called `startRecording` and call this function explicitly in the Builder code (ditto for stopping the recording)
- Remove the property/setter so that `status` returns to being just an attribute for tracking progress in Builder
- If the component is "Stop only", have the Component set `.status = STARTED` at the very beginning (which we can now do safely)

Bonus:
- I noticed that the dollar signs by the start/stop aren't being hidden/shown according to state, so I fixed that while I was in the neighbourhood
