### PR TITLE
FF: Routine Settings had lost the ability to use variables from "Set Each Routine" code

### DIFF
--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -1078,7 +1078,7 @@ class Routine(list):
         if self.settings.params['forceNonSlip'] and maxTime not in (0, FOREVER):
             nonSlipSafe  = True
         # if there are no components, default to 10s
-        if maxTime == 0:
+        if maxTime in (0, None):
             maxTime = 10
             nonSlipSafe = False
         return maxTime, nonSlipSafe

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -643,12 +643,19 @@ class Routine(list):
         # can we use non-slip timing?
         maxTime, useNonSlip = self.getMaxTime()
 
+        # this is the beginning of the routine, before the loop starts
         code = "# update component parameters for each repeat\n"
         buff.writeIndentedLines(code)
-        # This is the beginning of the routine, before the loop starts
         for event in self:
+            # don't write Routine Settings just yet...
+            if event is self.settings:
+                continue
+            # write the other Components'
             event.writeRoutineStartCode(buff)
             event.writeRoutineStartValidationCode(buff)
+        # write the Routine Settings code last
+        self.settings.writeRoutineStartCode(buff)
+        self.settings.writeRoutineStartValidationCode(buff)
 
         code = '# keep track of which components have finished\n'
         buff.writeIndentedLines(code)


### PR DESCRIPTION
Because we're now calculating the Routine's max duration at Routine start, rather than in the frame loop, variables set at Routine start couldn't be used because they weren't defined until after the Routine Settings code was written (as the settings are always the first Component). Fix is to just hold off on writing Routine Settings code until other Components' have written theirs