### PR TITLE
BF: KeyboardComponent allowed keys from spreadsheet caused namespace errors

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -171,7 +171,7 @@ class KeyboardComponent(BaseDeviceComponent):
 
     def writeRoutineStartCode(self, buff):
         code = (
-            "# create starting attributes for %(name)s"
+            "# create starting attributes for %(name)s\n"
             "%(name)s.keys = []\n"
             "%(name)s.rt = []\n"
             "_%(name)s_allKeys = []\n"

--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -170,10 +170,23 @@ class KeyboardComponent(BaseDeviceComponent):
         buff.writeIndentedLines(code % self.params)
 
     def writeRoutineStartCode(self, buff):
-        code = ("%(name)s.keys = []\n"
-                "%(name)s.rt = []\n"
-                "_%(name)s_allKeys = []\n")
+        code = (
+            "# create starting attributes for %(name)s"
+            "%(name)s.keys = []\n"
+            "%(name)s.rt = []\n"
+            "_%(name)s_allKeys = []\n"
+        )
         buff.writeIndentedLines(code % self.params)
+        # if allowedKeys looks like a variable, load it from global
+        allowedKeys = str(self.params['allowedKeys'])
+        allowedKeysIsVar = valid_var_re.match(str(allowedKeys)) and not allowedKeys == 'None'
+        if allowedKeysIsVar:
+            code = (
+                "# allowedKeys looks like a variable, so make sure it exists locally\n"
+                "%(allowedKeys)s = globals()['%(allowedKeys)s']\n"
+            )
+            buff.writeIndentedLines(code % self.params)
+
 
     def writeRoutineStartCodeJS(self, buff):
         code = ("%(name)s.keys = undefined;\n"


### PR DESCRIPTION
It's because of local vs global namespaces - the variables from the spreadsheet are defined globally, but because the allowedKeys code in a Keyboard Component can set the variable (when it converts it to a tuple or does eval or etc.) and because the run code is now in a function, Python reserves the local name and so if you reference it you get "Variable not defined" (even though it's in globals).

This fixes it by saying that, if the same conditions under which the allowedKeys code is written is True, add some code to the start of the Routine to use the global variable's value for the undefined local variable.