### PR TITLE
BF: Allow meaningful comparisons of KeyPress object instances with the same name

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -584,7 +584,8 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             if message.type == "KEYBOARD_PRESS":
                 # if message is from a key down event, make a new response
                 response = KeyPress(code=message.char, tDown=message.time, name=message.key)
-                response.rt = response.tDown - (self.clock.getLastResetTime() - self._iohubKeyboard.clock.getLastResetTime())
+                response.rt = response.tDown - (
+                    self.clock.getLastResetTime() - self._iohubKeyboard.clock.getLastResetTime())
                 self._keysStillDown.append(response)
             else:
                 # if message is from a key up event, alter existing response
@@ -611,9 +612,9 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
 
     def waitKeys(self, maxWait=float('inf'), keyList=None, waitRelease=True,
                  clear=True):
-        """Same as `~psychopy.hardware.keyboard.Keyboard.getKeys`, 
+        """Same as `~psychopy.hardware.keyboard.Keyboard.getKeys`,
         but halts everything (including drawing) while awaiting keyboard input.
-    
+
         :Parameters:
             maxWait : any numeric value.
                 Maximum number of seconds period and which keys to wait for.
@@ -633,9 +634,9 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             clear : **True** or False
                 Whether to clear the keyboard event buffer (and discard preceding
                 keypresses) before starting to monitor for new keypresses.
-    
+
         Returns None if times out.
-    
+
         """
         timer = psychopy.clock.Clock()
 
@@ -756,7 +757,7 @@ class _KeyBuffer(object):
         if not keyList and not waitRelease:
             keyPresses = list(self._keysStillDown)
             for k in list(self._keys):
-                if not any(x.name == k.name and x.tDown == k.tDown  for x in keyPresses):
+                if not any(x.name == k.name and x.tDown == k.tDown for x in keyPresses):
                     keyPresses.append(k)
             if clear:
                 self._keys = deque()

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -127,6 +127,12 @@ class KeyPress(BaseResponse):
                 core.quit()
             else:
                 print(thisKey.name, thisKey.tDown, thisKey.rt)
+
+    When comparing two KeyPress objects, they will only be considered equal if
+    both the name and tDown attributes are the same. This is to prevent
+    multiple keypresses from being considered equal if they are pressed at
+    different times. Conversely for inequality, if either the name or tDown
+    attributes are different, the KeyPress objects will be considered unequal.
     """
 
     fields = ["t", "value", "duration"]
@@ -158,10 +164,16 @@ class KeyPress(BaseResponse):
         BaseResponse.__init__(self, t=tDown, value=value)
 
     def __eq__(self, other):
-        return self.name == other
+        if hasattr(other, 'tDown'):
+            return self.name == other and self.tDown == other.tDown
+        else:
+            return self.name == other
 
     def __ne__(self, other):
-        return self.name != other
+        if hasattr(other, 'tDown'):
+            return self.name != other or self.tDown != other.tDown
+        else:
+            return self.name != other
 
 
 def getKeyboards():


### PR DESCRIPTION
This is a subtle bug I noticed when I was trying to understand how `KeyboardDevice.getKeys()` works. There is [this line that checks if a key is still wanted and not present before adding to output](https://github.com/psychopy/psychopy/blob/8558cace4cd07f1d81b68f6d2ee6bcf397fb49d1/psychopy/hardware/keyboard.py#L496), but the `in` operator relies on a robust implementation of `__eq__()` and `__ne__()` dunder methods. Looking at the implementations of them for `KeyPress` objects, they are just comparing the `name` attribute.

This causes a problem because if a subject presses the same key twice in-between `.getKeys()` calls, only the first press/release event of that key would be registered and outputted.

This PR improves how KeyPress object instances are compared by leveraging the `.tDown` attribute, with the design assumption that the same key can't be pressed twice at the exact the same, or at least in this universe :)