### PR TITLE
ENH: Added "force end Routine" option for Sound Component

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -712,6 +712,19 @@ class BaseComponent:
         # write if statement and indent
         buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
+        # store stop
+        code = (
+            "// keep track of stop time/frame for later\n"
+            "%(name)s.tStop = t;  // not accounting for scr refresh\n"
+            "%(name)s.frameNStop = frameN;  // exact frame index\n"
+        )
+        buff.writeIndentedLines(code % params)
+        # set status
+        code = (
+            "// update status\n"
+            "%(name)s.status = PsychoJS.Status.FINISHED;\n"
+        )
+        buff.writeIndentedLines(code % params)
 
         # Return True if stop test was written
         return buff.indentLevel - startIndent

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -304,7 +304,7 @@ class SoundComponent(BaseDeviceComponent):
                 )
             else:
                 code += (
-                    "%(name)s.play();\n"
+                    "%(name)s.stop();\n"
                 )
             buff.writeIndentedLines(code % self.params)
             # end Routine if asked

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -290,15 +290,8 @@ class SoundComponent(BaseDeviceComponent):
             # stop playback
             code = (
                 "// stop playback\n"
+                "%(name)s.stop();\n"
             )
-            if self.params['syncScreenRefresh'].val:
-                code += (
-                    "psychoJS.window.callOnFlip(function(){ %(name)s.stop(); });\n"
-                )
-            else:
-                code += (
-                    "%(name)s.stop();\n"
-                )
             buff.writeIndentedLines(code % self.params)
             # end Routine if asked
             if self.params['forceEndRoutine']:

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -269,7 +269,7 @@ class SoundComponent(BaseDeviceComponent):
         )
         buff.writeIndentedLines(code % self.params)
 
-        # the sound object is unusual, because it is
+        # the sound object is unusual, because it is controlling the playback stream
         buff.writeIndented("// start/stop %(name)s\n" % (self.params))
         # do this EVERY frame, even before/after playing?
         self.writeParamUpdates(buff, 'set every frame', target="PsychoJS")
@@ -283,7 +283,7 @@ class SoundComponent(BaseDeviceComponent):
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines('}\n')
-        
+
         # are we stopping this frame?
         indented = self.writeStopTestCodeJS(buff, extra=" || %(name)s.isFinished")
         if indented:
@@ -331,20 +331,20 @@ class SoundComponent(BaseDeviceComponent):
             buff.writeIndentedLines(code % self.params)
 
     def writeParamUpdate(
-            self, 
-            buff, 
-            compName, 
-            paramName, 
-            val, 
+            self,
+            buff,
+            compName,
+            paramName,
+            val,
             updateType,
-            params=None, 
+            params=None,
             target="PsychoPy",
     ):
         """
         Overload BaseComponent.writeParamUpdate to handle special case for SoundComponent
         """
         # when writing param updates for Sound.sound, needs to be `setValue` in JS
-        # (this is intended as a temporary patch - please delete when `setSound` in JS can accept 
+        # (this is intended as a temporary patch - please delete when `setSound` in JS can accept
         # the same range of values as in Py)
         if target == 'PsychoJS' and paramName == "sound":
             # get logging string
@@ -360,12 +360,12 @@ class SoundComponent(BaseDeviceComponent):
         else:
             # do normal stuff for every other param
             BaseDeviceComponent.writeParamUpdate(
-                self, 
-                buff, 
-                compName, 
-                paramName, 
-                val, 
+                self,
+                buff,
+                compName,
+                paramName,
+                val,
                 updateType,
-                params=params, 
+                params=params,
                 target=target,
             )

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -48,13 +48,13 @@ class SoundComponent(BaseDeviceComponent):
         self.type = 'Sound'
         self.url = "https://www.psychopy.org/builder/components/sound.html"
         self.exp.requirePsychopyLibs(['sound'])
-        self.order += [
-            "sound",  "syncScreenRefresh",  # Basic tab
-            "speakerIndex",  # Device tab
-            "volume", "hamming", "stopWithRoutine", "forceEndRoutine"  # Playback tab
-        ]
 
         # --- Basic params ---
+        self.order += [
+            "sound",  
+            "syncScreenRefresh",
+        ]
+
         hnt = _translate("When does the Component end? (blank to use the "
                          "duration of the media)")
         self.params['stopVal'].hint = hnt
@@ -67,11 +67,6 @@ class SoundComponent(BaseDeviceComponent):
             hint=hnt,
             label=_translate("Sound"))
         _allowed = ['constant', 'set every repeat', 'set every frame']
