### PR TITLE
added missing lines. es-co, es_es and es_us now completed.

### DIFF
--- a/psychopy/app/locale/es_CO/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/es_CO/LC_MESSAGE/messages.po
@@ -1,20 +1,20 @@
 # Part of the PsychoPy library.
 # Copyright (C) 2015 Jonathan Peirce
-# CLAUDIO DE LA ROSA MUNAR <cdelarosa@delarosaresearch.com>, 2023.
+# CLAUDIO ALFREDO DE LA ROSA MUNAR <cdelarosa@delarosaresearch.com>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PsychoPy 2023.2.3\n"
+"Project-Id-Version: PsychoPy 2023.2.1\n"
 "POT-Creation-Date: 2023-08-31 10:34-0500\n"
 "PO-Revision-Date: \n"
-"Last-Translator: Claudio de la Rosa Munar <cdelarosa@delarosaresearch.com>\n"
+"Last-Translator: Claudio Alfredo de la Rosa Munar <cdelarosa@delarosaresearch.com>\n"
 "Language-Team: psychopy_spanish@opensciencetools.org\n"
 "Language: es_CO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.1\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-Basepath: ../../../../..\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: _translate\n"
@@ -301,9 +301,8 @@ msgid "Compatibility information"
 msgstr "Información de compatibilidad"
 
 #: psychopy/app/_psychopyApp.py:654
-#, fuzzy
 msgid "tips.txt"
-msgstr "consejos.txt"
+msgstr "tips.txt"
 
 #: psychopy/app/_psychopyApp.py:692
 msgid "  Loading plugins..."
@@ -1981,7 +1980,7 @@ msgstr "Error de sintaxis de Python en el campo `{}`: {}"
 #: psychopy/app/builder/validators.py:528
 #, python-brace-format
 msgid "Looks like your variable '{code}' in '{displayName}' should be set to update."
-msgstr "Parece que su variable {code}’ en ‘{displayName}’ debe ser fijada en actualizar."
+msgstr "Parece que su variable’{code}’ en ‘{displayName}’ debe ser definido para actualizar."
 
 #: psychopy/app/builder/validators.py:548
 msgid "Python var `{}` in `{}` is same as Name"
@@ -2605,7 +2604,7 @@ msgstr "Cerrar el shell actual."
 
 #: psychopy/app/coder/repl.py:66
 msgid "Close the current shell and start a new one, this will clear any variables."
-msgstr "Cierre la ventana Shell / Cmd e inicie una nueva, esto borrará cualquier variables."
+msgstr "Cierre el sell actual y comience uno nuevo, esto borrará todas las variables."
 
 #: psychopy/app/coder/repl.py:86 psychopy/app/stdout/stdOutRich.py:223
 msgid "Clear all previous output."
@@ -2670,7 +2669,7 @@ msgstr "Esta versión es una actualización demasiado grande para manejarla auto
 
 #: psychopy/app/connections/updates.py:144
 msgid "Please fetch the latest version from www.psychopy.org and install manually."
-msgstr "Por favor obtenga la versión mas actualizada desde www.psychopy.org e instálela manualmente."
+msgstr "Por favor busque la última versión en www.psychopy.org e instálela de forma manual."
 
 #: psychopy/app/connections/updates.py:149
 msgid "Go to downloads"
@@ -3240,7 +3239,7 @@ msgstr ""
 #: psychopy/app/pavlovia_ui/project.py:676
 #, python-brace-format
 msgid "Could not find folder {directory}, please select a different local root."
-msgstr "No se encuentra la carpeta {directory}, por favor seleccione una nueva raiz."
+msgstr ""
 
 #: psychopy/app/pavlovia_ui/project.py:714
 msgid "Project info has changed, update online before closing?"
@@ -4339,7 +4338,7 @@ msgstr "Archivo de condiciones no encontrado: %s"
 
 #: psychopy/data/utils.py:377
 msgid "openpyxl or xlrd is required for loading excel files, but neither was found."
-msgstr "openpyxl o xlrd se requiere para cargar archivos de excel, pero ninguno se encontró."
+msgstr "openpyxl o xlrd es requerido para cargar archivos de excel, pero ninguno ha sido encontrado."
 
 #: psychopy/data/utils.py:452
 #, python-format
@@ -4432,7 +4431,7 @@ msgstr "Duración esperada(s)"
 
 #: psychopy/experiment/components/_base.py:106
 msgid "Store the onset/offset times in the data file (as well as in the log file)."
