### PR TITLE
BF: enable correct behavior of entry-points to load eyetrackers

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -43,7 +43,7 @@ _numpyRandomImports = ['random', 'randint', 'normal', 'shuffle', 'choice as rand
 
 # this is not a standard component - it will appear on toolbar not in
 # components panel
-ioDeviceMap = dict(ioUtil.getDeviceNames())
+ioDeviceMap = dict(ioUtil.getDeviceNames(device_name="eyetracker.hw"))
 ioDeviceMap['None'] = ""
 
 # Keyboard backend options

--- a/psychopy/iohub/devices/__init__.py
+++ b/psychopy/iohub/devices/__init__.py
@@ -10,6 +10,9 @@ import importlib
 from collections import deque
 from operator import itemgetter
 
+import sys
+from psychopy.plugins.util import getEntryPoints
+
 import numpy as np
 
 from .computer import Computer
@@ -138,7 +141,8 @@ class ioObject(metaclass=ioObjectMetaClass):
                     rpcList.append(d)
         return rpcList
 
-########### Base Abstract Device that all other Devices inherit from ##########
+
+# ########## Base Abstract Device that all other Devices inherit from ##########
 
 
 class Device(ioObject):
@@ -265,7 +269,7 @@ class Device(ioObject):
             None
 
         Returns:
-            (dict): The dictionary of the device configuration settings used 
+            (dict): The dictionary of the device configuration settings used
             to create the device.
 
         """
@@ -279,14 +283,23 @@ class Device(ioObject):
         contents.
 
         Args:
-            event_type_id (int): If specified, provides the ioHub DeviceEvent ID for which events should be returned for.  Events that have occurred but do not match the event ID specified are ignored. Event type ID's can be accessed via the EventConstants class; all available event types are class attributes of EventConstants.
+            event_type_id (int): If specified, provides the ioHub DeviceEvent ID for which events
+            should be returned for.  Events that have occurred but do not match the event ID
+            specified are ignored. Event type ID's can be accessed via the EventConstants class;
+            all available event types are class attributes of EventConstants.
 
-            clearEvents (int): Can be used to indicate if the events being returned should also be removed from the device event buffer. True (the default) indicates to remove events being returned. False results in events being left in the device event buffer.
+            clearEvents (int): Can be used to indicate if the events being returned should also be
+            removed from the device event buffer. True (the default) indicates to remove events
+            being returned. False results in events being left in the device event buffer.
 
-            asType (str): Optional kwarg giving the object type to return events as. Valid values are 'namedtuple' (the default), 'dict', 'list', or 'object'.
+            asType (str): Optional kwarg giving the object type to return events as. Valid values
+            are 'namedtuple' (the default), 'dict', 'list', or 'object'.
 
         Returns:
-            (list): New events that the ioHub has received since the last getEvents() or clearEvents() call to the device. Events are ordered by the ioHub time of each event, older event at index 0. The event object type is determined by the asType parameter passed to the method. By default a namedtuple object is returned for each event.
+            (list): New events that the ioHub has received since the last getEvents() or clearEvents()
+            call to the device. Events are ordered by the ioHub time of each event, older event at
+            index 0. The event object type is determined by the asType parameter passed to the method.
+            By default a namedtuple object is returned for each event.
 
         """
         self._iohub_server.processDeviceEvents()
@@ -322,11 +335,13 @@ class Device(ioObject):
                     call_proc_events=False)
         else:
             if filter_id:
-                [currentEvents.extend([fe for fe in l if fe[
-                                      DeviceEvent.EVENT_FILTER_ID_INDEX] == filter_id]) for l in list(self._iohub_event_buffer.values())]
+                [currentEvents.extend(
+                    [fe for fe in event if fe[
+                                      DeviceEvent.EVENT_FILTER_ID_INDEX] == filter_id]
+                                      ) for event in list(self._iohub_event_buffer.values())]
             else:
-                [currentEvents.extend(l)
-                 for l in list(self._iohub_event_buffer.values())]
+                [currentEvents.extend(event)
+                 for event in list(self._iohub_event_buffer.values())]
 
             if clearEvents is True and len(currentEvents) > 0:
                 self.clearEvents(filter_id=filter_id, call_proc_events=False)
@@ -385,7 +400,10 @@ class Device(ioObject):
 
 
         Args:
