### PR TITLE
FF: Fixes to TrialHandler2 to make communication via Liaison smoother

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -538,18 +538,31 @@ class ExperimentHandler(_ComparisonMixin):
         this = self.thisEntry
         # fetch data from each (potentially-nested) loop
         for thisLoop in self.loopsUnfinished:
-            names, vals = self._getLoopInfo(thisLoop)
-            for n, name in enumerate(names):
-                this[name] = vals[n]
-                # make sure name is in data names
-                if name not in self.dataNames:
-                    self.dataNames.append(name)
+            self.updateEntryFromLoop(thisLoop)
         # add the extraInfo dict to the data
         if type(self.extraInfo) == dict:
             this.update(self.extraInfo)
         self.entries.append(this)
         # add new entry with its
         self.thisEntry = {}
+
+    def updateEntryFromLoop(self, thisLoop):
+        """
+        Add all values from the given loop to the current entry.
+
+        Parameters
+        ----------
+        thisLoop : BaseLoopHandler
+            Loop to get fields from
+        """
+        # for each name and value in the current trial...
+        names, vals = self._getLoopInfo(thisLoop)
+        for n, name in enumerate(names):
+            # add/update value
+            self.thisEntry[name] = vals[n]
+            # make sure name is in data names
+            if name not in self.dataNames:
+                self.dataNames.append(name)
 
     def getAllEntries(self):
         """Fetches a copy of all the entries including a final (orphan) entry

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -1051,6 +1051,11 @@ class TrialHandler2(_BaseTrialHandler):
             msg = 'New trial (rep=%i, index=%i): %s'
             vals = (self.thisRepN, self.thisTrialN, self.thisTrial)
             logging.exp(msg % vals, obj=self.thisTrial)
+
+        # update experiment handler entry
+        exp = self.getExp()
+        if exp is not None:
+            exp.updateEntryFromLoop(self)
         
         return self.thisTrial
 

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -200,6 +200,14 @@ class TrialHandler(_BaseLoopHandler):
                     "        globals()[paramName] = %(name)s[paramName]\n")
             buff.writeIndentedLines(code % {'name': self.thisName})
 
+        # send data to Liaison before loop starts
+        if self.params['isTrials'].val:
+            buff.writeIndentedLines(
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendExperimentData()\n"
+            )
+
         # then run the trials loop
         code = "\nfor %s in %s:\n"
         buff.writeIndentedLines(code % (self.thisName, self.params['name']))
@@ -210,6 +218,14 @@ class TrialHandler(_BaseLoopHandler):
             "thisExp.timestampOnFlip(win, 'thisRow.t', format=globalClock.format)\n"
         )
         buff.writeIndentedLines(code % self.params)
+
+        # send data to Liaison at start of each iteration
+        if self.params['isTrials'].val:
+            buff.writeIndentedLines(
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendExperimentData()\n"
+            )
 
         # handle pausing
         code = (
@@ -342,9 +358,6 @@ class TrialHandler(_BaseLoopHandler):
             buff.writeIndentedLines(
                 "thisExp.nextEntry()\n"
                 "\n"
-                "if thisSession is not None:\n"
-                "    # if running in a Session with a Liaison client, send data up to now\n"
-                "    thisSession.sendExperimentData()\n"
             )
         # end of the loop. dedent
         buff.setIndentLevel(-1, relative=True)
@@ -352,7 +365,13 @@ class TrialHandler(_BaseLoopHandler):
                            % (self.params['nReps'], self.params['name']))
         buff.writeIndented("\n")
         # save data
-        if self.params['isTrials'].val == True:
+        if self.params['isTrials'].val:
+            # send final data to Liaison
+            buff.writeIndentedLines(
+                "if thisSession is not None:\n"
+                "    # if running in a Session with a Liaison client, send data up to now\n"
+                "    thisSession.sendExperimentData()\n"
+            )
             # a string to show all the available variables (if the conditions
             # isn't just None or [None])
             saveExcel = self.exp.settings.params['Save excel file'].val

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -1113,13 +1113,13 @@ class Session:
             How many trials into the future to look, by default 1
         start : int, optional
             How many trials into the future to start looking at, by default 0
+        asDict : bool
+            If True, convert Trial objects to a dict before returning (useful for Liaison)
         
         Returns
         -------
         list[Trial or dict or None]
             List of Trial objects n long. Any trials beyond the last trial are None.
-        asDict : bool
-            If True, convert Trial objects to a dict before returning (useful for Liaison)
         """
         # blank list to store trials in
         trials = []


### PR DESCRIPTION
- When a TrialHandler advances, it should tell ExperimentHandler what data the new trial has, so that this information is available via `thisExp` as soon as it is available via `thisTrial`
- Rather than sending data to Liaison after advancing the ExperimentHandler, we should send it at the start of a trial so the entries array has an entry for the current trial and the Liaison user has the opportunity to request future trials from the very start rather than from the start of the second trial