### PR TITLE
BF: check for pythonw executable on macOS in psychopyApp.py

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -73,17 +73,23 @@ Options:
             ('| packaged by conda-forge |' in sys.version or
              '|Anaconda' in sys.version)):
 
-        # On macOS with Anaconda, GUI applications need to be run using
+        # On macOS with Anaconda, GUI applications used to need to be run using
         # `pythonw`. Since we have no way to determine whether this is currently
         # the case, we run this script again -- ensuring we're definitely using
         # pythonw.
         import os
         env = os.environ
         PYTHONW = env.get('PYTHONW', 'False')
+        pyw_exe = sys.executable + 'w'
 
-        if PYTHONW != 'True':
+        # Updated 2024.1.6: as of Python 3, `pythonw` and `python` can be used
+        # interchangeably for wxPython applications on macOS with GUI support.
+        # The defaults and conda-forge channels no longer install python with a
+        # framework build (to do so: `conda install python=3.8 python.app`).
+        # Therefore `pythonw` often doesn't exist, and we can just use `python`.
+        if PYTHONW != 'True' and os.path.isfile(pyw_exe):
             from psychopy import core
-            cmd = [sys.executable + 'w', __file__]
+            cmd = [pyw_exe, __file__]
             if '--no-splash' in sys.argv:
                 cmd.append('--no-splash')
 


### PR DESCRIPTION
python3 supports Aqua window natively, so conda installed python doesn't have pythonw executable.

This is cherry-picked from #6436 to `dev`, now PR into `release`.