### PR TITLE
EyeLogic integration

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -119,6 +119,7 @@ class SettingsComponent:
             plCompanionAddress="neon.local",
             plCompanionPort=8080,
             plCompanionRecordingEnabled=True,
+            ecSampleRate='default',
             keyboardBackend="ioHub",
             filename=None, exportHTML='on Sync', endMessage=''
     ):
@@ -541,6 +542,7 @@ class SettingsComponent:
                            "plPupilRemoteAddress", "plPupilRemotePort", "plPupilRemoteTimeoutMs",
                            "plPupilCaptureRecordingEnabled", "plPupilCaptureRecordingLocation"],
             "Pupil Labs (Neon)": ["plCompanionAddress", "plCompanionPort", "plCompanionRecordingEnabled"],
+            "EyeLogic": ["ecSampleRate"],
         }
         for tracker in trackerParams:
             for depParam in trackerParams[tracker]:
@@ -755,6 +757,13 @@ class SettingsComponent:
             plCompanionRecordingEnabled, valType='bool', inputType="bool",
             hint=_translate("Recording enabled"),
             label=_translate("Recording enabled"), categ="Eyetracking"
+        )
+
+        # EyeLogic
+        self.params['ecSampleRate'] = Param(
+            ecSampleRate, valType='str', inputType="single",
+            hint=_translate("Eyetracker sampling rate: 'default' or <integer>[Hz]. Defaults to tracking mode '0'."),
+            label=_translate("Sampling rate"), categ="Eyetracking"
         )
 
         # Input
@@ -1640,6 +1649,22 @@ class SettingsComponent:
                 buff.writeIndentedLines(code % inits)
 
                 # Close runtime_settings dict
