### PR TITLE
BF: TextStim letter height wasn't settable each frame/Routine in JS

### DIFF
--- a/psychopy/experiment/components/text/__init__.py
+++ b/psychopy/experiment/components/text/__init__.py
@@ -95,6 +95,22 @@ class TextComponent(BaseVisualComponent):
         del self.params['fillColor']
         del self.params['borderColor']
 
+    def _getParamCaps(self, paramName):
+        """
+        TEMPORARY FIX
+
+        TextStim in JS doesn't accept `letterHeight` as a param. Ideally this needs to be fixed
+        in JS, but in the meantime overloading this function in Python to write `setHeight`
+        rather than `setLetterHeight` means it stops biting users.
+        """
+        # call base function
+        paramName = BaseVisualComponent._getParamCaps(self, paramName)
+        # replace letterHeight
+        if paramName == "LetterHeight":
+            paramName = "Height"
+
+        return paramName
+
     def writeInitCode(self, buff):
         # do we need units code?
         if self.params['units'].val == 'from exp settings':


### PR DESCRIPTION
Due to a difference between the name used by Builder and the name used by PsychoJS. Ideally we'd change the name to fit in PsychoJS, but this fix stops the bug hitting users in the meantime