### PR TITLE
FF: Initial value for Textbox orientation wasn't used

### DIFF
--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -261,6 +261,7 @@ class TextboxComponent(BaseVisualComponent):
                 "  letterHeight: %(letterHeight)s,\n"
                 "  lineSpacing: %(lineSpacing)s,\n"
                 "  size: %(size)s," + unitsStr +
+                "  ori: %(ori)s,\n"
                 "  color: %(color)s, colorSpace: %(colorSpace)s,\n"
                 "  fillColor: %(fillColor)s, borderColor: %(borderColor)s,\n"
                 "  languageStyle: %(languageStyle)s,\n"

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -252,6 +252,9 @@ class TextBox2(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin):
         self._text = ''
         self.text = self.startText = text if text is not None else ""
 
+        # not that we have text, set orientation
+        self.ori = ori
+
         # Initialise arabic reshaper
         arabic_config = {'delete_harakat': False,  # if present, retain any diacritics
                          'shift_harakat_position': False}  # shift by 1 to be compatible with the bidi algorithm

--- a/psychopy/visual/textbox2/textbox2.py
+++ b/psychopy/visual/textbox2/textbox2.py
@@ -252,7 +252,7 @@ class TextBox2(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin):
         self._text = ''
         self.text = self.startText = text if text is not None else ""
 
-        # not that we have text, set orientation
+        # now that we have text, set orientation
         self.ori = ori
 
         # Initialise arabic reshaper


### PR DESCRIPTION
My mistake, I'd been testing using `set each repeat` to make sure it could be set dynamically, so I missed that it actually didn't work *unless* it was dynamic :')