### PR TITLE
BF: Fix "Stop only" issue regardless of Component order

### DIFF
--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -12,7 +12,10 @@ class EyetrackerControl(AttributeGetSetMixin):
     def __init__(self, tracker, actionType="Start and Stop"):
         self.tracker = tracker
         self.actionType = actionType
-        self._status = tracker.isRecordingEnabled()
+        if actionType.lower() == "stop":
+            self._status = STARTED
+        else:
+            self._status = tracker.isRecordingEnabled()
 
     @property
     def status(self):


### PR DESCRIPTION
Builds on #6463 by handling when the EyetrackerControl stop object is created before the EyetrackerControl start object starts - in which case `tracker.isRecordingEnabled()` was always False when setting `._status`. If the action type is "Stop", then it should always start off as STARTED