### PR TITLE
FF: Set threshold to found value in findThreshold method

### DIFF
--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -459,7 +459,7 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
         # flip
         win.flip()
         # set to found threshold
-        self._setThreshold(int(threshold))
+        self._setThreshold(int(threshold), channel=channel)
 
         return int(threshold)
 

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -458,8 +458,10 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
         win.retrieveAutoDraw()
         # flip
         win.flip()
+        # set to found threshold
+        self._setThreshold(int(threshold))
 
-        return threshold
+        return int(threshold)
 
     def setThreshold(self, threshold, channel):
         if isinstance(channel, (list, tuple)):


### PR DESCRIPTION
Method was leaving threshold at the last value tried - which we never noticed as the last value was generally still perfectly within range. However the latest TPad firmware update introduces an inconsistency between the values returned on setting threshold (`AAO<channel> <threshold> -> <0 or 1>`) and the threshold at which the photodiode fires in data collection mode, so using this value gets too close to the fringes and makes this a problem.