### PR TITLE
BF: Allow Sound to stop on a condition rather than just time

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -52,9 +52,6 @@ class SoundComponent(BaseDeviceComponent):
             "volume", "hammingWindow",  # Playback tab
         ]
         # params
-        self.params['stopType'].allowedVals = ['duration (s)']
-        self.params['stopType'].hint = _translate('The maximum duration of a'
-                                                  ' sound in seconds')
         hnt = _translate("When does the Component end? (blank to use the "
                          "duration of the media)")
         self.params['stopVal'].hint = hnt


### PR DESCRIPTION
This was originally limited because Sound had to have a fixed duration to load, but this hasn't been the case for a while now. Setting stop val as a condition opens up the possibility for users to have a sound which stops when `soundsOwnName.isFinished` - simulating the behaviour which recent changes by myself and @mh105 have removed (i.e. setting `.status = FINISHED` if `.isFinished`, which had a number of problems).