### PR TITLE
BF: Fixed duplicate dependency install on MacOS and package installation in virtual environments

### DIFF
--- a/building/createInitFile.py
+++ b/building/createInitFile.py
@@ -134,8 +134,7 @@ if 'installing' not in locals():
 
         # set user site packages
         env['PYTHONUSERBASE'] = prefs.paths['packages']
-        env['PYTHONNOUSERSITE'] = '1'  # isolate user packages
-
+        
         # update environment, pass this to sub-processes (e.g. pip)
         os.environ.update(env)
 

--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -75,7 +75,6 @@ if 'installing' not in locals():
 
         # set user site packages
         env['PYTHONUSERBASE'] = prefs.paths['packages']
-        env['PYTHONNOUSERSITE'] = '1'  # isolate user packages
 
         # update environment, pass this to sub-processes (e.g. pip)
         os.environ.update(env)

--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -8,6 +8,7 @@ from psychopy.app import getAppInstance
 from psychopy.app.plugin_manager import PluginManagerPanel, PackageManagerPanel, InstallStdoutPanel
 from psychopy.experiment import getAllElements
 from psychopy.localization import _translate
+import psychopy.logging as logging
 import psychopy.tools.pkgtools as pkgtools
 import psychopy.app.jobs as jobs
 import sys
@@ -246,9 +247,22 @@ class EnvironmentManagerDlg(wx.Dialog):
         # On MacOS, we need to install to target instead of user since py2app
         # doesn't support user installs correctly, this is a workaround for that
         env = os.environ.copy()
+
         # build the shell command to run the script
-        command = [pyExec, '-m', 'pip', 'install', str(packageName), 
-                    '--user', '--prefer-binary']
+        command = [pyExec, '-m', 'pip', 'install', str(packageName)]
+
+        # check if we are inside a venv, don't use --user if we are
+        if hasattr(sys, 'real_prefix') or (
+                hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+            # we are in a venv
+            command.append('--user')
+            logging.warning(
+                "You are installing a package inside a virtual environment. "
+                "The package will be installed in the user site-packages directory."
+            )
+        
+        # add other options to the command
+        command += ['--prefer-binary', '--no-input', '--no-color']
             
         # write command to output panel
         self.output.writeCmd(" ".join(command))

--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -255,11 +255,12 @@ class EnvironmentManagerDlg(wx.Dialog):
         if hasattr(sys, 'real_prefix') or (
                 hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
             # we are in a venv
-            command.append('--user')
             logging.warning(
                 "You are installing a package inside a virtual environment. "
                 "The package will be installed in the user site-packages directory."
             )
+        else:
+            command.append('--user')
         
         # add other options to the command
         command += ['--prefer-binary', '--no-input', '--no-color']

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -202,6 +202,17 @@ def installPackage(package, target=None, upgrade=False, forceReinstall=False,
     if noDeps:
         cmd.append('--no-deps')
 
+    # check if we are in a virtual environment, if so, dont use --user
+    if hasattr(sys, 'real_prefix') or (
+            hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
+        # we are in a venv
+        cmd.append('--user')
+        logging.warning(
+            "You are installing a package inside a virtual environment. "
+            "The package will be installed in the user site-packages directory."
+        )
+
+    cmd.append('--prefer-binary')  # use binary wheels if available
     cmd.append('--no-input')  # do not prompt, we cannot accept input
     cmd.append('--no-color')  # no color for console, not supported
     cmd.append('--no-warn-conflicts')  # silence non-fatal errors

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -206,11 +206,12 @@ def installPackage(package, target=None, upgrade=False, forceReinstall=False,
     if hasattr(sys, 'real_prefix') or (
             hasattr(sys, 'base_prefix') and sys.base_prefix != sys.prefix):
         # we are in a venv
-        cmd.append('--user')
         logging.warning(
             "You are installing a package inside a virtual environment. "
             "The package will be installed in the user site-packages directory."
         )
+    else:
+        cmd.append('--user')
 
     cmd.append('--prefer-binary')  # use binary wheels if available
     cmd.append('--no-input')  # do not prompt, we cannot accept input


### PR DESCRIPTION
Fixes an issue when installing plugins where if a dependency is already shipped with PsychoPy, it won't download and install another copy in the user package directory. This issue was present on MacOS and not Windows.

Also added code to the package install routines that detects if we are in a virtual environment. This should allow the user to install packages when in a venv.