+                buff.setIndentLevel(-1, relative=True)
+                code = (
+                    "}\n"
+                )
+                buff.writeIndentedLines(code % inits)
+
+            elif self.params['eyetracker'] == "EyeLogic":
+                code = (
+                    "'runtime_settings': {\n"
+                )
+                buff.writeIndentedLines(code % inits)
+                buff.setIndentLevel(1, relative=True)
+                code = (
+                    "'sampling_rate': %(ecSampleRate)s,\n"
+                )
+                buff.writeIndentedLines(code % inits)
                 buff.setIndentLevel(-1, relative=True)
                 code = (
                     "}\n"

--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -4,6 +4,8 @@ from psychopy.experiment import Param
 from pathlib import Path
 from psychopy.alerts import alert
 
+import typing as T
+
 
 class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
     categories = ['Eyetracking']
@@ -28,6 +30,60 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
 
         self.exp.requirePsychopyLibs(['iohub', 'hardware'])
 
+        def hideParameterForTrackers(category: str, parameter: str, trackers: T.List[str]):
+            assert parameter in self.params.keys()
+            assert self.params[parameter].categ == category
+            dummyName = 'dummyVariable' + category.title()
+            if dummyName not in self.params.keys():
+                self.params[dummyName] = Param(True,
+                                              valType='bool', inputType="bool", categ=category,
+                                              hint=_translate(""),
+                                              label=_translate(""))
+                self.depends.append(
+                    {"dependsOn": dummyName,  # must be param name
+                     "condition": "",  # val to check for
+                     "param": dummyName,  # param property to alter
+                     "true": "hide",  # what to do with param if condition is True
+                     "false": "show",  # permitted: hide, show, enable, disable
+                     }
+                )
+
+            self.depends.append(
+                {"dependsOn": dummyName,  # must be param name
+                 "condition": "and hideParamForEyetrackers( ['" + "', '".join(trackers) + "'] )",
+                 "param": parameter,  # param property to alter
+                 "true": "hide",  # what to do with param if condition is True
+                 "false": "show",  # permitted: hide, show, enable, disable
+                 }
+            )
+
+        def showParameterForTrackers(category: str, parameter: str, trackers: T.List[str]):
+            assert parameter in self.params.keys()
+            assert self.params[parameter].categ == category
+            dummyName = 'dummyVariable' + category.title()
+            if dummyName not in self.params.keys():
+                self.params[dummyName] = Param(True,
+                                               valType='bool', inputType="bool", categ=category,
+                                               hint=_translate(""),
+                                               label=_translate(""))
+                self.depends.append(
+                    {"dependsOn": dummyName,  # must be param name
+                     "condition": "",  # val to check for
+                     "param": dummyName,  # param property to alter
+                     "true": "hide",  # what to do with param if condition is True
+                     "false": "show",  # permitted: hide, show, enable, disable
+                     }
+                )
+
+            self.depends.append(
+                {"dependsOn": dummyName,  # must be param name
+                 "condition": "and showParamForEyetrackers( ['" + "', '".join(trackers) + "'] )",
+                 "param": parameter,  # param property to alter
+                 "true": "show",  # what to do with param if condition is True
+                 "false": "hide",  # permitted: hide, show, enable, disable
+                 }
+            )
+
         # Basic params
         self.order += [
             "targetLayout",
@@ -35,23 +91,36 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
             "textColor"
         ]
 
-        del self.params['stopVal']
-        del self.params['stopType']
+        self.params['eyelogicCalibrationMode'] = Param("FIVE_POINTS",
+                                            valType='str', inputType="choice", categ='Basic',
+                                            allowedVals=['ONE_POINT', 'TWO_POINTS', 'FIVE_POINTS', 'NINE_POINTS'],
+                                            hint=_translate("Pre-defined target layouts"),
+                                            label=_translate("Target layout"))
+        showParameterForTrackers(category='Basic', parameter='eyelogicCalibrationMode', trackers=['EyeLogic'])
 
         self.params['targetLayout'] = Param(targetLayout,
                                             valType='str', inputType="choice", categ='Basic',
-                                            allowedVals=['THREE_POINTS', 'FIVE_POINTS', 'NINE_POINTS', "THIRTEEN_POINTS"],
+                                            allowedVals=['THREE_POINTS', 'FIVE_POINTS', 'NINE_POINTS', 'THIRTEEN_POINTS'],
                                             hint=_translate("Pre-defined target layouts"),
                                             label=_translate("Target layout"))
+        hideParameterForTrackers(category='Basic', parameter='targetLayout', trackers=['EyeLogic'] )
 
         self.params['randomisePos'] = Param(randomisePos,
                                             valType='bool', inputType="bool", categ='Basic',
                                             hint=_translate("Should the order of target positions be randomised?"),
                                             label=_translate("Randomise target positions"))
+        hideParameterForTrackers(category='Basic', parameter='randomisePos', trackers=['EyeLogic'] )
+
         self.params['textColor'] = Param(textColor,
-                                     valType='color', inputType="color", categ='Basic',
-                                     hint=_translate("Text foreground color"),
-                                     label=_translate("Text color"))
+                                         valType='color', inputType="color", categ='Basic',
+                                         hint=_translate("Text foreground color"),
+                                         label=_translate("Text color"))
+        hideParameterForTrackers(category='Basic', parameter='textColor', trackers=['EyeLogic'])
+
+        del self.params['stopVal']
+        del self.params['stopType']
+
+
         # Target Params
         self.order += [
             "targetStyle",
@@ -70,21 +139,27 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                      valType='color', inputType="color", categ='Target',
                                      hint=_translate("Fill color of the inner part of the target"),
                                      label=_translate("Inner fill color"))
+        hideParameterForTrackers(category='Target', parameter='innerFillColor', trackers=['EyeLogic'])
 
         self.params['innerBorderColor'] = Param(innerBorderColor,
                                            valType='color', inputType="color", categ='Target',
                                            hint=_translate("Border color of the inner part of the target"),
                                            label=_translate("Inner border color"))
+        hideParameterForTrackers(category='Target', parameter='innerBorderColor', trackers=['EyeLogic'])
+
 
         self.params['fillColor'] = Param(fillColor,
                                          valType='color', inputType="color", categ='Target',
                                          hint=_translate("Fill color of the outer part of the target"),
                                          label=_translate("Outer fill color"))
+        hideParameterForTrackers(category='Target', parameter='fillColor', trackers=['EyeLogic'])
+
 
         self.params['borderColor'] = Param(borderColor,
                                            valType='color', inputType="color", categ='Target',
                                            hint=_translate("Border color of the outer part of the target"),
                                            label=_translate("Outer border color"))
