### PR TITLE
FF: Plugins were *only* being found in the packages folder

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -424,19 +424,28 @@ def scanPlugins():
     """
     global _installed_plugins_
     _installed_plugins_ = {}  # clear the cache
-    for dist in pkg_resources.find_distributions(USER_PACKAGES_PATH):
-        if dist.has_metadata('entry_points.txt'):
-            entryMap = dist.get_entry_map()
-            if entryMap:
-                _installed_plugins_[dist.project_name] = entryMap
-            else:
-                logging.warning(
-                    "Package `{}` has an empty entry points map!".format(
-                        dist.project_name))
-        else:
-            logging.debug(
-                "Package `{}` does not define any entry points.".format(
-                    dist.project_name))
+    # get list of all packages
+    packages = importlib.metadata.distributions()
+    packages.update(
+        pkg_resources.find_distributions(USER_PACKAGES_PATH)
+    )
+    # iterate through installed packages
+    for name in packages:
+        # get distribution
+        dist = importlib.metadata.distribution(name)
+        # map all entry points
+        for ep in dist.entry_points:
+            # skip entry points which don't target PsychoPy
+            if not ep.group.startswith("psychopy"):
+                continue
+            # make sure we have an entry for this distribution
+            if dist.name not in _installed_plugins_:
+                _installed_plugins_[dist.name] = {}
+            # make sure we have an entry for this group
+            if ep.group not in _installed_plugins_[dist.name]:
+                _installed_plugins_[dist.name][ep.group] = {}
+            # map entry point
+            _installed_plugins_[dist.name][ep.group][ep.name] = ep
     
     return len(_installed_plugins_)
 
@@ -754,26 +763,27 @@ def loadPlugin(plugin):
         # that the entry points are valid. This prevents plugins from being
         # partially loaded which can cause all sorts of undefined behaviour.
         for attr, ep in attrs.items():
+            module_name = ep.module.split(".")[0]
             # Load the module the entry point belongs to, this happens
             # anyways when .load() is called, but we get to access it before
             # we start binding. If the module has already been loaded, don't
             # do this again.
-            if ep.module_name not in sys.modules:
+            if module_name not in sys.modules:
                 # Do stuff before loading entry points here, any executable code
                 # in the module will run to configure it.
                 try:
-                    imp = importlib.import_module(ep.module_name)
+                    imp = importlib.import_module(module_name)
                 except (ModuleNotFoundError, ImportError):
                     importSuccess = False
                     logging.error(
                         "Plugin `{}` entry point requires module `{}`, but it "
-                        "cannot be imported.".format(plugin, ep.module_name))
+                        "cannot be imported.".format(plugin, module_name))
                 except:
                     importSuccess = False
                     logging.error(
                         "Plugin `{}` entry point requires module `{}`, but an "
                         "error occurred while loading it.".format(
-                            plugin, ep.module_name))
+                            plugin, module_name))
                 else:
                     importSuccess = True
 
@@ -835,7 +845,7 @@ def loadPlugin(plugin):
             # If we get here, the entry point is valid and we can safely add it
             # to PsychoPy's namespace.
             validEntryPoints[fqn].append((targObj, attr, ep))
-
+    print(validEntryPoints)
     # Assign entry points that have been successfully loaded. We defer
     # assignment until all entry points are deemed valid to prevent plugins
     # from being partially loaded.

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -424,15 +424,8 @@ def scanPlugins():
     """
     global _installed_plugins_
     _installed_plugins_ = {}  # clear the cache
-    # get list of all packages
-    packages = importlib.metadata.distributions()
-    packages.update(
-        pkg_resources.find_distributions(USER_PACKAGES_PATH)
-    )
     # iterate through installed packages
-    for name in packages:
-        # get distribution
-        dist = importlib.metadata.distribution(name)
+    for dist in importlib.metadata.distributions(path=sys.path + [USER_PACKAGES_PATH]):
         # map all entry points
         for ep in dist.entry_points:
             # skip entry points which don't target PsychoPy
@@ -610,12 +603,12 @@ def loadPluginBuilderElements(plugin):
     # import all relevant classes
     for point in relevantPoints:
         try:
-            importlib.import_module(point.module_name)
+            importlib.import_module(point.module)
             return True
         except:
             # if import failed for any reason, log error and mark failure
             logging.error(
-                f"Failed to load {point.module_name}.{point.name} from plugin {plugin}."
+                f"Failed to load {point.module}.{point.name} from plugin {plugin}."
             )
             _failed_plugins_.append(plugin)
             return False

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -845,7 +845,6 @@ def loadPlugin(plugin):
             # If we get here, the entry point is valid and we can safely add it
             # to PsychoPy's namespace.
             validEntryPoints[fqn].append((targObj, attr, ep))
-    print(validEntryPoints)
     # Assign entry points that have been successfully loaded. We defer
     # assignment until all entry points are deemed valid to prevent plugins
     # from being partially loaded.


### PR DESCRIPTION
The problem was `pkg_resources.find_distributions(USER_PACKAGES_PATH)` - which was looking just in the plugins folder and nowhere else. We could add `sys.path` to this but it would become very slow (each module seems to add about a millisecond to the search time), whereas importlib.metadata takes about a millisecond total regardless of how many packages.