### PR TITLE
FF: Fix opacity not applying properly to border colors

### DIFF
--- a/psychopy/visual/basevisual.py
+++ b/psychopy/visual/basevisual.py
@@ -1762,17 +1762,10 @@ class BaseVisualStim(MinimalStim, WindowMixin, LegacyVisualMixin):
         (transparent). :ref:`Operations <attrib-operations>` are supported.
         Precisely how this is used depends on the :ref:`blendMode`.
         """
-        alphas = []
-        if hasattr(self, '_foreColor'):
-            alphas.append(self._foreColor.alpha)
-        if hasattr(self, '_fillColor'):
-            alphas.append(self._fillColor.alpha)
-        if hasattr(self, '_borderColor'):
-            alphas.append(self._borderColor.alpha)
-        if alphas:
-            return mean(alphas)
-        else:
+        if not hasattr(self, "_opacity"):
             return 1
+        
+        return self._opacity 
 
     @opacity.setter
     def opacity(self, value):
@@ -1780,6 +1773,7 @@ class BaseVisualStim(MinimalStim, WindowMixin, LegacyVisualMixin):
         if value is None:
             # If opacity is set to be None, this indicates that each color should handle its own opacity
             return
+        self._opacity = value
         if hasattr(self, '_foreColor'):
             if self._foreColor != None:
                 self._foreColor.alpha = value

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -371,7 +371,7 @@ class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
             GL.glLineWidth(self.lineWidth)
             if self.opacity is not None:
                 borderRGBA = self._borderColor.render('rgba1')
-                borderRGBA[-1] = 2. * self.opacity - 1.  # override opacity
+                borderRGBA[-1] = self.opacity  # override opacity
                 GL.glColor4f(*borderRGBA)
             else:
                 GL.glColor4f(*self._borderColor.render('rgba1'))


### PR DESCRIPTION
Opacity is already between 0 and 1, so doesn't need to be transformed to fit with an rgba1 color scheme