### PR TITLE
BF: allow getKeys() to return the same key pressed multiple times

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -572,7 +572,8 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             if message.type == "KEYBOARD_PRESS":
                 # if message is from a key down event, make a new response
                 response = KeyPress(code=message.char, tDown=message.time, name=message.key)
-                response.rt = response.tDown - (self.clock.getLastResetTime() - self._iohubKeyboard.clock.getLastResetTime())
+                response.rt = response.tDown - (
+                    self.clock.getLastResetTime() - self._iohubKeyboard.clock.getLastResetTime())
                 self._keysStillDown.append(response)
             else:
                 # if message is from a key up event, alter existing response
@@ -599,9 +600,9 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
 
     def waitKeys(self, maxWait=float('inf'), keyList=None, waitRelease=True,
                  clear=True):
-        """Same as `~psychopy.hardware.keyboard.Keyboard.getKeys`, 
+        """Same as `~psychopy.hardware.keyboard.Keyboard.getKeys`,
         but halts everything (including drawing) while awaiting keyboard input.
-    
+
         :Parameters:
             maxWait : any numeric value.
                 Maximum number of seconds period and which keys to wait for.
@@ -621,9 +622,9 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             clear : **True** or False
                 Whether to clear the keyboard event buffer (and discard preceding
                 keypresses) before starting to monitor for new keypresses.
-    
+
         Returns None if times out.
-    
+
         """
         timer = psychopy.clock.Clock()
 
@@ -748,7 +749,7 @@ class _KeyBuffer(object):
         if not keyList and not waitRelease:
             keyPresses = list(self._keysStillDown)
             for k in list(self._keys):
-                if not any(x.name == k.name and x.tDown == k.tDown  for x in keyPresses):
+                if not any(x.name == k.name and x.tDown == k.tDown for x in keyPresses):
                     keyPresses.append(k)
             if clear:
                 self._keys = deque()

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -493,7 +493,7 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
                 if resp.value in ignoreKeys:
                     wanted = False
             # if we got this far and the key is still wanted and not present, add it to output
-            if wanted and resp not in keys:
+            if wanted and not any(k is resp for k in keys):
                 keys.append(resp)
             # if clear=True, mark wanted responses as toClear
             if wanted and clear:

--- a/psychopy/iohub/client/keyboard.py
+++ b/psychopy/iohub/client/keyboard.py
@@ -11,11 +11,12 @@ from ..util import win32MessagePump
 from ..devices.keyboard import KeyboardInputEvent
 from ..constants import EventConstants, KeyboardConstants
 
-#pylint: disable=protected-access
+# pylint: disable=protected-access
 
 getTime = Computer.getTime
 kb_cls_attr_names = KeyboardInputEvent.CLASS_ATTRIBUTE_NAMES
 kb_mod_codes2labels = KeyboardConstants._modifierCodes2Labels
+
 
 class KeyboardEvent(ioEvent):
     """
@@ -42,13 +43,13 @@ class KeyboardEvent(ioEvent):
     def __init__(self, ioe_array):
         super(KeyboardEvent, self).__init__(ioe_array)
         for aname, aindex, in list(self._attrib_index.items()):
-            setattr(self, '_%s'%aname, ioe_array[aindex])
+            setattr(self, '_%s' % aname, ioe_array[aindex])
         self._modifiers = kb_mod_codes2labels(self._modifiers)
 
     @property
     def key(self):
         return self._key
-        
+
     @property
     def char(self):
         """The unicode value of the keyboard event, if available. This field is
@@ -87,7 +88,7 @@ class KeyboardEvent(ioEvent):
     def __str__(self):
         pstr = ioEvent.__str__(self)
         return '{}, key: {} char: {}, modifiers: {}'.format(pstr, self.key,
-                self.char, self.modifiers)
+                                                            self.char, self.modifiers)
 
     def __eq__(self, v):
         if isinstance(v, KeyboardEvent):
@@ -113,8 +114,8 @@ class KeyboardRelease(KeyboardEvent):
 
     def __init__(self, ioe_array):
         super(KeyboardRelease, self).__init__(ioe_array)
-        #self._duration = ioe_array[self._attrib_index['duration']]
-        #self._press_event_id = ioe_array[self._attrib_index['press_event_id']]
+        # self._duration = ioe_array[self._attrib_index['duration']]
+        # self._press_event_id = ioe_array[self._attrib_index['press_event_id']]
 
     @property
     def duration(self):
@@ -153,47 +154,47 @@ class KeyboardRelease(KeyboardEvent):
 class Keyboard(ioHubDeviceView):
     """The Keyboard device provides access to KeyboardPress and KeyboardRelease
     events as well as the current keyboard state.
