### PR TITLE
BF: Add default duration to eyetracker record component

### DIFF
--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -26,7 +26,7 @@ class EyetrackerRecordComponent(BaseComponent):
     def __init__(self, exp, parentName, name='etRecord',
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
-                 startEstim='', durationEstim='',
+                 startEstim='', durationEstim=1.0,
                  actionType="Start and Stop",
                  #legacy
                  save='final', configFile='myTracker.yaml'):


### PR DESCRIPTION
Eyetracker Record component needs duration in order to stop - so adding a duration value by default so users do not get confused why the experiment halts at the stop record.