### PR TITLE
BF: Get correct speech onset/offset times and write them to data file

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -520,25 +520,17 @@ class MicrophoneComponent(BaseDeviceComponent):
             )
             buff.writeIndentedLines(code % inits)
         if inits['speakTimes'] and inits['transcribeBackend'].val == "whisper":
+
             code = (
                 "# save transcription data\n"
                 "with open(os.path.join(%(name)sRecFolder, 'recording_%(name)s_%%s.json' %% tag), 'w') as fp:\n"
                 "    fp.write(%(name)sScript.response)\n"
                 "# save speaking start/stop times\n"
-                "%(name)sWordData = []\n"
-                "%(name)sSegments = %(name)s.lastScript.responseData.get('segments', {})\n"
-                "for thisSegment in %(name)sSegments.values():\n"
-                "    # for each segment...\n"
-                "    for thisWord in thisSegment.get('words', {}).values():\n"
-                "        # append word data\n"
-                "        %(name)sWordData.append(thisWord)\n"
-                "# if there were any words, store the start of first & end of last \n"
-                "if len(%(name)sWordData):\n"
-                "    thisExp.addData('%(name)s.speechStart', %(name)sWordData[0]['start'])\n"
-                "    thisExp.addData('%(name)s.speechEnd', %(name)sWordData[-1]['end'])\n"
-                "else:\n"
-                "    thisExp.addData('%(name)s.speechStart', '')\n"
-                "    thisExp.addData('%(name)s.speechEnd', '')\n"
+                "%(name)sSpeechInterval = %(name)s.lastScript.getSpeechInterval()\n"
+                "%(name)sSpeechOnset = %(name)sSpeechInterval[0]\n"
+                "%(name)sSpeechOffset = %(name)sSpeechInterval[1]\n"
+                "thisExp.addData('%(name)s.speechStart', %(name)sSpeechOnset)\n"
+                "thisExp.addData('%(name)s.speechEnd', %(name)sSpeechOffset)\n"
             )
             buff.writeIndentedLines(code % inits)
         # Write base end routine code


### PR DESCRIPTION
This fixes a bug where the speech onset/offset times aren't correctly being obtained from the transcriber's output. This also adds a method to the actual response object which can be used to obtain these values instead of inside the boilerplate code.