### PR TITLE
BF: fix dict keys for setting sample filter levels

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1506,8 +1506,8 @@ class SettingsComponent:
                 buff.writeIndentedLines(code % inits)
                 buff.setIndentLevel(1, relative=True)
                 code = (
-                            "'sample_filtering': %(elDataFiltering)s,\n"
-                            "'elLiveFiltering': %(elLiveFiltering)s,\n"
+                            "'FILTER_FILE': %(elDataFiltering)s,\n"
+                            "'FILTER_ONLINE': %(elLiveFiltering)s,\n"
                 )
                 buff.writeIndentedLines(code % inits)
                 buff.setIndentLevel(-1, relative=True)


### PR DESCRIPTION
I'm not sure how this bug got introduced in the first place, but `ioHub` has used the keys `FILTER_FILE` and `FILTER_ONLINE` to set the sample filter levels as seen [here](https://github.com/psychopy/psychopy-eyetracker-sr-research/blob/be603b2854e0e1db4ce0f413b3bbad1d7077d3b1/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py#L1355) and [here](https://github.com/psychopy/psychopy-eyetracker-sr-research/blob/be603b2854e0e1db4ce0f413b3bbad1d7077d3b1/psychopy_eyetracker_sr_research/sr_research/eyelink/default_eyetracker.yaml#L193).

But Builder generated `runtime_settings` dictionary used different keys (`sample_filtering` and `elLiveFiltering`), causing the correct filter levels never set on the EyeLink eye trackers.