### PR TITLE
BF: Re-add distro as a runtime dependency for linux & remove deprecated function.

### DIFF
--- a/psychopy/app/connections/sendusage.py
+++ b/psychopy/app/connections/sendusage.py
@@ -36,10 +36,10 @@ def sendUsageStats(app=None):
         OSXver, junk, architecture = platform.mac_ver()
         systemInfo = "OSX_%s" % (OSXver)
     elif sys.platform.startswith('linux'):
-        from distro import linux_distribution
+        import distro
         systemInfo = '%s_%s_%s' % (
             'Linux',
-            ':'.join([x for x in linux_distribution() if x != '']),
+            ':'.join([x for x in [distro.name(), distro.version(), distro.codename()] if x != '']),
             platform.release())
         if len(systemInfo) > 30:  # if it's too long PHP/SQL fails to store!?
             systemInfo = systemInfo[0:30]

--- a/psychopy/app/connections/updates.py
+++ b/psychopy/app/connections/updates.py
@@ -620,10 +620,10 @@ def sendUsageStats():
         OSXver, junk, architecture = platform.mac_ver()
         systemInfo = "OSX_%s_%s" % (OSXver, architecture)
     elif sys.platform.startswith('linux'):
-        from distro import linux_distribution
+        import distro
         systemInfo = '%s_%s_%s' % (
             'Linux',
-            ':'.join([x for x in linux_distribution() if x != '']),
+            ':'.join([x for x in [distro.name(), distro.version(), distro.codename()] if x != '']),
             platform.release())
         if len(systemInfo) > 30:  # if it's too long PHP/SQL fails to store!?
             systemInfo = systemInfo[0:30]

--- a/psychopy/demos/coder/hardware/testSoundLatency.py
+++ b/psychopy/demos/coder/hardware/testSoundLatency.py
@@ -94,8 +94,8 @@ elif sys.platform == 'win32':
     sysName = 'win'
     sysVer = platform.win32_ver()[0]
 elif sys.platform.startswith('linux'):
-    from distro import linux_distribution
-    sysName = 'linux_' + linux_distribution()
+    import distro
+    sysName = 'linux_' + '_'.join([distro.name(), distro.version(), distro.codename()])
     sysVer = platform.release()
 else:
     sysName = sysVer = 'n/a'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
     "pyobjc; platform_system == \"Darwin\"",
     "zeroconf; platform_system == \"Darwin\"",
     "python-xlib; platform_system == \"Linux\"",
+    "distro; platform_system == \"Linux\"",
     'tables<3.9; python_version < "3.9"',
     'tables; python_version >= "3.9"',
     'blosc2<2.2.8; python_version < "3.9"',  # dependency of tables


### PR DESCRIPTION
I noticed a "ModuleNotFoundError: No module named 'distro'" in the app log, and it looks like distro was not specified as a runtime dependency when switching to pdm?

It looks like distro.linux_distribution() has been deprecated since ~2021, so replaced those calls with something functionally similar. The main difference is that the original function returned a prettier codename (e.g. "Focal Fossa" instead of "focal"), but as far as I can tell that shouldn't have practical impacts?