### PR TITLE
NF: Added folder for plugin configuration files to user prefs directory

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -340,6 +340,36 @@ def refreshBundlePaths():
     return foundBundles
 
 
+def getPluginConfigPath(plugin):
+    """Get the path to the configuration file for a plugin.
+
+    This function returns the path to folder alloted to a plugin for storing
+    configuration files. This is useful for plugins that require user settings
+    to be stored in a file.
+
+    Parameters
+    ----------
+    plugin : str
+        Name of the plugin package to get the configuration file for.
+
+    Returns
+    -------
+    str
+        Path to the configuration file for the plugin.
+
+    """
+    # check if the plugin is installed first
+    if plugin not in _installed_plugins_:
+        raise ValueError("Plugin `{}` is not installed.".format(plugin))
+    
+    # get the config directory
+    import pathlib
+    configDir = pathlib.Path(prefs.paths['config']) / 'plugins' / plugin
+    configDir.mkdir(parents=True, exist_ok=True)
+
+    return configDir
+
+
 def installPlugin(package, local=True, upgrade=False, forceReinstall=False,
                   noDeps=False):
     """Install a plugin package.

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -364,7 +364,7 @@ def getPluginConfigPath(plugin):
     
     # get the config directory
     import pathlib
-    configDir = pathlib.Path(prefs.paths['config']) / 'plugins' / plugin
+    configDir = pathlib.Path(prefs.paths['configs']) / 'plugins' / plugin
     configDir.mkdir(parents=True, exist_ok=True)
 
     return configDir

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -157,7 +157,7 @@ class Preferences:
             'themes',  # define theme path
             'fonts',  # find / copy fonts
             'packages',  # packages and plugins
-            'config',  # config files for plugins
+            'configs',  # config files for plugins
             'cache',  # cache for downloaded and other temporary files
         )
 

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -101,6 +101,14 @@ class Preferences:
         self.loadAll()  # reloads, now getting all from .spec
 
     def getPaths(self):
+        """Get the paths to various directories and files used by PsychoPy.
+
+        If the paths are not found, they are created. Usually, this is only
+        necessary on the first run of PsychoPy. However, if the user has
+        deleted or moved the preferences directory, this method will recreate 
+        those directories.
+
+        """
         # on mac __file__ might be a local path, so make it the full path
         thisFileAbsPath = os.path.abspath(__file__)
         prefSpecDir = os.path.split(thisFileAbsPath)[0]
@@ -149,6 +157,7 @@ class Preferences:
             'themes',  # define theme path
             'fonts',  # find / copy fonts
             'packages',  # packages and plugins
+            'config',  # config files for plugins
             'cache',  # cache for downloaded and other temporary files
         )
 


### PR DESCRIPTION
This PR makes PsychoPy add a special folder to the user preferences directory called `config`. This directory is the standard location for plugins to write their configuration files to. The new function `getPluginConfigPath()` returns the path designated for a plugin to use without the user needing to compute the path themselves. For instance, `getPluginConfigPath('psychopy-visionscience')` returns `/path/to/.psychopy3/config/plugins/psychopy-visionscience`, creating the directory if a valid plugin is specified.