-msgstr "Almacene los tiempos de inicio/compensación en el archivo de datos (así como en el archivo de registro)."
+msgstr "Almacena los tiempos onset/offset en un archivo de datos (así como el archivo tipo log)."
 
 #: psychopy/experiment/components/_base.py:111
 msgid "Save onset/offset times"
@@ -5080,7 +5079,7 @@ msgstr "Velocidad de los puntos (desplazamiento por cuadro en las unidades espec
 
 #: psychopy/experiment/components/dots/__init__.py:92
 msgid "Coherence of the dots (fraction moving in the signal direction on any one frame)"
-msgstr "Coherencia de los puntos (fracción que se mueve en la dirección de la señal en cualquier cuadro)"
+msgstr "Coherencia en los puntos (fracción moviéndose en la dirección de la señal en cualquiera de los cuadros)."
 
 #: psychopy/experiment/components/dots/__init__.py:101
 msgid "Size of the dots IN PIXELS regardless of the set units"
@@ -5293,7 +5292,7 @@ msgstr "Una imagen para definir la máscara alfa (es decir, forma): gauss, círc
 
 #: psychopy/experiment/components/grating/__init__.py:73
 msgid "Spatial frequency of image repeats across the grating in 1 or 2 dimensions, e.g. 4 or [2,3]"
-msgstr "La frecuencia espacial de la imagen se repite a lo largo de la rejilla en 1 o 2 dimensiones, p. 4 o [2,3]"
+msgstr "La frecuencia espacial de la imagen se repite a través del degradado en 1 o 2 dimensiones, p.e. 4 o [2,3]"
 
 #: psychopy/experiment/components/grating/__init__.py:95 psychopy/experiment/components/image/__init__.py:116
 #: psychopy/experiment/components/movie/__init__.py:127 psychopy/experiment/components/polygon/__init__.py:103
@@ -5344,8 +5343,8 @@ msgstr "La imagen que se mostrará: un nombre de archivo, incluida la ruta"
 #: psychopy/experiment/components/image/__init__.py:63
 msgid "An image to define the alpha mask through which the image is seen - gauss, circle, None or a filename (including path)"
 msgstr ""
-"Una imagen para definir la máscara alfa a través de la cual se ve la imagen: gauss, círculo, Ninguno o un nombre de archivo "
-"(incluida la ruta)"
+"Una imagen para definir la mascará alpha a través de la cual la imagen es vista - gausiano, circulo, Ninguno o un nombre de "
+"archivo ( incluyendo su ruta)"
 
 #: psychopy/experiment/components/image/__init__.py:72
 msgid "Resolution of the mask if one is used."
@@ -5962,7 +5961,7 @@ msgstr "Color de la línea alrededor de la barra de progreso."
 
 #: psychopy/experiment/components/progress/__init__.py:65
 msgid "Value between 0 (not started) and 1 (complete) to set the progress bar to."
-msgstr "Valor entre 0 (no iniciado) y 1 (completo) para configurar la barra de progreso."
+msgstr "Valor entre 0 (no iniciado) y 1 ( completo) para definir la barra de progreso."
 
 #: psychopy/experiment/components/progress/__init__.py:67
 msgid "Progress"
@@ -6281,7 +6280,7 @@ msgstr "Ajuste de fondo"
 
 #: psychopy/experiment/components/routineSettings/__init__.py:147
 msgid "Save the start and stop times of this Routine (according to the global clock) to the data file."
-msgstr "Guarde los tiempos de inicio y finalización de esta rutina (según el reloj global) en el archivo de datos."
+msgstr "Guarda los tiempos de inicio y de finalización de esta rutina (de acuerdo al reloj global) del archivo de datos."
 
 #: psychopy/experiment/components/serialOut/__init__.py:29
 msgid "Serial out: send signals from a serial port"
@@ -6626,7 +6625,9 @@ msgstr "Guardar archivo hdf5"
 
 #: psychopy/experiment/components/settings/__init__.py:389
 msgid "How much output do you want in the log files? ('error' is fewest messages, 'debug' is most)"
-msgstr "¿Cuánta salida desea en los archivos de registro? (‘error’ es la menor cantidad de mensajes, ‘debug’ es la mayor parte)"
+msgstr ""
+"Que cantidad de salida usted quiere en el archivo tipo log? (‘error’ significa menos mensajes, ‘debug’ significa la mayor "
+"cantidad)"
 
 #: psychopy/experiment/components/settings/__init__.py:400
 msgid "Place the HTML files will be saved locally "
