### PR TITLE
BF: remove incorrect code on removing eyetracker generated by builder

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -2038,9 +2038,6 @@ class SettingsComponent:
             "    win.flip()\n"
             "# mark experiment handler as finished\n"
             "thisExp.status = FINISHED\n"
-            "# shut down eyetracker, if there is one\n"
-            "if deviceManager.getDevice('eyetracker') is not None:\n"
-            "    deviceManager.removeDevice('eyetracker')\n"
         )
         if self.params['Save log file'].val:
             code += (
@@ -2077,9 +2074,6 @@ class SettingsComponent:
             "    # and win.timeOnFlip() tasks get executed before quitting\n"
             "    win.flip()\n"
             "    win.close()\n"
-            "# shut down eyetracker, if there is one\n"
-            "if deviceManager.getDevice('eyetracker') is not None:\n"
-            "    deviceManager.removeDevice('eyetracker')\n"
         )
         if self.params['Save log file'].val:
             code += (


### PR DESCRIPTION
This BF is a bit complicated to explain. Essentially I was trying to figure out why is EyeLink eyetrackers not properly shutdown at the end of an experiment, which led me to these lines of code generated by builder that look like they are meant to shut down an eyetracker.

However, if we look at the [removeDevice()](https://github.com/psychopy/psychopy/blob/0a5945c936b0d23ea9240ec88841c05bc34866c7/psychopy/hardware/manager.py#L422) method, it relies on an exposed `close()` method. But for all ioHub devices, they are hosted on separate processes and accessed through [ioHubDeviceView](https://github.com/psychopy/psychopy/blob/eec43c3d58f7270379f4a05da8d923288e6ec592/psychopy/iohub/client/__init__.py#L123) instances over a server client. Therefore, calling `deviceManager.removeDevice('eyetracker')` doesn't actually shut down an eyetracker process (or in fact, any ioHub devices stored in this dictionary). The `ioHub` eyetracker is only shutdown when the ioServer is stopped as [a part](https://github.com/psychopy/psychopy/blob/0a5945c936b0d23ea9240ec88841c05bc34866c7/psychopy/app/runner/scriptProcess.py#L206) of the `core.quit()` procedures. The `terminateHubProcess()` method calls `_close()` on each of the ioHub devices, including `EyeTrackerDevice` such as for the [mousegaze](https://github.com/psychopy/psychopy/blob/0a5945c936b0d23ea9240ec88841c05bc34866c7/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py#L441).

I'm proposing to remove these confusing lines when generating script from builder, since they don't actually shut down eyetrackers. My primary problem of not closing EyeLink correctly is actually caused by something related: `_close()` isn't even implemented in the `psychopy-sr-research` package, which I'll PR to that repo to fix.