### PR TITLE
BF: enable mouse clickable from variable online

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -220,7 +220,7 @@ class MouseComponent(BaseComponent):
         code = (
             "// check if the mouse was inside our 'clickable' objects\n"
             "gotValidClick = false;\n"
-            "%(name)s.clickableObjects = %(clickable)s\n;"
+            "%(name)s.clickableObjects = eval(%(clickable)s)\n;"
             "// make sure the mouse's clickable objects are an array\n"
             "if (!Array.isArray(%(name)s.clickableObjects)) {\n"
             "    %(name)s.clickableObjects = [%(name)s.clickableObjects];\n"


### PR DESCRIPTION
needed to add eval() so that a value from a spreadsheet (which is read in as a string) is instead converted to an object/variable name that can be clicked.