### PR TITLE
BF: fix an issue with etRecord component for Stop Only

### DIFF
--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -12,7 +12,7 @@ class EyetrackerControl(AttributeGetSetMixin):
     def __init__(self, tracker, actionType="Start and Stop"):
         self.tracker = tracker
         self.actionType = actionType
-        self._status = NOT_STARTED
+        self._status = tracker.isRecordingEnabled()
 
     @property
     def status(self):


### PR DESCRIPTION
There is a bug with the etRecord component in builder because the constructor for `psychopy.hardware.eyetracker.EyetrackerControl` always initializes the `_status` attribute as `NOT_STARTED`. This causes an issue when the component is used under the "Stop Only" Record actions. In this scenario, two independent etRecord components are initialized, causing the bug, because the experiment can only change the status of the second component (supposed to stop recording) to `FINISHED` if the status is already `STARTED`.

Instead, the status of any `EyetrackerControl` instance should reflect whether recording is currently enabled for the tracker instance passed into the constructor. Looking through `psychopy.iohub.devices.eyetracker.hw`, `isRecordingEnabled()` is appropriately defined for everyone so this fix should work seamlessly.