-        self.params['volume'] = Param(
-            volume, valType='num', inputType="single", allowedTypes=[], updates='constant', categ='Playback',
-            allowedUpdates=_allowed[:],  # use a copy
-            hint=_translate("The volume (in range 0 to 1)"),
-            label=_translate("Volume"))
         msg = _translate(
             "A reaction time to a sound stimulus should be based on when "
             "the screen flipped")
@@ -82,6 +77,18 @@ class SoundComponent(BaseDeviceComponent):
             label=_translate("Sync start with screen"))
 
         # --- Playback params ---
+        self.order += [
+            "volume", 
+            "hamming", 
+            "stopWithRoutine", 
+            "forceEndRoutine",
+        ]
+        self.params['volume'] = Param(
+            volume, valType='num', inputType="single", allowedTypes=[], updates='constant', categ='Playback',
+            allowedUpdates=_allowed[:],  # use a copy
+            hint=_translate("The volume (in range 0 to 1)"),
+            label=_translate("Volume")
+        )
         self.params['hamming'] = Param(
             True, valType='bool', inputType="bool", updates='constant', categ='Playback',
             hint=_translate(
@@ -102,6 +109,9 @@ class SoundComponent(BaseDeviceComponent):
             label=_translate("Force end of Routine"))
 
         # --- Device params ---
+        self.order += [
+            "speakerIndex"
+        ]
         def getSpeakerLabels():
             from psychopy.hardware.speaker import SpeakerDevice
             labels = [_translate("Default")]

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -253,12 +253,13 @@ class SoundComponent(BaseDeviceComponent):
                 "%(name)s.stop()\n"
             )
             buff.writeIndentedLines(code % self.params)
-            # force end of Routine
-            code = (
-                "# %(name)s has finished playback, so force end Routine\n"
-                "continueRoutine = False\n"
-            )
-            buff.writeIndentedLines(code % self.params)
+            # force end of Routine if asked
+            if self.params['forceEndRoutine']:
+                code = (
+                    "# %(name)s has finished playback, so force end Routine\n"
+                    "continueRoutine = False\n"
+                )
+                buff.writeIndentedLines(code % self.params)
         # because of the 'if' statement of the time test
         buff.setIndentLevel(-indented, relative=True)
 

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -49,10 +49,12 @@ class SoundComponent(BaseDeviceComponent):
         self.url = "https://www.psychopy.org/builder/components/sound.html"
         self.exp.requirePsychopyLibs(['sound'])
         self.order += [
-            "sound",  # Basic tab
-            "volume", "hammingWindow",  # Playback tab
+            "sound",  "syncScreenRefresh",  # Basic tab
+            "speakerIndex",  # Device tab
+            "volume", "hamming", "stopWithRoutine", "forceEndRoutine"  # Playback tab
         ]
-        # params
+
+        # --- Basic params ---
         hnt = _translate("When does the Component end? (blank to use the "
                          "duration of the media)")
         self.params['stopVal'].hint = hnt
@@ -78,12 +80,8 @@ class SoundComponent(BaseDeviceComponent):
             updates='constant',
             hint=msg,
             label=_translate("Sync start with screen"))
+
         # --- Playback params ---
-        self.order += [
-            "hamming",
-            "stopWithRoutine",
-            "forceEndRoutine"
-        ]
         self.params['hamming'] = Param(
             True, valType='bool', inputType="bool", updates='constant', categ='Playback',
             hint=_translate(
@@ -101,14 +99,9 @@ class SoundComponent(BaseDeviceComponent):
             hint=_translate(
                 "Should the end of the sound cause the end of the Routine (e.g. trial)?"
             ),
-            label=_translate("Force end of Routine")
-        )
+            label=_translate("Force end of Routine"))
 
         # --- Device params ---
-        self.order += [
-            "speaker"
-        ]
-
         def getSpeakerLabels():
             from psychopy.hardware.speaker import SpeakerDevice
             labels = [_translate("Default")]
@@ -132,8 +125,7 @@ class SoundComponent(BaseDeviceComponent):
             hint=_translate(
                 "What speaker to play this sound on"
             ),
-            label=_translate("Speaker")
-        )
+            label=_translate("Speaker"))
 
     def writeDeviceCode(self, buff):
         inits = getInitVals(self.params)


### PR DESCRIPTION
Required a rewrite of the "stop" logic on the JS end to imitate isPlaying/isFinished until they're implemented in actual PsychoJS, as we need to know when the sound itself has finished if we're to end the Routine on the basis of it, but I've tested a few use cases out and it seems consistent with before.