### PR TITLE
PKG: trying to add google to py2app packages on 3.8

### DIFF
--- a/setupApp.py
+++ b/setupApp.py
@@ -131,6 +131,7 @@ if sys.version_info < (3, 9):
             'macropy',
         ]
     )
+    packages.append('google')  # otherwise it gets inserted into zip and won't sign
     packages.append('PyQt5')
     packages.remove('PyQt6')  # PyQt6 is not compatible with earlier PsychoPy versions
 


### PR DESCRIPTION
Otherwise google/_upb/_message.abi3.so etc get copied to site-packages zip file and can't be code-signed