### PR TITLE
FF: App starting view wasn't being respected

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -95,7 +95,7 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     # console.
     from psychopy.app._psychopyApp import PsychoPyApp
     _psychopyAppInstance = PsychoPyApp(
-        0, testMode=testMode, showSplash=showSplash, safeMode=safeMode)
+        0, testMode=testMode, showSplash=showSplash, safeMode=safeMode, startView=startView)
 
     # After the app is loaded, we hand off logging to the stream dispatcher
     # using the provided log file path. The dispatcher will write out any log

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -72,13 +72,6 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     if isAppStarted():  # do nothing it the app is already loaded
         return  # NOP
 
-    # process environment variables
-    startViewVal = os.environ.get('PSYCHOPYSTARTVIEW', None)
-    if startViewVal is not None:
-        startView = str(startViewVal).lower()
-        if startView not in ('coder', 'builder', 'runner'):
-            startView = None  # silently drop invalid values and use default
-
     # Make sure logging is started before loading the bulk of the main
     # application UI to catch as many errors as possible. After the app is
     # loaded, messages are handled by the `StdStreamDispatcher` instance.
@@ -127,19 +120,6 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
         # After this point, errors will appear in a dialog box. Messages will
         # continue to be written to the dialog.
         sys.excepthook = exceptionCallback
-
-        # open the frames if requested
-        if startView is not None:
-            frame = getAppFrame(startView)  # opens if not yet loaded
-            # raise frames to the top
-            if frame is not None:
-                if hasattr(frame, 'Raise'):
-                    frame.Raise()
-                else:
-                    logging.warning(
-                        'Frame has no `Raise()` method. Cannot raise it.')
-            else:
-                logging.error('Frame cannot be opened.')
 
         # Allow the UI to refresh itself. Don't do this during testing where the
         # UI is exercised programmatically.

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -521,24 +521,34 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             splash.SetText(_translate("  Creating frames..."))
         
         # get starting windows
-        if startView is None:
+        if startView in (None, []):
             # if no window specified, use default from prefs
             if self.prefs.app['defaultView'] == 'all':
                 startView = ["builder", "coder", "runner"]
             elif self.prefs.app['defaultView'] in ["builder", "coder", "runner"]:
                 startView = self.prefs.app['defaultView']
+            else:
+                startView = ["builder"]
+        # if specified as a single string, convert to list
         if isinstance(startView, str):
-            # if specified as a single string, convert to list
             startView = [startView]
         
-        # check from filetype if any windows need to be open
+        # get files to open from commandline args
         for arg in sys.argv:
-            if "builder" not in startView and arg.endswith(".psyexp"):
-                startView.append("builder")
-            if "coder" not in startView and arg.endswith(".py"):
-                startView.append("coder")
+            if arg.endswith(".psyexp"):
+                exps.append(arg)
+            if arg.endswith(".py"):
+                scripts.append(arg)
             if "runner" not in startView and arg.endswith(".psyrun"):
-                startView.append("runner")
+                runlist.append(arg)
+        
+        # show frames according to files
+        if exps and "builder" not in startView:
+            startView.append("builder")
+        if scripts and "coder" not in startView:
+            startView.append("coder")
+        if runlist and "runner" not in startView:
+            startView.append("runner")
 
         # create windows
         if "runner" in startView:

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -525,6 +525,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             # if no window specified, use default from prefs
             if self.prefs.app['defaultView'] == 'all':
                 startView = ["builder", "coder", "runner"]
+            elif self.prefs.app['defaultView'] == "last":
+                startView = self.prefs.appData['lastFrame']
             elif self.prefs.app['defaultView'] in ["builder", "coder", "runner"]:
                 startView = self.prefs.app['defaultView']
             else:

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -526,7 +526,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if self.prefs.app['defaultView'] == 'all':
                 startView = ["builder", "coder", "runner"]
             elif self.prefs.app['defaultView'] == "last":
-                startView = self.prefs.appData['lastFrame']
+                startView = self.prefs.appData['lastFrame'].split("-")
             elif self.prefs.app['defaultView'] in ["builder", "coder", "runner"]:
                 startView = self.prefs.app['defaultView']
             else:
@@ -1021,13 +1021,16 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
                 return  # user cancelled quit
 
         # save info about current frames for next run
-        if self.coder and len(self.getAllFrames("builder")) == 0:
-            self.prefs.appData['lastFrame'] = 'coder'
-        elif self.coder is None:
-            self.prefs.appData['lastFrame'] = 'builder'
-        else:
-            self.prefs.appData['lastFrame'] = 'both'
-
+        openFrames = []
+        for frame in self.getAllFrames():
+            if type(frame).__name__ == "BuilderFrame" and "builder" not in openFrames:
+                openFrames.append("builder")
+            if type(frame).__name__ == "CoderFrame" and "coder" not in openFrames:
+                openFrames.append("coder")
+            if type(frame).__name__ == "RunnerFrame" and "runner" not in openFrames:
+                openFrames.append("runner")
+        self.prefs.appData['lastFrame'] = "-".join(openFrames)
+        # save current version for next run
         self.prefs.appData['lastVersion'] = self.version
         # update app data while closing each frame
         # start with an empty list to be appended by each frame

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -520,7 +520,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
         if splash:
             splash.SetText(_translate("  Creating frames..."))
         
-        # open starting windows
+        # get starting windows
         if startView is None:
             # if no window specified, use default from prefs
             if self.prefs.app['defaultView'] == 'all':
