### PR TITLE
BF: detected installed packages in standalone app for py3.10

### DIFF
--- a/psychopy/__init__.py
+++ b/psychopy/__init__.py
@@ -53,7 +53,7 @@ if 'installing' not in locals():
         # Custom environment variable for people using PsychoPy as a library,
         # who don't want to use the custom site-packages location. If set to 1,
         # this will disable the custom site-packages location. Packages will be
-        # installed in the default, system dependent user's site-packages 
+        # installed in the default, system dependent user's site-packages
         # location.
         useDefaultSite = os.environ['PSYCHOPYNOPACKAGES'] == '1'
 
@@ -76,6 +76,15 @@ if 'installing' not in locals():
 
         # set user site packages
         env['PYTHONUSERBASE'] = prefs.paths['packages']
+
+        # set environment variable for pip to get egg-info of installed packages
+        if sys.platform == 'darwin':
+            # python 3.8 cannot parse the egg-info of zip-packaged dists
+            # correctly, so pip install will always install extra copies
+            # of dependencies. On python 3.10, we can force importlib to
+            # avoid this issue, but we need to use an environment variable
+            if sys.version_info >= (3, 10):
+                env['_PIP_USE_IMPORTLIB_METADATA'] = 'True'
 
         # update environment, pass this to sub-processes (e.g. pip)
         os.environ.update(env)


### PR DESCRIPTION
@peircej I finally tracked down why does `pip install` during plugins manager ignore the existing package distributions under `/Applications/PsychoPy.app/Contents/Resources/lib/python<major>.<minor>`. This issue affects both py3.8 and py3.10 on macOS, but the Windows installations are fine because they organize the python distributions in a slightly different file structure.

The root cause is due to the way distributions are packaged for the macOS builds. For python versions <3.11, `pip` uses its internal `pkg_resources` backend to find distributions on `sys.path`. But `pkg_resources` doesn't correctly resolve the distribution info inside zip files, yielding no detected distributions even though the correct `sys.path` is present.

This issue is pretty difficult to overcome for py3.8 because `pkg_resources` expects `.disc-info` folders for distributions during resolution. And the alternative `importlib` backend inside `pip` requires [a `name` attribute of `PathDistribution` objects](https://github.com/pypa/pip/blob/a5bad4b2c63f6ec9b5bd9e6b074bed82e5337f1f/src/pip/_internal/metadata/importlib/_compat.py#L82) that is only available after python 3.10. 

On py3.10, I dug up an undocumented environment variable `_PIP_USE_IMPORTLIB_METADATA` to force `importlib` as the backend in order to find distributions on `sys.path`. Fortunately this works fine and prevents the PsychoPy plugins manager from installing potentially conflicting versions of other dependent packages (e.g., `numpy`, `pyserial`, etc.) when installing plugin packages.

In the long run though, the macOS builds might need to use a more `pip`-compatible file structure for packages shipped with the PsychoPy app. Reading distribution info from the `.zip` file [will be dropped after `pip 24.3`](https://github.com/pypa/pip/issues/12330). Maybe both the package and `.dist-info` folders can be put into `~/Contents/Resources/lib/python<major>.<minor>` (or using the `~/Contents/Resources/lib/python<major>.<minor>/site-packages` convention)? This way all versions of `pip` on both py3.8 and py3.10 can resolve these existing distributions on macOS. The CPython files can still live inside the `.zip` file.

**Here's an example output from Plugins & Packages GUI inside PsychoPy on py3.10 after this fix:**
```
>> /Applications/PsychoPy.app/Contents/MacOS/python -m pip install psychopy-crs --user --prefer-binary --no-input --no-color --disable-pip-version-check
Collecting psychopy-crs

DEPRECATION: Loading egg at /Applications/PsychoPy.app/Contents/Resources/lib/python310.zip is deprecated. pip 24.3 will enforce this behaviour change. A possible replacement is to use pip for package installation.. Discussion can be found at https://github.com/pypa/pip/issues/12330

  Using cached psychopy_crs-0.0.2-py3-none-any.whl.metadata (2.0 kB)
Requirement already satisfied: pyserial in ./lib/python310.zip (from psychopy-crs) (3.5)
Requirement already satisfied: numpy in ./lib/python310.zip (from psychopy-crs) (1.26.4)
Using cached psychopy_crs-0.0.2-py3-none-any.whl (67 kB)
Installing collected packages: psychopy-crs


####################### Finished installing psychopy-crs #######################
For more information about the Cambridge Research Systems devices plugin, read the documentation at:
https://psychopy.github.io/psychopy-crs/
```