### PR TITLE
ENH: Provide PsychoPy experiment filename to the ioHub server

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1635,12 +1635,21 @@ class SettingsComponent:
             code = (
                 "\n"
                 "# Setup iohub keyboard\n"
-                "ioConfig['Keyboard'] = dict(use_keymap='psychopy')\n\n"
+                "ioConfig['Keyboard'] = dict(use_keymap='psychopy')\n"
             )
             buff.writeIndentedLines(code % inits)
 
         if self.needIoHub and self.params['keyboardBackend'] == 'PsychToolbox':
             alert(code=4550)
+
+        # Add experiment handler filename to ioConfig
+        if self.needIoHub:
+            code = (
+                "\n"
+                "# Setup iohub experiment\n"
+                "ioConfig['Experiment'] = dict(filename=thisExp.dataFileName)\n"
+            )
+            buff.writeIndentedLines(code % inits)
 
         # Start ioHub server
         if self.needIoHub:

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1408,6 +1408,7 @@ class SettingsComponent:
             "ioConfig = {}\n"
         )
         buff.writeIndentedLines(code % inits)
+
         # Add eyetracker config
         if self.params['eyetracker'] != "None":
             # Alert user if window is not fullscreen
@@ -1651,29 +1652,50 @@ class SettingsComponent:
             )
             buff.writeIndentedLines(code % inits)
 
-        # Start ioHub server
-        if self.needIoHub:
+        # Make ioDataStoreConfig dict
+        if self.params['Save hdf5 file'].val:
+            code = (
+                "\n"
+                "# --- Setup iohub hdf5 datastore ---\n"
+            )
+            buff.writeIndentedLines(code % inits)
             # Specify session
             code = (
-                "ioSession = '1'\n"
-                "if 'session' in expInfo:\n"
+                "ioSession = str(expInfo.get('session', '1'))\n"
+            )
+            buff.writeIndentedLines(code % inits)
+            # Create ioDataStoreConfig dict
+            code = (
+                "ioDataStoreConfig = {"
             )
             buff.writeIndentedLines(code % inits)
             buff.setIndentLevel(1, relative=True)
             code = (
-                    "ioSession = str(expInfo['session'])\n"
+                f"'experiment_code': %(expName)s,\n"  # noqa: F541
+                "'session_code': ioSession,\n"
+                "'datastore_name': thisExp.dataFileName,\n"
             )
             buff.writeIndentedLines(code % inits)
             buff.setIndentLevel(-1, relative=True)
-            # Start server
+            code = (
+                "}\n"
+            )
+            buff.writeIndentedLines(code % inits)
+
+        # Start ioHub server
+        if self.needIoHub:
+            code = (
+                "\n"
+                "# Start ioHub server\n"
+            )
+            buff.writeIndentedLines(code % inits)
             if self.params['Save hdf5 file'].val:
                 code = (
-                    f"ioServer = io.launchHubServer(window=win, experiment_code=%(expName)s, session_code=ioSession, "
-                    f"datastore_name=thisExp.dataFileName, **ioConfig)\n"
+                    "ioServer = io.launchHubServer(window=win, **ioDataStoreConfig, **ioConfig)\n"
                 )
             else:
                 code = (
-                    f"ioServer = io.launchHubServer(window=win, **ioConfig)\n"
+                    "ioServer = io.launchHubServer(window=win, **ioConfig)\n"
                 )
             buff.writeIndentedLines(code % inits)
         else:
@@ -1684,6 +1706,7 @@ class SettingsComponent:
 
         # store ioServer
         code = (
+            "\n"
             "# store ioServer object in the device manager\n"
             "deviceManager.ioServer = ioServer\n"
         )

--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -26,7 +26,7 @@ try:
     _DATA_STORE_AVAILABLE = True
 except ImportError:
     print2err('WARNING: pytables package not found. ',
-              'ioHub functionality will be disabled.')
+              'ioHub hdf5 datastore functionality will be disabled.')
 except Exception:
     printExceptionDetailsToStdErr()
 

--- a/psychopy/iohub/devices/experiment/default_experiment.yaml
+++ b/psychopy/iohub/devices/experiment/default_experiment.yaml
@@ -6,12 +6,23 @@
 # indicated here.
 #
 Experiment:
-    # name: The unique name to assign to the evice instance created.
+    # name: The unique name to assign to the device instance created.
     #   The device is accessed from within the PsychoPy script 
     #   using the name's value; therefore it must be a valid Python
     #   variable name as well.
     #
     name: experiment
+
+    # filename: The name of files saved by an attached PsychoPy experiment.
+    #   This is usually provided as PsychoPy ExperimentHandler.dataFileName.
+    #   It gives ioHub server awareness of filenames used by PsychoPy when a
+    #   DataStore file is not being saved by the ioHub. This handle is useful
+    #   when the ioHub is being used to monitor the PsychoPy experiment, but
+    #   all data is being saved by the PsychoPy ExperimentHandler, while there
+    #   are external data files transferred through the ioHub server that need
+    #   to be saved in the same naming convention as the PsychoPy data files.
+    #   Default value is Python None type. Valid value is any string.
+    filename:
 
     # monitor_event_types: Specify which of the device's supported event
     #   types you would like the ioHub to monitor for.

--- a/psychopy/iohub/devices/experiment/supported_config_settings.yaml
+++ b/psychopy/iohub/devices/experiment/supported_config_settings.yaml
@@ -4,7 +4,11 @@ Experiment:
         IOHUB_STRING:
             min_length: 1
             max_length: 32
-            first_char_alpha: True    
+            first_char_alpha: True
+    filename: 
+        IOHUB_STRING:
+            min_length: 0
+            first_char_alpha: False
     save_events: IOHUB_BOOL
     stream_events: True
     auto_report_events: True    


### PR DESCRIPTION
There is a niche situation with `ioHub` server that when the hdf5 datastore file option is not selected in the experiment setting, the `ioServer` stack on the subprocess server end does not have **any** access to the file naming convention used by PsychoPy (created by `psychopy.data.ExperimentHandler` when using Builder to generate scripts). Only when the hdf5 datastore option is selected, then a `dsfile` dictionary is passed to the server, and the `datastore_name=thisExp.dataFileName` gets exposed.

This is usually fine, except when `.dsfile` is `None`, the eyetracker plugins will not open a native recording file on the host PC (such as [here](https://github.com/psychopy/psychopy-eyetracker-sr-research/blob/be603b2854e0e1db4ce0f413b3bbad1d7077d3b1/psychopy_eyetracker_sr_research/sr_research/eyelink/eyetracker.py#L185)). This is not optimal behavior since users may want to download the eyetracker recording file **without** necessarily saving to the hdf5 datastore file format at the same time (especially considering that the two data saving files are redundant in many ways).

This PR adds a new `filename` attribute in `Experiment` yaml files to expose the PsychoPy experiment filename to the ioHub server end. This way, the Eyetracking plugin codes can access the PsychoPy filename as a backup option to open an eyetracker recording file and download it with appropriate naming at the end of an experiment.