### PR TITLE
FF: Set save speech times to false by default

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -56,7 +56,7 @@ class MicrophoneComponent(BaseDeviceComponent):
                  startEstim='', durationEstim='',
                  channels='auto', device=None,
                  sampleRate='DVD Audio (48kHz)', maxSize=24000,
-                 outputType='default', speakTimes=True, trimSilent=False,
+                 outputType='default', speakTimes=False, trimSilent=False,
                  transcribe=False, transcribeBackend="Whisper",
                  transcribeLang="en-US", transcribeWords="",
                  transcribeWhisperModel="base",


### PR DESCRIPTION
Speech onset offsets only work if a transcriber installed - so doesn't make sense to have this as default True (False hope ...)