@@ -7018,7 +7019,7 @@ msgstr "Código personalizado"
 
 #: psychopy/experiment/components/static/__init__.py:32
 msgid "Static: Static screen period (e.g. an ISI). Useful for pre-loading stimuli."
-msgstr "Estático: Período de pantalla estático (por ejemplo, un ISI). Útil para precarga de estímulos."
+msgstr "Estatica: Periodo de tiempo estático (p.e. un ISI). Útil para precargar estímulos."
 
 #: psychopy/experiment/components/static/__init__.py:49
 msgid "Custom code to be run during the static period (after updates)"
@@ -7274,8 +7275,8 @@ msgid ""
 "To have a fixed random sequence provide an integer of your choosing here. Leave blank to have a new random sequence on each run "
 "of the experiment."
 msgstr ""
-"Para tener una secuencia aleatoria fija, proporcione aquí un número entero de su elección. Déjelo en blanco para tener una nueva "
-"secuencia aleatoria en cada ejecución del experimento."
+"Para tener una secuencia aleatoria fija provea un número entero de su preferencia aquí. Deje en blanco para tener una secuencia "
+"aleatoria para cada ejecución de este experimento."
 
 #: psychopy/experiment/loops.py:145 psychopy/experiment/loops.py:490 psychopy/experiment/loops.py:627
 msgid ""
@@ -8071,7 +8072,7 @@ msgstr ""
 
 #: psychopy/preferences/hints.py:67
 msgid "Show an error dialog when PsychoPy encounters an unhandled internal error."
-msgstr "Muestra un cuadro de diálogo de error cuando PsychoPy encuentra un error interno no controlado."
+msgstr "Muestra un dialogo de error cuando PsychoPy encuentra un error interno no manejado."
 
 #: psychopy/preferences/hints.py:70
 msgid "Theme"
@@ -8431,7 +8432,7 @@ msgstr "PavloviaSession.createProject recibió un nombre de espacio ({namespace}
 #: psychopy/projects/pavlovia.py:310
 #, python-brace-format
 msgid "Project `{namespace}/{name}` already exists, please choose another name."
-msgstr "El proyecto `{namespace}/{name}` ya existe, elija otro nombre."
+msgstr "El proyecto `{namespace}/{name}` ya existe, por favor escoja otro nombre."
 
 #: psychopy/projects/pavlovia.py:462
 msgid "Most stars"
@@ -8493,7 +8494,7 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Error de sincronización: no se pudo encontrar el proyecto con id {}"
+"La Sincronización falló - no se ha podido encontrar proyecto con id {}"
 
 #: psychopy/projects/pavlovia.py:1186
 msgid "Avatar is too big, should be at most 200 KB."
@@ -8909,9 +8910,9 @@ msgid ""
 "                </p>"
 msgstr ""
 "<p>Recursos:\n"
-" | <a href=\"https://www.psychopy.org/documentation.html\">En-documentación de línea</a>\n"
-" | Descargar <a href=\"https://www.psychopy.org/PsychoPyManual.pdf\">Manual en PDF</a>\n"
-" | <a href=\"https://discourse.psychopy.org\">Buscar usuario-archivos de grupo</a>\n"
+"                |<a href=\"https://www.psychopy.org/documentation.html\">En-documentación de línea</a>\n"
+"                | Descargar <a href=\"https://www.psychopy.org/PsychoPyManual.pdf\">Manual en PDF</a>\n"
+"                |<a href=\"https://discourse.psychopy.org\">Buscar usuario-archivos de grupo</a>\n"
 "</p>"
 
 #: psychopy/tools/wizard.py:455
@@ -9023,7 +9024,7 @@ msgstr "luego vuelve a cambiar. No necesitas hacer nada."
 
 #: psychopy/tools/wizard.py:567
 msgid "Optional: For best results, please quit all email programs, web-browsers, "
-msgstr "Opcional: para obtener mejores resultados, cierre todos los programas de correo electrónico, navegadores web, "
+msgstr "Opcional: Para mejorar resultados, por favor finalice todos los programas de e-mail, navegadores de internet,"
 
 #: psychopy/tools/wizard.py:570
 msgid "Dropbox, backup or sync services, and others."

--- a/psychopy/app/locale/es_US/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/es_US/LC_MESSAGE/messages.po
@@ -1,20 +1,20 @@
 # Part of the PsychoPy library.
 # Copyright (C) 2015 Jonathan Peirce
