### PR TITLE
Revert "BF: pin pip to 24.0 for plugins on py3.8"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     ]
     
 dependencies = [
-    "pip==24.0",  # for plugins install. 24.1.2 broke py3.8 plugins (on macos)
     "numpy<2.0",  # use numpy<1.24 for psychopy<2023.1
     "scipy",
     "matplotlib",


### PR DESCRIPTION
Reverts psychopy/psychopy#6758

We'll handle this at build time rather than in dependencies (it shouldn't be such a strict requirement)