### PR TITLE
BF: Fix JS translation of `.pop()` when there's no index

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -337,7 +337,14 @@ class pythonTransformer(ast.NodeTransformer):
         # The default first argument for pop is -1 (remove the last item).
         elif func.attr == 'pop':
             func.attr = 'splice'
-            args = args if args else [ast.Constant(value=-1, kind=None)]
+            # if no args, construct an index that's `<name>.length-1`
+            if not args:
+                args = ast.BinOp(
+                    ast.Attribute(value=func.value, attr="length"), 
+                    ast.Sub(),
+                    ast.Constant(1, kind="int")
+                )
+            # add 1 as a second argument so the last item is deleted
             args = [args, [ast.Constant(value=1, kind=None)]]
 
             return ast.Call(

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -67,7 +67,7 @@ class TestTranspiler:
             {'py': "a.upper()", 'js': "a.toUpperCase();\n"},
             {'py': "a.extend([4, 5, 6])", 'js': "a.concat([4, 5, 6]);\n"},
             {'py': "a.pop(0)", 'js': "a.splice(0, 1);\n"},
-            {'py': "a.pop()", 'js': "a.splice((- 1), 1);\n"},
+            {'py': "a.pop()", 'js': "a.splice((a.length - 1), 1);\n"},
         ]
         # Try each case
         for case in cases:


### PR DESCRIPTION
Current if you do:
```
a.pop()
```
you get
```
 a.splice((- 1), 1)
```

JS doesn't have negative indexing, so can't splice the -1st value. Instead, we should use `<name>.length - 1`, to give:
```
a.splice(a.length-1, 1)
```