### PR TITLE
SYS: Add GitHub action to check PRs to release can be merged into dev

### DIFF
--- a/.github/workflows/merge_conflicts.yaml
+++ b/.github/workflows/merge_conflicts.yaml
@@ -1,0 +1,34 @@
+# upon any changes to the release branch, check that they can be safely merged back into the dev branch
+# if this fails, try cherry picking conflicting commits into the dev branch then rerun
+name: Check conflicts
+
+on:
+  workflow_dispatch:
+    inputs:
+        branch:
+            description: 'Branch to test merge conflicts on'
+            type: string
+            required: true
+  pull_request:
+    branches: [ release ]
+
+jobs:
+  conflicts:
+    name: Check that this branch can be merged into dev without conflicts
+    runs-on: macos-11
+
+    steps:
+    - name: Checkout dev branch
+      uses: actions/checkout@v4
+      with:
+        ref: dev
+    
+    - name: Try to merge (if triggered by a PR)
+      if: github.head_ref
+      run: |
+        git merge --no-commit --no-ff ${{ github.head_ref }}
+    
+    - name: Try to merge (if triggered by a button)
+      if: ${{ inputs.branch }}
+      run: |
+        git merge --no-commit --no-ff ${{ inputs.branch }}


### PR DESCRIPTION
Meaning we can pre-emp merge conflicts with the dev branch before we choose to pull in something to release.

I expect when this fails we'll just pull in anyway then handle the conflict, but it means we know when one is about to crop up so can handle it while it's just a few lines rather than having to trawl through loads every time.

Worth noting: This doesn't actually *commit* the merge, it just does it locally and it's abandoned when the runner shuts down.