### PR TITLE
BF: Save to the color cache when rendering.

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -389,7 +389,8 @@ class Color:
         adj = np.clip(self.rgb * contrast, -1, 1)
         buffer = self.copy()
         buffer.rgb = adj
-        return getattr(buffer, space)
+        self._renderCache[space] = getattr(buffer, space)
+        return self._renderCache[space]
 
     def __repr__(self):
         """If colour is printed, it will display its class and value.


### PR DESCRIPTION
The _renderCache wasn't being used, and so the color was recomputed every call regardless of previous state. This improves some cases related to https://github.com/psychopy/psychopy/issues/6353, but not a total panacea. E.g. 

```python
from psychopy import visual
from timeit import default_timer
from statistics import mean, median

w = visual.Window([400, 400], checkTiming=False)
rct = []
for i in range(100):
    rct.append(visual.Rect(w, width=0.1, height=0.1, fillColor='red'))

times = []
for i in range(100):
    t0 = default_timer()
    for r in rct:
        r.draw()
    times.append(default_timer() - t0)
    w.flip()

w.close()

print(f'median: {median(times)}, mean: {mean(times)}')
```

Improves overall CPU time from ~17ms to ~4ms.