### PR TITLE
BF: Fix `obj.contains is not a function` error in JS

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -220,7 +220,13 @@ class MouseComponent(BaseComponent):
         code = (
             "// check if the mouse was inside our 'clickable' objects\n"
             "gotValidClick = false;\n"
-            "for (const obj of [%(clickable)s]) {\n"
+            "%(name)s.clickableObjects = %(clickable)s\n;"
+            "// make sure the mouse's clickable objects are an array\n"
+            "if (!Array.isArray(%(name)s.clickableObjects)) {\n"
+            "    %(name)s.clickableObjects = [%(name)s.clickableObjects];\n"
+            "}\n"
+            "// iterate through clickable objects and check each\n"
+            "for (const obj of %(name)s.clickableObjects) {\n"
             "    if (obj.contains(%(name)s)) {\n"
             "        gotValidClick = true;\n"
         )


### PR DESCRIPTION
Problem arises because we're trying to figure out from the value of the `clickable` param whether the values are a list or not, but Builder doesn't know the difference between a variable name that's a list and a variable name that's a single stimuli. Solution is to check at runtime and convert to an array if not already, so we can safely iterate.