### PR TITLE
FF: add default allowed Keys as empty

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -395,6 +395,9 @@ def getInitVals(params, target="PsychoPy"):
         elif name in ('movie', 'latitude', 'longitude', 'elevation', 'azimuth', 'speechPoint'):
             inits[name].val = 'None'
             inits[name].valType = 'code'
+        elif name == 'allowedKeys':
+            inits[name].val = "[]"
+            inits[name].valType = 'code'
         else:
             print("I don't know the appropriate default value for a '%s' "
                   "parameter. Please email the mailing list about this error" %


### PR DESCRIPTION
Provide default allowedKeys so that an error message isn't sent when `KeyBoard` component `Allowed keys` is `set every repeat`.