-# CLAUDIO DE LA ROSA MUNAR <cdelarosa@delarosaresearch.com>, 2023.
+# CLAUDIO ALFREDO DE LA ROSA MUNAR <cdelarosa@delarosaresearch.com>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PsychoPy 2023.2.3\n"
+"Project-Id-Version: PsychoPy 2023.2.1\n"
 "POT-Creation-Date: 2023-08-31 10:34-0500\n"
 "PO-Revision-Date: \n"
-"Last-Translator: Claudio de la Rosa Munar <cdelarosa@delarosaresearch.com>\n"
+"Last-Translator: Claudio Alfredo de la Rosa Munar <cdelarosa@delarosaresearch.com>\n"
 "Language-Team: psychopy_spanish@opensciencetools.org\n"
-"Language: es_US\n"
+"Language: es_CO\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.4.1\n"
+"X-Generator: Poedit 3.4.2\n"
 "X-Poedit-Basepath: ../../../../..\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-KeywordsList: _translate\n"
@@ -301,9 +301,8 @@ msgid "Compatibility information"
 msgstr "Información de compatibilidad"
 
 #: psychopy/app/_psychopyApp.py:654
-#, fuzzy
 msgid "tips.txt"
-msgstr "consejos.txt"
+msgstr "tips.txt"
 
 #: psychopy/app/_psychopyApp.py:692
 msgid "  Loading plugins..."
@@ -1981,7 +1980,7 @@ msgstr "Error de sintaxis de Python en el campo `{}`: {}"
 #: psychopy/app/builder/validators.py:528
 #, python-brace-format
 msgid "Looks like your variable '{code}' in '{displayName}' should be set to update."
-msgstr "Parece que su variable {code}’ en ‘{displayName}’ debe ser fijada en actualizar."
+msgstr "Parece que su variable’{code}’ en ‘{displayName}’ debe ser definido para actualizar."
 
 #: psychopy/app/builder/validators.py:548
 msgid "Python var `{}` in `{}` is same as Name"
@@ -2605,7 +2604,7 @@ msgstr "Cerrar el shell actual."
 
 #: psychopy/app/coder/repl.py:66
 msgid "Close the current shell and start a new one, this will clear any variables."
-msgstr "Cierre la ventana Shell / Cmd e inicie una nueva, esto borrará cualquier variables."
+msgstr "Cierre el sell actual y comience uno nuevo, esto borrará todas las variables."
 
 #: psychopy/app/coder/repl.py:86 psychopy/app/stdout/stdOutRich.py:223
 msgid "Clear all previous output."
@@ -2670,7 +2669,7 @@ msgstr "Esta versión es una actualización demasiado grande para manejarla auto
 
 #: psychopy/app/connections/updates.py:144
 msgid "Please fetch the latest version from www.psychopy.org and install manually."
-msgstr "Por favor obtenga la versión mas actualizada desde www.psychopy.org e instálela manualmente."
+msgstr "Por favor busque la última versión en www.psychopy.org e instálela de forma manual."
 
 #: psychopy/app/connections/updates.py:149
 msgid "Go to downloads"
@@ -3240,7 +3239,7 @@ msgstr ""
 #: psychopy/app/pavlovia_ui/project.py:676
 #, python-brace-format
 msgid "Could not find folder {directory}, please select a different local root."
-msgstr "No se encuentra la carpeta {directory}, por favor seleccione una nueva raiz."
+msgstr ""
 
 #: psychopy/app/pavlovia_ui/project.py:714
 msgid "Project info has changed, update online before closing?"
@@ -4339,7 +4338,7 @@ msgstr "Archivo de condiciones no encontrado: %s"
 
 #: psychopy/data/utils.py:377
 msgid "openpyxl or xlrd is required for loading excel files, but neither was found."
-msgstr "openpyxl o xlrd se requiere para cargar archivos de excel, pero ninguno se encontró."
+msgstr "openpyxl o xlrd es requerido para cargar archivos de excel, pero ninguno ha sido encontrado."
 
 #: psychopy/data/utils.py:452
 #, python-format
@@ -4432,7 +4431,7 @@ msgstr "Duración esperada(s)"
 
 #: psychopy/experiment/components/_base.py:106
 msgid "Store the onset/offset times in the data file (as well as in the log file)."
