### PR TITLE
DOC: Document Linux better and tee output

### DIFF
--- a/docs/source/download.rst
+++ b/docs/source/download.rst
@@ -104,20 +104,26 @@ On a MacOS machine, `brew` can be used to install |PsychoPy|::
 Linux
 ~~~~~~~~~~~~~~~~~
 
-We are aware that the procedure for installing on Linux is often rather painful. 
+We are aware that the procedure for installing on Linux is often rather painful.
 This is not the platform that the core PsychoPy developers currently use so support
 is less good than on some platforms. Feel free to jump in and help improve it as a
-contributor! :-) 
+contributor! :-)
 
 There used to be neurodebian and Gentoo packages for |PsychoPy| but these are both
-badly outdated. We'd recommend you do:
+badly outdated. We'd recommend you first make sure you have a compatible Python
+version installed (currently ``>=3.8, <3.11``). If you need an older version, you
+can on Ubuntu for example do:
 
 .. code-block:: bash
 
-    # with --no-deps flag if you want to install dependencies manually
-    pip install psychopy
+    sudo add-apt-repository ppa:deadsnakes/ppa
+    sudo apt update
+    sudo apt install python3.10-venv python3.10-dev
+    python3.10 -m venv path/to/new/psychopyenv  # choose a path of interest!
+    source path/to/new/psychopyenv/bin/activate
 
-**Then fetch a wxPython wheel** for your platform from:
+Once you have a compatible Python activated, **copy the link to a wxPython wheel** for
+your platform from:
 
 https://extras.wxpython.org/wxPython4/extras/linux/gtk3/
 
@@ -125,16 +131,28 @@ and having downloaded the right wheel you can then install it with something lik
 
 .. code-block:: bash
 
-  pip install path/to/your/wxpython.whl
+  pip install https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/wxPython-4.2.1-cp310-cp310-linux_x86_64.whl
 
-wxPython>4.0 and doesn't have universal wheels yet which is why you have to
+``wxPython>=4.0`` doesn't have universal wheels yet which is why you have to
 find and install the correct wheel for your particular flavor of linux.
+If a wheel is not yet available for your platform (e.g., a new version of Linux),
+you will have to build it manually. For example, you can use ``pip download wxPython``,
+extract the archive, enter the directory, and try ``python setup.py bdist_wheel`` to
+build a wheel yourself. You will likely need to install some system build dependencies.
+Once it builds, you can install for example with ``pip install dist/wxPython*.whl``.
 
 For some reasons wxPython (wx.html2) is using an older version of libwebkitgtk
 e.g. psychopy will not show up
 to fix this (of our own risk):
 sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu bionic main universe'
 sudo apt install -t bionic libwebkitgtk-1.0-0
+
+Finally, you can do:
+
+.. code-block:: bash
+
+    # with --no-deps flag if you want to install dependencies manually
+    pip install psychopy
 
 **Building Python PsychToolbox bindings:**
 
@@ -160,14 +178,14 @@ as needed:
 Anaconda and Miniconda
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Support for conda was contributed and is badly outdated but you may be able to 
-get it working using `pip install` within your conda environment. 
+Support for conda was contributed and is badly outdated but you may be able to
+get it working using `pip install` within your conda environment.
 
 Generally we recommend you use StandalonePsychoPy instead, for experiment creation,
 as an entirely separate app, and use your conda installation for other (e.g. analysis)
 scripts.
 
-Alternatively if someone wants to jump in and get things working here again that 
+Alternatively if someone wants to jump in and get things working here again that
 would be appreciated by other users I'm sure.
 
 .. _developers_install:

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -33,6 +33,28 @@ _psychopyAppInstance = None
 REQUIRES_RESTART = False
 
 
