### PR TITLE
RF: Decouple setting status from triggering playback/clock resets/etc.

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -476,7 +476,7 @@ class BaseComponent:
             extra = " " + extra
         code += f"{extra}) {{\n"
         # write if statement and indent
-        buff.writeIndented(code)
+        buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
 
         code = (f"// keep track of start time/frame for later\n"
@@ -675,7 +675,7 @@ class BaseComponent:
             extra = " " + extra
         code += f"{extra}) {{\n"
         # write if statement and indent
-        buff.writeIndentedLines(code)
+        buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
 
         # Return True if stop test was written

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -312,7 +312,7 @@ class BaseComponent:
         """
         pass
 
-    def writeStartTestCode(self, buff):
+    def writeStartTestCode(self, buff, extra=""):
         """
         Test whether we need to start (if there is a start time at all)
 
@@ -326,6 +326,15 @@ class BaseComponent:
             buff.writeIndentedLines(code % self.params)
             buff.setIndentLevel(-indented, relative=True)
         ```
+
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
 
         # Get starting indent level
@@ -349,26 +358,36 @@ class BaseComponent:
             "# if %(name)s is starting this frame...\n"
         )
         buff.writeIndentedLines(code % params)
+        # add starting if statement
         if self.params['startType'].val == 'time (s)':
             # if startVal is an empty string then set to be 0.0
-            if (isinstance(self.params['startVal'].val, str) and
-                    not self.params['startVal'].val.strip()):
+            if (
+                isinstance(self.params['startVal'].val, str) 
+                and not self.params['startVal'].val.strip()
+            ):
                 self.params['startVal'].val = '0.0'
-            code = (f"if {params['name']}.status == NOT_STARTED and "
-                    f"{t} >= {params['startVal']}-frameTolerance:\n")
+            code = (
+                "if %(name)s.status == NOT_STARTED and {} >= %(startVal)s-frameTolerance"
+            ).format(t)
         elif self.params['startType'].val == 'frame N':
-            code = (f"if {params['name']}.status == NOT_STARTED and "
-                    f"frameN >= {params['startVal']}:\n")
+            code = (
+                "if %(name)s.status == NOT_STARTED and frameN >= %(startVal)s"
+            )
         elif self.params['startType'].val == 'condition':
-            code = (f"if {params['name']}.status == NOT_STARTED and "
-                    f"{params['startVal']}:\n")
+            code = (
+                "if %(name)s.status == NOT_STARTED and %(startVal)s"
+            )
         else:
-            msg = f"Not a known startType ({params['startVal']}) for {params['name']}"
+            msg = f"Not a known startType (%(startVal)s) for %(name)s"
             raise CodeGenerationException(msg % self.params)
-
-        buff.writeIndented(code)
-
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}:\n"
+        # write if statement and indent
+        buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
+
         params = self.params
         code = (f"# keep track of start time/frame for later\n"
                 f"{params['name']}.frameNStart = frameN  # exact frame index\n"
@@ -411,8 +430,17 @@ class BaseComponent:
         # Return True if start test was written
         return buff.indentLevel - startIndent
 
-    def writeStartTestCodeJS(self, buff):
+    def writeStartTestCodeJS(self, buff, extra=""):
         """Test whether we need to start
+                           
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
         # Get starting indent level
         startIndent = buff.indentLevel
@@ -424,24 +452,33 @@ class BaseComponent:
         params = self.params
         if self.params['startType'].val == 'time (s)':
             # if startVal is an empty string then set to be 0.0
-            if (isinstance(self.params['startVal'].val, str) and
-                    not self.params['startVal'].val.strip()):
+            if (
+                isinstance(self.params['startVal'].val, str) 
+                and not self.params['startVal'].val.strip()
+            ):
                 self.params['startVal'].val = '0.0'
-            code = (f"if (t >= {params['startVal']} "
-                    f"&& {params['name']}.status === PsychoJS.Status.NOT_STARTED) {{\n")
+            code = (
+                "if (t >= %(startVal)s && %(name)s.status === PsychoJS.Status.NOT_STARTED"
+            )
         elif self.params['startType'].val == 'frame N':
-            code = (f"if (frameN >= {params['startVal']} "
-                    f"&& {params['name']}.status === PsychoJS.Status.NOT_STARTED) {{\n")
+            code = (
+                "if (frameN >= %(startVal)s && %(name)s.status === PsychoJS.Status.NOT_STARTED"
+            )
         elif self.params['startType'].val == 'condition':
-            code = (f"if (({params['startVal']}) "
-                    f"&& {params['name']}.status === PsychoJS.Status.NOT_STARTED) {{\n")
+            code = (
+                "if ((%(startVal)s) && %(name)s.status === PsychoJS.Status.NOT_STARTED"
+            )
         else:
-            msg = f"Not a known startType ({params['startVal']}) for {params['name']}"
+            msg = f"Not a known startType (%(startVal)s) for %(name)s"
             raise CodeGenerationException(msg)
-
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}) {{\n"
+        # write if statement and indent
         buff.writeIndented(code)
-
         buff.setIndentLevel(+1, relative=True)
+
         code = (f"// keep track of start time/frame for later\n"
                 f"{params['name']}.tStart = t;  // (not accounting for frame time here)\n"
                 f"{params['name']}.frameNStart = frameN;  // exact frame index\n\n")
@@ -450,7 +487,7 @@ class BaseComponent:
         # Return True if start test was written
         return buff.indentLevel - startIndent
 
-    def writeStopTestCode(self, buff):
+    def writeStopTestCode(self, buff, extra=""):
         """
         Test whether we need to stop (if there is a stop time at all)
 
@@ -464,6 +501,15 @@ class BaseComponent:
             buff.writeIndentedLines(code % self.params)
             buff.setIndentLevel(-indented, relative=True)
         ```
+             
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
 
         # Get starting indent level
@@ -492,26 +538,41 @@ class BaseComponent:
                 alerttools.alert(4120, strFields={'component': self.params['name']})
 
         if self.params['stopType'].val == 'time (s)':
-            code = (f"# is it time to stop? (based on local clock)\n"
-                    f"if tThisFlip > {params['stopVal']}-frameTolerance:\n"
-                    )
+            code = (
+                "# is it time to stop? (based on local clock)\n"
+                "if tThisFlip > %(stopVal)s-frameTolerance"
+            )
         # duration in time (s)
         elif (self.params['stopType'].val == 'duration (s)'):
-            code = (f"# is it time to stop? (based on global clock, using actual start)\n"
-                    f"if tThisFlipGlobal > {params['name']}.tStartRefresh + {params['stopVal']}-frameTolerance:\n")
+            code = (
+                "# is it time to stop? (based on global clock, using actual start)\n"
+                "if tThisFlipGlobal > %(name)s.tStartRefresh + %(stopVal)s-frameTolerance"
+            )
         elif self.params['stopType'].val == 'duration (frames)':
-            code = (f"if frameN >= ({params['name']}.frameNStart + {params['stopVal']}):\n")
+            code = (
+                "if frameN >= (%(name)s.frameNStart + %(stopVal)s)"
+            )
         elif self.params['stopType'].val == 'frame N':
-            code = f"if frameN >= {params['stopVal']}:\n"
+            code = (
+                "if frameN >= %(stopVal)s"
+            )
         elif self.params['stopType'].val == 'condition':
-            code = f"if bool({params['stopVal']}):\n"
+            code = (
+                "if bool(%(stopVal)s)"
+            )
         else:
-            msg = (f"Didn't write any stop line for startType={params['startType']}, "
-                   f"stopType={params['stopType']}")
+            msg = (
+                "Didn't write any stop line for startType=%(startType)s, stopType=%(stopType)s"
+            )
             raise CodeGenerationException(msg)
-
-        buff.writeIndentedLines(code)
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}:\n"
+        # write if statement and indent
+        buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
+
         code = (f"# keep track of stop time/frame for later\n"
                 f"{params['name']}.tStop = t  # not accounting for scr refresh\n"
                 f"{params['name']}.tStopRefresh = tThisFlipGlobal  # on global time\n"
@@ -547,8 +608,17 @@ class BaseComponent:
         # Return True if stop test was written
         return buff.indentLevel - startIndent
 
-    def writeStopTestCodeJS(self, buff):
+    def writeStopTestCodeJS(self, buff, extra=""):
         """Test whether we need to stop
+                           
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
         # Get starting indent level
         startIndent = buff.indentLevel
@@ -559,45 +629,59 @@ class BaseComponent:
 
         params = self.params
         if self.params['stopType'].val == 'time (s)':
-            code = (f"frameRemains = {params['stopVal']} "
-                    f" - psychoJS.window.monitorFramePeriod * 0.75;"
-                    f"  // most of one frame period left\n"
-                    f"if (({params['name']}.status === PsychoJS.Status.STARTED || {params['name']}.status === PsychoJS.Status.FINISHED) "
-                    f"&& t >= frameRemains) {{\n")
+            code = (
+                "frameRemains = %(stopVal)s - psychoJS.window.monitorFramePeriod * 0.75;"
+                "// most of one frame period left\n"
+                "if ((%(name)s.status === PsychoJS.Status.STARTED || %(name)s.status === "
+                "PsychoJS.Status.FINISHED) && t >= frameRemains"
+            )
         # duration in time (s)
-        elif (self.params['stopType'].val == 'duration (s)' and
-              self.params['startType'].val == 'time (s)'):
-            code = (f"frameRemains = {params['startVal']} + {params['stopVal']}"
-                    f" - psychoJS.window.monitorFramePeriod * 0.75;"
-                    f"  // most of one frame period left\n"
-                    f"if ({params['name']}.status === PsychoJS.Status.STARTED "
-                    f"&& t >= frameRemains) {{\n")
+        elif (
+            self.params['stopType'].val == 'duration (s)'
+            and self.params['startType'].val == 'time (s)'
+        ):
+            code = (
+                "frameRemains = %(startVal)s + %(stopVal)s - psychoJS.window.monitorFramePeriod "
+                "* 0.75;"
+                "// most of one frame period left\n"
+                "if (%(name)s.status === PsychoJS.Status.STARTED && t >= frameRemains"
+            )
         # start at frame and end with duratio (need to use approximate)
         elif self.params['stopType'].val == 'duration (s)':
-            code = (f"if ({params['name']}.status === PsychoJS.Status.STARTED "
-                    f"&& t >= ({params['name']}.tStart + {params['stopVal']})) {{\n")
+            code = (
+                "if (%(name)s.status === PsychoJS.Status.STARTED && t >= (%(name)s.tStart + "
+                "%(stopVal)s)"
+            )
         elif self.params['stopType'].val == 'duration (frames)':
-            code = (f"if ({params['name']}.status === PsychoJS.Status.STARTED "
-                    f"&& frameN >= ({params['name']}.frameNStart + {params['stopVal']})) {{\n")
+            code = (
+                "if (%(name)s.status === PsychoJS.Status.STARTED && frameN >= "
+                "(%(name)s.frameNStart + %(stopVal)s)"
+            )
         elif self.params['stopType'].val == 'frame N':
-            code = (f"if ({params['name']}.status === PsychoJS.Status.STARTED "
-                    f"&& frameN >= {params['stopVal']}) {{\n")
+            code = (
+                "if (%(name)s.status === PsychoJS.Status.STARTED && frameN >= %(stopVal)s"
+            )
         elif self.params['stopType'].val == 'condition':
-            code = (f"if ({params['name']}.status === PsychoJS.Status.STARTED "
-                    f"&& Boolean({params['stopVal']})) {{\n")
+            code = (
+                "if (%(name)s.status === PsychoJS.Status.STARTED && Boolean(%(stopVal)s)"
+            )
         else:
-            msg = (f"Didn't write any stop line for startType="
-                   f"{params['startType']}, "
-                   f"stopType={params['stopType']}")
+            msg = (
+                "Didn't write any stop line for startType=%(startType)s, stopType=%(stopType)s"
+            )
             raise CodeGenerationException(msg)
-
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}) {{\n"
+        # write if statement and indent
         buff.writeIndentedLines(code)
         buff.setIndentLevel(+1, relative=True)
 
         # Return True if stop test was written
         return buff.indentLevel - startIndent
 
-    def writeActiveTestCode(self, buff):
+    def writeActiveTestCode(self, buff, extra=""):
         """
         Test whether component is started and has not finished.
 
@@ -611,17 +695,30 @@ class BaseComponent:
         buff.writeIndentedLines(code % self.params)
         self.exitActiveTest(buff)
         ```
+           
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
         # Newline
         buff.writeIndentedLines("\n")
         # Get starting indent level
         startIndent = buff.indentLevel
 
-        # Write if statement
+        # construct if statement
         code = (
             "# if %(name)s is active this frame...\n"
-            "if %(name)s.status == STARTED:\n"
+            "if %(name)s.status == STARTED"
         )
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}:\n"
         buff.writeIndentedLines(code % self.params)
         # Indent
         buff.setIndentLevel(+1, relative=True)
@@ -639,7 +736,7 @@ class BaseComponent:
             buff.writeIndentedLines(code)
         return buff.indentLevel - startIndent
 
-    def writeActiveTestCodeJS(self, buff):
+    def writeActiveTestCodeJS(self, buff, extra=""):
         """
         Test whether component is started and has not finished.
 
@@ -652,6 +749,15 @@ class BaseComponent:
         )
         self.exitActiveTestJS(buff)
         ```
+                   
+        Parameters
+        ----------
+        buff : io.StringIO
+            Text buffer to write code to.
+        extra : str
+            Additional conditions to check, including any boolean operators (and, or, etc.). Use 
+            `%(key)s` syntax to insert the values of any necessary params. Default is an empty 
+            string.
         """
         # Get starting indent level
         startIndent = buff.indentLevel
@@ -659,13 +765,17 @@ class BaseComponent:
         # Newline
         buff.writeIndentedLines("\n")
 
-        # Write if statement
+        # construct if statement
         code = (
             "// if %(name)s is active this frame...\n"
-            "if (%(name)s.status == STARTED) {\n"
+            "if (%(name)s.status == STARTED"
         )
+        # add any other conditions and finish the statement
+        if extra and not extra.startswith(" "):
+            extra = " " + extra
+        code += f"{extra}) {{\n"
+        # write if statement and indent
         buff.writeIndentedLines(code % self.params)
-        # Indent
         buff.setIndentLevel(+1, relative=True)
 
         if self.checkNeedToUpdate('set every frame'):

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -275,6 +275,7 @@ class ButtonComponent(BaseVisualComponent):
         indented = self.writeStartTestCode(buff)
         if indented:
             code = (
+                "%(name)s.buttonClock.reset()"
                 "%(name)s.setAutoDraw(True)\n"
             )
             buff.writeIndentedLines(code % self.params)

--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -275,7 +275,7 @@ class ButtonComponent(BaseVisualComponent):
         indented = self.writeStartTestCode(buff)
         if indented:
             code = (
-                "%(name)s.buttonClock.reset()"
+                "win.callOnFlip(%(name)s.buttonClock.reset)\n"
                 "%(name)s.setAutoDraw(True)\n"
             )
             buff.writeIndentedLines(code % self.params)

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -223,7 +223,7 @@ class SoundComponent(BaseDeviceComponent):
         buff.setIndentLevel(-indented, relative=True)
 
         # write code for stopping
-        indented = self.writeStopTestCode(buff)
+        indented = self.writeStopTestCode(buff, extra=" or %(name)s.isFinished")
         if indented:
             code = ("%(name)s.stop()\n")
             buff.writeIndentedLines(code % self.params)
@@ -231,15 +231,8 @@ class SoundComponent(BaseDeviceComponent):
         buff.setIndentLevel(-indented, relative=True)
 
         # write code to run while active
-        indented = self.writeActiveTestCode(buff)
+        indented = self.writeActiveTestCode(buff, extra=" or %(name)s.isPlaying")
         if indented:
-            # update status according to playback
-            code = (
-                "# if sound is finished but %(name)s has time left, finish it now\n"
-                "if %(name)s.isFinished:\n"
-                "    %(name)s.status = FINISHED\n" 
-            )
-            buff.writeIndentedLines(code % self.params)
             # dedent
             buff.setIndentLevel(-indented, relative=True)
 

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -230,13 +230,18 @@ class SoundComponent(BaseDeviceComponent):
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)
 
-        # update status according to playback
-        code = (
-            "# if sound is finished but %(name)s has time left, finish it now\n"
-            "if %(name)s.isFinished:\n"
-            "    %(name)s.status = FINISHED\n" 
-        )
-        buff.writeIndentedLines(code % self.params)
+        # write code to run while active
+        indented = self.writeActiveTestCode(buff)
+        if indented:
+            # update status according to playback
+            code = (
+                "# if sound is finished but %(name)s has time left, finish it now\n"
+                "if %(name)s.isFinished:\n"
+                "    %(name)s.status = FINISHED\n" 
+            )
+            buff.writeIndentedLines(code % self.params)
+            # dedent
+            buff.setIndentLevel(-indented, relative=True)
 
     def writeFrameCodeJS(self, buff):
         """Write the code that will be called every frame

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -232,10 +232,8 @@ class SoundComponent(BaseDeviceComponent):
 
         # update status according to playback
         code = (
-            "# update %(name)s status according to whether it's playing\n"
-            "if %(name)s.isPlaying:\n"
-            "    %(name)s.status = STARTED\n"
-            "elif %(name)s.isFinished:\n"
+            "# if sound is finished but %(name)s has time left, finish it now\n"
+            "if %(name)s.isFinished:\n"
             "    %(name)s.status = FINISHED\n" 
         )
         buff.writeIndentedLines(code % self.params)

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -222,18 +222,15 @@ class SoundComponent(BaseDeviceComponent):
             buff.writeIndentedLines(code % self.params)
         buff.setIndentLevel(-indented, relative=True)
 
-        # write code while active
-        indented = self.writeActiveTestCode(buff)
-        if indented:
-            code = (
-                "# update %(name)s status according to whether it's playing\n"
-                "if %(name)s.isPlaying:\n"
-                "    %(name)s.status = STARTED\n"
-                "elif %(name)s.isFinished:\n"
-                "    %(name)s.status = FINISHED\n" 
-            )
-            buff.writeIndentedLines(code % self.params)
-        buff.setIndentLevel(-indented, relative=True)
+        # update status according to playback
+        code = (
+            "# update %(name)s status according to whether it's playing\n"
+            "if %(name)s.isPlaying:\n"
+            "    %(name)s.status = STARTED\n"
+            "elif %(name)s.isFinished:\n"
+            "    %(name)s.status = FINISHED\n" 
+        )
+        buff.writeIndentedLines(code % self.params)
 
         # write code for stopping
         indented = self.writeStopTestCode(buff)

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -222,6 +222,14 @@ class SoundComponent(BaseDeviceComponent):
             buff.writeIndentedLines(code % self.params)
         buff.setIndentLevel(-indented, relative=True)
 
+        # write code for stopping
+        indented = self.writeStopTestCode(buff)
+        if indented:
+            code = ("%(name)s.stop()\n")
+            buff.writeIndentedLines(code % self.params)
+        # because of the 'if' statement of the time test
+        buff.setIndentLevel(-indented, relative=True)
+
         # update status according to playback
         code = (
             "# update %(name)s status according to whether it's playing\n"
@@ -231,14 +239,6 @@ class SoundComponent(BaseDeviceComponent):
             "    %(name)s.status = FINISHED\n" 
         )
         buff.writeIndentedLines(code % self.params)
-
-        # write code for stopping
-        indented = self.writeStopTestCode(buff)
-        if indented:
-            code = ("%(name)s.stop()\n")
-            buff.writeIndentedLines(code % self.params)
-        # because of the 'if' statement of the time test
-        buff.setIndentLevel(-indented, relative=True)
 
     def writeFrameCodeJS(self, buff):
         """Write the code that will be called every frame

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -216,9 +216,9 @@ class SoundComponent(BaseDeviceComponent):
         indented = self.writeStartTestCode(buff)
         if indented:
             if self.params['syncScreenRefresh'].val:
-                code = ("%(name)s.play(when=win)  # sync with win flip\n") % self.params
+                code = ("%(name)s.play(when=win)  # sync with win flip\n")
             else:
-                code = "%(name)s.play()  # start the sound (it finishes automatically)\n" % self.params
+                code = "%(name)s.play()  # start the sound (it finishes automatically)\n"
             buff.writeIndentedLines(code % self.params)
         buff.setIndentLevel(-indented, relative=True)
 

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -1725,7 +1725,7 @@ class Camera:
 
         # current camera frame since the start of recording
         self._player = None  # media player instance
-        self._status = NOT_STARTED
+        self.status = NOT_STARTED
         self._isRecording = False
         self._bufferSecs = float(bufferSecs)
         self._lastFrame = None  # use None to avoid imports for ImageStim
@@ -1942,20 +1942,6 @@ class Camera:
 
         """
         return getCameraDescriptions(collapse=collapse)
-
-    @property
-    def status(self):
-        """Status flag for the camera (`int`).
-
-        Can be either `RECORDING`, `STOPPED`, `STOPPING`, or `NOT_STARTED`. This 
-        property used in Builder output scripts and does not update on its own.
-
-        """
-        return self._status
-
-    @status.setter
-    def status(self, value):
-        self._status = value
 
     @property
     def device(self):

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -588,11 +588,9 @@ class SoundPTB(_SoundBase):
         """Function called on End Of Stream
         """
         self._loopsFinished += 1
-        if self.loops == 0:
+        if self.loops - self._loopsFinished <= 0:
             self.stop(reset=reset, log=False)
             self._isFinished = True
-        elif 0 < self.loops <= self._loopsFinished:
-            self.stop(reset=reset, log=False)
 
         if log and self.autoLog:
             logging.exp(u"Sound %s reached end of file" % self.name, obj=self)

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -340,11 +340,13 @@ class SoundPTB(_SoundBase):
     @property
     def isPlaying(self):
         """`True` if the audio playback is ongoing."""
+        self._checkPlaybackFinished()
         return self._isPlaying
 
     @property
     def isFinished(self):
         """`True` if the audio playback has completed."""
+        self._checkPlaybackFinished()
         return self._isFinished
 
     def _getDefaultSampleRate(self):
@@ -359,27 +361,6 @@ class SoundPTB(_SoundBase):
         if not self.track:
             return None
         return self.track.status
-
-    @property
-    def status(self):
-        """status gives a simple value from psychopy.constants to indicate
-        NOT_STARTED, STARTED, FINISHED, PAUSED
-
-        Psychtoolbox sounds also have a statusDetailed property with further info"""
-
-        if self.__dict__['status']==STARTED:
-            # check portaudio to see if still playing
-            pa_status = self.statusDetailed
-            if not pa_status['Active'] and pa_status['State']==0:
-                # we were playing and now not so presumably FINISHED
-                self._EOS()
-
-        return self.__dict__['status']
-
-
-    @status.setter
-    def status(self, newStatus):
-        self.__dict__['status'] = newStatus
 
     @property
     def volume(self):

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -345,8 +345,7 @@ class SoundPTB(_SoundBase):
     @property
     def isFinished(self):
         """`True` if the audio playback has completed."""
-        self._checkPlaybackFinished()
-        return self._isFinished
+        return self._checkPlaybackFinished()
 
     def _getDefaultSampleRate(self):
         """Check what streams are open and use one of these"""

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -558,7 +558,7 @@ class SoundPTB(_SoundBase):
         """Stops the sound without reset, so that play will continue from here if needed
         """
         if self.isPlaying:
-            self.stop(reset=False)
+            self.stop(reset=False, log=False)
             if log and self.autoLog:
                 logging.exp(u"Sound %s paused" % (self.name), obj=self)
 

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -340,7 +340,6 @@ class SoundPTB(_SoundBase):
     @property
     def isPlaying(self):
         """`True` if the audio playback is ongoing."""
-        self._checkPlaybackFinished()
         return self._isPlaying
 
     @property

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -512,8 +512,16 @@ class SoundPTB(_SoundBase):
     def _checkPlaybackFinished(self):
         """Checks whether playback has finished by looking up the status.
         """
+        # get detailed status from backend
         pa_status = self.statusDetailed
-        self._isFinished = not pa_status['Active'] and pa_status['State'] == 0
+        # was the sound already finished?
+        wasFinished = self._isFinished
+        # is it finished now?
+        isFinished = self._isFinished = not pa_status['Active'] and pa_status['State'] == 0
+        # if it wasn't finished but now is, do end of stream behaviour
+        if isFinished and not wasFinished:
+            self._EOS()
+        
         return self._isFinished
 
     def play(self, loops=None, when=None, log=True):

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -588,9 +588,11 @@ class SoundPTB(_SoundBase):
         """Function called on End Of Stream
         """
         self._loopsFinished += 1
-        if self.loops - self._loopsFinished <= 0:
+        if self._loopsFinished <= self.loops:
             self.stop(reset=reset, log=False)
             self._isFinished = True
+        else:
+            self._isFinished = False
 
         if log and self.autoLog:
             logging.exp(u"Sound %s reached end of file" % self.name, obj=self)

--- a/psychopy/sound/backend_pysound.py
+++ b/psychopy/sound/backend_pysound.py
@@ -288,17 +288,6 @@ class SoundPySoundCard(_SoundBase):
             logging.error(msg % fileName)
             raise ValueError(msg % fileName)
 
-    @property
-    def status(self):
-        # NB this is stored by the _callbacks class for fast access when
-        # data buffer needs filling (_callbacks class does not have a
-        # reference back here)
-        return self.__dict__['status']
-
-    @status.setter
-    def status(self, status):
-        self.__dict__['status'] = status
-
     def _setSndFromArray(self, thisArray):
         """For pysoundcard all sounds are ultimately played as an array so
         other setSound methods are going to call this having created an arr

--- a/psychopy/visual/button.py
+++ b/psychopy/visual/button.py
@@ -57,18 +57,6 @@ class ButtonStim(TextBox2):
         # Return True if pressed in
         return bool(self.listener.isPressedIn(self))
 
-    @property
-    def status(self):
-        if hasattr(self, "_status"):
-            return self._status
-
-    @status.setter
-    def status(self, value):
-        if value == STARTED and self._status not in [STARTED, PAUSED]:
-            self.buttonClock.reset()  # Reset clock
-        # Set status
-        self._status = value
-
     def reset(self):
         """
         Clear previously stored times on / off and check current click state.


### PR DESCRIPTION
More detail:
- Camera and SoundPysound had setters for status which didn't do anything
- Rather than ButtonStim assuming it needs to reset its clock when set to STARTED from NOT_STARTED, explicitly reset its clock in the Builder code
- As identified by @mh105 in #6560, SoundPTB was calling `_EOS()` when its status was set to STARTED, which could stop playback if `isFinished` and `isPlaying` aren't set correctly (which, if the previous Routine was force ended, they weren't) - this PR addresses this by removing the `.status` attribute setter and instead updating `isFinished`/`isPlaying` when they are queried

Fixes #6557