### PR TITLE
BF: correct how sound component status is updated in loops of routines

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -223,7 +223,7 @@ class SoundComponent(BaseDeviceComponent):
         # Write stop code
         indented = self.writeStopTestCode(buff)
         if indented:
-            code = ("%(name)s.stop()\n")
+            code = ("%(name)s._EOS()\n")
             buff.writeIndentedLines(code % self.params)
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -228,16 +228,6 @@ class SoundComponent(BaseDeviceComponent):
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)
 
-        # Update status
-        code = (
-            "# update %(name)s status according to whether it's playing\n"
-            "if %(name)s.isPlaying:\n"
-            "    %(name)s.status = STARTED\n"
-            "elif %(name)s.isFinished:\n"
-            "    %(name)s.status = FINISHED\n"
-        )
-        buff.writeIndentedLines(code % self.params)
-
     def writeFrameCodeJS(self, buff):
         """Write the code that will be called every frame
         """

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -293,6 +293,7 @@ class SoundComponent(BaseDeviceComponent):
             # stop at the end of the Routine, if requested
             code = (
                 "%(name)s.pause()  # ensure sound has stopped at end of Routine\n"
+                "%(name)s.status = PAUSED\n"
             )
             buff.writeIndentedLines(code % self.params)
         # get parent to write code too (e.g. store onset/offset times)


### PR DESCRIPTION
There are three inter-related bugs in release 2024.1.5 with the PTB audio backend (likely with other backends as well) in Builder generated scripts under a specific setting when:
1) a routine containing a sound component is repeated in a loop, and 
2) there is a concurrent response component that can force end the routine.

The most obvious behavior is reported in #6557, but they have other more subtle unwanted outcomes. All three problems came from logics around [this section](https://github.com/psychopy/psychopy/blob/f53539e50633afb044d212385b99b08f89925e37/psychopy/sound/backend_ptb.py#L370) of `@property def status(self)` in the PTB backend.

1. Using `stop()` does not properly end a sound component.
**Explanation:** This bug is because in the `writeFrameCode()`, `.stop()` is called after `.status = FINISHED`. This means when `.status` was called, `._isPlaying` is still `True`, hence no `_EOS()` call is triggered as it should. Then the `._isFinished` attribute is never turned to `True` for the sound component. Also, after `.status` gets updated to `FINISHED`, even if we make another call to trigger the `@property status` function, we can't enter the `_EOS` if statement since `status` is no longer `STARTED`. So the ordering of setting status and `stop()` is an issue. Calling `stop()` first and then `.status = FINISHED` would have been perfectly fine, but it's tricky to do with re-using the `BaseDeviceComponent.writeStopTestCode()` to write this part of the code in generating scripts with Builder.
**Bug Fix:** I played around with a few approaches to handle this, including making additional `.status` calls or exposing a new method. But really the cleanest way is to call `_EOS()` directly, which will in turn call `stop()`. I do realize calling a private function isn't good practice, so feel free to push to this branch to make a wrapper to `_EOS()` and call that instead. But under the hood, calling `_EOS()` instead of `stop()` is what we need to execute at the stopping frame, which will properly set `._isFinished` to `False`.

2. Using `pause()` at the end of a routine does not set the status correctly.
**Explanation:** At the end of a routine, `pause()` sets `._isPlaying` to `False` but does not update the `.status`. At the next loop of the routine, `.seek(0)` doesn't change `_isFinished` because of the first bug, and the `.status = NOT_STARTED` immediately below will trigger the `@property status` function, since `.status` is `STARTED` before the setter, this calls the `_EOS()` routine and sets `._isFinished` to `True`. Because of the bug below that repeatedly updates `status` in every frame, if the sound component is not scheduled to start at time 0, the first frame will toggle the `.status` to `FINISHED` since `._isFinished` is `True`, and the sound on this next loop never gets played.
**Bug Fix:** I added `.status = PAUSED` after `pause()` at the end of a routine, which promptly triggers the `@property status` function and updates the status.

3. Setting sound component status every frame can end / start sound playing at incorrect times.
**Explanation:** I'm not sure what led to adding this extra section in the first place, but it looks redundant from the codes already there checking for sound component start/end in each frame. In fact, invoking the `@property status` function on every frame could have unexpected buggy behaviors. For example, when a sound finishes playing in-between two frames, this status update section will call `.status = STARTED` because `._isPlaying` is still `True`. Then since the sound stream has reached the end of the sound file, the `._EOS()` function gets called, and then `.stop()` gets called before the next frame that is supposed to log when the sound stopped, introducing an offset in the logged timing.
**Bug Fix:** I simply deleted this section and in all my testing, sound components seem to play just fine. It seems dangerous to me to use `isPlaying` and `isFinished` to update status, since these two private attributes are not directly accessed by users. Having this status update every frame will often skip important starting and stopping frame code sections gated by if statements like `.status == NOT_STARTED and tThisFlip >= 0.0-frameTolerance` and `.status == STARTED`.