### PR TITLE
BF: Set MovieComponent.status to FINISHED when playback finishes

### DIFF
--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -274,6 +274,7 @@ class MovieComponent(BaseVisualComponent):
         """
         buff.writeIndented("\n")
         buff.writeIndented("# *%s* updates\n" % self.params['name'])
+
         # writes an if statement to determine whether to draw etc
         indented = self.writeStartTestCode(buff)
         if indented:
@@ -286,7 +287,8 @@ class MovieComponent(BaseVisualComponent):
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)
 
-        indented = self.writeStopTestCode(buff)
+        # write code for stopping
+        indented = self.writeStopTestCode(buff, extra=" or %(name)s.isFinished")
         if indented:
             code = (
                 "%(name)s.setAutoDraw(False)\n"
@@ -296,6 +298,7 @@ class MovieComponent(BaseVisualComponent):
             buff.writeIndentedLines(code % self.params)
         # to get out of the if statement
         buff.setIndentLevel(-indented, relative=True)
+
         # set parameters that need updating every frame
         # do any params need updating? (this method inherited from _base)
         if self.checkNeedToUpdate('set every frame'):

--- a/psychopy/experiment/components/movie/__init__.py
+++ b/psychopy/experiment/components/movie/__init__.py
@@ -275,6 +275,16 @@ class MovieComponent(BaseVisualComponent):
         buff.writeIndented("\n")
         buff.writeIndented("# *%s* updates\n" % self.params['name'])
 
+        # set parameters that need updating every frame
+        # do any params need updating? (this method inherited from _base)
+        if self.checkNeedToUpdate('set every frame'):
+            code = "if %(name)s.status == STARTED:  # only update if being drawn\n" % self.params
+            buff.writeIndented(code)
+
+            buff.setIndentLevel(+1, relative=True)  # to enter the if block
+            self.writeParamUpdates(buff, 'set every frame')
+            buff.setIndentLevel(-1, relative=True)  # to exit the if block
+
         # writes an if statement to determine whether to draw etc
         indented = self.writeStartTestCode(buff)
         if indented:
@@ -299,15 +309,6 @@ class MovieComponent(BaseVisualComponent):
         # to get out of the if statement
         buff.setIndentLevel(-indented, relative=True)
 
-        # set parameters that need updating every frame
-        # do any params need updating? (this method inherited from _base)
-        if self.checkNeedToUpdate('set every frame'):
-            code = "if %(name)s.status == STARTED:  # only update if being drawn\n" % self.params
-            buff.writeIndented(code)
-
-            buff.setIndentLevel(+1, relative=True)  # to enter the if block
-            self.writeParamUpdates(buff, 'set every frame')
-            buff.setIndentLevel(-1, relative=True)  # to exit the if block
         # do force end of trial code
         if self.params['forceEndRoutine'].val is True:
             code = ("if %s.isFinished:  # force-end the Routine\n"


### PR DESCRIPTION
Just like a SoundComponent, movieComponent should also log the stopping time by using the new `extra=` argument to `writeStopTestCode()` that @TEParsons and I added.

Also, the parameter update block in the writeFrameCode() needs to occur before the other blocks (such as `.play()`), otherwise we see one frame that's not following the per-frame update rule.