-            enabled (bool):  True (default) == Start to report device events to the ioHub Process. False == Stop Reporting Events to the ioHub Process. Most Device types automatically start sending events to the ioHUb Process, however some devices like the EyeTracker and AnlogInput device's do not. The setting to control this behavior is 'auto_report_events'
+            enabled (bool):  True (default) == Start to report device events to the ioHub Process.
+            False == Stop Reporting Events to the ioHub Process. Most Device types automatically
+            start sending events to the ioHUb Process, however some devices like the EyeTracker and
+            AnlogInput device's do not. The setting to control this behavior is 'auto_report_events'
 
         Returns:
             bool: The current reporting state.
@@ -517,14 +535,14 @@ class Device(ioObject):
         if self.isReportingEvents():
             self._native_event_buffer.append(e)
 
-    def _addEventListener(self, l, eventTypeIDs):
+    def _addEventListener(self, event, eventTypeIDs):
         for ei in eventTypeIDs:
-            self._event_listeners.setdefault(ei, []).append(l)
+            self._event_listeners.setdefault(ei, []).append(event)
 
-    def _removeEventListener(self, l):
+    def _removeEventListener(self, event):
         for etypelisteners in list(self._event_listeners.values()):
-            if l in etypelisteners:
-                etypelisteners.remove(l)
+            if event in etypelisteners:
+                etypelisteners.remove(event)
 
     def _getEventListeners(self, forEventType):
         return self._event_listeners.get(forEventType, [])
@@ -653,10 +671,16 @@ class Device(ioObject):
         Since any callbacks should take as little time to process as possible,
         a two stage approach is used to turn a native device event into an ioHub
         Device event representation:
-            #. This method is called by the native device interface as a callback, providing the necessary information to be able to create an ioHub event. As little processing should be done in this method as possible.
-            #. The data passed to this method, along with the time the callback was called, are passed as a tuple to the Device classes _addNativeEventToBuffer method.
-            #. During the ioHub Servers event processing routine, any new native events that have been added to the ioHub Server using the _addNativeEventToBuffer method are passed individually to the _getIOHubEventObject method, which must also be implemented by the given Device subclass.
-            #. The _getIOHubEventObject method is responsible for the actual conversion of the native event representation to the required ioHub Event representation for the accociated event type.
+            #. This method is called by the native device interface as a callback, providing the necessary
+            # information to be able to create an ioHub event. As little processing should be done in this
+            # method as possible.
+            #. The data passed to this method, along with the time the callback was called, are passed as a
+            # tuple to the Device classes _addNativeEventToBuffer method.
+            #. During the ioHub Servers event processing routine, any new native events that have been added
+            # to the ioHub Server using the _addNativeEventToBuffer method are passed individually to the
+            # _getIOHubEventObject method, which must also be implemented by the given Device subclass.
+            #. The _getIOHubEventObject method is responsible for the actual conversion of the native event
+            # representation to the required ioHub Event representation for the accociated event type.
 
         Args:
             args(tuple): tuple of non keyword arguments passed to the callback.
@@ -704,7 +728,8 @@ class Device(ioObject):
     def __del__(self):
         self._close()
 
-########### Base Device Event that all other Device Events inherit from ##
+
+# ########## Base Device Event that all other Device Events inherit from ##
 
 
 class DeviceEvent(ioObject):
@@ -921,26 +946,24 @@ class DeviceEvent(ioObject):
     @classmethod
     def createEventAsNamedTuple(cls, valueList):
         return cls.namedTupleClass(*valueList)
+
+
 #
 # Import Devices and DeviceEvents
 #
 
 
-import sys
-from psychopy.plugins.util import getEntryPoints
-
-
 def importDeviceModule(modulePath):
     """
-    Resolve an import string to import the module for a particular device. 
-    
-    Will iteratively check plugin entry points too. 
+    Resolve an import string to import the module for a particular device.
+
+    Will iteratively check plugin entry points too.
 
     Parameters
     ----------
     modulePath : str
         Import path for the requested module
-    
+
     Return
     ------
     types.ModuleType
@@ -970,7 +993,7 @@ def importDeviceModule(modulePath):
                 module = importlib.import_module(relModPath, package=group)
             except ModuleNotFoundError:
                 continue
-            
+
     # raise error if all import options failed
     if module is None:
         raise ModuleNotFoundError(
@@ -984,7 +1007,7 @@ def importDeviceModule(modulePath):
 def import_device(module_path, device_class_name):
     # get module from module_path
     module = importDeviceModule(module_path)
-    
+
     # get device class from module
     device_class = getattr(module, device_class_name)
 
@@ -1005,6 +1028,7 @@ def import_device(module_path, device_class_name):
         setattr(sys.modules[__name__], event_class_name, event_class)
 
     return device_class, device_class_name, event_classes
+
 
 try:
     if getattr(sys.modules[__name__], 'Display', None) is None:

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -233,8 +233,8 @@ def getDevicePaths(device_name=""):
 
         """
         yaml_paths = []
