### PR TITLE
FF: "Param object has no attribute 'copy'" error

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -347,8 +347,11 @@ class Param():
             return False
         # if not a clear alias, use bool method of value
         return bool(self.val)
-
-    def __deepcopy__(self, memo):
+    
+    def copy(self):
+        """
+        Create a copy of this Param object
+        """
         return Param(
             val=self.val,
             valType=self.valType,
@@ -364,6 +367,9 @@ class Param():
             canBePath=self.canBePath,
             categ=self.categ
         )
+
+    def __deepcopy__(self, memo):
+        return self.copy()
 
     @property
     def _xml(self):


### PR DESCRIPTION
In #6702 I called `Param.copy` without realising it doesn't have a copy method 🤦 It's actually `__deepcopy__` (called during `copy.deepcopy`)

Fixed by moving the functionality to a .copy method and calling that in __deepcopy__