### PR TITLE
BF: correct syntax for mic max recording parameter

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -300,7 +300,7 @@ class MicrophoneComponent(BaseDeviceComponent):
             "    deviceClass='psychopy.hardware.microphone.MicrophoneDevice',\n"
             "    deviceName=%(deviceLabel)s,\n"
             "    index=%(device)s,\n"
-            "    maxRecordingSize=%(maxSize)s\n"
+            "    maxRecordingSize=%(maxSize)s,\n"
         )
         if self.params['device'].val not in ("None", "", None):
             code += (


### PR DESCRIPTION
Syntax error was being raised from the mic component because a comma was missing after maxRecordingSize