### PR TITLE
RF: Replace pkg_resources.parse_version with packaging.version.Version

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -23,7 +23,7 @@ profiling = False  # turning on will save profile files in currDir
 
 import psychopy
 from psychopy import prefs
-from pkg_resources import parse_version
+from packaging.version import Version
 from . import urls
 from . import frametracker
 from . import themes
@@ -636,7 +636,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             tipFile = os.path.join(
                 self.prefs.paths['resources'], _translate("tips.txt"))
             tipIndex = self.prefs.appData['tipIndex']
-            if parse_version(wx.__version__) >= parse_version('4.0.0a1'):
+            if Version(wx.__version__) >= Version('4.0.0a1'):
                 tp = wx.adv.CreateFileTipProvider(tipFile, tipIndex)
                 showTip = wx.adv.ShowTip(None, tp)
             else:
@@ -652,7 +652,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
 
         # doing this once subsequently enables the app to open & switch among
         # wx-windows on some platforms (Mac 10.9.4) with wx-3.0:
-        v = parse_version
+        v = Version
         if sys.platform == 'darwin':
             if v('3.0') <= v(wx.__version__) < v('4.0'):
                 _Showgui_Hack()  # returns ~immediately, no display
@@ -1067,7 +1067,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             "For stimulus generation and experimental control in Python.\n"
             "PsychoPy depends on your feedback. If something doesn't work\n"
             "then let us know at psychopy-users@googlegroups.com")
-        if parse_version(wx.__version__) >= parse_version('4.0a1'):
+        if Version(wx.__version__) >= Version('4.0a1'):
             info = wx.adv.AboutDialogInfo()
             showAbout = wx.adv.AboutBox
         else:

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -23,7 +23,7 @@ import numpy
 import requests
 import io
 
-from pkg_resources import parse_version
+from packaging.version import Version
 import wx.stc
 from wx.lib import scrolledpanel
 from wx.lib import platebtn
@@ -50,7 +50,7 @@ try:
 except ImportError:
     from wx import PseudoDC
 
-if parse_version(wx.__version__) < parse_version('4.0.3'):
+if Version(wx.__version__) < Version('4.0.3'):
     wx.NewIdRef = wx.NewId
 
 from psychopy.localization import _translate
@@ -3535,7 +3535,7 @@ class FlowCanvas(wx.ScrolledWindow, handlers.ThemeMixin):
 
         # create a PseudoDC to record our drawing
         self.pdc = PseudoDC()
-        if parse_version(wx.__version__) < parse_version('4.0.0a1'):
+        if Version(wx.__version__) < Version('4.0.0a1'):
             self.pdc.DrawRoundedRectangle = self.pdc.DrawRoundedRectangleRect
         self.pen_cache = {}
         self.brush_cache = {}

--- a/psychopy/app/builder/dialogs/dlgsConditions.py
+++ b/psychopy/app/builder/dialogs/dlgsConditions.py
@@ -12,7 +12,7 @@ import sys
 import pickle
 import wx
 from wx.lib.expando import ExpandoTextCtrl, EVT_ETC_LAYOUT_NEEDED
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from psychopy import gui
 from psychopy.experiment.utils import valid_var_re
@@ -116,7 +116,7 @@ class DlgConditions(wx.Dialog):
         except wx._core.PyNoAppError:  # only needed during development?
             self.madeApp = True
             global app
-            if parse_version(wx.__version__) < parse_version('2.9'):
+            if Version(wx.__version__) < Version('2.9'):
                 app = wx.PySimpleApp()
             else:
                 app = wx.App(False)

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -13,12 +13,12 @@ import psychopy.experiment.utils
 from psychopy.tools import stringtools
 from psychopy.localization import _translate
 from . import experiment
-from pkg_resources import parse_version
+from packaging.version import Version
 from psychopy.tools.fontmanager import FontManager
 
 fontMGR = FontManager()
 