-msgstr "Almacene los tiempos de inicio/compensación en el archivo de datos (así como en el archivo de registro)."
+msgstr "Almacena los tiempos onset/offset en un archivo de datos (así como el archivo tipo log)."
 
 #: psychopy/experiment/components/_base.py:111
 msgid "Save onset/offset times"
@@ -5080,7 +5079,7 @@ msgstr "Velocidad de los puntos (desplazamiento por cuadro en las unidades espec
 
 #: psychopy/experiment/components/dots/__init__.py:92
 msgid "Coherence of the dots (fraction moving in the signal direction on any one frame)"
-msgstr "Coherencia de los puntos (fracción que se mueve en la dirección de la señal en cualquier cuadro)"
+msgstr "Coherencia en los puntos (fracción moviéndose en la dirección de la señal en cualquiera de los cuadros)."
 
 #: psychopy/experiment/components/dots/__init__.py:101
 msgid "Size of the dots IN PIXELS regardless of the set units"
@@ -5293,7 +5292,7 @@ msgstr "Una imagen para definir la máscara alfa (es decir, forma): gauss, círc
 
 #: psychopy/experiment/components/grating/__init__.py:73
 msgid "Spatial frequency of image repeats across the grating in 1 or 2 dimensions, e.g. 4 or [2,3]"
-msgstr "La frecuencia espacial de la imagen se repite a lo largo de la rejilla en 1 o 2 dimensiones, p. 4 o [2,3]"
+msgstr "La frecuencia espacial de la imagen se repite a través del degradado en 1 o 2 dimensiones, p.e. 4 o [2,3]"
 
 #: psychopy/experiment/components/grating/__init__.py:95 psychopy/experiment/components/image/__init__.py:116
 #: psychopy/experiment/components/movie/__init__.py:127 psychopy/experiment/components/polygon/__init__.py:103
@@ -5344,8 +5343,8 @@ msgstr "La imagen que se mostrará: un nombre de archivo, incluida la ruta"
 #: psychopy/experiment/components/image/__init__.py:63
 msgid "An image to define the alpha mask through which the image is seen - gauss, circle, None or a filename (including path)"
 msgstr ""
-"Una imagen para definir la máscara alfa a través de la cual se ve la imagen: gauss, círculo, Ninguno o un nombre de archivo "
-"(incluida la ruta)"
+"Una imagen para definir la mascará alpha a través de la cual la imagen es vista - gausiano, circulo, Ninguno o un nombre de "
+"archivo ( incluyendo su ruta)"
 
 #: psychopy/experiment/components/image/__init__.py:72
 msgid "Resolution of the mask if one is used."
@@ -5962,7 +5961,7 @@ msgstr "Color de la línea alrededor de la barra de progreso."
 
 #: psychopy/experiment/components/progress/__init__.py:65
 msgid "Value between 0 (not started) and 1 (complete) to set the progress bar to."
-msgstr "Valor entre 0 (no iniciado) y 1 (completo) para configurar la barra de progreso."
+msgstr "Valor entre 0 (no iniciado) y 1 ( completo) para definir la barra de progreso."
 
 #: psychopy/experiment/components/progress/__init__.py:67
 msgid "Progress"
@@ -6281,7 +6280,7 @@ msgstr "Ajuste de fondo"
 
 #: psychopy/experiment/components/routineSettings/__init__.py:147
 msgid "Save the start and stop times of this Routine (according to the global clock) to the data file."
-msgstr "Guarde los tiempos de inicio y finalización de esta rutina (según el reloj global) en el archivo de datos."
+msgstr "Guarda los tiempos de inicio y de finalización de esta rutina (de acuerdo al reloj global) del archivo de datos."
 
 #: psychopy/experiment/components/serialOut/__init__.py:29
 msgid "Serial out: send signals from a serial port"
@@ -6626,7 +6625,9 @@ msgstr "Guardar archivo hdf5"
 
 #: psychopy/experiment/components/settings/__init__.py:389
 msgid "How much output do you want in the log files? ('error' is fewest messages, 'debug' is most)"
-msgstr "¿Cuánta salida desea en los archivos de registro? (‘error’ es la menor cantidad de mensajes, ‘debug’ es la mayor parte)"
+msgstr ""
+"Que cantidad de salida usted quiere en el archivo tipo log? (‘error’ significa menos mensajes, ‘debug’ significa la mayor "
+"cantidad)"
 
 #: psychopy/experiment/components/settings/__init__.py:400
 msgid "Place the HTML files will be saved locally "
