### PR TITLE
BF: movie component Volume inputType should be single instead of float

### DIFF
--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -80,7 +80,7 @@ class MovieComponent(BaseVisualComponent):
 
         msg = _translate("How loud should audio be played?")
         self.params["volume"] = Param(
-            volume, valType='num', inputType="float", categ='Playback',
+            volume, valType='num', inputType="single", categ='Playback',
             hint=msg,
             label=_translate("Volume"))
 


### PR DESCRIPTION
`float` isn't a valid parameter `inputType`; `single` has been used for other components