### PR TITLE
BF: Fix whisper transcriber sometimes being initialised twice (and breaking as a result)

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -48,6 +48,10 @@ class MicrophoneComponent(BaseDeviceComponent):
     onlineTranscribers = {
         "Google": "google",
     }
+    # dict mapping transcriber names to importable paths
+    transcriberPaths = {
+        'google': "psychopy.sound.transcribe:GoogleCloudTranscriber"
+    }
 
     def __init__(self, exp, parentName, name='mic',
                  startType='time (s)', startVal=0.0,
@@ -352,13 +356,18 @@ class MicrophoneComponent(BaseDeviceComponent):
 
     def writeRunOnceInitCode(self, buff):
         inits = getInitVals(self.params)
+        # get transcriber path
+        if inits['transcribeBackend'].val in MicrophoneComponent.transcriberPaths:
+            inits['transcriberPath'] = MicrophoneComponent.transcriberPaths[inits['transcribeBackend'].val]
+        else:
+            inits['transcriberPath'] = inits['transcribeBackend'].val
         # check if the user wants to do transcription
         if inits['transcribe'].val:
             code = (
                 "# Setup speech-to-text transcriber for audio recordings\n"
                 "from psychopy.sound.transcribe import setupTranscriber\n"
                 "setupTranscriber(\n"
-                "    '%(transcribeBackend)s'")
+                "    '%(transcriberPath)s'")
         
             # handle advanced config options
             if inits['transcribeBackend'].val == 'Whisper':


### PR DESCRIPTION
Because `psychopy-whisper` defines an entry point targeting its transcriber, whisper is initialised whenever `activatePlugins` is called. Because the PsychoPy app runs in a different process to experiments, running a whisper experiment from Builder was loading whisper's DLLs twice in two processes, which whisper doesn't like.

The reason the entry point was needed is that `psychopy.sound.setupTranscriber` needs to know what class to setup from name, and to detect this it needed to have been loaded via entry point. The solution is to not refer to it by name from Builder, and instead simply give the full path as a string (so that `setupTranscriber` can then import it from the string). 

Accompanying commit in the psychopy-whisper repo:
https://github.com/psychopy/psychopy-whisper/commit/4d82ae41d860a782e4ac7a9e6fbf049c01920ad5
(we'll need to do a release of this to match)