### PR TITLE
Removes recording-enabled setting in Pupil Labs eyetrackers

### DIFF
--- a/docs/source/api/iohub/device/default_yaml_configs/default_pupil_core_eyetracker.yaml
+++ b/docs/source/api/iohub/device/default_yaml_configs/default_pupil_core_eyetracker.yaml
@@ -56,7 +56,6 @@ eyetracker.hw.pupil_labs.pupil_core.EyeTracker:
             port: 50020
             timeout_ms: 1000
         pupil_capture_recording:
-            enabled: True
             location: Null # Use Pupil Capture default recording location
         # Subscribe to pupil data only, does not require calibration or surface setup
         pupillometry_only: False

--- a/docs/source/api/iohub/device/default_yaml_configs/default_pupil_neon_eyetracker.yaml
+++ b/docs/source/api/iohub/device/default_yaml_configs/default_pupil_neon_eyetracker.yaml
@@ -53,5 +53,4 @@ eyetracker.hw.pupil_labs.neon.EyeTracker:
     runtime_settings:
         companion_address: neon.local
         companion_port: 8080
-        recording_enabled: True
         camera_calibration: scene_camera.json

--- a/psychopy/app/Resources/routine_templates/Basic.psyexp
+++ b/psychopy/app/Resources/routine_templates/Basic.psyexp
@@ -53,7 +53,6 @@
     <Param val="CONTINUOUS" valType="str" updates="None" name="mgMove"/>
     <Param val="0.5" valType="num" updates="None" name="mgSaccade"/>
     <Param val="0.6" valType="num" updates="None" name="plConfidenceThreshold"/>
-    <Param val="True" valType="bool" updates="None" name="plPupilCaptureRecordingEnabled"/>
     <Param val="" valType="str" updates="None" name="plPupilCaptureRecordingLocation"/>
     <Param val="127.0.0.1" valType="str" updates="None" name="plPupilRemoteAddress"/>
     <Param val="50020" valType="num" updates="None" name="plPupilRemotePort"/>

--- a/psychopy/app/Resources/routine_templates/Misc.psyexp
+++ b/psychopy/app/Resources/routine_templates/Misc.psyexp
@@ -53,7 +53,6 @@
     <Param val="CONTINUOUS" valType="str" updates="None" name="mgMove"/>
     <Param val="0.5" valType="num" updates="None" name="mgSaccade"/>
     <Param val="0.6" valType="num" updates="None" name="plConfidenceThreshold"/>
-    <Param val="True" valType="bool" updates="None" name="plPupilCaptureRecordingEnabled"/>
     <Param val="" valType="str" updates="None" name="plPupilCaptureRecordingLocation"/>
     <Param val="127.0.0.1" valType="str" updates="None" name="plPupilRemoteAddress"/>
     <Param val="50020" valType="num" updates="None" name="plPupilRemotePort"/>

--- a/psychopy/app/Resources/routine_templates/Online.psyexp
+++ b/psychopy/app/Resources/routine_templates/Online.psyexp
@@ -59,9 +59,7 @@
     <Param val="0.5" valType="num" updates="None" name="mgSaccade"/>
     <Param val="neon.local" valType="str" updates="None" name="plCompanionAddress"/>
     <Param val="8080" valType="num" updates="None" name="plCompanionPort"/>
-    <Param val="True" valType="bool" updates="None" name="plCompanionRecordingEnabled"/>
     <Param val="0.6" valType="num" updates="None" name="plConfidenceThreshold"/>
-    <Param val="True" valType="bool" updates="None" name="plPupilCaptureRecordingEnabled"/>
     <Param val="" valType="str" updates="None" name="plPupilCaptureRecordingLocation"/>
     <Param val="127.0.0.1" valType="str" updates="None" name="plPupilRemoteAddress"/>
     <Param val="50020" valType="num" updates="None" name="plPupilRemotePort"/>

--- a/psychopy/app/Resources/routine_templates/Trials.psyexp
+++ b/psychopy/app/Resources/routine_templates/Trials.psyexp
@@ -53,7 +53,6 @@
     <Param val="CONTINUOUS" valType="str" updates="None" name="mgMove"/>
     <Param val="0.5" valType="num" updates="None" name="mgSaccade"/>
     <Param val="0.6" valType="num" updates="None" name="plConfidenceThreshold"/>
