### PR TITLE
ENH: Skip routine setup when 'Skip if' condition is set

### DIFF
--- a/psychopy/app/locale/ar_001/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/ar_001/LC_MESSAGE/messages.po
@@ -6552,7 +6552,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave blank to "
+"Skip this Routine if the value in this control evaluates to True. Leave blank to "
 "not skip."
 msgstr ""
 

--- a/psychopy/app/locale/de_DE/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/de_DE/LC_MESSAGE/messages.po
@@ -6694,7 +6694,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/es_CO/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/es_CO/LC_MESSAGE/messages.po
@@ -6222,7 +6222,7 @@ msgid "When should this Routine end, if not already ended by a Component? Leave 
 msgstr "¿Cuándo debe finalizar esta rutina, si aún no la finalizó un Componente? Dejar en blanco para infinito."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
-msgid "Skip this Routine if the value in this contorl evaluates to True. Leave blank to not skip."
+msgid "Skip this Routine if the value in this control evaluates to True. Leave blank to not skip."
 msgstr "Omita esta Rutina si el valor en este control se evalúa como Verdadero. Deje en blanco para no omitir."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:78

--- a/psychopy/app/locale/es_ES/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/es_ES/LC_MESSAGE/messages.po
@@ -6222,7 +6222,7 @@ msgid "When should this Routine end, if not already ended by a Component? Leave 
 msgstr "¿Cuándo debe finalizar esta rutina, si aún no la finalizó un Componente? Dejar en blanco para infinito."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
-msgid "Skip this Routine if the value in this contorl evaluates to True. Leave blank to not skip."
+msgid "Skip this Routine if the value in this control evaluates to True. Leave blank to not skip."
 msgstr "Omita esta Rutina si el valor en este control se evalúa como Verdadero. Deje en blanco para no omitir."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:78

--- a/psychopy/app/locale/es_US/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/es_US/LC_MESSAGE/messages.po
@@ -6222,7 +6222,7 @@ msgid "When should this Routine end, if not already ended by a Component? Leave 
 msgstr "¿Cuándo debe finalizar esta rutina, si aún no la finalizó un Componente? Dejar en blanco para infinito."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
-msgid "Skip this Routine if the value in this contorl evaluates to True. Leave blank to not skip."
+msgid "Skip this Routine if the value in this control evaluates to True. Leave blank to not skip."
 msgstr "Omita esta Rutina si el valor en este control se evalúa como Verdadero. Deje en blanco para no omitir."
 
 #: psychopy/experiment/components/routineSettings/__init__.py:78

--- a/psychopy/app/locale/et_EE/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/et_EE/LC_MESSAGE/messages.po
@@ -6551,7 +6551,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/fr_FR/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/fr_FR/LC_MESSAGE/messages.po
@@ -6557,7 +6557,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/he_IL/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/he_IL/LC_MESSAGE/messages.po
@@ -6548,7 +6548,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/hi_IN/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/hi_IN/LC_MESSAGE/messages.po
@@ -6541,7 +6541,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/it_IT/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/it_IT/LC_MESSAGE/messages.po
@@ -6542,7 +6542,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/app/locale/ja_JP/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/ja_JP/LC_MESSAGE/messages.po
@@ -6414,7 +6414,7 @@ msgstr ""
 
 #: experiment/components/routineSettings/__init__.py:72
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 "入力された式が真の場合, このルーチンをスキップします. スキップしない場合は空"

--- a/psychopy/app/locale/tr_TR/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/tr_TR/LC_MESSAGE/messages.po
@@ -6547,7 +6547,7 @@ msgstr ""
 
 #: psychopy/experiment/components/routineSettings/__init__.py:76
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -203,18 +203,23 @@ class RoutineSettingsComponent(BaseComponent):
         params = self.params.copy()
         if params['stopVal'] in ("None", None, ""):
             params['stopVal'].val = "None"
-        # Store Routine start time (UTC)
-        if self.params['saveStartStop']:
-            code = (
-                "psychoJS.experiment.addData('%(name)s.started', globalClock.getTime());\n"
-            )
-            buff.writeIndentedLines(code % params)
-        # Skip Routine if condition is met
+
+        # process skip if logic first
         if params['skipIf'].val not in ('', None, -1, 'None'):
             code = (
                 "// skip this Routine if its 'Skip if' condition is True\n"
                 "continueRoutine = continueRoutine && !(%(skipIf)s);\n"
-                "maxDurationReached = False\n"
+                "maxDurationReached = false\n"
+                "if (%(skipIf)s) {\n"
+                "   return Scheduler.Event.NEXT;\n"
+                "}\n"
+            )
+            buff.writeIndentedLines(code % params)
+        
+        # Store Routine start time (UTC)
+        if self.params['saveStartStop']:
+            code = (
+                "psychoJS.experiment.addData('%(name)s.started', globalClock.getTime());\n"
             )
             buff.writeIndentedLines(code % params)
         # calculate expected Routine duration

--- a/psychopy/localization/messages.pot
+++ b/psychopy/localization/messages.pot
@@ -6243,7 +6243,7 @@ msgstr ""
 
 #: ../experiment/components/routineSettings/__init__.py:71
 msgid ""
-"Skip this Routine if the value in this contorl evaluates to True. Leave "
+"Skip this Routine if the value in this control evaluates to True. Leave "
 "blank to not skip."
 msgstr ""
 


### PR DESCRIPTION
This changes the behavior of the Builder 'Skip if' option to also skip component initialization. This is useful for skipping routines under conditions where the content of the component might be undefined, and avoids setup work for stimuli that will never be shown.