### PR TITLE
BF: follow-up fixes from setting SoundComponent status in #6562

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -209,7 +209,13 @@ class SoundComponent(BaseDeviceComponent):
     def writeFrameCode(self, buff):
         """Write the code that will be called every frame
         """
-        # Write start code
+        # Write start code to update parameters. Unlike BaseVisualComponents, which
+        # inserts writeActiveTestCode() after the start code, we need to insert it
+        # here before the start code to provide the correct parameters for calling
+        # the play() method.
+
+        buff.writeIndented("\n")
+        buff.writeIndented(f"# *{self.params['name']}* updates\n")
         self.writeParamUpdates(buff, 'set every frame')
 
         # write code for starting
@@ -229,12 +235,6 @@ class SoundComponent(BaseDeviceComponent):
             buff.writeIndentedLines(code % self.params)
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)
-
-        # write code to run while active
-        indented = self.writeActiveTestCode(buff, extra=" or %(name)s.isPlaying")
-        if indented:
-            # dedent
-            buff.setIndentLevel(-indented, relative=True)
 
     def writeFrameCodeJS(self, buff):
         """Write the code that will be called every frame

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -86,7 +86,7 @@ def getDevices(kind=None):
     kind can be None, 'input' or 'output'
     The dict keys are names, and items are dicts of properties
     """
-    if sys.platform=='win32':
+    if sys.platform == 'win32':
         deviceTypes = 13  # only WASAPI drivers need apply!
     else:
         deviceTypes = None
@@ -97,7 +97,7 @@ def getDevices(kind=None):
         allDevs = audio.get_devices(device_type=deviceTypes)
 
     # annoyingly query_devices is a DeviceList or a dict depending on number
-    if type(allDevs) == dict:
+    if isinstance(allDevs, dict):
         allDevs = [allDevs]
 
     for ii, dev in enumerate(allDevs):
@@ -180,13 +180,13 @@ class _StreamsDict(dict):
             raise SoundFormatError(
                 "Tried to create audio stream {} but {} already exists "
                 "and {} doesn't support multiple portaudio streams"
-                    .format(label, list(self.keys())[0], sys.platform)
+                .format(label, list(self.keys())[0], sys.platform)
             )
         else:
 
             # create new stream
             self[label] = _MasterStream(sampleRate, channels, blockSize,
-                                       device=defaultOutput)
+                                        device=defaultOutput)
         return label, self[label]
 
 
@@ -209,9 +209,9 @@ class _MasterStream(audio.Stream):
         self.duplex = duplex
         self.blockSize = blockSize
         self.label = getStreamLabel(sampleRate, channels, blockSize)
-        if type(device) == list and len(device):
+        if isinstance(device, list) and len(device):
             device = device[0]
-        if type(device)==str:  # we need to convert name to an ID or make None
+        if isinstance(device, str):  # we need to convert name to an ID or make None
             devs = getDevices('output')
             if device in devs:
                 deviceID = devs[device]['DeviceIndex']
@@ -226,16 +226,16 @@ class _MasterStream(audio.Stream):
         if not systemtools.isVM_CI():  # Github Actions VM does not have a sound device
             try:
                 audio.Stream.__init__(self, device_id=deviceID, mode=mode+8,
-                                    latency_class=audioLatencyClass,
-                                    freq=sampleRate, 
-                                    channels=channels,
-                                    )  # suggested_latency=suggestedLatency
-            except OSError as e:
+                                      latency_class=audioLatencyClass,
+                                      freq=sampleRate,
+                                      channels=channels,
+                                      )  # suggested_latency=suggestedLatency
+            except OSError as e:  # noqa: F841
                 audio.Stream.__init__(self, device_id=deviceID, mode=mode+8,
-                                    latency_class=audioLatencyClass,
-                                    # freq=sampleRate, 
-                                    channels=channels,
-                                    )
+                                      latency_class=audioLatencyClass,
+                                      # freq=sampleRate,
+                                      channels=channels,
+                                      )
                 self.sampleRate = self.status['SampleRate']
                 print("Failed to start PTB.audio with requested rate of "
                       "{} but succeeded with a default rate ({}). "
@@ -244,14 +244,14 @@ class _MasterStream(audio.Stream):
             except TypeError as e:
                 print("device={}, mode={}, latency_class={}, freq={}, channels={}"
                       .format(device, mode+8, audioLatencyClass, sampleRate, channels))
-                raise(e)
+                raise e
             except Exception as e:
                 audio.Stream.__init__(self, mode=mode+8,
-                                    latency_class=audioLatencyClass,
-                                    freq=sampleRate, 
-                                    channels=channels,
-                                    )
-                
+                                      latency_class=audioLatencyClass,
+                                      freq=sampleRate,
+                                      channels=channels,
+                                      )
+
                 if "there isn't any audio output device" in str(e):
                     print("Failed to load audio device:\n"
                           "    '{}'\n"
@@ -329,7 +329,7 @@ class SoundPTB(_SoundBase):
         self.sndArr = None
         self.hamming = hamming
         self._hammingWindow = None  # will be created during setSound
-        self.win=syncToWin
+        self.win = syncToWin
         # setSound (determines sound type)
         self.setSound(value, secs=self.secs, octave=self.octave,
                       hamming=self.hamming)
@@ -382,9 +382,9 @@ class SoundPTB(_SoundBase):
     @stereo.setter
     def stereo(self, val):
         self.__dict__['stereo'] = val
-        if val == True:
+        if val is True:
             self.__dict__['channels'] = 2
-        elif val == False:
+        elif val is False:
             self.__dict__['channels'] = 1
         elif val == -1:
             self.__dict__['channels'] = -1
@@ -458,7 +458,6 @@ class SoundPTB(_SoundBase):
         self._channelCheck(
             self.sndArr)  # Check for fewer channels in stream vs data array
 
-
     def _setSndFromArray(self, thisArray):
 
         self.sndArr = np.asarray(thisArray).astype('float32')
@@ -508,7 +507,7 @@ class SoundPTB(_SoundBase):
                 "experiment settings**".format(self.channels, array.shape[1]))
             logging.error(msg)
             raise ValueError(msg)
