### PR TITLE
BF: Restore some backwards-compatability to GUI

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -229,8 +229,8 @@ class Dlg(QtWidgets.QDialog):
 
         return textLabel
 
-    def addField(self, key, label='', initial='', color='', choices=None, tip='',
-                 required=False, enabled=True):
+    def addField(self, key, initial='', color='', choices=None, tip='',
+                 required=False, enabled=True, label=None):
         """Adds a (labelled) input field to the dialogue box,
         optional text color and tooltip.
 
@@ -240,6 +240,10 @@ class Dlg(QtWidgets.QDialog):
 
         Returns a handle to the field (but not to the label).
         """
+        # if not given a label, use key (sans-pipe syntax)
+        if label is None:
+            label, _ = util.parsePipeSyntax(key)
+
         self.inputFieldNames.append(label)
         if choices:
             self.inputFieldTypes[label] = str
@@ -345,9 +349,9 @@ class Dlg(QtWidgets.QDialog):
         # set required (attribute is checked later by validate fcn)
         inputBox.required = required
 
-        if len(color):
+        if color is not None and len(color):
             inputBox.setPalette(inputLabel.palette())
-        if len(tip):
+        if tip is not None and len(tip):
             inputBox.setToolTip(tip)
         inputBox.setEnabled(enabled)
         self.layout.addWidget(inputBox, self.irow, 1)


### PR DESCRIPTION
When adding "pipe syntax" (the ability to specify a field as fixed, required, etc. by adding `|fix`, `|req`, etc.) we switched from using lists to manage the data in GUI to using a dict. Two problems arising from this are:
1. As fields now need to have a key to index by, I added a required parameter "key" to the beginning of `Dlg.addField`. This is fine if you're supplying named arguments to this function, but adding an arg to the beginning breaks positional arguments. This PR fixes this by moving the optional param `label` to the end - essentially shifting everything else forwards.
2. If `label` was not supplied, as is the case if previously supplying the labels via the first positional argument (which is now `key`), the labels were blank. To fix this, I've changed the default for `label` to `None` and, if left as None, it will inherit the value of `key` with any pipe syntax removed.

Addresses (but doesn't fully fix, as the output is still a dict so we still need to document this better) #6790 and #6781