### PR TITLE
BF: use inspect.getfile to check path of plugin entry points

### DIFF
--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -279,12 +279,12 @@ def getDevicePaths(device_name=""):
                 continue
 
             if hasattr(ep_target, "configFile"):
-                # if entry point target is a class that binds to a yaml file, use it
+                # if entry point target binds to a yaml file, use it
                 scs_yaml_paths.append(
                     (ep_target.configFile.parent, ep_target.configFile.name)
                 )
-            else:  # otherwise, check the local folder of the entry point target
-                deviceConfig = _getDevicePaths(os.path.dirname(ep_target.__file__))
+            else:  # otherwise, check the local folder of the target module or class
+                deviceConfig = _getDevicePaths(os.path.dirname(inspect.getfile(ep_target)))
                 scs_yaml_paths.extend(deviceConfig)
 
     # Use import_device() method for built-in devices

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -823,6 +823,13 @@ def loadPlugin(plugin):
                     # return False
             try:
                 ep = ep.load()  # load the entry point
+
+                # Raise a warning if the plugin is being loaded from a zip file.
+                if '.zip' in inspect.getfile(ep):
+                    logging.warning(
+                        "Plugin `{}` is being loaded from a zip file. This may "
+                        "cause issues with the plugin's functionality.".format(plugin))
+
             except ImportError as e:
                 logging.error(
                     "Failed to load entry point `{}` of plugin `{}`. "
@@ -843,14 +850,10 @@ def loadPlugin(plugin):
 
                 return False
 
-            if hasattr(ep, '__file__') and '.zip' in ep.__file__:
-                logging.warning(
-                    "Plugin `{}` is being loaded from a zip file. This may "
-                    "cause issues with the plugin's functionality.".format(plugin))
-
             # If we get here, the entry point is valid and we can safely add it
             # to PsychoPy's namespace.
             validEntryPoints[fqn].append((targObj, attr, ep))
+
     # Assign entry points that have been successfully loaded. We defer
     # assignment until all entry points are deemed valid to prevent plugins
     # from being partially loaded.


### PR DESCRIPTION
Fix a bug that got introduced in #6610 - I forgot to consider the use of entry-points for classes in addition to importing modules.

Classes require a different way from modules for checking the file path, as previously done correctly by @TEParsons using `inspect.getfile()`, which #6610 incorrectly removed. This BF adds that back.

- moves the logging warning inside the `try` block after `ep.load()`, so that if a plugin fails to load, it won't crash the entire script.
- addresses comments https://github.com/psychopy/psychopy/commit/fd5f50750ce1515da99b4721b4e7a30902684f98#commitcomment-143749931 and https://github.com/psychopy/psychopy/pull/6610#discussion_r1658738517.
- replaces FF commits 9032984 and 3a472e8.