+        hideParameterForTrackers(category='Target', parameter='borderColor', trackers=['EyeLogic'])
 
         self.params['colorSpace'] = Param(colorSpace,
                                           valType='str', inputType="choice", categ='Target',
@@ -92,32 +167,38 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                           hint=_translate(
                                               "In what format (color space) have you specified the colors? (rgb, dkl, lms, hsv)"),
                                           label=_translate("Color space"))
+        hideParameterForTrackers(category='Target', parameter='colorSpace', trackers=['EyeLogic'])
 
         self.params['borderWidth'] = Param(borderWidth,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Width of the line around the outer part of the target"),
                                            label=_translate("Outer border width"))
+        hideParameterForTrackers(category='Target', parameter='borderWidth', trackers=['EyeLogic'])
 
         self.params['innerBorderWidth'] = Param(innerBorderWidth,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Width of the line around the inner part of the target"),
                                            label=_translate("Inner border width"))
+        hideParameterForTrackers(category='Target', parameter='innerBorderWidth', trackers=['EyeLogic'])
 
         self.params['outerRadius'] = Param(outerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the outer part of the target"),
                                            label=_translate("Outer radius"))
+        hideParameterForTrackers(category='Target', parameter='outerRadius', trackers=['EyeLogic'])
 
         self.params['innerRadius'] = Param(innerRadius,
                                            valType='num', inputType="single", categ='Target',
                                            hint=_translate("Size (radius) of the inner part of the target"),
                                            label=_translate("Inner radius"))
+        hideParameterForTrackers(category='Target', parameter='innerRadius', trackers=['EyeLogic'])
 
         self.params['units'] = Param(units,
                                      valType='str', inputType="choice", categ='Target',
                                      allowedVals=['from exp settings'], direct=False,
                                      hint=_translate("Units of dimensions for this stimulus"),
                                      label=_translate("Spatial units"))
+        hideParameterForTrackers(category='Target', parameter='units', trackers=['EyeLogic'])
 
         # Animation Params
         self.order += [
@@ -136,6 +217,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                             hint=_translate("Should the target move to the next position after a "
                                                             "keypress or after an amount of time?"),
                                             label=_translate("Progress mode"))
+        hideParameterForTrackers(category='Animation', parameter='progressMode', trackers=['EyeLogic'])
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -151,6 +233,8 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                          hint=_translate(
                                              "Time limit (s) after which progress to next position"),
                                          label=_translate("Target duration"))
+        hideParameterForTrackers(category='Animation', parameter='targetDur', trackers=['EyeLogic'])
+
 
         self.depends.append(
             {"dependsOn": "progressMode",  # must be param name
@@ -166,17 +250,21 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                          hint=_translate(
                                              "Duration of the target expand/contract animation"),
                                          label=_translate("Expand / contract duration"))
+        hideParameterForTrackers(category='Animation', parameter='expandDur', trackers=['EyeLogic'])
+
 
         self.params['expandScale'] = Param(expandScale,
                                            valType='num', inputType="single", categ='Animation',
                                            hint=_translate("How many times bigger than its size the target grows"),
                                            label=_translate("Expand scale"))
+        hideParameterForTrackers(category='Animation', parameter='expandScale', trackers=['EyeLogic'])
 
         self.params['movementAnimation'] = Param(movementAnimation,
                                                  valType='bool', inputType="bool", categ='Animation',
                                                  hint=_translate(
                                                      "Enable / disable animations as target stim changes position"),
                                                  label=_translate("Animate position changes"))
+        hideParameterForTrackers(category='Animation', parameter='movementAnimation', trackers=['EyeLogic'])
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -192,6 +280,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                            hint=_translate(
                                                "Duration of the animation during position changes."),
                                            label=_translate("Movement duration"))