-    
+
     Examples:
 
         A. Print all keyboard events received for 5 seconds::
-    
+
             from psychopy.iohub import launchHubServer
             from psychopy.core import getTime
-            
+
             # Start the ioHub process. 'io' can now be used during the
             # experiment to access iohub devices and read iohub device events.
             io = launchHubServer()
-            
+
             keyboard = io.devices.keyboard
-                    
+
             # Check for and print any Keyboard events received for 5 seconds.
             stime = getTime()
             while getTime()-stime < 5.0:
                 for e in keyboard.getEvents():
                     print(e)
-            
+
             # Stop the ioHub Server
             io.quit()
-            
+
         B. Wait for a keyboard press event (max of 5 seconds)::
-    
+
             from psychopy.iohub import launchHubServer
             from psychopy.core import getTime
-            
+
             # Start the ioHub process. 'io' can now be used during the
             # experiment to access iohub devices and read iohub device events.
             io = launchHubServer()
-            
+
             keyboard = io.devices.keyboard
-                    
+
             # Wait for a key keypress event ( max wait of 5 seconds )
             presses = keyboard.waitForPresses(maxWait=5.0)
-            
+
             print(presses)
-            
+
             # Stop the ioHub Server
-            io.quit()         
+            io.quit()
     """
     KEY_PRESS = EventConstants.KEYBOARD_PRESS
     KEY_RELEASE = EventConstants.KEYBOARD_RELEASE
@@ -228,8 +229,8 @@ class Keyboard(ioHubDeviceView):
         """
         kb_state = self.getCurrentDeviceState()
 
-        events = {int(k):v for k,v in list(kb_state.get('events').items())}
-        pressed_keys = {int(k):v for k,v in list(kb_state.get('pressed_keys',{}).items())}
+        events = {int(k): v for k, v in list(kb_state.get('events').items())}
+        pressed_keys = {int(k): v for k, v in list(kb_state.get('pressed_keys', {}).items())}
 
         self._reporting = kb_state.get('reporting_events')
         self._pressed_keys.clear()
@@ -289,11 +290,10 @@ class Keyboard(ioHubDeviceView):
         self._reporting = self.enableEventReporting(r)
         return self._reporting
 
-
     def clearEvents(self, event_type=None, filter_id=None):
         self._clearLocalEvents(event_type)
         return self._clearEventsRPC(event_type=event_type,
-                                      filter_id=filter_id)
+                                    filter_id=filter_id)
 
     def getKeys(self, keys=None, chars=None, ignoreKeys=None, mods=None, duration=None,
                 etype=None, clear=True):

--- a/psychopy/tests/test_hardware/test_keyboard.py
+++ b/psychopy/tests/test_hardware/test_keyboard.py
@@ -26,6 +26,33 @@ class _TestBaseKeyboard:
             assert keys[-1] is evt
             assert keys[-1].value == case['val']
 
+    def testAcceptDuplicateResponses(self):
+        """
+        Test that KeyboardDevice can receive multiple presses of the same key without accepting
+        genuine duplicates (e.g. KeyPress objects added twice, or the same object added for press
+        and release)
+        """
+        # clear
+        self.kb.clearEvents()
+        # press space twice and don't release
+        resp1 = self.kb.makeResponse(tDown=0.1, code="space")
+        resp2 = self.kb.makeResponse(tDown=0.2, code="space")
+        # make sure we only have 2 press objects
+        keys = self.kb.getKeys(waitRelease=False, clear=False)
+        assert len(keys) == 2
+        # simulate a release
+        resp1.duration = 0.2
+        resp2.duration = 0.1
+        self.kb.responses += [resp1, resp2]
+        # we should still only have 2 press objects (as these are duplicates)
+        keys = self.kb.getKeys(waitRelease=True, clear=False)
+        assert len(keys) == 2
+        # add the same objects again for no good reason
+        self.kb.responses += [resp1, resp2]
+        # we should STILL only have 2 press objects
+        keys = self.kb.getKeys(waitRelease=True, clear=False)
+        assert len(keys) == 2
+
     def testMuteOutsidePsychopyNotSlower(self):
         """
         Test that responses aren't worryingly slower when using muteOutsidePsychopy


### PR DESCRIPTION
_(Replaces #6478 I accidentally messed up detached HEAD with `psychopy/release` using rebase in that PR. This one should be correct)._

Fixes the bug of `.getKeys()` not returning the same key pressed multiple times using the change suggested by @TEParsons  [here](https://github.com/psychopy/psychopy/pull/6474#issuecomment-2120394130).

This BF maintains the `KeyPress() == KeyPress()` comparison using only the `name` attribute.