### PR TITLE
FF: re-enable logging warning when ep.__file__ exists

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -830,7 +830,7 @@ def loadPlugin(plugin):
 
                 return False
 
-            if hasattr(ep, 'file') and '.zip' in ep.__file__:
+            if hasattr(ep, '__file__') and '.zip' in ep.__file__:
                 logging.warning(
                     "Plugin `{}` is being loaded from a zip file. This may "
                     "cause issues with the plugin's functionality.".format(plugin))


### PR DESCRIPTION
There was a typo and `ep.file` will likely *never* exist so the warning would never be produced