### PR TITLE
BF: pin pip to 24.0 for plugins on py3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     ]
     
 dependencies = [
+    "pip==24.0",  # for plugins install. 24.1.2 broke py3.8 plugins (on macos)
     "numpy<2.0",  # use numpy<1.24 for psychopy<2023.1
     "scipy",
     "matplotlib",


### PR DESCRIPTION
fixes #6734

pip 24.1.2 works fine on py3.10 but crashes plugin install on py3.8 on macos

thanks to @mh105 for tracking down