### PR TITLE
BF: Builder: Ensure frame rate is stored.

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1870,7 +1870,7 @@ class SettingsComponent:
             "if expInfo is not None:\n"
             "    # get/measure frame rate if not already in expInfo\n"
             "    if win._monitorFrameRate is None:\n"
-            "        win.getActualFrameRate(infoMsg=%(frameRateMsg)s)\n"
+            "        win._monitorFrameRate = win.getActualFrameRate(infoMsg=%(frameRateMsg)s)\n"
             "    expInfo['frameRate'] = win._monitorFrameRate\n"
             )
             buff.writeIndentedLines(code % params)


### PR DESCRIPTION
The frame rate wasn't being saved into win._monitorFrameRate, and so expInfo['frameRate'] was also None.