### PR TITLE
BF: Builder files were marked as modified as soon as opened

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1359,7 +1359,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # update icons
         self.updateRunModeIcons()
         # update experiment mode
-        if self.exp is not None:
+        if self.exp is not None and self.exp.runMode != mode:
             self.exp.runMode = mode
             # mark as modified
             self.setIsModified(True)


### PR DESCRIPTION
Basically:
- Opening a file meant loading its saved pilot/run mode
- Loading this meant changing the toggle
- Changing the toggle raised an event
- The even changed the pilot/run mode
- Changing the pilot/run mode marked the file as modified

The solution is to have changing the pilot/run mode only mark modified if changing it to something different from before.