### PR TITLE
BF: catch AttributeError for sound.getDevices() when opening PreferenceDlg

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -430,7 +430,7 @@ class PreferencesDlg(wx.Dialog):
         # get sound devices for "audioDevice" property
         try:
             devnames = sorted(sound.getDevices('output'))
-        except (ValueError, OSError, ImportError):
+        except (ValueError, OSError, ImportError, AttributeError):
             devnames = []
 
         audioConf = self.prefsCfg['hardware']['audioDevice']

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -435,7 +435,7 @@ class PreferencesDlg(wx.Dialog):
 
         audioConf = self.prefsCfg['hardware']['audioDevice']
         self.audioDevDefault = audioConf \
-            if type(audioConf) != list else list(audioConf)
+            if type(audioConf) is list else list(audioConf)
         self.audioDevNames = [
             dev.replace('\r\n', '') for dev in devnames
             if dev != self.audioDevDefault]


### PR DESCRIPTION
When opening the preference window with conda installed psychopy application on macOS, not catching the `AttributeError` triggers an error of the problem and shuts down the psychopy software. Explicitly catching this type of error here allows the preference window to properly open even when PTB doesn't import correctly on macOS.

This is cherry-picked from #6436, now PR into `release`.