### PR TITLE
BF/ENH: Replace buggy template finding code for loops/form/counterbalance

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -212,8 +212,7 @@ class ParamCtrls():
         elif param.inputType == 'table':
             self.valueCtrl = paramCtrls.TableCtrl(
                 parent, 
-                val=param.val, 
-                valType=param.valType,
+                param=param,
                 fieldName=fieldName, 
                 size=wx.Size(int(self.valueWidth), 24))
         elif param.inputType == 'color':

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -941,19 +941,15 @@ class TableCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin, _FileMixin):
     def validate(self, evt=None):
         """Redirect validate calls to global validate method, assigning appropriate valType"""
         validate(self, "file")
-        # Disable Excel button if value is from a variable
-        if "$" in self.GetValue():
-            self.xlBtn.Disable()
-            return
-        # disable Excel button if invalid or not known until runtime
-        if any((
-            not self.valid,
-            "$" in self.GetValue(),
-        )):
-            self.xlBtn.Disable()
-        # re-enable Excel button if blank and we have a template
-        if "template" in self.param.ctrlParams and not self.GetValue().strip():
-            self.xlBtn.Enable()
+        # if field is blank, enable/diable according to whether there's a template
+        if not self.GetValue().strip():
+            self.xlBtn.Enable("template" in self.param.ctrlParams)
+        # otherwise, enable/disable according to validity
+        else:
+            self.xlBtn.Enable(self.valid)
+            # if value isn't known until runtime, always disable Excel button
+            if "$" in self.GetValue():
+                self.xlBtn.Disable()
 
     def openExcel(self, event):
         """Either open the specified excel sheet, or make a new one from a template"""

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -27,7 +27,7 @@ class FormComponent(BaseVisualComponent):
 
     def __init__(self, exp, parentName,
                  name='form',
-                 items='.csv',
+                 items='',
                  textHeight=0.03,
                  font="Open Sans",
                  randomize=False,
@@ -76,7 +76,11 @@ class FormComponent(BaseVisualComponent):
             items, valType='file', inputType="table", allowedTypes=[], categ='Basic',
             updates='constant',
             hint=_translate("The csv filename containing the items for your survey."),
-            label=_translate("Items"))
+            label=_translate("Items"),
+            ctrlParams={
+                'template': Path(__file__).parent / "formItems.xltx"
+            }
+        )
 
         self.params['Text Height'] = Param(
             textHeight, valType='num', inputType="single", allowedTypes=[], categ='Formatting',

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -17,6 +17,7 @@ The code that writes out a *_lastrun.py experiment file is (in order):
 """
 
 from copy import deepcopy
+from pathlib import Path
 from xml.etree.ElementTree import Element
 
 from psychopy.experiment import getInitVals
@@ -111,7 +112,11 @@ class TrialHandler(_BaseLoopHandler):
             hint=_translate("Name of a file specifying the parameters for "
                             "each condition (.csv, .xlsx, or .pkl). Browse "
                             "to select a file. Right-click to preview file "
-                            "contents, or create a new file."))
+                            "contents, or create a new file."),
+            ctrlParams={
+                'template': Path(__file__).parent / "loopTemplate.xltx"
+            }
+        )
         self.params['endPoints'] = Param(
             list(endPoints), valType='num', inputType="single", updates=None, allowedUpdates=None,
             label=_translate('End points'),
@@ -645,11 +650,37 @@ class MultiStairHandler(_BaseLoopHandler):
             label=_translate('Conditions'),
             hint=_translate("A list of dictionaries describing the "
                             "differences between each staircase"))
+
+        def getTemplate():
+            """
+            Method to get the template for this loop's chosen stair type. This is specified as a
+            method rather than a simple value as the control needs to update its target according
+            to the current value of stairType.
+
+            Returns
+            -------
+            pathlib.Path
+                Path to the appropriate template file
+            """
+            # root folder
+            root = Path(__file__).parent
+            # get file path according to stairType param
+            if self.params['stairType'] == "QUEST":
+                return root / "questTemplate.xltx"
+            elif self.params['stairType'] == "questplus":
+                return root / "questPlusTemplate.xltx"
+            else:
+                return root / "staircaseTemplate.xltx"
+
         self.params['conditionsFile'] = Param(
             conditionsFile, valType='file', inputType='table', updates=None, allowedUpdates=None,
             label=_translate('Conditions'),
             hint=_translate("An xlsx or csv file specifying the parameters "
-                            "for each condition"))
+                            "for each condition"),
+            ctrlParams={
+                'template': getTemplate
+            }
+        )
         self.params['isTrials'] = Param(
             isTrials, valType='bool', inputType='bool', updates=None, allowedUpdates=None,
             label=_translate("Is trials"),

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -116,7 +116,7 @@ class Param():
     def __init__(self, val, valType, inputType=None, allowedVals=None, allowedTypes=None,
                  hint="", label="", updates=None, allowedUpdates=None,
                  allowedLabels=None, direct=True,
-                 canBePath=True,
+                 canBePath=True, ctrlParams=None,
                  categ="Basic"):
         """
 
@@ -174,6 +174,9 @@ class Param():
         canBePath : bool
             Is it possible for this parameter to be a path? Setting to False will disable
             filepath sanitization (e.g. for textbox you may not want to replace \ with /)
+        ctrlParams : dict
+            Extra information to pass to the control, such as the Excel template file to use in a
+            `table` control.
         categ : str
             Category (tab) under which this param appears in Builder.
 
@@ -197,6 +200,7 @@ class Param():
         self.codeWanted = False
         self.canBePath = canBePath
         self.direct = direct
+        self.ctrlParams = ctrlParams or {}
         self.plugin = None
         if inputType:
             self.inputType = inputType

--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -119,35 +119,67 @@ class Param():
                  canBePath=True,
                  categ="Basic"):
         """
-        @param val: the value for this parameter
-        @type val: any
-        @param valType: the type of this parameter ('num', 'str', 'code')
-        @type valType: string
-        @param allowedVals: possible vals for this param
-            (e.g. units param can only be 'norm','pix',...)
-        @type allowedVals: any
-        @param allowedTypes: if other types are allowed then this is
-            the possible types this parameter can have
-            (e.g. rgb can be 'red' or [1,0,1])
-        @type allowedTypes: list
-        @param hint: describe this parameter for the user
-        @type hint: string
-        @param updates: how often does this parameter update
-            ('experiment', 'routine', 'set every frame')
-        @type updates: string
-        @param allowedUpdates: conceivable updates for this param
-            [None, 'routine', 'set every frame']
-        @type allowedUpdates: list
-        @param categ: category for this parameter
-            will populate tabs in Component Dlg
-        @type allowedUpdates: string
-        @param canBePath: is it possible for this parameter to be
-            a path? If so, writing as str will check for pathlike
-            characters and sanitise if needed.
-        @type canBePath: bool
-        @param direct: purely used in the test suite, marks whether this
-        param's value is expected to appear in the script
-        @type direct: bool
+
+        Parameters
+        ----------
+        val : any
+            The value for this parameter
+        valType : str
+            The type of this parameter, one of:
+            - str: A string, will be compiled with " around it
+            - extendedStr: A long string, will be compiled with " around it and linebreaks will
+              be preserved
+            - code: Some code, will be compiled verbatim or translated to JS (no ")
+            - extendedCode: A block of code, will be compiled verbatim or translated to JS and
+              linebreaks will be preserved
+            - file: A file path, will be compiled like str but will replace unescaped \ with /
+            - list: A list of values, will be compiled like code but if there's no [] or () then
+              these are added
+            Note that, if value begins with a $, it will always be treated as code regardless of
+            valType
+        inputType : str
+            The type of control to make for this parameter in Builder, one of:
+            - single: A single-line text control
+            - multi: A multi-line text control
+            - color: A single-line text control with a button to open the color picker
+            - survey: A single-line text control with a button to open Pavlovia surveys list
+            - file: A single-line text control with a button to open a file browser
+            - fileList: Several file controls with buttons to add/remove
+            - table: A file control with an additional button to open in Excel
+            - choice: A single-choice control (dropdown)
+            - multiChoice: A multi-choice control (tickboxes)
+            - richChoice: A single-choice control (dropdown) with rich text for each option
+            - bool: A single checkbox control
+            - dict: Several key:value pair controls with buttons to add/remove fields
+        allowedVals : list[str]
+            Possible vals for this param (e.g. units param can only be 'norm','pix',...),
+            these are used in the compiled code
+        allowedLabels : list[str] or None
+            Labels corresponding to each value in allowedVals, these are displayed in Builder but
+            not used in the compiled code. Leave as None to simply copy allowedVals.
+        hint : str
+            Tooltip to display when param is hovered over
+        label : str
+            Label to display next to param
+        updates : str
+            How often does this parameter update, usually one of:
+            - constant: Value is set just the once
+            - set every repeat: Value is set at the start of each Routine
+            - set every frame: Value is set each frame
+        allowedUpdates : list[str]
+            List of values to show in the choice control for updates.
+        direct : bool
+            Are we expecting the value of this param to directly appear in the compiled code?
+            Mostly used by the test suite to check that params which should be used are used.
+        canBePath : bool
+            Is it possible for this parameter to be a path? Setting to False will disable
+            filepath sanitization (e.g. for textbox you may not want to replace \ with /)
+        categ : str
+            Category (tab) under which this param appears in Builder.
+
+        Deprecated params
+        -----------------
+        allowedTypes
         """
         super(Param, self).__init__()
         self.label = label

