### PR TITLE
BF: Unregister event monitors iohub calibration

### DIFF
--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -408,11 +408,10 @@ class EyeTracker(EyeTrackerDevice):
         cal_run = calibration.runCalibration()
         calibration.window.close()
 
-        # NOTE - The following line has been commented out to prevent ioHub from 
-        # losing keyboard input after the window is closed. The new keyboard 
-        # input system does not require this call anymore.
-        # calibration._unregisterEventMonitors()
+        calibration._unregisterEventMonitors()
         calibration.clearAllEventBuffers()
+        del calibration.window
+        del calibration
 
         if cal_run:
             return {"RESULT": "CALIBRATION_OK"}


### PR DESCRIPTION
This PR is going to undo commit 9808929, which I believe is an incorrect commit.

If we don't remove the registered EventMonitors instantiated by the `calibration` instance, they are going to keep hijacking key releases to `space` and `escape` because of this event handler: https://github.com/psychopy/psychopy/blob/7969ebb2308adb0f790f10a84cd5de10c1dd6c66/psychopy/iohub/devices/eyetracker/calibration/procedure.py#L122

It might have appeared like `calibration._unregisterEventMonitors()` was not required anymore, but that's likely because the keyboard events was set to `press` instead of `release`.

One can test out in 2024.1.4: after the eyetracker calibration component, key **releases** to `space` and `escape` no longer work as intended.

@peircej I noticed that this same line has been commented out in the separate eye tracking plugin packages such as in `psychopy-eyetracker-sr-research`:
```
# genv._unregisterEventMonitors()
```
It would be great if those pip packages could be updated for this issue as well.