-        # try to walk both the internal iohub_device_path and user-level packages folder
-        for route in (os.walk(iohub_device_path), os.walk(prefs.paths['packages'])):
+        # search the internal iohub_device_path for device config files
+        for route in os.walk(iohub_device_path):
             for root, _, files in route:
                 # check each file in the route to see if it's a config yaml
                 device_folder = None

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -18,6 +18,7 @@ import psychopy.logging as logging
 import psychopy.plugins as plugins
 from importlib.metadata import entry_points
 from pathlib import Path
+from psychopy.preferences import prefs
 
 ########################
 #
@@ -34,8 +35,6 @@ try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
-
-from psychopy.preferences import prefs
 
 
 def saveConfig(config, dst_path):
@@ -143,7 +142,7 @@ def module_directory(local_function):
 def getSupportedConfigSettings(moduleName, deviceClassName=None):
     """Get the supported configuration settings for a device.
 
-    These are usually stored as YAML files within the module directory that 
+    These are usually stored as YAML files within the module directory that
     defines the device class.
 
     Parameters
@@ -152,10 +151,10 @@ def getSupportedConfigSettings(moduleName, deviceClassName=None):
         The name of the module to get the path for. Must be a package that defines
         `__init__.py`.
     deviceClassName : str, optional
-        The name of the specific device class to get the path for. If not provided, 
-        the default configuration file will be searched for in the module 
+        The name of the specific device class to get the path for. If not provided,
+        the default configuration file will be searched for in the module
         directory.
-    
+
     Returns
     -------
     str
@@ -176,13 +175,13 @@ def getSupportedConfigSettings(moduleName, deviceClassName=None):
             "Found ioHub device configuration file: {0}".format(yamlFile))
 
         return str(yamlFile)
-        
+
     # file name for yaml file name convention for single file
     yamlFile = yamlRoot / pathlib.Path('supported_config_settings.yaml')
     if not yamlFile.exists():  # nothing is found
         raise FileNotFoundError(
             "No config file found in module dir {0}".format(moduleName))
-    
+
     logging.debug(
         "Found ioHub device configuration file: {0}".format(yamlFile))
 
@@ -385,6 +384,7 @@ def getDeviceNames(device_name="eyetracker.hw", get_paths=True):
             names.append((d_config.get('manufacturer_name'), d_path))
     return names
 
+
 def getDeviceFile(device_name, file_name):
     """
     Returns the contents of file_name for the specified device. If file_name does not exist, None is returned.
@@ -396,6 +396,7 @@ def getDeviceFile(device_name, file_name):
     if device_name.endswith(".EyeTracker"):
         device_name = device_name[:-11]
     device_paths = getDevicePaths(device_name)
+
     device_sconfigs = []
     for dpath, _ in device_paths:
         device_sconfigs.append(readConfig(os.path.join(dpath, file_name)))
@@ -403,6 +404,7 @@ def getDeviceFile(device_name, file_name):
         # simplify return value when only one device was requested
         return list(device_sconfigs[0].values())[0]
     return device_sconfigs
+
 
 def getDeviceSupportedConfig(device_name):
     """
@@ -412,6 +414,7 @@ def getDeviceSupportedConfig(device_name):
     :return: dict
     """
     return getDeviceFile(device_name, 'supported_config_settings.yaml')
+
 
 if sys.platform == 'win32':
     import pythoncom
@@ -433,6 +436,7 @@ if sys.platform == 'win32':
 else:
     def win32MessagePump():
         pass
+
 
 # PsychoPy Window Hide / Show functions.
 # Windows 10 and macOS have different code that needs to be called
@@ -456,6 +460,7 @@ def hideWindow(win, force=False):
     else:
         print("Warning: Unhandled sys.platform: ", sys.platform)
 
+
 def showWindow(win, force=False):
     """
     If needed, hide / minimize the in.
@@ -473,6 +478,7 @@ def showWindow(win, force=False):
         pass
     else:
         print("Warning: Unhandled sys.platform: ", sys.platform)
+
 
 def createCustomCalibrationStim(win, cal_settings):
     """