@@ -540,9 +540,9 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if "runner" not in startView and arg.endswith(".psyrun"):
                 startView.append("runner")
 
-        # Create windows
+        # create windows
         if "runner" in startView:
-            # open Runner is requested
+            # open Runner if requested
             try:
                 self.showRunner(fileList=runlist)
             except Exception as err:
@@ -587,6 +587,12 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
                     "Requested: {}\n"
                     "Err: {}"
                 ).format(exps, err))
+        
+        if "direct" in startView:
+            self.showRunner()
+            for exp in [file for file in sys.argv if file.endswith('.psyexp') or file.endswith('.py')]:
+                self.runner.panel.runFile(exp)
+
         # if we started a busy cursor which never finished, finish it now
         if wx.IsBusy():
             wx.EndBusyCursor()

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2024 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
+import argparse
 import os
 import sys
 import subprocess
@@ -160,15 +161,17 @@ def main():
 
         """)
         sys.exit()
-
-    # show a specific app window if requested
-    startAppView = None
-    if '-b' in sys.argv or '--builder' in sys.argv:
-        startAppView = 'builder'
-    elif '-c' in sys.argv or '--coder' in sys.argv:
-        startAppView = 'coder'
-    elif '-r' in sys.argv or '--runner' in sys.argv:
-        startAppView = 'runner'
+    
+    # parse args
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--builder', dest='builder', action="store_true")
+    parser.add_argument('-b', dest='builder', action="store_true")
+    parser.add_argument('--coder', dest='coder', action="store_true")
+    parser.add_argument('-c', dest='coder', action="store_true")
+    parser.add_argument('--runner', dest='runner', action="store_true")
+    parser.add_argument('-r', dest='runner', action="store_true")
+    parser.add_argument('-x', dest='direct', action='store_true')
+    view = parser.parse_args()
 
     while True:  # loop if we exit and want to restart
         # Updated 2024.1.6: as of Python 3, `pythonw` and `python` can be used
@@ -192,8 +195,11 @@ def main():
         # construct the argument string for the `startApp` function
         startArgs = []
         startArgs += ['showSplash={}'.format('--no-splash' not in sys.argv)]
-        if startAppView is not None:
-            startArgs += ['startView={}'.format(repr(startAppView))]
+        startAppView = []
+        for key in ("builder", "coder", "runner"):
+            if getattr(view, key):
+                startAppView.append(key)
+        startArgs += ['startView={}'.format(repr(startAppView))]
         startArgs = ', '.join(startArgs)
 
         # Start command for the PsychoPy application, can't call this file 

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -196,7 +196,7 @@ def main():
         startArgs = []
         startArgs += ['showSplash={}'.format('--no-splash' not in sys.argv)]
         startAppView = []
-        for key in ("builder", "coder", "runner"):
+        for key in ("builder", "coder", "runner", "direct"):
             if getattr(view, key):
                 startAppView.append(key)
         startArgs += ['startView={}'.format(repr(startAppView))]

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -56,7 +56,7 @@
     # display tips when starting PsychoPy
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
-    defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    defaultView = option('last', 'builder', 'coder', 'runner', 'all', default='last')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,9 +149,9 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    # How much output to display in the console / app when piloting ('error' is fewest messages, 'debug' is most).
     pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -56,7 +56,7 @@
     # display tips when starting PsychoPy
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
-    defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    defaultView = option('last', 'builder', 'coder', 'runner', 'all', default='last')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,9 +149,9 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    # How much output to display in the console / app when piloting ('error' is fewest messages, 'debug' is most).
     pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -56,7 +56,7 @@
     # display tips when starting PsychoPy
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
-    defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    defaultView = option('last', 'builder', 'coder', 'runner', 'all', default='last')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,9 +149,9 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    # How much output to display in the console / app when piloting ('error' is fewest messages, 'debug' is most).
     pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -56,7 +56,7 @@
     # display tips when starting PsychoPy
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
-    defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    defaultView = option('last', 'builder', 'coder', 'runner', 'all', default='last')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window
@@ -149,9 +149,9 @@
     forceWindowed = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
-    # How much output to include *in the log file* when piloting ('error' is fewest messages, 'debug' is most)
+    # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)
     pilotLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='debug')
-    # How much output to display *in the app* ('error' is fewest messages, 'debug' is most). This will not affect how much is displayed in the log file.
+    # How much output to display in the console / app when piloting ('error' is fewest messages, 'debug' is most).
     pilotConsoleLoggingLevel = option('error', 'warning', 'data', 'exp', 'info', 'debug', default='warning')
     # Show an orange border around the window when in piloting mode
     showPilotingIndicator = boolean(default=True)

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -52,7 +52,7 @@
     # display tips when starting PsychoPy
     showStartupTips = boolean(default='True')
     # what windows to display when PsychoPy starts
-    defaultView = option('builder', 'coder', 'runner', 'all', default='all')
+    defaultView = option('last', 'builder', 'coder', 'runner', 'all', default='last')
     # reset preferences to defaults on next restart of PsychoPy
     resetPrefs = boolean(default='False') # default must be False!
     # save any unsaved preferences before closing the window


### PR DESCRIPTION
Previously, the app figured out which windows to open based on command line arguments (`-c` for coder, `-b` for builder, `-r` for runner), but now that we're doing a two-step process (to facilitate in-app restarting) these are obscured by the interpreter option (which is always `-c`) so Builder was never opening.

Solution is to parse command line arguments during the first step, and pass the parsed options as init arguments to the PsychoPyApp class.