### PR TITLE
TEST: Skip speed-sensitive tests if running in a VM

### DIFF
--- a/psychopy/tests/test_app/test_speed.py
+++ b/psychopy/tests/test_app/test_speed.py
@@ -3,7 +3,7 @@ import sys
 import numpy
 from pathlib import Path
 
-from ..utils import TESTS_DATA_PATH
+from psychopy.tests.utils import TESTS_DATA_PATH, RUNNING_IN_VM
 
 import shutil
 from tempfile import mkdtemp
@@ -16,6 +16,9 @@ from ... import logging
 class TestSpeed:
     def setup_method(self):
         self.tmp_dir = mkdtemp(prefix='psychopy-tests-app')
+        # skip speed tests under vm
+        if RUNNING_IN_VM:
+            pytest.skip()
 
     def teardown_method(self):
         shutil.rmtree(self.tmp_dir, ignore_errors=True)

--- a/psychopy/tests/test_hardware/test_keyboard.py
+++ b/psychopy/tests/test_hardware/test_keyboard.py
@@ -3,6 +3,7 @@ from psychopy.hardware import keyboard
 import pytest
 import time
 from psychopy import logging
+from psychopy.tests.utils import RUNNING_IN_VM
 
 
 class _TestBaseKeyboard:
@@ -59,6 +60,9 @@ class _TestBaseKeyboard:
         """
         # skip this test on Linux (as MOP *is* slower due to having to use subprocess)
         if sys.platform == "linux":
+            pytest.skip()
+        # skip speed tests under vm
+        if RUNNING_IN_VM:
             pytest.skip()
 
         # array to store times

--- a/psychopy/tests/test_visual/test_image.py
+++ b/psychopy/tests/test_visual/test_image.py
@@ -3,10 +3,8 @@ from pathlib import Path
 from psychopy import visual, colors, core
 from .test_basevisual import _TestUnitsMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
-from .. import utils
-
-from ..utils import TESTS_DATA_PATH
-
+from psychopy.tests import utils
+import pytest
 
 class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
     """
@@ -17,7 +15,7 @@ class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
         self.win = visual.Window()
         self.obj = visual.ImageStim(
             self.win,
-            str(Path(TESTS_DATA_PATH) / 'testimage.jpg'),
+            str(Path(utils.TESTS_DATA_PATH) / 'testimage.jpg'),
             colorSpace='rgb1',
         )
 
@@ -187,6 +185,9 @@ class TestImageAnimation:
         """
         Check that images can be updated sufficiently fast to create frame animations
         """
+        # skip speed tests under vm
+        if utils.RUNNING_IN_VM:
+            pytest.skip()
         # Create clock
         clock = core.Clock()
         # Try at each size

--- a/psychopy/tests/utils.py
+++ b/psychopy/tests/utils.py
@@ -6,6 +6,7 @@ import shutil
 import numpy as np
 import io
 from psychopy import logging, colors
+from psychopy.tools import systemtools
 
 try:
     from PIL import Image
@@ -13,6 +14,9 @@ except ImportError:
     import Image
 
 import pytest
+
+# boolean indicating whether tests are running in a VM
+RUNNING_IN_VM = systemtools.isVM_CI() is not None
 
 # define the path where to find testing data
 # so tests could be ran from any location


### PR DESCRIPTION
These tests are still important to have for when we have regular actual-physical-computer-sitting-in-the-lab tests up and running, but because VM speeds are so variable we get a lot of false negatives in PRs which are actually fine.