### PR TITLE
BF: starting and stopping times for EyetrackerRecordComponent

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -881,7 +881,7 @@ class BaseComponent:
 
         return duration, numericStop
 
-    def getStartAndDuration(self):
+    def getStartAndDuration(self, params=None):
         """Determine the start and duration of the stimulus
         purely for Routine rendering purposes in the app (does not affect
         actual drawing during the experiment)
@@ -890,7 +890,16 @@ class BaseComponent:
 
         nonSlipSafe indicates that the component's duration is a known fixed
         value and can be used in non-slip global clock timing (e.g for fMRI)
+
+        Parameters
+        ----------
+        params : dict[Param]
+            Dict of params to use. If None, will use the values in `self.params`.
         """
+        # if not given any params, use from self
+        if params is None:
+            params = self.params
+
         # If has a start, calculate it
         if 'startType' in self.params:
             startTime, numericStart = self.getStart()

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -95,14 +95,19 @@ class EyetrackerRecordComponent(BaseComponent):
         timeline reflecting the status of EyetrackerRecordComponent instead of
         the eyetracker device, and ensure proper nonSlip timing determination
         """
-        # Check if the actionType is 'Start Only' or 'Stop Only'
+        # make a copy of params so we can change stuff harmlessly
+        params = self.params.copy()
+        # check if the actionType is 'Start Only' or 'Stop Only'
         if self.params['actionType'].val == 'Start Only':
+            # if only starting, pretend stop is 0
             self.params['stopType'].val = 'duration (s)'
             self.params['stopVal'].val = 0.0
         elif self.params['actionType'].val == 'Stop Only':
+            # if only stopping, pretend start was 0
             self.params['startType'].val = 'time (s)'
             self.params['startVal'].val = 0.0
-        return super().getStartAndDuration()
+        
+        return super().getStartAndDuration(params)
 
     def writeInitCode(self, buff):
         inits = self.params

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -89,11 +89,12 @@ class EyetrackerRecordComponent(BaseComponent):
         self.order = self.order[:1]+['actionType']+self.order[1:]
 
     def getStartAndDuration(self):
+        """ Due to the different action types hiding either the start or stop
+        field parameters, we need to force the start and stop criteria to correct
+        types and values, make sure the component is displayed accurately on the
+        timeline reflecting the status of EyetrackerRecordComponent instead of
+        the eyetracker device, and ensure proper nonSlip timing determination
         """
-        Due to the different action types hiding either the start or stop
-        parameter, we need to force the start and stop times to correct types,
-        make sure the component is displayed correctly on the timeline, and
-        ensure correct behavior of nonSlip timing determination."""
         # Check if the actionType is 'Start Only' or 'Stop Only'
         if self.params['actionType'].val == 'Start Only':
             self.params['stopType'].val = 'duration (s)'

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -88,6 +88,21 @@ class EyetrackerRecordComponent(BaseComponent):
         #       in .order has no effect
         self.order = self.order[:1]+['actionType']+self.order[1:]
 
+    def getStartAndDuration(self):
+        """
+        Due to the different action types hiding either the start or stop
+        parameter, we need to force the start and stop times to correct types,
+        make sure the component is displayed correctly on the timeline, and
+        ensure correct behavior of nonSlip timing determination."""
+        # Check if the actionType is 'Start Only' or 'Stop Only'
+        if self.params['actionType'].val == 'Start Only':
+            self.params['stopType'].val = 'duration (s)'
+            self.params['stopVal'].val = 0.0
+        elif self.params['actionType'].val == 'Stop Only':
+            self.params['startType'].val = 'time (s)'
+            self.params['startVal'].val = 0.0
+        return super().getStartAndDuration()
+
     def writeInitCode(self, buff):
         inits = self.params
         # Make a controller object

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -26,7 +26,7 @@ class EyetrackerRecordComponent(BaseComponent):
     def __init__(self, exp, parentName, name='etRecord',
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=1.0,
-                 startEstim='', durationEstim=1.0,
+                 startEstim='', durationEstim='',
                  actionType="Start and Stop",
                  stopWithRoutine=False,
                  # legacy


### PR DESCRIPTION
1. I tested out the change in #6599, and it doesn't impact experiment flow as far as my tests went. I'm proposing to revert it for clarify. @RebeccaHirst Perhaps you could provide a minimal test for the experiment halting behavior you described?
2. I also looked into how non-slip timing behaves with `EyetrackerRecordComponent`, and I think it isn't behaving intuitively at the moment and can be buggy under certain situations. The BF here provides a simple solution.

----------------------

A key ambiguity is what should determine the display of an `EyetrackerRecordComponent` on the timeline: should it show when the component starts and stops, or should it show when the underlying eyetracker recording starts and stops? Given our discussion in #6567, I think it makes more sense to decouple the concept of a component, which is what users are manipulating in Builder, from whatever underlying device (Sound, Eyetracker, etc.) is getting controlled by the component. This is especially important for `EyetrackerRecordComponent` because we have the unusual need of only starting or stopping an eyetracker.

I believe this agrees with the design principle behind how the start and stop times of a `Component` are used to determine whether a `Routine` is safe for non-slip timing. Right now if a user adds a `Start Only` type `EyetrackerRecordComponent` into a `Routine`, that will automatically make the routine not non-slip safe. This is not actually accurate because the `EyetrackerRecordComponent` is marked as `FINISHED` immediately after it starts, so it does not cause any additional timing uncertainty beyond what the rest of the routine is doing.

The visual display of the `EyetrackerRecordComponent` also runs beyond the right edge of the timeline. This is potentially confusing because the component itself is marked as `FINISHED` as soon as recording has started (updated in 9157901). Similarly for a `Stop Only` type `EyetrackerRecordComponent`, the visual display goes beyond the left edge of the timeline, but component is really just marked as `STARTED` on the first frame loop, not before. So if users are using the status of these `Start Only` and `Stop Only` type `EyetrackerRecordComponent`s based on the visual timeline to control other parts of the experiment, there could be surprising behaviors.

Additionally, right now `duration (s)` is one of the options for stopping of a `Stop Only` type `EyetrackerRecordComponent`, but since the `Start` parameter field is hidden away, this component can't be set properly since there is missing start time to determine total duration.

Lastly, when we toggle among the three types of `EyetrackerRecordComponent`, while `[startVal]` or `[stopVal]` gets reset, `[startType]` or `[stopType]` doesn't. So if some start or stop type (such as `Condition`) was first used, and the parameter field got hidden away because users decided to employ a different `actionType`, that hidden parameter will still be set to the previous type behind the scene. This may cause strange behaviors difficult to debug.

----------------------

A `Component` simply can't do all of 1) displaying the starting/stopping status of the underlying device, 2) displaying the status of the component itself, and 3) be used to determine non-slip timing, at the same time. We can only achieve two out of three. A simple way to break the current ambiguity is to intercept the `getStartAndDuration()` function call for `EyetrackerRecordComponent`. Depending on the `actionType`, we enforce any hidden parameter field to some standard values that should reflect the status of the `Component` (not the device) when displaying on the timeline, as well as that can be used to determine accurate timing, achieving 2) and 3).
