### PR TITLE
BF: use default speaker device if index is default

### DIFF
--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -1,5 +1,5 @@
 from psychopy.hardware import BaseDevice
-from psychopy.sound import setDevice, getDevices
+from psychopy.sound import setDevice, getDevices, backend
 
 
 class SpeakerDevice(BaseDevice):
@@ -8,6 +8,19 @@ class SpeakerDevice(BaseDevice):
         if not isinstance(index, (int, float)) or index < 0:
             profiles = self.getAvailableDevices()
             index = profiles[0]['index']
+
+            # check if a default device is set and update index
+            if hasattr(backend, 'defaultOutput'):
+                defaultDevice = backend.defaultOutput
+                if isinstance(defaultDevice, int):
+                    # if a default device index is set, use it
+                    index = defaultDevice
+                elif isinstance(defaultDevice, str):
+                    # if a default device is set by name, find it
+                    for profile in profiles:
+                        if profile['deviceName'] == defaultDevice:
+                            index = profile['index']
+
         # store index
         self.index = index
         # set global device (best we can do for now)

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -1,12 +1,14 @@
 from psychopy.hardware import BaseDevice
 from psychopy.sound import setDevice, getDevices, backend
+from psychopy import logging
 
 
 class SpeakerDevice(BaseDevice):
     def __init__(self, index):
+        profiles = self.getAvailableDevices()
+
         # use first device if index is default
         if not isinstance(index, (int, float)) or index < 0:
-            profiles = self.getAvailableDevices()
             index = profiles[0]['index']
 
             # check if a default device is set and update index
@@ -20,6 +22,9 @@ class SpeakerDevice(BaseDevice):
                     for profile in profiles:
                         if profile['deviceName'] == defaultDevice:
                             index = profile['index']
+
+        if index < 0 or index >= len(profiles):
+            logging.error("No speaker device found with index %d" % index)
 
         # store index
         self.index = index

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -12,7 +12,7 @@ class SpeakerDevice(BaseDevice):
             # check if a default device is set and update index
             if hasattr(backend, 'defaultOutput'):
                 defaultDevice = backend.defaultOutput
-                if isinstance(defaultDevice, int):
+                if isinstance(defaultDevice, (int, float)):
                     # if a default device index is set, use it
                     index = defaultDevice
                 elif isinstance(defaultDevice, str):

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -68,9 +68,9 @@ audioLib = None
 audioDriver = None
 backend = None
 
-# These are the names that can be used in the prefs to specifiy audio libraries. 
-# The available libraries are hard-coded at this point until we can overhaul 
-# the sound library to be more modular. 
+# These are the names that can be used in the prefs to specifiy audio libraries.
+# The available libraries are hard-coded at this point until we can overhaul
+# the sound library to be more modular.
 _audioLibs = ['PTB', 'sounddevice', 'pyo', 'pysoundcard', 'pygame']
 failed = []  # keep track of audio libs that failed to load
 
@@ -91,12 +91,12 @@ for thisLibName in prefs.hardware['audioLib']:
     logging.info(f"Trying to load audio library: {thisLibName}")
 
     # Iterate over the list of audioLibs and try to load the first one that
-    # is supported. If none are supported, load PTB as a fallback. If PTB isn't 
+    # is supported. If none are supported, load PTB as a fallback. If PTB isn't
     # installed, raise an error.
     thisLibName = thisLibName.lower()
 
     # lowercased list of valid audio libraries for safe comparisons
-    validLibs = [libName.lower() for libName in _audioLibs]  
+    validLibs = [libName.lower() for libName in _audioLibs]
 
     # check if `thisLibName` is a valid audio library
     if thisLibName not in validLibs:
@@ -119,7 +119,7 @@ for thisLibName in prefs.hardware['audioLib']:
                 failed.append(thisLibName)
                 continue
             else:
-                break 
+                break
         else:
             logging.warning("PTB backend is not supported on 32-bit Python. "
                             "Trying another backend...")
@@ -154,7 +154,7 @@ for thisLibName in prefs.hardware['audioLib']:
             break
     elif thisLibName == 'pygame':
         # pygame is a cross-platform audio library. It is no longer supported by
-        # PsychoPy, but we keep it here for backwards compatibility until 
+        # PsychoPy, but we keep it here for backwards compatibility until
         # something breaks.
         try:
             from . import backend_pygame as backend
@@ -178,11 +178,11 @@ for thisLibName in prefs.hardware['audioLib']:
     else:
         # Catch-all for invalid audioLib prefs.
         msg = ("audioLib pref should be one of {!r}, not {!r}"
-                .format(_audioLibs, thisLibName))
+               .format(_audioLibs, thisLibName))
         raise ValueError(msg)
 else:
     # if we get here, there is no audioLib that is supported, try for PTB
-    msg = ("Failed to load any of the audioLibs: {!r}. Falling back to " 
+    msg = ("Failed to load any of the audioLibs: {!r}. Falling back to "
            "PsychToolbox ('ptb') backend for sound. Be sure to add 'ptb' to "
            "preferences to avoid seeing this message again.".format(failed))
     logging.error(msg)
@@ -233,12 +233,12 @@ def setDevice(dev, kind=None):
     if dev is None:
         # if given None, do nothing
         return
-    
+
     global backend  # pull from module namespace
     if not hasattr(backend, 'defaultOutput'):
         raise IOError("Attempting to SetDevice (audio) but not supported by "
                       "the current audio library ({!r})".format(audioLib))
-    
+
     if hasattr(dev, 'name'):
         dev = dev['name']
 
@@ -266,14 +266,14 @@ if backend is None:
 elif hasattr(backend, 'defaultOutput'):
     pref = prefs.hardware['audioDevice']
     # is it a list or a simple string?
-    if type(prefs.hardware['audioDevice'])==list:
+    if isinstance(pref, list):
         # multiple options so use zeroth
-        dev = prefs.hardware['audioDevice'][0]
+        dev = pref[0]
     else:
         # a single option
-        dev = prefs.hardware['audioDevice']
+        dev = pref
     # is it simply "default" (do nothing)
-    if dev=='default' or systemtools.isVM_CI():
+    if dev == 'default' or systemtools.isVM_CI():
         pass  # do nothing
     elif dev not in backend.getDevices(kind='output'):
         deviceNames = sorted(backend.getDevices(kind='output').keys())


### PR DESCRIPTION
Right now if a Speaker Component has the `Default` option selected for the _Speaker_ setting, it uses the first device and forces the global device to this first device for everyone else. This does not really achieve what `Default` is expected to do, which should check any existing `backend.defaultOutput` and just use that.

It looks like different sound components cannot play to different speakers right now with a single MasterStream in the backend. But inheriting whatever `defaultOutput` is already set at is better than forcing everyone else to use the **first** device.