### PR TITLE
BF: fix double position offset for Line polygon shape

### DIFF
--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -187,8 +187,8 @@ class PolygonComponent(BaseVisualComponent):
                     "    size=%(size)s,\n" % inits)
 
         code += ("    ori=%(ori)s, pos=%(pos)s, anchor=%(anchor)s,\n"
-                 "    lineWidth=%(lineWidth)s, "
-                 "    colorSpace=%(colorSpace)s,  lineColor=%(lineColor)s, fillColor=%(fillColor)s,\n"
+                 "    lineWidth=%(lineWidth)s,\n"
+                 "    colorSpace=%(colorSpace)s, lineColor=%(lineColor)s, fillColor=%(fillColor)s,\n"
                  "    opacity=%(opacity)s, " % inits)
 
         depth = -self.getPosInRoutine()

--- a/psychopy/layout.py
+++ b/psychopy/layout.py
@@ -171,16 +171,16 @@ class Vector:
             self.valid = False
 
         # Replace None with the matching window dimension
-        if (value == None).any() or np.isnan(value).any():
+        if (value == None).any() or np.isnan(value).any():  # noqa: E711
             win = Vector((1, 1), units="norm", win=self.win)
             if len(value.shape) == 1:
-                value[value == None] = getattr(win, units)[value == None]
+                value[value == None] = getattr(win, units)[value == None]  # noqa: E711
                 value[np.isnan(value)] = getattr(win, units)[np.isnan(value)]
             else:
                 value[np.isnan(value[:, 0]), 0] = getattr(win, units)[0]
                 value[np.isnan(value[:, 1]), 1] = getattr(win, units)[1]
-                value[value[:, 0] == None, 0] = getattr(win, units)[0]
-                value[value[:, 1] == None, 1] = getattr(win, units)[1]
+                value[value[:, 0] == None, 0] = getattr(win, units)[0]  # noqa: E711
+                value[value[:, 1] == None, 1] = getattr(win, units)[1]  # noqa: E711
 
         assert self.valid, (f"Array of position/size values must be either "
                             f"Nx1, Nx2 or Nx3, not {value.shape}")

--- a/psychopy/layout.py
+++ b/psychopy/layout.py
@@ -832,19 +832,13 @@ class Vertices:
         value *= self._flip
         # Account for anchor
         value -= self.anchorAdjust * getattr(self.size, units)
+        # Account for pos
+        if self.pos is None:
+            raise ValueError(
+                u"Cannot not calculate absolute positions of vertices without "
+                u"a pos attribute")
 
-        # NOTE: This is commented out because the pos attribute is already used
-        # to calculate the absolute position of the vertices during drawing.
-        # If we subtract the pos attribute again, the vertices will be offset
-        # by the pos attribute twice, and the orientation calculation will be off.
-
-        # # Account for pos
-        # if self.pos is None:
-        #     raise ValueError(
-        #         u"Cannot not calculate absolute positions of vertices without "
-        #         u"a pos attribute")
-        # value -= getattr(self.pos, units)
-
+        value -= getattr(self.pos, units)
         self.base = value  # apply
 
     @property

--- a/psychopy/layout.py
+++ b/psychopy/layout.py
@@ -832,13 +832,19 @@ class Vertices:
         value *= self._flip
         # Account for anchor
         value -= self.anchorAdjust * getattr(self.size, units)
-        # Account for pos
-        if self.pos is None:
-            raise ValueError(
-                u"Cannot not calculate absolute positions of vertices without "
-                u"a pos attribute")
 
-        value -= getattr(self.pos, units)
+        # NOTE: This is commented out because the pos attribute is already used
+        # to calculate the absolute position of the vertices during drawing.
+        # If we subtract the pos attribute again, the vertices will be offset
+        # by the pos attribute twice, and the orientation calculation will be off.
+
+        # # Account for pos
+        # if self.pos is None:
+        #     raise ValueError(
+        #         u"Cannot not calculate absolute positions of vertices without "
+        #         u"a pos attribute")
+        # value -= getattr(self.pos, units)
+
         self.base = value  # apply
 
     @property

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -173,7 +173,7 @@ class Line(ShapeStim):
             lineColorSpace=None,
             fillColor=None,
             fillColorSpace=lineColorSpace,  # have these set to the same
-            vertices=None,  # vertices will be overwritten by _vertices.setas()
+            vertices=(start, end),
             anchor=anchor,
             closeShape=False,
             pos=pos,
@@ -192,7 +192,6 @@ class Line(ShapeStim):
             color=color,
             colorSpace=colorSpace)
 
-        self._vertices.setas([start, end], self.units)
         del self._tesselVertices
 
     @property

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -173,7 +173,7 @@ class Line(ShapeStim):
             lineColorSpace=None,
             fillColor=None,
             fillColorSpace=lineColorSpace,  # have these set to the same
-            vertices=None,
+            vertices=None,  # vertices will be overwritten by _vertices.setas()
             anchor=anchor,
             closeShape=False,
             pos=pos,


### PR DESCRIPTION
As reported by #6509, polygon `Line` shapes in builder do not have correct position setting. After looking into this a bit, I believe the problem comes from the fact that `WindowMixin` methods already take the `.pos` attribute into account when drawing shapes that carry the `Vertices` class instances in the `_vertices` attribute. So subtracting `.pos` again will offset the `Line` shape twice, resulting in incorrect positioning and orientation.

@TEParsons I noticed that the `Vertices.setas()` method is really only used by the `visual.Line` class alone and not by any other polygon shapes. This makes me wonder whether [these lines](https://github.com/psychopy/psychopy/blob/aebf519ede786c4a16749c56f44fd0d89bd519d8/psychopy/layout.py#L831) accounting for flip and anchor are also erroneously repeating what shape drawing functions already take care of, when the changes are non-zero. I didn't have time to look into this too closely but I want to flag it for you.