+        hideParameterForTrackers(category='Animation', parameter='movementDur', trackers=['EyeLogic'])
 
         self.depends.append(
             {"dependsOn": "movementAnimation",  # must be param name
@@ -207,6 +296,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                            hint=_translate(
                                                "Duration of the delay between positions."),
                                            label=_translate("Target delay"))
+        hideParameterForTrackers(category='Animation', parameter='targetDelay', trackers=['EyeLogic'])
 
     def writeMainCode(self, buff):
         # Alert user if eyetracking isn't setup
@@ -215,6 +305,8 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
         # Get inits
         inits = self.params
         # Code-ify 'from exp settings'
+        if self.exp.eyetracking == 'EyeLogic':
+            inits['targetLayout'] = inits['eyelogicCalibrationMode']
         if self.params['units'].val == 'from exp settings':
             inits['units'].val = None
         # Synonymise expand dur and target dur

--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -80,7 +80,7 @@ class EyetrackerCalibration:
         pkgName = ".".join(tracker.split(".")[:-1])
         clsName = tracker.split(".")[-1]
         # make sure pkgName is fully qualified
-        if not pkgName.startswith("psychopy.iohub.devices."):
+        if not pkgName.startswith("psychopy.iohub.devices.") and not 'eyetracker' in pkgName:
             pkgName = "psychopy.iohub.devices." + pkgName
         # import package
         pkg = importlib.import_module(pkgName)

--- a/psychopy/iohub/devices/eyetracker/hw/eyelogic/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/hw/eyelogic/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Part of the PsychoPy library
+# Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import psychopy.logging as logging
+
+try:
+    from psychopy_eyetracker_eyelogic.eyelogic import (
+        __file__,
+        EyeTracker,
+        MonocularEyeSampleEvent,
+        BinocularEyeSampleEvent,
+        FixationStartEvent,
+        FixationEndEvent,
+        SaccadeStartEvent,
+        SaccadeEndEvent,
+        BlinkStartEvent,
+        BlinkEndEvent
+    )
+except (ModuleNotFoundError, ImportError, NameError):
+    logging.error(
+        "The EyeLogic eyetracker requires package 'psychopy-eyetracker-eyelogic' to "
+        "be installed. Please install this package and restart the session to "
+        "enable support.")
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/iohub/devices/eyetracker/hw/eyelogic/calibration.py
+++ b/psychopy/iohub/devices/eyetracker/hw/eyelogic/calibration.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+# Part of the PsychoPy library
+# Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import psychopy.logging as logging
+
+try:
+    from psychopy_eyetracker_eyelogic.eyelogic.calibration import (EyeLogicCalibrationProcedure)
+except (ModuleNotFoundError, ImportError, NameError):
+    logging.error(
+        "The eyelogic eyetracker requires package 'psychopy-eyetracker-eyelogic' to "
+        "be installed. Please install this package and restart the session to "
+        "enable support.")
+
+
+if __name__ == "__main__":
+    pass

--- a/psychopy/iohub/devices/eyetracker/hw/eyelogic/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/eyelogic/eyetracker.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Part of the PsychoPy library
+# Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
+# Distributed under the terms of the GNU General Public License (GPL).
+
+import psychopy.logging as logging
+
+try:
+    from psychopy_eyetracker_eyelogic.eyelogic.eyetracker import EyeTracker
+except (ModuleNotFoundError, ImportError, NameError):
+    logging.error(
+        "The EyeLogic eyetracker requires package 'psychopy-eyetracker-eyelogic' to "
+        "be installed. Please install this package and restart the session to "
+        "enable support.")
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
4af446f1a6b2547b9f07a6fc15ef48837f6af1be
Due to an issue, the origin of which I do not know, eyetracker iOHubDeviceView class names do not point to iohub.devices.eyetracker... but to the plugin packages. Prepending "psychopy.iohub.devices" to these will lead to a failed call to import_module.
I am currently in communication with @TEParsons on this issue. We may yet be resolve the issue in a different manner.

636edf612d158cdcec115ac03490fc5230ff1eac
Adds basic support. Tracker will be found and work (mostly): 
- calibration procedure settings tab contains a large number of unnecessary parameters
- the possible values of the only necessary parameter "Target Layout" are only partially applicable (FIVE & NINE)

59e903ff1b8226e22e0820cbb9cb6d34b8b5c755
- removes unncessary calibration parameters
- updates calibration process settings tab on change of eyetracker
- fixes the above issue concerning the applicability of "Target Layout"'s values