### PR TITLE
FF: entrypoint may not be a file

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -830,7 +830,7 @@ def loadPlugin(plugin):
 
                 return False
 
-            if '.zip' in ep.__file__:
+            if hasattr(ep, 'file') and '.zip' in ep.__file__:
                 logging.warning(
                     "Plugin `{}` is being loaded from a zip file. This may "
                     "cause issues with the plugin's functionality.".format(plugin))


### PR DESCRIPTION
...in which case it won't have a `__file__` attribute

error added in fd5f50750ce1515da99b4721b4e7a30902684f98