--- a/psychopy/experiment/routines/counterbalance/__init__.py
+++ b/psychopy/experiment/routines/counterbalance/__init__.py
@@ -91,7 +91,11 @@ class CounterbalanceRoutine(BaseStandaloneRoutine):
             hint=_translate(
                 "Name of a file specifying the parameters for each group (.csv, .xlsx, or .pkl). Browse to select "
                 "a file. Right-click to preview file contents, or create a new file."
-            ))
+            ),
+            ctrlParams={
+                'template': Path(__file__).parent / "counterbalanceItems.xltx"
+            }
+        )
 
         self.params['conditionsVariable'] = Param(
             conditionsVariable, valType='code', inputType="single", categ="Basic",


### PR DESCRIPTION
As identified in #6501, the xltx files for various templates weren't always being found. 

We've gone back and forth fixing for one case & breaking for another with this, so this PR does away with the current system of "we climb the parent tree of the control until we find something with a reference to the Component/Routine/loop then check that name against an internal dict" as that method was prone to failure when using the control in a different context.

Instead, I just supply the path to the template *in the Param*. This is both less buggy and easier to understand for contributors - plus it makes it possible to add a new Excel template with a plugin rather than having to edit the base PsychoPy code.

To avoid cluttering the Param class too much, I've called the new attribute `ctrlParams` (i.e. "parameters controlling how the control looks") so that we can use the same attribute for other UI specific stuff.

The attached file contains one of each thing which uses the Excel templates, and also a loop containing a valid file link. Clicking on the Excel button for each of them seems to do the correct thing in this branch:
[testXltFind.zip](https://github.com/psychopy/psychopy/files/15502445/testXltFind.zip)