### PR TITLE
FF: Remove call to `site.main()` on MacOS

### DIFF
--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -142,7 +142,7 @@ if 'installing' not in locals():
         # make sure site knows about our custom user site-packages
         site.USER_SITE = prefs.paths['userPackages']
         site.ENABLE_USER_SITE = True
-        site.main()
+        # site.main()
 
         # add paths from main plugins/packages (installed by plugins manager)
         site.addsitedir(prefs.paths['userPackages'])  # user site-packages
@@ -159,6 +159,13 @@ if 'installing' not in locals():
             if str(prefs.paths['userScripts']) not in _envPath:
                 os.environ['PATH'] = os.pathsep.join([
                     os.environ['PATH'], str(prefs.paths['userScripts'])])
+
+        if sys.platform == 'darwin' and sys._framework:
+            # add scripts path for user packages to system PATH
+            fwBinPath = os.path.join(sys.prefix, 'bin')
+            if fwBinPath not in os.environ['PATH']:
+                os.environ['PATH'] = os.pathsep.join([
+                    fwBinPath, os.environ['PATH']])
     
     # add paths from general preferences
     for _pathName in prefs.general['paths']:

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -83,7 +83,7 @@ if 'installing' not in locals():
         # make sure site knows about our custom user site-packages
         site.USER_SITE = prefs.paths['userPackages']
         site.ENABLE_USER_SITE = True
-        site.main()
+        # site.main()
 
         # add paths from main plugins/packages (installed by plugins manager)
         site.addsitedir(prefs.paths['userPackages'])  # user site-packages
@@ -100,6 +100,13 @@ if 'installing' not in locals():
             if str(prefs.paths['userScripts']) not in _envPath:
                 os.environ['PATH'] = os.pathsep.join([
                     os.environ['PATH'], str(prefs.paths['userScripts'])])
+
+        if sys.platform == 'darwin' and sys._framework:
+            # add scripts path for user packages to system PATH
+            fwBinPath = os.path.join(sys.prefix, 'bin')
+            if fwBinPath not in os.environ['PATH']:
+                os.environ['PATH'] = os.pathsep.join([
+                    fwBinPath, os.environ['PATH']])
     
     # add paths from general preferences
     for _pathName in prefs.general['paths']:

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -39,9 +39,17 @@ import site
 # import path. 
 
 # set user site-packages dir
-site.USER_BASE = prefs.paths['packages']
-site.USER_SITE = None  # clear, recompute this value 
-logging.debug('User site-packages dir set to: %s' % site.getusersitepackages())
+if os.environ.get('PSYCHOPYNOPACKAGES', '0') == '1':
+    site.ENABLE_USER_SITE = True
+    site.USER_SITE = prefs.paths['userPackages']
+    site.USER_BASE = None
+    logging.debug(
+        'User site-packages dir set to: %s' % site.getusersitepackages())
+    
+    # add paths from main plugins/packages (installed by plugins manager)
+    site.addsitedir(prefs.paths['userPackages'])  # user site-packages
+    site.addsitedir(prefs.paths['userInclude'])  # user include
+    site.addsitedir(prefs.paths['packages'])  # base package dir
 
 if not site.USER_SITE in sys.path:
     site.addsitedir(site.getusersitepackages()) 


### PR DESCRIPTION
Removes the call to `site.main()` which breaks when used in the app bundle