### PR TITLE
BF: clear keys to initialize keyboard when starting a routine

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -173,6 +173,7 @@ class KeyboardComponent(BaseDeviceComponent):
         code = (
             "# create starting attributes for %(name)s\n"
             "%(name)s.keys = []\n"
+            "%(name)s.getKeys(clear=True)\n"
             "%(name)s.rt = []\n"
             "_%(name)s_allKeys = []\n"
         )
@@ -186,7 +187,6 @@ class KeyboardComponent(BaseDeviceComponent):
                 "%(allowedKeys)s = globals()['%(allowedKeys)s']\n"
             )
             buff.writeIndentedLines(code % self.params)
-
 
     def writeRoutineStartCodeJS(self, buff):
         code = ("%(name)s.keys = undefined;\n"


### PR DESCRIPTION
This is a critical BF about keyboard event buffering and clearing.

Right now with 2024.1.4, there is a bug that if keyboards are pressed/released before the start of a routine that contains a keyboard component, these premature keyboard presses/releases will get instantly pulled by `.getKeys()` during each frame. This can cause all sorts of bad outcomes such as force ending a routine right away or registering a 16ms RT for the first keyboard event during the routine.

The key problem here is that the template for writing Routine start code from the builder for a keyboard component only adds `"%(name)s.keys = []\n"` to the beginning of a routine. [However, there's no appropriate `@attributeSetter` method for the `.keys` attribute.](https://github.com/psychopy/psychopy/blob/b2c92e9c7ca9b55a3df7c15559f3cb2b270378f3/psychopy/hardware/keyboard.py#L187) So setting a keyboard instance's `keys` attribute to `[]` does nothing to the buffer of the device kept in the `.device` attribute. This means all key press events since the `keyboard.Keyboard(deviceName='xxx')` constructor at the beginning of an experiment, as long as they have not been consumed by other keyboard listeners, will get pulled when the status of this keyboard component turns to `STARTED`.

I think `.clearEvents()` might be a more appropriate method to call here, but I don't know if that method is overloaded by all implementations of devices. So I just added `.getKeys(clear=True)` here to consume events in the device buffer. 

A related comment is that I think it's dangerous to have a mutable attribute `.keys` attached to the Keyboard object instance - it can be modified into anything without any ties to the underlying `.device` attribute. I think having a `keys()` method that calls into the buffer of the `device` might be a tighter design.