### PR TITLE
BF: Param updates control should be enabled when there's a Static Component

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -308,7 +308,7 @@ class ParamCtrls():
             # set by integer index, not string value
             self.updateCtrl.SetSelection(index)
 
-        if param.allowedUpdates != None and len(param.allowedUpdates) == 1:
+        if self.updateCtrl is not None and len(self.updateCtrl.GetItems()) == 1:
             self.updateCtrl.Disable()  # visible but can't be changed
 
     def _getCtrlValue(self, ctrl):


### PR DESCRIPTION
Otherwise, parameters with only one option for their update method (i.e. Sound.sound) can never be set via an ISI as the control detects that there's only one option and disables.

Fix is to disable based on the final number of options once the control is created, rather than the theoretical number of options based on `allowedUpdates`