### PR TITLE
ENH: Add method to continuously dispatch hardware messages for x seconds

### DIFF
--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -14,6 +14,7 @@ __all__ = [
 
 import json
 import inspect
+import time
 
 
 class BaseResponse:
@@ -169,6 +170,25 @@ class BaseResponseDevice(BaseDevice):
         Method to dispatch messages from the device to any nodes or listeners attached.
         """
         pass
+
+    def dispatchMessagesFor(self, duration=0.01):
+        """
+        Continuously call `.dispatchMessages` for a set period of time, so that any messages 
+        caught mid-sending are completed by subsequent `.dispatchMessages` calls. In most cases 
+        this is the same as calling `.dispatchMessages`. If running within a frame loop or any 
+        time sensitive scenario, use `.dispatchMessages` instead.
+
+        Parameters
+        ----------
+        duration : float, optional
+            Time (s) to continuously call `.dispatchMessages` for, by default 0.01
+        """
+        # start timing
+        start = time.time()
+        # call continuously until duration is reached
+        while time.time() - start < duration:
+            self.dispatchMessages()
+
 
     def parseMessage(self, message):
         raise NotImplementedError(

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -1,5 +1,5 @@
 import json
-from psychopy import core, layout, logging
+from psychopy import layout, logging
 from psychopy.hardware import base, DeviceManager
 from psychopy.localization import _translate
 from psychopy.hardware import keyboard
@@ -123,15 +123,15 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
         rect.fillColor = "black"
         rect.draw()
         win.flip()
-        # dispatch an clear so we're starting fresh
-        self.dispatchMessages()
+        # dispatch an clear so we're starting fresh (slowly, so we definitely catch them)
+        self.dispatchMessagesFor(duration=0.1)
         self.clearResponses()
         # show white
         rect.fillColor = "white"
         rect.draw()
         win.flip()
-        # dispatch messages
-        self.dispatchMessages()
+        # dispatch messages (slowly, so we definitely catch them)
+        self.dispatchMessagesFor(duration=0.1)
         # start off with no channels
         channels = []
         # iterate through potential channels
@@ -155,7 +155,6 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
             Size of the area of certainty. Essentially, the size of the last (smallest) rectangle which the photodiode
             was able to detect.
         """
-        clock = core.Clock()
         # keyboard to check for escape
         kb = keyboard.Keyboard(deviceName="photodiodeValidatorKeyboard")
         # stash autodraw
@@ -235,10 +234,8 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
                 label.draw()
                 rect.draw()
                 win.flip()
-                # dispatch parent messages continuously for 0.1s (make sure diode has time)
-                clock.reset()
-                while clock.getTime() < 0.1:
-                    self.dispatchMessages()
+                # dispatch messages (slowly, so we definitely catch them)
+                self.dispatchMessagesFor(duration=0.1)
                 # check for escape before entering recursion
                 if kb.getKeys(['escape']):
                     return None

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -1,5 +1,5 @@
 import json
-from psychopy import layout, logging
+from psychopy import core, layout, logging
 from psychopy.hardware import base, DeviceManager
 from psychopy.localization import _translate
 from psychopy.hardware import keyboard
@@ -155,6 +155,7 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
             Size of the area of certainty. Essentially, the size of the last (smallest) rectangle which the photodiode
             was able to detect.
         """
+        clock = core.Clock()
         # keyboard to check for escape
         kb = keyboard.Keyboard(deviceName="photodiodeValidatorKeyboard")
         # stash autodraw
@@ -234,8 +235,10 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
                 label.draw()
                 rect.draw()
                 win.flip()
-                # dispatch parent messages
-                self.dispatchMessages()
+                # dispatch parent messages continuously for 0.1s (make sure diode has time)
+                clock.reset()
+                while clock.getTime() < 0.1:
+                    self.dispatchMessages()
                 # check for escape before entering recursion
                 if kb.getKeys(['escape']):
                     return None


### PR DESCRIPTION
Needed for the BBTK TPad as it we need to dispatch only as much data as is on the buffer in the case of frame-by-frame dispatch, but need complete messages in the case of finding the diode on screen.