### PR TITLE
BF: hide that visible mouse, please

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1724,7 +1724,7 @@ class DraggingMixin:
         """
         # if we don't have reference to a mouse, make one
         if not isinstance(self.mouse, Mouse):
-            self.mouse = Mouse(win=self.win)
+            self.mouse = Mouse(visible=self.win.mouseVisible, win=self.win)
             # make sure it has an initial pos for rel pos comparisons
             self.mouse.lastPos = self.mouse.getPos()
         # store value


### PR DESCRIPTION
This problem has been around for a while that the mouse stays visible despite people being in fullscreen and unchecking the "Show Mouse" box. I think the culprit is here: https://github.com/psychopy/psychopy/blob/7969ebb2308adb0f790f10a84cd5de10c1dd6c66/psychopy/event.py#L838

For some reason whenever we draw some visual objects, there is a logic in `draggable()` to create a new mouse with default `visible=True`, therefore overriding `win.mouseVisible` no matter how many times people try to set it to `False` manually.

This PR provides a simple fix.