### PR TITLE
BF: Fixed .js file not being found when using "Use version" (removed _legacy from suffix)

### DIFF
--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -61,7 +61,7 @@ def generateScript(exp, outfile, target="PsychoPy"):
         # if compiling to JS, js file needs to have legacy filename
         _stem, _ext = os.path.splitext(outfile)
         if _ext == ".js":
-            outfile = _stem + "_legacy" + _ext
+            outfile = _stem + _ext
         # generate command to run compile from requested version
         cmd = [
             pythonExec, '-m', compiler, str(exp.legacyFilename), '-o', outfile

--- a/psychopy/scripts/psyexpCompile.py
+++ b/psychopy/scripts/psyexpCompile.py
@@ -58,10 +58,6 @@ def generateScript(exp, outfile, target="PsychoPy"):
         # make sure we have a legacy save file
         if not Path(exp.legacyFilename).is_file():
             exp.saveToXML(filename=exp.filename)
-        # if compiling to JS, js file needs to have legacy filename
-        _stem, _ext = os.path.splitext(outfile)
-        if _ext == ".js":
-            outfile = _stem + _ext
         # generate command to run compile from requested version
         cmd = [
             pythonExec, '-m', compiler, str(exp.legacyFilename), '-o', outfile


### PR DESCRIPTION
When a psychopy builder file has been synced to pavlovia, the pavlovia project creates the url run.pavlovia.org/username/projectname where projectname is the name of the js file it is looking for. If you use Use Version then at the moment it compiles projectname_legacy.js - which means that file is not used by the pavlovia project. We need the js file that is compiled to always be the same name as the .psyexp file we are working on and syncing from, even if a different version is used.

Here we prevent the "_legacy.js" ONLY on the js files so it only affects this part of the compiling process.