### PR TITLE
ENH: Removed setPavloviaUser methods from builder.py and coder.py

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1632,10 +1632,6 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # Run debug function from runner
         self.app.runner.panel.runOnlineDebug(evt=evt)
 
-    def setPavloviaUser(self, user):
-        # TODO: update user icon on button to user avatar
-        pass
-
     @property
     def project(self):
         """A PavloviaProject object if one is known for this experiment

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2873,10 +2873,6 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # TODO: Allow user to run project from coder
         pass
 
-    def setPavloviaUser(self, user):
-        # TODO: update user icon on button to user avatar
-        pass
-
     def resetPrefs(self, event):
         """Reset preferences to default"""
         # Present "are you sure" dialog


### PR DESCRIPTION
In psychopy\app\coder\coder.py in lines 2876 to 2878 and in psychopy\app\builder\builder.py in lines 1635 to 1637 there was: def setPavloviaUser(self, user). I removed both methods as instructed in pull requests #6485 and #6486 by @TEParsons.

I hadn't understood that it was already being handled. Sorry for the inconvenience. Hope this helps!