### PR TITLE
BF: remove second whisper option from mic transcriber backend drop down

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -34,8 +34,7 @@ onlineTranscribers = {
     "Google": "GOOGLE"
 }
 localTranscribers = {
-    "Google": "google",
-    "Whisper": "whisper", 
+    "Google": "google"
 }
 allTranscribers = {**localTranscribers, **onlineTranscribers}
 
@@ -533,7 +532,7 @@ class MicrophoneComponent(BaseDeviceComponent):
                 "%(loop)s.addData('%(name)s.script', %(name)sScript)\n"
             )
             buff.writeIndentedLines(code % inits)
-        if inits['speakTimes'] and inits['transcribeBackend'].val == "whisper":
+        if inits['speakTimes'] and inits['transcribeBackend'].val == "Whisper":
 
             code = (
                 "# save transcription data\n"


### PR DESCRIPTION
There were two whisper options appearing in the options for the transcriber backends which was having some knock on effects when people accidentally selected the wrong whisper. This removes that incorrect Whisper.