### PR TITLE
FF: fix startView on macOS that opens psychopyApp.py

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -546,7 +546,11 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if arg.endswith(".psyexp"):
                 exps.append(arg)
             if arg.endswith(".py"):
-                scripts.append(arg)
+                if sys.platform == 'darwin' and arg.endswith("psychopyApp.py"):
+                    # in wx4 on mac this is called erroneously by App.__init__
+                    continue
+                else:
+                    scripts.append(arg)
             if "runner" not in startView and arg.endswith(".psyrun"):
                 runlist.append(arg)
         


### PR DESCRIPTION
The `defaultView` preference setting does not work correctly on macOS at the moment due to `psychopyApp.py` and the Coder view always get opened by default.