### PR TITLE
DOC: make a note that writeRoutineEndCode does not save onset/offset times

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -300,6 +300,8 @@ class BaseComponent:
             loop = currLoop.params['name']
             name = self.params['name']
 
+            # NOTE: this function does not write any code right now!
+
     def writeRoutineEndCodeJS(self, buff):
         """Write the code that will be called at the end of
         a routine (e.g. to save data)


### PR DESCRIPTION
I noticed this while working on some other things for `SoundComponent`, but it looks like the `writeRoutineEndCode()` method of `BaseComponent` doesn't actually write code when generating scripts from Builder to save onset/offset times at the end of a routine. Is this expected...? It's just that almost all components have this parameter, and it was surprising there isn't corresponding code gets written for it. I apologize in advance if this is mistaken, and feel free to close it.