-if parse_version(wx.__version__) < parse_version('4.0.0a1'):
+if Version(wx.__version__) < Version('4.0.0a1'):
     _ValidatorBase = wx.PyValidator
 else:
     _ValidatorBase = wx.Validator

--- a/psychopy/app/connections/updates.py
+++ b/psychopy/app/connections/updates.py
@@ -12,7 +12,7 @@ import time
 import zipfile
 import platform
 import os
-from pkg_resources import parse_version
+from packaging.version import Version
 import wx
 import wx.lib.filebrowsebutton
 try:
@@ -116,8 +116,8 @@ class Updater():
             raise(err)
         skip = self.app.prefs.appData['skipVersion'] == self.latest['version']
         if newer and not skip:
-            if (parse_version(self.latest['lastUpdatable'])
-                    <= parse_version(self.runningVersion)):
+            if (Version(self.latest['lastUpdatable'])
+                    <= Version(self.runningVersion)):
                 # go to the updating window
                 confirmDlg = SuggestUpdateDialog(
                     self.latest, self.runningVersion)
@@ -338,8 +338,8 @@ class InstallUpdateDialog(wx.Dialog):
             msg += _translate("Check proxy settings in preferences.")
             self.statusMessage.SetLabel(msg)
             return
-        elif (parse_version(self.latest['version'])
-                  < parse_version(self.runningVersion)):
+        elif (Version(self.latest['version'])
+                  < Version(self.runningVersion)):
             msg = _translate(
                 "You are running PsychoPy (%(running)s), which is ahead of "
                 "the latest official version (%(latest)s)") % {
@@ -354,8 +354,8 @@ class InstallUpdateDialog(wx.Dialog):
                 "PsychoPy v%(latest)s is available\nYou are running v%(running)s")
             msg = txt % {'latest': self.latest['version'],
                          'running': self.runningVersion}