-        
+
     def _checkPlaybackFinished(self):
         """Checks whether playback has finished by looking up the status.
         """
@@ -521,7 +520,7 @@ class SoundPTB(_SoundBase):
         # if it wasn't finished but now is, do end of stream behaviour
         if isFinished and not wasFinished:
             self._EOS()
-        
+
         return self._isFinished
 
     def play(self, loops=None, when=None, log=True):
@@ -533,7 +532,7 @@ class SoundPTB(_SoundBase):
         """
         if self._checkPlaybackFinished():
             self.stop(reset=True)
-        
+
         if loops is not None and self.loops != loops:
             self.setLoops(loops)
 

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -340,7 +340,8 @@ class SoundPTB(_SoundBase):
     @property
     def isPlaying(self):
         """`True` if the audio playback is ongoing."""
-        _ = self._checkPlaybackFinished()  # update _isPlaying if sound has stopped
+        # This will update _isPlaying if sound has stopped by _EOS()
+        _ = self._checkPlaybackFinished()
         return self._isPlaying
 
     @property

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -340,6 +340,7 @@ class SoundPTB(_SoundBase):
     @property
     def isPlaying(self):
         """`True` if the audio playback is ongoing."""
+        _ = self._checkPlaybackFinished()  # update _isPlaying if sound has stopped
         return self._isPlaying
 
     @property
@@ -556,7 +557,7 @@ class SoundPTB(_SoundBase):
     def pause(self, log=True):
         """Stops the sound without reset, so that play will continue from here if needed
         """
-        if self.isPlaying:
+        if self._isPlaying:
             self.stop(reset=False, log=False)
             if log and self.autoLog:
                 logging.exp(u"Sound %s paused" % (self.name), obj=self)
@@ -565,7 +566,7 @@ class SoundPTB(_SoundBase):
         """Stop the sound and return to beginning
         """
         # this uses FINISHED for some reason, all others use STOPPED
-        if not self.isPlaying:
+        if not self._isPlaying:
             return
 
         self.track.stop()

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -589,10 +589,11 @@ class SoundPTB(_SoundBase):
         """Function called on End Of Stream
         """
         self._loopsFinished += 1
-        if self._loopsFinished <= self.loops:
+        if self._loopsFinished >= self._loopsRequested:
+            # if we have finished all requested loops
             self.stop(reset=reset, log=False)
-            self._isFinished = True
         else:
+            # reset _isFinished back to False
             self._isFinished = False
 
         if log and self.autoLog:


### PR DESCRIPTION
Three follow-up fixes from our threads in #6562, starting a new PR to make things clearer.

- We don't need to invoke `writeActiveTestCode()` here because we call `writeParamUpdates()` at the beginning of `writeFrameCode()` already. I cleaned this up a bit to follow the `BaseComponent` formatting in generated scripts.
- Calling `_checkPlaybackFinished()` can now possibly update the `_isPlaying` attribute through `_EOS() -> stop()`, so adding the function call back to the `isPlaying()` method. Update `pause()` and `stop()` to check function status, both for clearer syntax and to avoid extra calls of `_checkPlaybackFinished()`.
- The loop counting comparison  in `_EOS()` is flipped, likely due to confusing use of the attribute `.loops`. Switched to use `_loopsRequested` instead and removed an extra setting of `self._isFinished = True` since `_EOS()` can only be entered when `self._isFinished == True`.