@@ -7018,7 +7019,7 @@ msgstr "Código personalizado"
 
 #: psychopy/experiment/components/static/__init__.py:32
 msgid "Static: Static screen period (e.g. an ISI). Useful for pre-loading stimuli."
-msgstr "Estático: Período de pantalla estático (por ejemplo, un ISI). Útil para precarga de estímulos."
+msgstr "Estatica: Periodo de tiempo estático (p.e. un ISI). Útil para precargar estímulos."
 
 #: psychopy/experiment/components/static/__init__.py:49
 msgid "Custom code to be run during the static period (after updates)"
@@ -7274,8 +7275,8 @@ msgid ""
 "To have a fixed random sequence provide an integer of your choosing here. Leave blank to have a new random sequence on each run "
 "of the experiment."
 msgstr ""
-"Para tener una secuencia aleatoria fija, proporcione aquí un número entero de su elección. Déjelo en blanco para tener una nueva "
-"secuencia aleatoria en cada ejecución del experimento."
+"Para tener una secuencia aleatoria fija provea un número entero de su preferencia aquí. Deje en blanco para tener una secuencia "
+"aleatoria para cada ejecución de este experimento."
 
 #: psychopy/experiment/loops.py:145 psychopy/experiment/loops.py:490 psychopy/experiment/loops.py:627
 msgid ""
@@ -8071,7 +8072,7 @@ msgstr ""
 
 #: psychopy/preferences/hints.py:67
 msgid "Show an error dialog when PsychoPy encounters an unhandled internal error."
-msgstr "Muestra un cuadro de diálogo de error cuando PsychoPy encuentra un error interno no controlado."
+msgstr "Muestra un dialogo de error cuando PsychoPy encuentra un error interno no manejado."
 
 #: psychopy/preferences/hints.py:70
 msgid "Theme"
@@ -8431,7 +8432,7 @@ msgstr "PavloviaSession.createProject recibió un nombre de espacio ({namespace}
 #: psychopy/projects/pavlovia.py:310
 #, python-brace-format
 msgid "Project `{namespace}/{name}` already exists, please choose another name."
-msgstr "El proyecto `{namespace}/{name}` ya existe, elija otro nombre."
+msgstr "El proyecto `{namespace}/{name}` ya existe, por favor escoja otro nombre."
 
 #: psychopy/projects/pavlovia.py:462
 msgid "Most stars"
@@ -8493,7 +8494,7 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Error de sincronización: no se pudo encontrar el proyecto con id {}"
+"La Sincronización falló - no se ha podido encontrar proyecto con id {}"
 
 #: psychopy/projects/pavlovia.py:1186
 msgid "Avatar is too big, should be at most 200 KB."
@@ -8909,9 +8910,9 @@ msgid ""
 "                </p>"
 msgstr ""
 "<p>Recursos:\n"
-" | <a href=\"https://www.psychopy.org/documentation.html\">En-documentación de línea</a>\n"
-" | Descargar <a href=\"https://www.psychopy.org/PsychoPyManual.pdf\">Manual en PDF</a>\n"
-" | <a href=\"https://discourse.psychopy.org\">Buscar usuario-archivos de grupo</a>\n"
+"                |<a href=\"https://www.psychopy.org/documentation.html\">En-documentación de línea</a>\n"
+"                | Descargar <a href=\"https://www.psychopy.org/PsychoPyManual.pdf\">Manual en PDF</a>\n"
+"                |<a href=\"https://discourse.psychopy.org\">Buscar usuario-archivos de grupo</a>\n"
 "</p>"
 
 #: psychopy/tools/wizard.py:455
@@ -9023,7 +9024,7 @@ msgstr "luego vuelve a cambiar. No necesitas hacer nada."
 
 #: psychopy/tools/wizard.py:567
 msgid "Optional: For best results, please quit all email programs, web-browsers, "
-msgstr "Opcional: para obtener mejores resultados, cierre todos los programas de correo electrónico, navegadores web, "
+msgstr "Opcional: Para mejorar resultados, por favor finalice todos los programas de e-mail, navegadores de internet,"
 
 #: psychopy/tools/wizard.py:570
 msgid "Dropbox, backup or sync services, and others."


### PR DESCRIPTION
Added missing lines on translation. This translation can replace es_es as well. Some files and folders are missing on locale folder (one of the locale folders within the release with additional files needed for language execution are missing, not allowing es_co to be used nor es_us - This generates error on execution when those language variants are selected), needs URGENT attention from Spanish language team, Thanks,  Claudio