### PR TITLE
BF: Fix Builder getting start/stop times when using non-slip timing

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1052,18 +1052,18 @@ class BaseComponent:
             params = self.params
 
         # If has a start, calculate it
-        if 'startType' in self.params:
+        if 'startType' in params:
             startTime, numericStart = self.getStart()
         else:
             startTime, numericStart = None, False
 
         # If has a stop, calculate it
-        if 'stopType' in self.params:
+        if 'stopType' in params:
             duration, numericStop = self.getDuration(startTime=startTime)
         else:
             duration, numericStop = 0, False
 
-        nonSlipSafe = numericStop and (numericStart or self.params['stopType'].val == 'time (s)')
+        nonSlipSafe = numericStop and (numericStart or params['stopType'].val == 'time (s)')
         return startTime, duration, nonSlipSafe
 
     def getPosInRoutine(self):

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1034,8 +1034,17 @@ class BaseComponent:
 
     def getStartAndDuration(self, params=None):
         """Determine the start and duration of the stimulus
+
+        When nonSlipSafe is False, the outputs of this function are used
         purely for Routine rendering purposes in the app (does not affect
-        actual drawing during the experiment)
+        actual drawing during the experiment).
+
+        When nonSlipSafe is True or when `forceNonSlip` is True, the outputs
+        of this function are used to determine maxTime of routine, which is
+        written into the generated script during writeMainCode() to as a part
+        of the stopping criteria of the routine while loop. In these two cases,
+        the outputs of this function does affect actual during during the
+        experiment (not only for Routine rendering purposes in the app).
 
         start, duration, nonSlipSafe = component.getStartAndDuration()
 

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -1078,8 +1078,8 @@ class Routine(list):
                     nonSlipSafe = False
                 if duration == FOREVER:
                     # only the *start* of an unlimited event should contribute
-                    # to maxTime
-                    duration = 0  # plus some minimal duration so it's visible
+                    # to maxTime, plus some minimal duration so it's visible
+                    duration = 0 if self.settings.params['forceNonSlip'] else 1
                 # now see if we have a end t value that beats the previous max
                 try:
                     # will fail if either value is not defined:


### PR DESCRIPTION
**Three things in this PR:**

1. BF of the other half of the bug during #6607 by 859a93a that I missed during #6615. Small scale bug that has only affected `EyetrackerRecordComponent` so far, but it's good to fix for the future.

2. There is a misleading function header in BaseComponent.getStartAndDuration() that hints that the method outputs do not affect stimulus presentation, which is not actually accurate when `nonSlipSafe==True`. This is especially a confusing problem due to recent #6603 that adds the `forceNonSlip` option to Routine setting. I've updated the method header to make it very clear how is nonSlip timing used downstream to prevent future bugs to get introduced here (I'm especially worried about future component subclasses overriding this method).

3. Right now it's hard to see components with `FOREVER` duration at the end of a routine because they are no longer adding some minimal duration to make it visible (updated in 26f862d5838fee03b7ef88e06acb92f691fcc23c, which is the right thing to change otherwise `forceNonSlip` won't work correctly). So I've made a QoL change to add back 1s minimal duration to visualize components better on the timeline, **unless** `forceNonSlip` is `True`, in which case there's probably a very good reason to do so, and the person can live with sub-optimal display.