### PR TITLE
SYS: Hide Validator Routine until 2025.1

### DIFF
--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -19,7 +19,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
     iconFile = Path(__file__).parent / 'photodiode_validator.png'
     tooltip = _translate('Photodiode validator')
     deviceClasses = []
-    version = "2024.2.0"
+    version = "2025.1.0"
 
     def __init__(
             self,


### PR DESCRIPTION
As it's still only fully implemented for one device (the BBTK TPad), we're holding back until next release. Anyone curious can still use it by changing this one, it just won't be visible in the Components panel until next time.