### PR TITLE
BF/RF: Code to load Builder-relevant entry points was broken and obsolete

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -574,52 +574,6 @@ def isStartUpPlugin(plugin):
     return plugin in listPlugins(which='startup')
 
 
-def loadPluginBuilderElements(plugin):
-    """
-    Load entry points from plugin which are relevant to Builder, e.g.
-    Component/Routine extensions for listing available hardware backends.
-
-    Parameters
-    ----------
-    plugin : str
-        Name of the plugin package to load. This usually refers to the package
-        or project name.
-
-    Returns
-    -------
-    bool
-        `True` if successful, `False` if failed.
-    """
-    # if plugin has already failed to load once, don't try again
-    if plugin in _failed_plugins_:
-        return False
-    # get entry points for plugin
-    ep = pluginEntryPoints(plugin)
-    # define modules in which entry points are relevant to Builder
-    modules = (
-        "psychopy.experiment.routines",
-        "psychopy.experiment.components",
-    )
-    # get any points pointing to these modules
-    relevantPoints = []
-    for mod in modules:
-        pts = ep.get(mod, {})
-        relevantPoints += list(pts.values())
-    # import all relevant classes
-    for point in relevantPoints:
-        try:
-            point.load()
-            return True
-        except Exception as err:
-            # if import failed for any reason, log error and mark failure
-            logging.error(
-                f"Failed to load {point.value}.{point.name} from plugin {plugin}. Original error: "
-                f"{err}"
-            )
-            _failed_plugins_.append(plugin)
-            return False
-
-
 def loadPlugin(plugin):
     """Load a plugin to extend PsychoPy.
 
@@ -1151,7 +1105,6 @@ def activatePlugins(which='all'):
     # load each plugin and apply any changes to Builder
     for plugin in listPlugins(which):
         loadPlugin(plugin)
-        loadPluginBuilderElements(plugin)
 
 
 # Keep track of currently installed window backends. When a window is loaded,

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -608,12 +608,13 @@ def loadPluginBuilderElements(plugin):
     # import all relevant classes
     for point in relevantPoints:
         try:
-            ep.load()
+            point.load()
             return True
-        except:
+        except Exception as err:
             # if import failed for any reason, log error and mark failure
             logging.error(
-                f"Failed to load {point.value}.{point.name} from plugin {plugin}."
+                f"Failed to load {point.value}.{point.name} from plugin {plugin}. Original error: "
+                f"{err}"
             )
             _failed_plugins_.append(plugin)
             return False


### PR DESCRIPTION
The original bug is that `loadPluginBuilderElements` (a function I wrote a while back) called load on the wrong object and so failed to load the entry points, logging an error but seemingly not breaking anything. The reason it didn't break anything is that the function is completely obsolete - all it does is load builder-relevant entry points, but all psychopy-relevant entry points are loaded in `activatePlugins` already. So this PR now just removes that function.