### PR TITLE
FF: Plugin transcriber backends weren't recognised by Builder

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -497,7 +497,7 @@ class MicrophoneComponent(BaseDeviceComponent):
             inits['transcribeBackend'].val = None
         # Warn user if their transcriber won't work locally
         if inits['transcribe'].val:
-            if  inits['transcribeBackend'].val in self.localTranscribers:
+            if  self.params['transcribeBackend'].val in self.localTranscribers:
                 inits['transcribeBackend'].val = self.localTranscribers[self.params['transcribeBackend'].val]
             else:
                 default = list(self.localTranscribers.values())[0]
@@ -567,7 +567,7 @@ class MicrophoneComponent(BaseDeviceComponent):
     def writeRoutineEndCodeJS(self, buff):
         inits = getInitVals(self.params)
         inits['routine'] = self.parentName
-        if inits['transcribeBackend'].val in self.allTranscribers:
+        if self.params['transcribeBackend'].val in self.allTranscribers:
             inits['transcribeBackend'].val = self.allTranscribers[self.params['transcribeBackend'].val]
         # Warn user if their transcriber won't work online
         if inits['transcribe'].val and inits['transcribeBackend'].val not in self.onlineTranscribers.values():

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -30,14 +30,6 @@ except (ImportError, ModuleNotFoundError):
 # Get list of sample rates
 sampleRates = {r[1]: r[0] for r in sampleRateQualityLevels.values()}
 
-onlineTranscribers = {
-    "Google": "GOOGLE"
-}
-localTranscribers = {
-    "Google": "google"
-}
-allTranscribers = {**localTranscribers, **onlineTranscribers}
-
 
 class MicrophoneComponent(BaseDeviceComponent):
     """An event class for capturing short sound stimuli"""
@@ -49,6 +41,14 @@ class MicrophoneComponent(BaseDeviceComponent):
                          'duration), okay for spoken words')
     deviceClasses = ['psychopy.hardware.microphone.MicrophoneDevice']
 
+    # dict of available transcribers (plugins can add entries to this)
+    localTranscribers = {
+        "Google": "google",
+    }
+    onlineTranscribers = {
+        "Google": "google",
+    }
+
     def __init__(self, exp, parentName, name='mic',
                  startType='time (s)', startVal=0.0,
                  stopType='duration (s)', stopVal=2.0,
@@ -56,7 +56,7 @@ class MicrophoneComponent(BaseDeviceComponent):
                  channels='auto', device=None,
                  sampleRate='DVD Audio (48kHz)', maxSize=24000,
                  outputType='default', speakTimes=False, trimSilent=False,
-                 transcribe=False, transcribeBackend="Whisper",
+                 transcribe=False, transcribeBackend="none",
                  transcribeLang="en-US", transcribeWords="",
                  transcribeWhisperModel="base",
                  transcribeWhisperDevice="auto",
@@ -209,7 +209,8 @@ class MicrophoneComponent(BaseDeviceComponent):
 
         self.params['transcribeBackend'] = Param(
             transcribeBackend, valType='code', inputType='choice', categ='Transcription',
-            allowedLabels=list(allTranscribers), allowedVals=list(allTranscribers.values()),
+            allowedVals=list(self.allTranscribers.values()),
+            allowedLabels=list(self.allTranscribers),
             direct=False,
             hint=_translate("What transcription service to use to transcribe audio?"),
             label=_translate("Transcription backend")
@@ -281,7 +282,14 @@ class MicrophoneComponent(BaseDeviceComponent):
             "true": "show",  # what to do with param if condition is True
             "false": "hide",  # permitted: hide, show, enable, disable
         })
-
+    
+    @property
+    def allTranscribers(self):
+        """
+        Dict of all available transcribers (combines MicrophoneComponent.localTranscribers and 
+        MicrophoneComponent.onlineTranscribers)
+        """
+        return {'None': "none", **self.localTranscribers, **self.onlineTranscribers}
 
     def writeDeviceCode(self, buff):
         """
@@ -489,10 +497,10 @@ class MicrophoneComponent(BaseDeviceComponent):
             inits['transcribeBackend'].val = None
         # Warn user if their transcriber won't work locally
         if inits['transcribe'].val:
-            if  inits['transcribeBackend'].val in localTranscribers:
-                inits['transcribeBackend'].val = localTranscribers[self.params['transcribeBackend'].val]
+            if  inits['transcribeBackend'].val in self.localTranscribers:
+                inits['transcribeBackend'].val = self.localTranscribers[self.params['transcribeBackend'].val]
             else:
-                default = list(localTranscribers.values())[0]
+                default = list(self.localTranscribers.values())[0]
                 alert(4610, strFields={"transcriber": inits['transcribeBackend'].val, "default": default})
         # Store recordings from this routine
         code = (
@@ -559,11 +567,11 @@ class MicrophoneComponent(BaseDeviceComponent):
     def writeRoutineEndCodeJS(self, buff):
         inits = getInitVals(self.params)
         inits['routine'] = self.parentName
-        if inits['transcribeBackend'].val in allTranscribers:
-            inits['transcribeBackend'].val = allTranscribers[self.params['transcribeBackend'].val]
+        if inits['transcribeBackend'].val in self.allTranscribers:
+            inits['transcribeBackend'].val = self.allTranscribers[self.params['transcribeBackend'].val]
         # Warn user if their transcriber won't work online
-        if inits['transcribe'].val and inits['transcribeBackend'].val not in onlineTranscribers.values():
-            default = list(onlineTranscribers.values())[0]
+        if inits['transcribe'].val and inits['transcribeBackend'].val not in self.onlineTranscribers.values():
+            default = list(self.onlineTranscribers.values())[0]
             alert(4605, strFields={"transcriber": inits['transcribeBackend'].val, "default": default})
 
         # Write base end routine code


### PR DESCRIPTION
The MicrophoneComponent was just using a static variable which already had Whisper as an option (even when the plugin wasn't installed). This PR converts these to attributes of the MicrophoneComponent class, so that plugins can register backends by adding to these attributes. Will be accompanied by a PR to psychopy-whisper adding the necessary behaviour there to plug into this.

Ideally we should add an implementation like in ButtonBox and PhotodiodeValidator where backends are registered via a subclass with its own methods for writing init code, device code, etc. rather than having these hardcoded into PsychoPy, but that's a much bigger change for after the release.