### PR TITLE
ENH: Add preference to control logging messages shown in the app specifically

### DIFF
--- a/psychopy/app/stdout/stdOutRich.py
+++ b/psychopy/app/stdout/stdOutRich.py
@@ -168,11 +168,6 @@ class StdOutRich(wx.richtext.RichTextCtrl, _BaseErrorHandler, handlers.ThemeMixi
 
             # sanitize message
             inStr = sanitize(inStr)
-            # get app logging level from prefs
-            targetLvl = logging._levelNames.get(
-                prefs.app['appLoggingLevel'].upper(),
-                logging.ERROR
-            )
 
             for thisLine in inStr.splitlines(True):
                 try:
@@ -205,9 +200,8 @@ class StdOutRich(wx.richtext.RichTextCtrl, _BaseErrorHandler, handlers.ThemeMixi
                             lvl = thisLvl
                             break
                     # if level allowed by prefs, set style and write
-                    if lvl >= targetLvl:
-                        self.BeginStyle(self.logLevelStyles[lvl])
-                        self.WriteText(thisLine)
+                    self.BeginStyle(self.logLevelStyles[lvl])
+                    self.WriteText(thisLine)
                 else:
                     # anything else
                     self.BeginStyle(self._styles['base'])

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -2059,6 +2059,8 @@ class SettingsComponent:
             "    # Flip one final time so any remaining win.callOnFlip() \n"
             "    # and win.timeOnFlip() tasks get executed\n"
             "    win.flip()\n"
+            "# return console logger level to WARNING\n"
+            "logging.console.setLevel(logging.WARNING)\n"
             "# mark experiment handler as finished\n"
             "thisExp.status = FINISHED\n"
             "# shut down eyetracker, if there is one\n"

--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -312,7 +312,7 @@ class _Logger():
         self.toFlush = []  # a new empty list
 
 root = _Logger()
-console = LogFile()
+console = LogFile(level=WARNING)
 
 
 def flush(logger=root):

--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -76,6 +76,9 @@ _levelNames = {
     'DEBUG': DEBUG,
     'NOTSET': NOTSET}
 
+# string to search for level names in a log message
+_levelNamesRe = "|".join(key for key in _levelNames if isinstance(key, str))
+
 _prefEncoding = locale.getpreferredencoding()
 
 def getLevel(level):

--- a/psychopy/logging.py
+++ b/psychopy/logging.py
@@ -191,6 +191,10 @@ class LogFile():
     def setLevel(self, level):
         """Set a new minimal level for the log file/stream
         """
+        # if given a name, get corresponding integer value
+        if isinstance(level, str):
+            level = getLevel(level)
+        # make sure we (now) have an integer
         if type(level) is not int:
             raise TypeError("LogFile.setLevel() should be given an int, which"
                             "is usually one of logging.INFO (not logging.info)")

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -57,6 +57,8 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
+    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,7 +151,7 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include in the log files when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -57,8 +57,6 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
-    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -151,8 +149,10 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -57,6 +57,8 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
+    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,7 +151,7 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include in the log files when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -57,8 +57,6 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
-    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -151,8 +149,10 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -57,6 +57,8 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
+    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,7 +151,7 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include in the log files when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -57,8 +57,6 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
-    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -151,8 +149,10 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -57,6 +57,8 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
+    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,7 +151,7 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include in the log files when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -57,8 +57,6 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most)
-    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -151,8 +149,10 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log files* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -53,6 +53,8 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -145,7 +147,7 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include in the log files when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -53,8 +53,6 @@
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
     defaultView = option('builder', 'coder', 'runner', 'all', default='all')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
-    appLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -147,8 +145,10 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
+    # How much output to display in the console / app when piloting ('error' is fewest messages, 'debug' is most).
+    pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting


### PR DESCRIPTION
Essentially, the problem we have is that researchers want as much information logged as possible, but *don't* want to trawl through huge amounts of gunk in the stdout panel. The solution I think is to have two different settings for log file level and app output level.

Currently, we control logging level in Experiment Settings as the log file is linked to the experiment and used in analysis (so we don't want it changing when different users run the same study). However, how much output you want in the runner panel is more a matter of personal preference and also isn't linked to the experiment (as there are log messages sent to Runner when e.g. a plugin fails to load, when no experiment is running), so I've put this in preferences rather than experiment settings.

The last potential point of confusion is which of these two is over-ridden by pilot mode (it's the log file setting), so I've updated the label to make that a bit clearer.

*For the science team*: Don't worry about reviewing the code itself, I've requested review from y'all in the sense that I want to check that this behaviour is good and intuitive. Does what I describe above sound good? If you pull down this branch and play around with some different settings, does the logging behave as you'd expect?