### PR TITLE
BF: Fixed crash when mono is specified if the microphone device supports stereo as default

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -110,6 +110,15 @@ class MicrophoneComponent(BaseDeviceComponent):
                 "local experiments - online experiments ask the participant which mic to use."
             )
         )
+        # grey out device settings when device is default
+        for depParam in ("channels", "sampleRate"):
+            self.depends.append({
+                "dependsOn": "device",  # if...
+                "condition": "== 'None'",  # is...
+                "param": depParam,  # then...
+                "true": "hide",  # should...
+                "false": "show",  # otherwise...
+            })
         if stereo is not None:
             # If using a legacy mic component, work out channels from old bool value of stereo
             channels = ['mono', 'stereo'][stereo]
@@ -291,9 +300,14 @@ class MicrophoneComponent(BaseDeviceComponent):
             "    deviceClass='psychopy.hardware.microphone.MicrophoneDevice',\n"
             "    deviceName=%(deviceLabel)s,\n"
             "    index=%(device)s,\n"
+            "    maxRecordingSize=%(maxSize)s\n"
+        )
+        if self.params['device'].val not in ("None", "", None):
+            code += (
             "    channels=%(channels)s, \n"
             "    sampleRateHz=%(sampleRate)s, \n"
-            "    maxRecordingSize=%(maxSize)s\n"
+            )
+        code += (
             ")\n"
         )
         buff.writeOnceIndentedLines(code % inits)


### PR DESCRIPTION
This PR adds checks to mic settings to ensure they are compatible with the default for the mic. If not, we try and find a device config that does match those settings. If that doesn't work, we override the user settings with a warning to allow the program to continue, using the default mic settings recommended by the audio library.

It might be best to either grey out the mic settings when default is specified, or ensure that we are always getting the default mic and only populating fields with valid values associated with it.