### PR TITLE
Window & event fixes for Linux

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -52,15 +52,6 @@ if haveGLFW:
 else:
     useGLFW = False
 
-
-if havePyglet:
-    # get the default display
-    if pyglet.version < '1.4':
-        _default_display_ = pyglet.window.get_platform().get_default_display()
-    else:
-        _default_display_ = pyglet.canvas.get_display()
-
-
 import psychopy.core
 from psychopy.tools.monitorunittools import cm2pix, deg2pix, pix2cm, pix2deg
 from psychopy import logging
@@ -411,7 +402,7 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
         # for each (pyglet) window, dispatch its events before checking event
         # buffer
         windowSystem = 'pyglet'
-        for win in _default_display_.get_windows():
+        for win in pyglet.app.windows:
             try:
                 win.dispatch_events()  # pump events on pyglet windows
             except ValueError as e:  # pragma: no cover
@@ -532,7 +523,7 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
     while not got_keypress and timer.getTime() < maxWait:
         # Pump events on pyglet windows if they exist.
         if havePyglet:
-            for win in _default_display_.get_windows():
+            for win in pyglet.app.windows:
                 win.dispatch_events()
 
         # Get keypresses and return if anything is pressed.
@@ -892,7 +883,7 @@ class Mouse:
             # for each (pyglet) window, dispatch its events before checking
             # event buffer
 
-            for win in _default_display_.get_windows():
+            for win in pyglet.app.windows:
                 win.dispatch_events()  # pump events on pyglet windows
 
             # else:
@@ -997,7 +988,7 @@ def clearEvents(eventType=None):
     if not havePygame or not display.get_init():  # pyglet
         # For each window, dispatch its events before
         # checking event buffer.
-        for win in _default_display_.get_windows():
+        for win in pyglet.app.windows:
             win.dispatch_events()  # pump events on pyglet windows
 
         if eventType == 'mouse':

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -33,6 +33,8 @@ except ImportError:
     havePyglet = False
 try:
     import glfw
+    if not glfw.init():
+        raise ImportError
     haveGLFW = True
 except ImportError:
     haveGLFW = False
@@ -398,7 +400,10 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
         for evts in evt.get(locals.KEYDOWN):
             # pygame has no keytimes
             keys.append((pygame.key.name(evts.key), 0))
-    elif havePyglet:
+
+    global _keyBuffer
+
+    if havePyglet:
         # for each (pyglet) window, dispatch its events before checking event
         # buffer
         windowSystem = 'pyglet'
@@ -411,16 +416,14 @@ def getKeys(keyList=None, modifiers=False, timeStamped=False):
                 # specific to certain systems and versions of Python.
                 logging.error(u'Failed to handle keypress')
 
-        global _keyBuffer
         if len(_keyBuffer) > 0:
             # then pyglet is running - just use this
             keys = _keyBuffer
             # _keyBuffer = []  # DO /NOT/ CLEAR THE KEY BUFFER ENTIRELY
 
-    elif haveGLFW:
+    if haveGLFW:
         windowSystem = 'glfw'
-        # 'poll_events' is called when a window is flipped, all the callbacks
-        # populate the buffer
+        glfw.poll_events()
         if len(_keyBuffer) > 0:
             keys = _keyBuffer
 
@@ -521,11 +524,6 @@ def waitKeys(maxWait=float('inf'), keyList=None, modifiers=False,
     got_keypress = False
 
     while not got_keypress and timer.getTime() < maxWait:
-        # Pump events on pyglet windows if they exist.
-        if havePyglet:
-            for win in pyglet.app.windows:
-                win.dispatch_events()
-
         # Get keypresses and return if anything is pressed.
         keys = getKeys(keyList=keyList, modifiers=modifiers,
                        timeStamped=timeStamped)
@@ -879,12 +877,14 @@ class Mouse:
         if usePygame:
             return mouse.get_pressed()
         else:
-            # False:  # havePyglet: # like in getKeys - pump the events
             # for each (pyglet) window, dispatch its events before checking
             # event buffer
+            if havePyglet:
+                for win in pyglet.app.windows:
+                    win.dispatch_events()  # pump events on pyglet windows
 
-            for win in pyglet.app.windows:
-                win.dispatch_events()  # pump events on pyglet windows
+            if haveGLFW:
+                glfw.poll_events()
 
             # else:
             if not getTime:
@@ -988,8 +988,12 @@ def clearEvents(eventType=None):
     if not havePygame or not display.get_init():  # pyglet
         # For each window, dispatch its events before
         # checking event buffer.
-        for win in pyglet.app.windows:
-            win.dispatch_events()  # pump events on pyglet windows
+        if havePyglet:
+            for win in pyglet.app.windows:
+                win.dispatch_events()  # pump events on pyglet windows
+
+        if haveGLFW:
+            glfw.poll_events()
 
         if eventType == 'mouse':
             pass
@@ -1215,6 +1219,11 @@ def _onGLFWKey(*args, **kwargs):
 
     # TODO - support for key emulation
     win_ptr, key, scancode, action, modifiers = args
+
+    # only send events for PRESS and REPEAT to match pyglet behavior
+    if action == glfw.RELEASE:
+        return
+
     global useText
     
     if key == glfw.KEY_UNKNOWN:

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -179,20 +179,27 @@ class PygletBackend(BaseBackend):
                     'integer greater than two. Disabling.')
                 win.multiSample = False
 