-            if (parse_version(self.latest['lastUpdatable'])
-                                  <= parse_version(self.runningVersion)):
+            if (Version(self.latest['lastUpdatable'])
+                                  <= Version(self.runningVersion)):
                 msg += _translate("\nYou can update to the latest version automatically")
             else:
                 msg += _translate("\nYou cannot update to the latest version "

--- a/psychopy/app/dialogs.py
+++ b/psychopy/app/dialogs.py
@@ -18,7 +18,7 @@ from wx.lib.newevent import NewEvent
 
 from psychopy import logging
 from psychopy.localization import _translate
-from pkg_resources import parse_version
+from packaging.version import Version
 
 
 class MessageDialog(wx.Dialog):
@@ -652,7 +652,7 @@ class ListWidget(GlobSizer):
 
 
 if __name__ == '__main__':
-    if parse_version(wx.__version__) < parse_version('2.9'):
+    if Version(wx.__version__) < Version('2.9'):
         app = wx.PySimpleApp()
     else:
         app = wx.App(False)

--- a/psychopy/app/pavlovia_ui/search.py
+++ b/psychopy/app/pavlovia_ui/search.py
@@ -14,7 +14,6 @@ from psychopy.projects import pavlovia
 
 import copy
 import wx
-from pkg_resources import parse_version
 from wx.lib import scrolledpanel as scrlpanel
 import wx.lib.mixins.listctrl as listmixin
 

--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -15,7 +15,7 @@ from psychopy.app.themes import icons
 from . import dialogs
 from psychopy import localization, prefs
 from psychopy.localization import _translate
-from pkg_resources import parse_version
+from packaging.version import Version
 from psychopy import sound
 from psychopy.app.utils import getSystemFonts
 import collections
@@ -781,7 +781,7 @@ class PreferencesDlg(wx.Dialog):
 
 if __name__ == '__main__':
     from psychopy import preferences
-    if parse_version(wx.__version__) < parse_version('2.9'):
+    if Version(wx.__version__) < Version('2.9'):
         app = wx.PySimpleApp()
     else:
         app = wx.App(False)

--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -23,7 +23,7 @@ import time
 import sys
 from datetime import datetime
 
-from pkg_resources import parse_version
+from packaging.version import Version
 
 try:
     import pyglet
@@ -507,7 +507,7 @@ def _dispatchWindowEvents():
     # let's see if pyglet collected any event in meantime
     try:
         # this takes focus away from command line terminal window:
-        if parse_version(pyglet.version) < parse_version('1.2'):
+        if Version(pyglet.version) < Version('1.2'):
             # events for sounds/video should run independently of wait()
             pyglet.media.dispatch_events()
     except AttributeError:

--- a/psychopy/data/__init__.py
+++ b/psychopy/data/__init__.py
@@ -3,7 +3,7 @@
 
 import sys
 
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from .base import DataHandler
 from .experiment import ExperimentHandler
@@ -27,7 +27,7 @@ from .fit import (FitFunction, FitCumNormal, FitLogistic, FitNakaRushton,
 try:
     # import openpyxl
     import openpyxl
-    if parse_version(openpyxl.__version__) >= parse_version('2.4.0'):
+    if Version(openpyxl.__version__) >= Version('2.4.0'):
         # openpyxl moved get_column_letter to utils.cell
         from openpyxl.utils.cell import get_column_letter
     else:

--- a/psychopy/data/base.py
+++ b/psychopy/data/base.py
@@ -11,7 +11,7 @@ import codecs
 import numpy as np
 import pandas as pd
 import json_tricks
-from pkg_resources import parse_version
+from packaging.version import Version
 
 import psychopy
 from psychopy import logging
@@ -23,7 +23,7 @@ from .utils import _getExcelCellName
 
 try:
     import openpyxl
-    if parse_version(openpyxl.__version__) >= parse_version('2.4.0'):
+    if Version(openpyxl.__version__) >= Version('2.4.0'):
         # openpyxl moved get_column_letter to utils.cell
         from openpyxl.utils.cell import get_column_letter
     else:

--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -7,7 +7,7 @@ import pickle
 import copy
 import warnings
 import numpy as np
-from pkg_resources import parse_version
+from packaging.version import Version
 
 import psychopy
 from psychopy import logging
@@ -26,7 +26,7 @@ except ImportError:
 try:
     # import openpyxl
     import openpyxl
-    if parse_version(openpyxl.__version__) >= parse_version('2.4.0'):
+    if Version(openpyxl.__version__) >= Version('2.4.0'):
         # openpyxl moved get_column_letter to utils.cell
         from openpyxl.utils.cell import get_column_letter
     else:

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from collections import OrderedDict
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from psychopy import logging, exceptions
 from psychopy.tools.filetools import pathToString
@@ -22,7 +22,7 @@ from psychopy.localization import _translate
 
 try:
     import openpyxl
-    if parse_version(openpyxl.__version__) >= parse_version('2.4.0'):
+    if Version(openpyxl.__version__) >= Version('2.4.0'):
         # openpyxl moved get_column_letter to utils.cell
         from openpyxl.utils.cell import get_column_letter
     else:
@@ -378,7 +378,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
             )
 
         # data_only was added in 1.8
-        if parse_version(openpyxl.__version__) < parse_version('1.8'):
+        if Version(openpyxl.__version__) < Version('1.8'):
             wb = load_workbook(filename=fileName)
         else:
             wb = load_workbook(filename=fileName, data_only=True)
@@ -398,7 +398,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         fieldNames = []
         rangeCols = []
         for colN in range(nCols):
-            if parse_version(openpyxl.__version__) < parse_version('2.0'):
+            if Version(openpyxl.__version__) < Version('2.0'):
                 fieldName = ws.cell(_getExcelCellName(col=colN, row=0)).value
             else:
                 # From 2.0, cells are referenced with 1-indexing: A1 == cell(row=1, column=1)
@@ -414,7 +414,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
         for rowN in range(1, nRows):  # skip header first row
             thisTrial = {}
             for rangeColsIndex, colN in enumerate(rangeCols):
-                if parse_version(openpyxl.__version__) < parse_version('2.0'):
+                if Version(openpyxl.__version__) < Version('2.0'):
                     val = ws.cell(_getExcelCellName(col=colN, row=0)).value
                 else:
                     # From 2.0, cells are referenced with 1-indexing: A1 == cell(row=1, column=1)

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -22,7 +22,7 @@ import xml.etree.ElementTree as xml
 from xml.dom import minidom
 from copy import deepcopy, copy
 from pathlib import Path
-from pkg_resources import parse_version
+from packaging.version import Version
 
 import psychopy
 from psychopy import data, __version__, logging
@@ -469,13 +469,13 @@ class Experiment:
         # copy self
         exp = deepcopy(self)
         # parse version
-        targetVersion = parse_version(targetVersion)
+        targetVersion = Version(targetVersion)
         # change experiment version
         exp.psychopyVersion = targetVersion
         # iterate through Routines
         for rtName, rt in copy(exp.routines).items():
             # if Routine was added after the target version, remove it
-            if hasattr(type(rt), "version") and parse_version(rt.version) > targetVersion:
+            if hasattr(type(rt), "version") and Version(rt.version) > targetVersion:
                 exp.routines.pop(rtName)
             # if Routine is a standalone, we're done
             if isinstance(rt, BaseStandaloneRoutine):
@@ -483,7 +483,7 @@ class Experiment:
             # iterate through Components
             for comp in copy(rt):
                 # if Component was added after target version, remove it
-                if hasattr(type(comp), "version") and parse_version(comp.version) > targetVersion:
+                if hasattr(type(comp), "version") and Version(comp.version) > targetVersion:
                     i = rt.index(comp)
                     rt.pop(i)
 
@@ -789,10 +789,10 @@ class Experiment:
             return
         self.psychopyVersion = root.get('version')
         # If running an experiment from a future version, send alert to change "Use Version"
-        if parse_version(psychopy.__version__) < parse_version(self.psychopyVersion):
+        if Version(psychopy.__version__) < Version(self.psychopyVersion):
             alert(code=4051, strFields={'version': self.psychopyVersion})
         # If versions are either side of 2021, send alert
-        if parse_version(psychopy.__version__) >= parse_version("2021.1.0") > parse_version(self.psychopyVersion):
+        if Version(psychopy.__version__) >= Version("2021.1.0") > Version(self.psychopyVersion):
             alert(code=4052, strFields={'version': self.psychopyVersion})
 
         # Parse document nodes

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -13,11 +13,11 @@ import wx
 import numpy
 import os
 from psychopy.localization import _translate
-from pkg_resources import parse_version
+from packaging.version import Version
 
 OK = wx.ID_OK
 
-thisVer = parse_version(wx.__version__)
+thisVer = Version(wx.__version__)
 
 def ensureWxApp():
     # make sure there's a wxApp prior to showing a gui, e.g., for expInfo
@@ -26,9 +26,9 @@ def ensureWxApp():
         wx.Dialog(None, -1)  # not shown; FileDialog gives same exception
         return True
     except wx._core.PyNoAppError:
-        if thisVer < parse_version('2.9'):
+        if thisVer < Version('2.9'):
             return wx.PySimpleApp()
-        elif thisVer >= parse_version('4.0') and thisVer < parse_version('4.1'):
+        elif thisVer >= Version('4.0') and thisVer < Version('4.1'):
             raise Exception(
                     "wx>=4.0 clashes with pyglet and making it unsafe "
                     "as a PsychoPy gui helper. Please install PyQt (4 or 5)"

--- a/psychopy/iohub/datastore/__init__.py
+++ b/psychopy/iohub/datastore/__init__.py
@@ -7,7 +7,7 @@
 import os
 import atexit
 import numpy as np
-from pkg_resources import parse_version
+from packaging.version import Version
 from ..server import DeviceEvent
 from ..constants import EventConstants
 from ..errors import ioHubError, printExceptionDetailsToStdErr, print2err
@@ -15,7 +15,7 @@ from ..errors import ioHubError, printExceptionDetailsToStdErr, print2err
 import tables
 from tables import parameters, StringCol, UInt32Col, UInt16Col, NoSuchNodeError
 
-if parse_version(tables.__version__) < parse_version('3'):
+if Version(tables.__version__) < Version('3'):
     from tables import openFile as open_file
 
     create_table = "createTable"

--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -12,10 +12,10 @@ import numpy
 
 from ..errors import print2err
 
-from pkg_resources import parse_version
+from packaging.version import Version
 import tables
 
-if parse_version(tables.__version__) < parse_version('3'):
+if Version(tables.__version__) < Version('3'):
     from tables import openFile as open_file
 
     walk_groups = "walkGroups"

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -8,13 +8,13 @@ import platform
 from pathlib import Path
 from .. import __version__
 
-from pkg_resources import parse_version
+from packaging.version import Version
 import shutil
 
 try:
     import configobj
     if (sys.version_info.minor >= 7 and
-            parse_version(configobj.__version__) < parse_version('5.1.0')):
+            Version(configobj.__version__) < Version('5.1.0')):
         raise ImportError('Installed configobj does not support Python 3.7+')
     _haveConfigobj = True
 except ImportError:
@@ -217,12 +217,12 @@ class Preferences:
         # Check what version user themes were last updated in
         if (userThemeDir / "last.ver").is_file():
             with open(userThemeDir / "last.ver", "r") as f:
-                lastVer = parse_version(f.read())
+                lastVer = Version(f.read())
         else:
             # if no version available, assume it was the first version to have themes
-            lastVer = parse_version("2020.2.0")
+            lastVer = Version("2020.2.0")
         # If version has changed since base themes last copied, they need updating
-        updateThemes = lastVer < parse_version(__version__)
+        updateThemes = lastVer < Version(__version__)
         # Copy base themes to user themes folder if missing or need update
         for file in baseThemeDir.glob("*.json"):
             if updateThemes or not (Path(self.paths['themes']) / file.name).is_file():

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -17,7 +17,7 @@ import subprocess
 import traceback
 
 import pandas
-from pkg_resources import parse_version
+from packaging.version import Version
 
 from psychopy import logging, prefs, exceptions
 from psychopy.tools.filetools import DictStorage, KnownProjects

--- a/psychopy/tests/test_app/conftest.py
+++ b/psychopy/tests/test_app/conftest.py
@@ -9,12 +9,12 @@ py.test fixtures to create an instance of PsychoPyApp for testing
 """
 
 import pytest
-from pkg_resources import parse_version
+from packaging.version import Version
 import psychopy.app as app
 from PIL import Image
 Image.DEBUG = False
 
-if parse_version(pytest.__version__) < parse_version('5'):
+if Version(pytest.__version__) < Version('5'):
     class VersionError(Exception):
         pass
     raise VersionError("PsychoPy test suite requires pytest>=5.4")

--- a/psychopy/tests/test_experiment/needs_wx/genComponsTemplate.py
+++ b/psychopy/tests/test_experiment/needs_wx/genComponsTemplate.py
@@ -2,10 +2,10 @@ import sys
 import os
 import io
 
-from pkg_resources import parse_version
+from packaging.version import Version
 import wx
 
-if parse_version(wx.__version__) < parse_version('2.9'):
+if Version(wx.__version__) < Version('2.9'):
     tmpApp = wx.PySimpleApp()
 else:
     tmpApp = wx.App(False)
@@ -26,7 +26,7 @@ try:
     allComp = getAllComponents(fetchIcons=False)
 except Exception:
     import wx
-    if parse_version(wx.__version__) < parse_version('2.9'):
+    if Version(wx.__version__) < Version('2.9'):
         tmpApp = wx.PySimpleApp()
     else:
         tmpApp = wx.App(False)

--- a/psychopy/tests/test_experiment/needs_wx/test_components.py
+++ b/psychopy/tests/test_experiment/needs_wx/test_components.py
@@ -8,7 +8,7 @@ import warnings
 from psychopy import constants
 from psychopy.experiment import getAllComponents, Param, utils
 from psychopy import experiment
-from pkg_resources import parse_version
+from packaging.version import Version
 
 # use "python genComponsTemplate.py --out" to generate a new profile to test against
 #   = analogous to a baseline image to compare screenshots
@@ -44,7 +44,7 @@ class TestComponents():
             cls.allComp = getAllComponents(fetchIcons=False)
         except Exception:
             import wx
-            if parse_version(wx.__version__) < parse_version('2.9'):
+            if Version(wx.__version__) < Version('2.9'):
                 tmpApp = wx.PySimpleApp()
             else:
                 tmpApp = wx.App(False)

--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -17,7 +17,7 @@ import psychopy  # for currently loaded version
 from psychopy import prefs
 # the following will all have been imported so import here and reload later
 from psychopy import logging, tools, web, constants, preferences, __version__
-from pkg_resources import parse_version
+from packaging.version import Version
 from importlib import reload
 from packaging.version import Version, InvalidVersion, VERSION_PATTERN
 
@@ -194,7 +194,7 @@ def getPsychoJSVersionStr(currentVersion, preferredVersion=''):
 
     # do we shorten minor versions ('3.4.2' to '3.4')?
     # only from 3.2 onwards
-    if (parse_version('3.2')) <= parse_version(useVerStr) < parse_version('2021') \
+    if (Version('3.2')) <= Version(useVerStr) < Version('2021') \
             and len(useVerStr.split('.')) > 2:
         # e.g. 2020.2 not 2021.2.5
         useVerStr = '.'.join(useVerStr.split('.')[:2])
@@ -385,9 +385,9 @@ def versionOptions(local=True):
     majorMinor = sorted(
         list({'.'.join(v.split('.')[:2])
               for v in availableVersions(local=local)}),
-        key=parse_version, 
+        key=Version, 
         reverse=True)
-    major = sorted(list({v.split('.')[0] for v in majorMinor}), key=parse_version, reverse=True)
+    major = sorted(list({v.split('.')[0] for v in majorMinor}), key=Version, reverse=True)
     special = ['latest']
     return special + major + majorMinor
 
@@ -402,7 +402,7 @@ def _localVersions(forceCheck=False):
             tagInfo = subprocess.check_output(cmd.split(), cwd=VERSIONSDIR,
                                               env=constants.ENVIRON).decode('UTF-8')
             allTags = tagInfo.splitlines()
-            _localVersionsCache = sorted(allTags, key=parse_version, reverse=True)
+            _localVersionsCache = sorted(allTags, key=Version, reverse=True)
     return _localVersionsCache
 
 
@@ -421,7 +421,7 @@ def _remoteVersions(forceCheck=False):
                        for line in tagInfo.decode().splitlines()
                        if '^{}' not in line]
             # ensure most recent (i.e., highest) first
-            _remoteVersionsCache = sorted(allTags, key=parse_version, reverse=True)
+            _remoteVersionsCache = sorted(allTags, key=Version, reverse=True)
     return _remoteVersionsCache
 
 
@@ -443,19 +443,19 @@ def _versionFilter(versions, wxVersion):
     # logging.info(msg)
     versions = [ver for ver in versions
                 if ver == 'latest'
-                or parse_version(ver) >= parse_version('1.90')
+                or Version(ver) >= Version('1.90')
                 and len(ver) > 1]
 
     # Get WX Compatibility
     compatibleWX = '4.0'
-    if wxVersion is not None and parse_version(wxVersion) >= parse_version(compatibleWX):
+    if wxVersion is not None and Version(wxVersion) >= Version(compatibleWX):
         # msg = _translate("wx version: {}. Filtering versions of "
         #                  "PsychoPy only compatible with wx >= version {}".format(wxVersion,
         #                                                                       compatibleWX))
         # logging.info(msg)
         return [ver for ver in versions
                 if ver == 'latest'
-                or parse_version(ver) > parse_version('1.85.04')
+                or Version(ver) > Version('1.85.04')
                 and len(ver) > 1]
     return versions
 
@@ -474,7 +474,7 @@ def availableVersions(local=True, forceCheck=False):
             return sorted(
                 list(set([psychopy.__version__] + _localVersions(forceCheck) + _remoteVersions(
                     forceCheck))),
-                key=parse_version,
+                key=Version,
                 reverse=True)
     except subprocess.CalledProcessError:
         return []

--- a/psychopy/tools/wizard.py
+++ b/psychopy/tools/wizard.py
@@ -17,9 +17,9 @@ import wx
 import numpy as np
 import platform
 import codecs
-from pkg_resources import parse_version
+from packaging.version import Version
 
-if parse_version(wx.__version__) < parse_version('2.9'):
+if Version(wx.__version__) < Version('2.9'):
     tmpApp = wx.PySimpleApp()
 else:
     tmpApp = wx.App(False)
@@ -88,7 +88,7 @@ class BaseWizard():
             'prefs.html#application-settings-app">Preferences -> App</a>')
         report.append(('locale', items['systemLocale'], msg, False))
         msg = ''
-        v = parse_version
+        v = Version
         thisV = v(items['pythonVersion'])
         if (thisV < v('2.7') or (v('3.0') <= thisV < v('3.6'))
             ):

--- a/psychopy/visual/helpers.py
+++ b/psychopy/visual/helpers.py
@@ -10,7 +10,7 @@
 
 import os
 import copy
-from pkg_resources import parse_version
+from packaging.version import Version
 from pathlib import Path
 from psychopy import logging, colors, prefs
 
@@ -31,7 +31,7 @@ _nImageResizes = 0
 
 try:
     import matplotlib
-    if parse_version(matplotlib.__version__) > parse_version('1.2'):
+    if Version(matplotlib.__version__) > Version('1.2'):
         from matplotlib.path import Path as mplPath
     else:
         from matplotlib import nxutils
@@ -61,7 +61,7 @@ def pointInPolygon(x, y, poly):
 
     # faster if have matplotlib tools:
     if haveMatplotlib:
-        if parse_version(matplotlib.__version__) > parse_version('1.2'):
+        if Version(matplotlib.__version__) > Version('1.2'):
             return mplPath(poly).contains_point([x, y])
         else:
             try:
@@ -133,7 +133,7 @@ def polygonsOverlap(poly1, poly2):
 
     # faster if have matplotlib tools:
     if haveMatplotlib:
-        if parse_version(matplotlib.__version__) > parse_version('1.2'):
+        if Version(matplotlib.__version__) > Version('1.2'):
             if any(mplPath(poly1_vert_pix).contains_points(poly2_vert_pix)):
                 return True
             return any(mplPath(poly2_vert_pix).contains_points(poly1_vert_pix))

--- a/setupApp.py
+++ b/setupApp.py
@@ -8,7 +8,7 @@ import sys
 from sys import platform
 import setuptools  # noqa: setuptools complains if it isn't implicitly imported before distutils
 from distutils.core import setup
-from pkg_resources import parse_version
+from packaging.version import Version
 import bdist_mpkg  # noqa: needed to build bdist, even though not explicitly used here
 import py2app  # noqa: needed to build app bundle, even though not explicitly used here
 from ctypes.util import find_library
@@ -50,7 +50,7 @@ frameworks.extend(opencvLibs)
 import macholib
 #print("~"*60 + "macholib version: "+macholib.__version__)
 
-if parse_version(macholib.__version__) <= parse_version('1.7'):
+if Version(macholib.__version__) <= Version('1.7'):
     print("Applying macholib patch...")
     import macholib.dyld
     import macholib.MachOGraph


### PR DESCRIPTION
As pointed out in #6455, pkg_resources is deprecated and won't work when we need to upgrade to Python >3.11. Some of its uses are quite involved and will need a bit more thought to replace, but `pkg_resources.parse_version` is fully synonymous with `packaging.version.Version` so this PR just does a like-for-like substitution