### PR TITLE
BF: Creating project from ribbon raised error

### DIFF
--- a/psychopy/app/ribbon.py
+++ b/psychopy/app/ribbon.py
@@ -1005,7 +1005,7 @@ class PavloviaProjectCtrl(FrameRibbonDropdownButton):
         else:
             name = path = ""
         # open dlg to create new project
-        createDlg = sync.CreateDlg(self,
+        createDlg = sync.CreateDlg(self.frame,
                                    user=pavlovia.getCurrentSession().user,
                                    name=name,
                                    path=path)


### PR DESCRIPTION
Because the new project dialog was given the ribbon button as its parent, not the Builder frame (which has the necessary attributes). Fixes #6703