### PR TITLE
BF: Save mouse.corr for online studies

### DIFF
--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -192,7 +192,7 @@ class MouseComponent(BaseComponent):
             "// check whether click was in correct object\n"
             "if (gotValidClick) {\n"
             "    corr = 0;\n"
-            "    corrAns = %(correctAns)s;\n"
+            "    corrAns = eval( %(correctAns)s);\n"
             "    for (let obj of [corrAns]) {\n"
             "        if (obj.contains(%(name)s)) {\n"
             "            corr = 1;\n"


### PR DESCRIPTION
Mouse.corr was not storing for online studies because the value fed into the correct field was being read as a string not a variable. 

Similar to this fix. https://github.com/psychopy/psychopy/pull/6668

Previously was returning obj.contains is not a function because the value fed into the correct field needs to be interpreted as the name of an object not a string.