### PR TITLE
PKG: fix code to extract base version string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,7 +139,7 @@ requires = [
     "distro; platform_system == \"Linux\"",
     "tomlkit",
     "packaging",
-    "six", 
+    "six",  # for configobj
     ]
 build-backend = "pdm.backend"
 


### PR DESCRIPTION
We already have packaging.version so let's use that to fetch the baseversion