+# Adapted from
+# https://code.activestate.com/recipes/580767-unix-tee-like-functionality-via-a-python-class/
+# (BSD 3-Clause)
+class _Tee(object):
+    def __init__(self, fid):
+        self._other_fid = fid
+
+    def write(self, s):
+        sys.__stdout__.write(s)
+        self._other_fid.write(s)
+
+    def writeln(self, s):
+        self.write(s + '\n')
+
+    def close(self):
+        self._other_fid.close()
+
+    def flush(self):
+        self._other_fid.flush()
+        sys.__stdout__.flush()
+
+
 def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     """Start the PsychoPy GUI.
 
@@ -88,7 +110,7 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
 
         # NOTE - messages and errors cropping up before this point will go to
         # console, afterwards to 'last_app_load.log'.
-        sys.stderr = sys.stdout = lastRunLog  # redirect output to file
+        sys.stderr = sys.stdout = _Tee(lastRunLog)  # redirect output to file
 
     # Create the application instance which starts loading it.
     # If `testMode==True`, all messages and errors (i.e. exceptions) will log to
@@ -148,7 +170,7 @@ def restartApp():
     """Restart the PsychoPy application instance.
 
     This will write a file named '.restart' to the user preferences directory
-    and quit the application. The presence of this file will indicate to the 
+    and quit the application. The presence of this file will indicate to the
     launcher parent process that the app should restart.
 
     The app restarts with the same arguments as the original launch. This is
@@ -160,11 +182,11 @@ def restartApp():
     """
     if not isAppStarted():
         return
-    
+
     # write a restart file to the user preferences directory
     from psychopy.preferences import prefs
     restartFilePath = os.path.join(prefs.paths['userPrefsDir'], '.restart')
-    
+
     with open(restartFilePath, 'w') as restartFile:
         restartFile.write('')  # empty file
 
@@ -288,7 +310,7 @@ def getAppFrame(frameName):
             _psychopyAppInstance.showRunner()
         else:
             raise AttributeError('Cannot load frame. Method not available.')
-        
+
         frameRef = getattr(_psychopyAppInstance, frameName, None)
 
     return frameRef


### PR DESCRIPTION
I just tried installing PsychoPy on Linux using `pip install psychopy` on Ubuntu 24.04 and it didn't work, so I figured I'd update the install docs a bit to mention:

1. How to get an older, PsychoPy-compatible Python (3.10) on your system
2. Provide some minimal breadcrumbs about how to get wxPython installed on newer Ubuntu (the wheels they provide only go up to 22.04)
3. Only suggest `pip install psychopy` *after* the wxPython step. Locally for me wxPython would not build properly as part of `pip install wxpython` (separately or as a PsychoPy dependency), which is probably a bug at their end. But the suggestion I have in there now to `pip download` then `python setup.py bdist_wheel` *did* work. But in any case, regardless of whether wheels are available for your platform or you have to build them manually, you probably want to do it before installing psychopy.
4. Improve the command-line output of running `psychopy`.

For (4 this involved creating a little `Tee` class that both writes to a file and to `sys.__stdout__`. This was inspired by the fact that during debugging when I was missing some stuff, I would get:
```
$ psychopy  # immediate exit with no output, but:
$ echo $?
1
```
With the `_Tee` in place, now I get something more informative because the output is printed in addition to going to the `last_app_load.log`:
```
$ psychopy
Traceback (most recent call last):
  File "/home/larsoner/python/virtualenvs/psychopy/bin/psychopy", line 8, in <module>
    sys.exit(main())
  File "/home/larsoner/python/psychopy/psychopy/app/psychopyApp.py", line 105, in main
    start_app()
  File "/home/larsoner/python/psychopy/psychopy/app/psychopyApp.py", line 27, in start_app
    _ = startApp(showSplash=showSplash)  # main loop
  File "/home/larsoner/python/psychopy/psychopy/app/__init__.py", line 117, in startApp
    from psychopy.app._psychopyApp import PsychoPyApp
  File "/home/larsoner/python/psychopy/psychopy/app/_psychopyApp.py", line 10, in <module>
    from psychopy.app.colorpicker import PsychoColorPicker
  File "/home/larsoner/python/psychopy/psychopy/app/colorpicker/__init__.py", line 9, in <module>
    import wx
ModuleNotFoundError: No module named 'wx'
```
When I check, this output does indeed mirror `$ cat ~/.psychopy3/last_app_load.log`.