### PR TITLE
BF: the py3.10 standalone app failed to launch on macos-arm chips

### DIFF
--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -21,46 +21,19 @@ def _localFunc():
 
 IOHUB_DIRECTORY = module_directory(_localFunc)
 
-def _usingRosetta():
-    """Check whether we are running under rosetta on a mac"""
-    if sys.platform != 'darwin' or platform.processor() != 'i386':
-        # platform.processor is actually the arch of binary not processor
-        return False
-    # running i386 python on mac needs more investigation
-    import subprocess
-    proc = subprocess.run(["sysctl", "-n", "sysctl.proc_translated"], capture_output=True, text=True)
-    if proc.returncode == 0 and proc.stdout.strip() == "1":
-        return True # confirmed we're using rosetta
-    elif proc.returncode == 0 and proc.stdout.strip() == "0":
-        return False # confirmed we're NOT using rosetta
-    else:  # older macs don't have sysctl.proc_translated
-        print2err('WARNING: unable to determine if running under rosetta. Assuming NOT')
-        return False
-
-def _haveTables():
-    """Check if tables is available (if safe to try)"""
-    # if running rosetta (i386 python on arm64 mac) then don't *try* to import tables
-    # anything else we can *try* to import tables and see if it fails
-    if _usingRosetta():
-        # if we try to load the tables module on arm64 we get a seg fault
-        # we don't want to even try until we can work out how to detect
-        # in advance whether the library is arm64 or not
-        print2err('WARNING: running on arm64 mac which may crash loading pytables. ',
-                'ioHub hdf5 datastore functionality will be disabled for now.')
-        return False
-    try:
-        import tables
-        return True
-    except ImportError:
-        print2err('WARNING: pytables package not found. ',
-                'ioHub hdf5 datastore functionality will be disabled.')
-        return False
-    except Exception:
-        printExceptionDetailsToStdErr()
-
-_DATA_STORE_AVAILABLE = _haveTables()
-if _DATA_STORE_AVAILABLE:
-    import tables  # not sure if any part of iohub needed this in the namespace
+try:
+    import tables
+    _DATA_STORE_AVAILABLE = True
+except ModuleNotFoundError:
+    print2err('WARNING: pytables package not found. ',
+            'ioHub hdf5 datastore functionality will be disabled.')
+    _DATA_STORE_AVAILABLE = False
+except ImportError:
+    print2err('WARNING: pytables package failed to load. ',
+            'ioHub hdf5 datastore functionality will be disabled.')
+    _DATA_STORE_AVAILABLE = False
+except Exception:
+    printExceptionDetailsToStdErr()
 
 from psychopy.iohub.constants import EventConstants, KeyboardConstants, MouseConstants
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,7 @@ dependencies = [
     "zeroconf; platform_system == \"Darwin\"",
     "python-xlib; platform_system == \"Linux\"",
     "distro; platform_system == \"Linux\"",
-    'tables<3.9; python_version < "3.9"',
-    'tables; python_version >= "3.9"',
-    'blosc2<2.2.8; python_version < "3.9"',  # dependency of tables
+    'tables==3.8.0',  # pin to 3.8.0 until Rosetta crash fixed
     "packaging>=24.1",
 ]
 


### PR DESCRIPTION
The issue is now [tracked down to pytables==3.9.2](https://github.com/PyTables/PyTables/issues/1186) and so we're pinning tables to 3.8.0 for now (for all platforms)