### PR TITLE
FF: Change iohub port to avoid conflicts with Whisper transcription

### DIFF
--- a/psychopy/iohub/default_config.yaml
+++ b/psychopy/iohub/default_config.yaml
@@ -1,5 +1,5 @@
 global_event_buffer: 2048
-udp_port: 9034
+udp_port: 9036
 msgpump_interval: 0.001
 data_store:
     enable: False


### PR DESCRIPTION
Changes the default port of iohub from 9034 -> 9036 to avoid conflicts with the Whisper transcription backend. 