### PR TITLE
PKG: uninstall legacy installation from `%appdata%`

### DIFF
--- a/buildCompleteInstaller.nsi
+++ b/buildCompleteInstaller.nsi
@@ -198,6 +198,7 @@ Section Uninstall
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
   RMDir /r "$INSTDIR"
+  RMDir /r "$APPDATA\psychopy3"
   ; NB we don't uninstall avbin - it might be used by another python installation
 
   ;shortcuts

--- a/building/buildCompleteInstaller.nsi
+++ b/building/buildCompleteInstaller.nsi
@@ -199,6 +199,7 @@ Section Uninstall
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
   RMDir /r "$INSTDIR"
+  RMDir /r "$APPDATA\psychopy3"
   ; NB we don't uninstall avbin - it might be used by another python installation
 
   ;shortcuts


### PR DESCRIPTION
I had a issue while remove old installation and install new version on Windows. new version was detected old packages from these appdata to block me to open the Psychopy setting GUI unless I removed the dir.

I'm not sure of the impact of this, but it seems like the uninstall operation should keep clean?