@@ -537,12 +543,12 @@ def updateDict(add_to, add_from):
 
 def updateSettings(d, u):
     for k, v in u.items():
-        if type(k) == bytes:
+        if isinstance(k, bytes):
             k = k.decode('UTF-8')
         if isinstance(v, collections.abc.Mapping):
             d[k] = updateSettings(d.get(k, {}), v)
         else:
-            if type(v) == bytes:
+            if isinstance(v, bytes):
                 v = v.decode('UTF-8')
             d[k] = v
     return d
@@ -563,7 +569,7 @@ def convertCamelToSnake(name, lower_snake=True):
 # A couple date / time related utility functions
 
 getCurrentDateTime = datetime.datetime.now
-getCurrentDateTimeString = lambda: getCurrentDateTime().strftime("%Y-%m-%d %H:%M")
+getCurrentDateTimeString = lambda: getCurrentDateTime().strftime("%Y-%m-%d %H:%M")  # noqa: E731
 
 
 # rgb255 color utils

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -16,6 +16,7 @@ import collections.abc
 import pathlib
 import psychopy.logging as logging
 import psychopy.plugins as plugins
+from psychopy.plugins.util import getEntryPoints
 from importlib.metadata import entry_points
 from pathlib import Path
 from psychopy.preferences import prefs
@@ -269,7 +270,7 @@ def getDevicePaths(device_name=""):
 
     if 'eyetracker' in device_name.lower():
         # Find entry points targeting psychopy.iohub.devices.eyetracker
-        for ep in entry_points()['psychopy.iohub.devices.eyetracker']:
+        for ep in getEntryPoints('psychopy.iohub.devices.eyetracker', submodules=False, flatten=True):
             # load the target the entry point points to, it could be a class or a module
             try:
                 ep_target = ep.load()

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -365,10 +365,10 @@ def getDeviceNames(device_name="eyetracker.hw", get_paths=True):
         print(eyetrackers)
 
     Output:
-        [('GazePoint', 'eyetracker.hw.gazepoint.gp3.EyeTracker'),
+        [('GazePoint', 'eyetracker.gazepoint.EyeTracker'),
          ('MouseGaze', 'eyetracker.hw.mouse.EyeTracker'),
-         ('SR Research Ltd', 'eyetracker.hw.sr_research.eyelink.EyeTracker'),
-         ('Tobii Technology', 'eyetracker.hw.tobii.EyeTracker')]
+         ('SR Research Ltd', 'eyetracker.eyelink.EyeTracker'),
+         ('Tobii Technology', 'eyetracker.tobii.EyeTracker')]
     """
     names = []
     dconfigs = getDeviceDefaultConfig(device_name)

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -832,6 +832,11 @@ def loadPlugin(plugin):
 
                 return False
 
+            if '.zip' in ep.__file__:
+                logging.warning(
+                    "Plugin `{}` is being loaded from a zip file. This may "
+                    "cause issues with the plugin's functionality.".format(plugin))
+
             # If we get here, the entry point is valid and we can safely add it
             # to PsychoPy's namespace.
             validEntryPoints[fqn].append((targObj, attr, ep))
@@ -844,7 +849,7 @@ def loadPlugin(plugin):
             # add the object to the module or unbound class
             setattr(targObj, attr, ep)
             logging.debug(
-                "Assigning to entry point `{}` to `{}`.".format(
+                "Assigning the entry point `{}` to `{}`.".format(
                     ep.__name__, fqn + '.' + attr))
 
             # --- handle special cases ---

--- a/psychopy/plugins/util.py
+++ b/psychopy/plugins/util.py
@@ -8,14 +8,14 @@ def getEntryPoints(module, submodules=True, flatten=True):
     Parameters
     ----------
     module : str
-        Import string for the target module (e.g. 
+        Import string for the target module (e.g.
         `"psychopy.iohub.devices"`)
     submodules : bool, optional
-        If True, will also get entry points which target a 
+        If True, will also get entry points which target a
         submodule of the given module. By default True.
     flatten : bool, optional
-        If True, will return a flat list of entry points. If 
-        False, will return a dict arranged by target group. By 
+        If True, will return a flat list of entry points. If
+        False, will return a dict arranged by target group. By
         default True.
     """
     # start off with a blank list/dict