+        skip_screen_warn = False
         if platform.system() == 'Linux':
-            display = pyglet.canvas.Display()
+            from pyglet.canvas.xlib import NoSuchDisplayException
+            try:
+                display = pyglet.canvas.Display(x_screen=win.screen)
+                # in this case, we'll only get a single x-screen back
+                skip_screen_warn = True
+            except NoSuchDisplayException:
+                # Maybe xinerama? Try again and get the specified screen later
+                display = pyglet.canvas.Display(x_screen=0)
+
             allScrs = display.get_screens()
         else:
-            if pyglet.version < '1.4':
-                allScrs = _default_display_.get_screens()
-            else:
-                allScrs = _default_display_.get_screens()
+            allScrs = _default_display_.get_screens()
 
-        # Screen (from Exp Settings) is 1-indexed,
+        # Screen (from Exp Settings) is 0-indexed,
         # so the second screen is Screen 1
         if len(allScrs) < int(win.screen) + 1:
-            logging.warn("Requested an unavailable screen number - "
-                         "using first available.")
+            if not skip_screen_warn:
+                logging.warn("Requested an unavailable screen number - "
+                             "using first available.")
             thisScreen = allScrs[0]
         else:
             thisScreen = allScrs[win.screen]
@@ -247,7 +254,7 @@ class PygletBackend(BaseBackend):
             self.winHandle = pyglet.window.Window(
                 width=w, height=h,
                 caption="PsychoPy",
-                fullscreen=self._isFullScr,
+                fullscreen=win._isFullScr,
                 config=config,
                 screen=thisScreen,
                 style=style)

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -31,7 +31,6 @@ from psychopy.visual.basevisual import (
 )
 # from psychopy.visual.helpers import setColor
 import psychopy.visual
-from psychopy.contrib import tesselate
 
 pyglet.options['debug_gl'] = False
 GL = pyglet.gl
@@ -578,6 +577,7 @@ class ShapeStim(BaseShapeStim):
         # TO-DO: handle borders properly for multiloop stim like holes
         # likely requires changes in ContainerMixin to iterate over each
         # border loop
+        from psychopy.contrib import tesselate
 
         self.border = copy.deepcopy(newVertices)
         tessVertices = []  # define to keep the linter happy

--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -242,7 +242,7 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
         if GL:  # because of pytest fail otherwise
             try:
                 GL.glDeleteLists(self._listID, 1)
-            except (ImportError, ModuleNotFoundError, TypeError):
+            except (ImportError, ModuleNotFoundError, TypeError, GL.lib.GLException):
                 pass  # if pyglet no longer exists
 
     @attributeSetter


### PR DESCRIPTION
 - On linux, the `Display` is not the same as the `_default_display_`, meaning that events on the opened window were not being dispatched. This switches to pumping all the windows listed in `pyglet.app.windows`. Only tested on Ubuntu 20.04 so far.
 - GLFW events were not pumped in the event module, and so e.g. `waitKeys` would hang. This pumps GLFW at the same points as pyglet, and makes sure glfw is properly initialized before assuming it's available.
 - Unfortunately, https://github.com/psychopy/psychopy/pull/5889 broke the separate-X-screen case (e.g. as seen in some PTB setups). This hopefully handles both cases, though for my specific setup the pyglet shadow window also needed to be disabled (something about sharing GLX contexts across separate X screens?). Tested on Ubuntu 20.04, both with xorg.config enabled and disabled.
    - The `tesselate` import was moved to later in the process to allow the shadow window to be disabled.

Related issues:
https://github.com/psychopy/psychopy/issues/5407
https://github.com/psychopy/psychopy/issues/5906
https://github.com/psychopy/psychopy/issues/5888
