### PR TITLE
BF: Allow Microphone to be found by name OR index

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -64,11 +64,6 @@ def addComponent(compClass):
 
     # check type and attributes of the class
     if not issubclass(compClass, (BaseComponent, BaseVisualComponent)):
-        logging.warning(
-            "Component `{}` does not appear to be a subclass of "
-            "`psychopy.experiment.components._base.BaseComponent`. This will be skipped."
-            .format(compName)
-        )
         return
     elif not hasattr(compClass, 'categories'):
         logging.warning(


### PR DESCRIPTION
Needed because Microphone indices are shuffled whenever the PC restarts