### PR TITLE
BF: Import eyetracker device classes safely regardless of the package location

### DIFF
--- a/psychopy/hardware/eyetracker.py
+++ b/psychopy/hardware/eyetracker.py
@@ -1,6 +1,7 @@
 from psychopy.constants import STARTED, NOT_STARTED, PAUSED, STOPPED, FINISHED
 from psychopy.alerts import alert
 from psychopy import logging
+from psychopy.iohub.devices import importDeviceModule
 from psychopy.tools.attributetools import AttributeGetSetMixin
 from copy import copy
 import importlib
@@ -83,7 +84,7 @@ class EyetrackerCalibration:
         if not pkgName.startswith("psychopy.iohub.devices."):
             pkgName = "psychopy.iohub.devices." + pkgName
         # import package
-        pkg = importlib.import_module(pkgName)
+        pkg = importDeviceModule(pkgName)
         # get tracker class
         trackerCls = getattr(pkg, clsName)
         # get self as dict

--- a/psychopy/iohub/client/__init__.py
+++ b/psychopy/iohub/client/__init__.py
@@ -1119,9 +1119,7 @@ class ioHubConnection():
             if local_class:
                 d = local_class(self, dev_cls_name, dev_config)
             else:
-                full_device_class_name = getFullClassName(dev_cls).replace('psychopy.iohub.devices.', "")
-                full_device_class_name = full_device_class_name.replace('eyetracker.EyeTracker', 'EyeTracker')
-                d = ioHubDeviceView(self, full_device_class_name, dev_cls_name, dev_config)
+                d = ioHubDeviceView(self, dev_mod_pth + "." + dev_cls_name, dev_cls_name, dev_config)
 
             self.devices.addDevice(name, d)
             return d

--- a/psychopy/iohub/devices/deviceConfigValidation.py
+++ b/psychopy/iohub/devices/deviceConfigValidation.py
@@ -7,6 +7,7 @@ import socket
 import os
 import numbers  # numbers.Integral is like (int, long) but supports Py3
 from psychopy import colors
+from psychopy.iohub.devices import importDeviceModule
 from psychopy.tools import arraytools
 from ..util import yload, yLoader, module_directory, getSupportedConfigSettings
 from ..errors import print2err
@@ -488,7 +489,7 @@ def validateDeviceConfiguration(
         current_device_config):
     """Validate the device configuration settings provided.
     """
-    validation_module = importlib.import_module(relative_module_path)
+    validation_module = importDeviceModule(relative_module_path)
     validation_file_path = getSupportedConfigSettings(validation_module)
 
     # use a default config if we can't get the YAML file

--- a/psychopy/iohub/server.py
+++ b/psychopy/iohub/server.py
@@ -28,7 +28,7 @@ from .net import MAX_PACKET_SIZE
 from .util import convertCamelToSnake, win32MessagePump
 from .util import yload, yLoader
 from .constants import DeviceConstants, EventConstants
-from .devices import DeviceEvent, import_device
+from .devices import DeviceEvent, import_device, importDeviceModule
 from .devices import Computer
 from .devices.deviceConfigValidation import validateDeviceConfiguration
 getTime = Computer.getTime
@@ -846,7 +846,7 @@ class ioServer():
         else:
             dev_mod_pth += dev_cls_name.lower()
         # convert subdirectory to path
-        dev_mod = importlib.import_module(dev_mod_pth)
+        dev_mod = importDeviceModule(dev_mod_pth)
         dev_file_pth = os.path.dirname(dev_mod.__file__)
         # get config from path
         dev_conf_pth = os.path.join(dev_file_pth,

--- a/psychopy/plugins/util.py
+++ b/psychopy/plugins/util.py
@@ -1,0 +1,39 @@
+import importlib.metadata
+
+
+def getEntryPoints(module, submodules=True, flatten=True):
+    """
+    Get entry points which target a particular module.
+
+    Parameters
+    ----------
+    module : str
+        Import string for the target module (e.g. 
+        `"psychopy.iohub.devices"`)
+    submodules : bool, optional
+        If True, will also get entry points which target a 
+        submodule of the given module. By default True.
+    flatten : bool, optional
+        If True, will return a flat list of entry points. If 
+        False, will return a dict arranged by target group. By 
+        default True.
+    """
+    # start off with a blank list/dict
+    entryPointsList = []
+    entryPointsDict = {}
+    # iterate through groups
+    for group, points in importlib.metadata.entry_points().items():
+        # does this group correspond to the requested module?
+        if submodules:
+            targeted = group.startswith(module)
+        else:
+            targeted = group == module
+        # if group is targeted, add entry points
+        if targeted:
+            entryPointsList += points
+            entryPointsDict[group] = points
+    # return list or dict according to flatten arg
+    if flatten:
+        return entryPointsList
+    else:
+        return entryPointsDict


### PR DESCRIPTION
The problems we've been having with importing EyeTracker classes from plugins stem from the `import_device` method in ioHub. The reason being that they expect an absolute path within PsychoPy - it can't import from even registered entry points as `__import__` can only get to the top level.

The solution is for PsychoPy to look for entry points into `psychopy.iohub.devices` (or submodules therein) and then use `importlib.import_module` to resolve the module path given in the YAML file relative to the entry point target. So the eyetracker plugins should specify an entry point which inserts a module into the `psychopy.iohub.devices.eyetracker` namespace like so:
```
[project.entry-points."psychopy.iohub.devices.eyetracker"]
<module name> = "<plugin name (with _ rather than -)>.<module name>"
```
and then specify the path in the YAML relative to `psychopy.iohub.devices` (as usual):
```
eyetracker.<module name>.eyetracker.EyeTracker
```