### PR TITLE
BF:  coder GUI fixes

### DIFF
--- a/psychopy/app/coder/codeEditorBase.py
+++ b/psychopy/app/coder/codeEditorBase.py
@@ -106,14 +106,6 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl, handlers.ThemeMixin):
         deleteItem = wx.MenuItem(menu, self.DeleteID, _translate("Delete"))
         selectItem = wx.MenuItem(menu, self.SelectAllID, _translate("Select All"))
 
-        # Check whether items should be enabled
-        undoItem.Enable(self.CanUndo())
-        redoItem.Enable(self.CanRedo())
-        cutItem.Enable(self.CanCut())
-        copyItem.Enable(self.CanCopy())
-        pasteItem.Enable(self.CanPaste())
-        deleteItem.Enable(self.CanCopy())
-
         # Append items to menu
         menu.Append(undoItem)
         menu.Append(redoItem)
@@ -124,6 +116,14 @@ class BaseCodeEditor(wx.stc.StyledTextCtrl, handlers.ThemeMixin):
         menu.AppendSeparator()
         menu.Append(deleteItem)
         menu.Append(selectItem)
+
+        # Check whether items should be enabled
+        undoItem.Enable(self.CanUndo())
+        redoItem.Enable(self.CanRedo())
+        cutItem.Enable(self.CanCut())
+        copyItem.Enable(self.CanCopy())
+        pasteItem.Enable(self.CanPaste())
+        deleteItem.Enable(self.CanCopy())
 
         self.PopupMenu(menu)
         menu.Destroy()

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2070,6 +2070,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         #     self.OnFindClose(None)
 
     def OnFindClose(self, event):
+        self.findDlg.Destroy()
         self.findDlg = None
 
     def OnFileHistory(self, evt=None):


### PR DESCRIPTION
Two things I noticed while using coder on Linux:

1. Right-clicking in the coder view led to this assertion:

> Traceback (most recent call last):
>   File "/home/testdev/py/psychopy/psychopy/app/coder/codeEditorBase.py", line 110, in OnContextMenu
>     undoItem.Enable(self.CanUndo())
> wx._core.wxAssertionError: C++ assertion ""m_menuItem"" failed at /home/wxpy/wxPython-4.2.1/ext/wxWidgets/src/gtk/menu.cpp(803) in Enable(): invalid menu item

and flipping the enable/append order seems to resolve it.

2. The "find" dialog couldn't be exited by clicking the (x) button, only by cancel/esc key. Explicitly destroying the dialog seems to resolve it.

Tested on Ubuntu 20.04, and doesn't seem to adversely affect behavior on Windows.