### PR TITLE
BF: fixes unmet expectation on import of psychopy-eyetracker-eyelogic

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -764,7 +764,10 @@ def loadPlugin(plugin):
         for attr, ep in attrs.items():
             try:
                 # parse the module name from the entry point value
-                module_name, _ = ep.value.split(':', 1)
+                if ':' in ep.value:
+                    module_name, _ = ep.value.split(':', 1)
+                else:
+                    module_name = ep.value
                 module_name = module_name.split(".")[0]
             except ValueError:
                 logging.error(


### PR DESCRIPTION
This is necessary to allow psychopy-eyetracker-eyelogic to work, as the expectation that the entry-point contains a ':' is not met for entry-points of the form
```
[project.entry-points."psychopy.iohub.devices.eyetracker"]
eyelogic = "psychopy_eyetracker_eyelogic.eyelogic"
```
as we had agreed upon using. Looking at the current state of the [sr-research](https://github.com/psychopy/psychopy-eyetracker-sr-research) plugin this does not seem to have changed.

I believe this should also effect the sr research plugin. I am not sure why this had not reared it's head while testing that plugin. Perhaps this has to do with the fact that the other (non-eyelogic) plugins still have their stubs in iohub/devices/eyetracker/hw?
