### PR TITLE
BF: correct import backend_pysound after module name change

### DIFF
--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -163,7 +163,7 @@ for thisLibName in prefs.hardware['audioLib']:
         # pysoundcard is a wrapper around PortAudio, which is a cross-platform
         # audio library.
         try:
-            from . import backend_pysoundcard as backend
+            from . import backend_pysound as backend
             Sound = backend.SoundPySoundCard
         except Exception:
             failed.append(thisLibName)

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -128,6 +128,8 @@ for thisLibName in prefs.hardware['audioLib']:
         # pyo is a wrapper around PortAudio, which is a cross-platform audio
         # library. It is the recommended backend for Windows and Linux.
         try:
+            # Caution: even import failed inside, we still get a module object.
+            # This is not the case for other backends and may not be desired.
             from . import backend_pyo as backend
             Sound = backend.SoundPyo
             pyoSndServer = backend.pyoSndServer
@@ -141,6 +143,8 @@ for thisLibName in prefs.hardware['audioLib']:
         # sounddevice is a wrapper around PortAudio, which is a cross-platform
         # audio library. It is the recommended backend for Windows and Linux.
         try:
+            # Caution: even import failed inside, we still get a module object.
+            # This is not the case for other backends and may not be desired.
             from . import backend_sounddevice as backend
             Sound = backend.SoundDeviceSound
         except Exception:

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -66,6 +66,7 @@ pyoSndServer = None
 Sound = None
 audioLib = None
 audioDriver = None
+backend = None
 
 # These are the names that can be used in the prefs to specifiy audio libraries. 
 # The available libraries are hard-coded at this point until we can overhaul 
@@ -200,7 +201,7 @@ else:
     # if we get here, there is no audioLib that is supported
     logging.error(
         "No audioLib could be loaded. Tried: {}\n Check whether the necessary "
-        "audioLibs are installed".format(prefs.hardware['audioLib']))
+        "audioLibs are installed.".format(prefs.hardware['audioLib']))
 
 # warn the user
 if audioLib is not None:
@@ -253,7 +254,12 @@ def setDevice(dev, kind=None):
 
 # Set the device according to user prefs (if current lib allows it)
 deviceNames = []
-if hasattr(backend, 'defaultOutput'):
+if backend is None:
+    raise ImportError("None of the audio library backends could be imported. "
+                      "Tried: {}\n Check whether the necessary audioLibs are "
+                      "installed and can be imported successfully."
+                      .format(prefs.hardware['audioLib']))
+elif hasattr(backend, 'defaultOutput'):
     pref = prefs.hardware['audioDevice']
     # is it a list or a simple string?
     if type(prefs.hardware['audioDevice'])==list:

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -15,7 +15,7 @@ a given time in the future.
 By default PsychoPy will try to use the following Libs, in this order, for
 sound reproduction but you can alter the order in
 preferences > hardware > audioLib:
-    ['sounddevice', 'pygame', 'pyo']
+    ['sounddevice', 'pyo', 'pygame']
 For portaudio-based backends (all except for pygame) there is also a
 choice of the underlying sound driver (e.g. ASIO, CoreAudio etc).
 

--- a/psychopy/sound/backend_pysound.py
+++ b/psychopy/sound/backend_pysound.py
@@ -25,6 +25,7 @@ def init(rate=44100, stereo=True, buffer=128):
     pass
     # for compatibility with other backends but not needed
 
+
 def getDevices(kind=None):
     """Returns a dict of dict of audio devices of specified `kind`
 
@@ -32,14 +33,15 @@ def getDevices(kind=None):
     """
     devs = {}
     for ii, dev in enumerate(soundcard.device_info()):
-        if (dev['max_output_channels']==0 and kind=='output' or
-                dev['max_input_channels']==0 and kind=='input'):
+        if (dev['max_output_channels'] == 0 and kind == 'output' or
+                dev['max_input_channels'] == 0 and kind == 'input'):
             continue
         # newline characters must be removed
-        devName = dev['name'].replace('\r\n','')
+        devName = dev['name'].replace('\r\n', '')
         devs[devName] = dev
         dev['id'] = ii
     return devs
+
 
 # these will be controlled by sound.__init__.py
 defaultInput = None


### PR DESCRIPTION
The pysoundcard file name has been changed to `backend_pysound` instead of `backend_pysoundcard`. This BF fixes an attempt to import it.

This is cherry-picked from #6436, now PR into `release`.