### PR TITLE
BF: fix trial data writing when there are multiple key presses including None

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -423,7 +423,9 @@ class TrialHandler(_BaseTrialHandler):
                 if hasattr(tmpData, 'tolist'):  # is a numpy array
                     strVersion = str(tmpData.tolist())
                     # for numeric data replace None with a blank cell
+                    replaceNone = False
                     if tmpData.dtype.kind not in 'SaUV':
+                        replaceNone = True
                         strVersion = strVersion.replace('None', '')
                 elif tmpData in [None, 'None']:
                     strVersion = ''
@@ -442,11 +444,18 @@ class TrialHandler(_BaseTrialHandler):
                 if (len(strVersion) and
                             strVersion[0] in '[(' and
                             strVersion[-1] in '])'):
+                    if replaceNone:
+                        # Add None back so that the str is valid for eval
+                        strVersion = strVersion.replace('[,', '[None,')
+                        strVersion = strVersion.replace(', ,', ', None,')
                     tup = eval(strVersion)  # convert back to a tuple
                     for entry in tup:
                         # contents of each entry is a list or tuple so keep in
                         # quotes to avoid probs with delim
-                        thisLine.append(str(entry))
+                        currentEntry = str(entry)
+                        if replaceNone:
+                            currentEntry = currentEntry.replace('None', '')
+                        thisLine.append(currentEntry)
                 else:
                     thisLine.extend(strVersion.split(','))
 

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -420,10 +420,10 @@ class TrialHandler(_BaseTrialHandler):
             for thisDataOut in dataOut:
                 # make a string version of the data and then format it
                 tmpData = dataAnal[thisDataOut][stimN]
+                replaceNone = False
                 if hasattr(tmpData, 'tolist'):  # is a numpy array
                     strVersion = str(tmpData.tolist())
                     # for numeric data replace None with a blank cell
-                    replaceNone = False
                     if tmpData.dtype.kind not in 'SaUV':
                         replaceNone = True
                         strVersion = strVersion.replace('None', '')

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -437,13 +437,13 @@ class TrialHandler(_BaseTrialHandler):
                     strVersion = "--"
                 # handle list of values (e.g. rt_raw )
                 if (len(strVersion) and
-                            strVersion[0] in '[(' and
-                            strVersion[-1] in '])'):
+                        strVersion[0] in '[(' and
+                        strVersion[-1] in '])'):
                     strVersion = strVersion[1:-1]  # skip first and last chars
                 # handle lists of lists (e.g. raw of multiple key presses)
                 if (len(strVersion) and
-                            strVersion[0] in '[(' and
-                            strVersion[-1] in '])'):
+                        strVersion[0] in '[(' and
+                        strVersion[-1] in '])'):
                     if replaceNone:
                         # Add None back so that the str is valid for eval
                         strVersion = strVersion.replace('[,', '[None,')

--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -423,7 +423,7 @@ class TrialHandler(_BaseTrialHandler):
                 if hasattr(tmpData, 'tolist'):  # is a numpy array
                     strVersion = str(tmpData.tolist())
                     # for numeric data replace None with a blank cell
-                    if tmpData.dtype.kind not in ['SaUV']:
+                    if tmpData.dtype.kind not in 'SaUV':
                         strVersion = strVersion.replace('None', '')
                 elif tmpData in [None, 'None']:
                     strVersion = ''


### PR DESCRIPTION
When there are multiple key presses in a trial, data from all trials are stored as a list of lists. However, for numerical data that underwent replacing `'None'` with `''`, this creates invalid syntaxes when converting `strVersion` back to a tuple using `eval()`.

This is because `eval("[1, , 2]")`, etc. is not a valid syntax. Current PR fixes the issue to allow an empty cell to be written into the output file for trials containing data in the form of lists of lists.