-    <Param val="True" valType="bool" updates="None" name="plPupilCaptureRecordingEnabled"/>
     <Param val="" valType="str" updates="None" name="plPupilCaptureRecordingLocation"/>
     <Param val="127.0.0.1" valType="str" updates="None" name="plPupilRemoteAddress"/>
     <Param val="50020" valType="num" updates="None" name="plPupilRemotePort"/>

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -114,11 +114,9 @@ class SettingsComponent:
             plPupilRemoteAddress="127.0.0.1",
             plPupilRemotePort=50020,
             plPupilRemoteTimeoutMs=1000,
-            plPupilCaptureRecordingEnabled=True,
             plPupilCaptureRecordingLocation="",
             plCompanionAddress="neon.local",
             plCompanionPort=8080,
-            plCompanionRecordingEnabled=True,
             ecSampleRate='default',
             keyboardBackend="ioHub",
             filename=None, exportHTML='on Sync',
@@ -541,8 +539,8 @@ class SettingsComponent:
             "Tobii Technology": ["tbModel", "tbLicenseFile", "tbSerialNo", "tbSampleRate"],
             "Pupil Labs": ["plPupillometryOnly", "plSurfaceName", "plConfidenceThreshold",
                            "plPupilRemoteAddress", "plPupilRemotePort", "plPupilRemoteTimeoutMs",
-                           "plPupilCaptureRecordingEnabled", "plPupilCaptureRecordingLocation"],
-            "Pupil Labs (Neon)": ["plCompanionAddress", "plCompanionPort", "plCompanionRecordingEnabled"],
+                           "plPupilCaptureRecordingLocation"],
+            "Pupil Labs (Neon)": ["plCompanionAddress", "plCompanionPort"],
             "EyeLogic": ["ecSampleRate"],
         }
         for tracker in trackerParams:
@@ -734,11 +732,6 @@ class SettingsComponent:
             hint=_translate("Pupil remote timeout (ms)"),
             label=_translate("Pupil remote timeout (ms)"), categ="Eyetracking"
         )
-        self.params['plPupilCaptureRecordingEnabled'] = Param(
-            plPupilCaptureRecordingEnabled, valType='bool', inputType="bool",
-            hint=_translate("Pupil capture recording enabled"),
-            label=_translate("Pupil capture recording enabled"), categ="Eyetracking"
-        )
         self.params['plPupilCaptureRecordingLocation'] = Param(
             plPupilCaptureRecordingLocation, valType='str', inputType="single",
             hint=_translate("Pupil capture recording location"),
@@ -753,11 +746,6 @@ class SettingsComponent:
             plCompanionPort, valType='num', inputType="single",
             hint=_translate("Companion port"),
             label=_translate("Companion port"), categ="Eyetracking"
-        )
-        self.params['plCompanionRecordingEnabled'] = Param(
-            plCompanionRecordingEnabled, valType='bool', inputType="bool",
-            hint=_translate("Recording enabled"),
-            label=_translate("Recording enabled"), categ="Eyetracking"
         )
 
         # EyeLogic
@@ -1615,7 +1603,6 @@ class SettingsComponent:
 
                 # Define runtime_settings > pupil_capture_recording dict
                 code = (
-                    "'enabled': %(plPupilCaptureRecordingEnabled)s,\n"
                     "'location': %(plPupilCaptureRecordingLocation)s,\n"
                 )
                 buff.writeIndentedLines(code % inits)
@@ -1646,7 +1633,6 @@ class SettingsComponent:
                 code = (
                     "'companion_address': %(plCompanionAddress)s,\n"
                     "'companion_port': %(plCompanionPort)s,\n"
-                    "'recording_enabled': %(plCompanionRecordingEnabled)s,\n"
                 )
                 buff.writeIndentedLines(code % inits)
 


### PR DESCRIPTION
Perhaps this setting existed before the eyetracker start/stop functions existed, but now it seems superfluous.

This is paired with [a PR for the Pupil Labs eyetracker plugin](https://github.com/psychopy/psychopy-eyetracker-pupil-labs/pull/7)