### PR DESCRIPTION
I looked through the recent `dev` commits about using entry-points to manage eyetrackers as plugins to PsychoPy. There are some subtleties in `importDeviceModule()` and `getDevicePaths()` that weren't handled correctly, which prevented the desired uses of entry-points. These are all fixed now. At least EyeLink eyetrackers can be imported as plugins as long as the plugin repository (`psychopy-eyetracker-sr-research`) also has all the correct fixes. I've made a [PR](https://github.com/psychopy/psychopy-eyetracker-sr-research/pull/10) to `psychopy-eyetracker-sr-research` to document changes that may need to be mirrored to other device plugins.

----------------

There are a few points that I would like to raise here for future references, in case the development team has a different design principle in mind.

1) The motivation of using entry-points as plugins is usually to remove any explicit binding of plugin modules in the main application, and to resolve them dynamically by checking entry-points. This means that all the device-specific directories under [`psychopy/iohub/devices/eyetracker/hw`](https://github.com/psychopy/psychopy/tree/d38eab61d954511eba1c65a9e83f418d4cd4cd97/psychopy/iohub/devices/eyetracker/hw) except for `mouse` can be safely removed when things work properly. I would recommend to do that and **then test** how all the eyetrackers work with plugins installed. If there's a hidden dependency on the `psychopy/iohub/devices/eyetracker/hw` path somewhere in PsychoPy, this is an efficient way to catch them all.

2) Standalone apps based on python libraries have a peculiar behavior: when you first open the Builder App, it first looks into packaged executables in `/Applications/PsychoPy.app/Contents/Resources/lib/python38.zip`. This means that even though an updated user-specific package got installed to `~/.psychopy3/packages/lib/python/site-packages`, the `entry-point.txt` specification will point incorrectly into subdirectories of `python38.zip`! `os.walk()` doesn't work over zip files, and therefore some of the logics around getting config files will fail. This is a general problem with conflicting package namespaces in Python, so when packaging the python library for the next standalone release, all executables for plugins that can now be installed to `~/.psychopy3/packages/lib/python/site-packages` and managed with the GUI should be removed. This way there is no ambiguity about which plugin module is actually getting used. Interestingly, if you open a new Python console session in the Coder app, it does use the later namespace installed in the user specific package directory instead of from `python38.zip`, which only seems to get used when first starting the PsychoPy App. This matters because with the new entry-point logic, I couldn't get my `SR Research Ltd` option to show up in the experiment setting panel, and it took me a while to figure out why. I had to rezip `python38.zip` after deleting the version 0.0.2 `psychopy-eyetracker-sr-research` packaged inside in order for things to work.

3) One potential misconception of entry-points is that they are distinct from module trees specific to a process. This means that `setattr(targObj, attr, ep)` allows one to do `from targObj import attr` but it doesn't allow one to do `import targObj.attr` because the `ep` module is added with the namespace `attr` as an **attribute**, not **module**, to the existing entry point module `targObj`. So one shouldn't expect absolute or relative imports to work automatically. This issue shows up in how the added `importDeviceModule()` method was hoping to import plugin modules, which was failing.

4) Because ioHub manages devices through a greenlet server hosted on a separate subprocess, this complexity of entry-points and module namespace gets doubled, and it requires special attention. Even though [`psychopy.plugins` is adding entry point targets to existing class/module objects](https://github.com/psychopy/psychopy/blob/d38eab61d954511eba1c65a9e83f418d4cd4cd97/psychopy/plugins/__init__.py#L845C13-L845C39), this action has no effect whatsoever on the ioHub subprocess, which doesn't inherit these Python objects in the first place. So in order for things to work, we need to modify the `sys.modules` dictionary (again even already done on the main process) based on entry-points when first attempting to import devices from plugins on the `ioHub` subprocess, such that future imports can work intuitively like `import targObj.attr` or even `from targObj.attr.subpkg import xxx`.

5) I reduced the `os.walk()` from going through both the provided `iohub_device_path` and the entire user-level packages folder. This is because if a user installed multiple plugins with files called `supported_config_settings.yaml`, this may fail in confusing ways. The issue is that the for loop breaks at the first `supported_config_settings.yaml` found without checking whether it is the correct `supported_config_settings.yaml` for the requested device. It is probably ok when used with `device_name=""`, but when requesting configs for specific devices this could be very problematic. Since entry-points are working correctly now, the specified `iohub_device_path` should be accurate based on the entry-point `__file__`.
