### PR TITLE
FF: suppress GLFW-related warnings during init in events.py

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -32,9 +32,12 @@ try:
 except ImportError:
     havePyglet = False
 try:
+    import warnings
     import glfw
-    if not glfw.init():
-        raise ImportError
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        if not glfw.init():
+            raise ImportError
     haveGLFW = True
 except ImportError:
     haveGLFW = False


### PR DESCRIPTION
This should catch warnings seemingly related to M1+ Macs + older GLFW versions? I don't have access to a Mac, so haven't tested yet.