### PR TITLE
BF: pyglet controls of macOS NSWindow with multiple screens 

### DIFF
--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -891,7 +891,7 @@ class DeviceManager:
                 win, text=str(n + 1),
                 size=1, pos=0,
                 alignment="center", anchor="center",
-                letterHeight=0.5, bold=True,
+                letterHeight=0.25, bold=True,
                 fillColor=None, color="white"
             )
             lbls.append(lbl)

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -345,13 +345,9 @@ class PygletBackend(BaseBackend):
             # (but need to alter x,y handling then)
             self.winHandle.set_mouse_visible(False)
         if not win.pos:
-            # work out where the centre should be
-            if win.useRetina:
-                win.pos = [(thisScreen.width - win.clientSize[0]/2) / 2,
-                           (thisScreen.height - win.clientSize[1]/2) / 2]
-            else:
-                win.pos = [(thisScreen.width - win.clientSize[0]) / 2,
-                           (thisScreen.height - win.clientSize[1]) / 2]
+            # work out the location of the top-left corner to place at the screen center
+            win.pos = [(thisScreen.width - win.clientSize[0]) / 2,
+                       (thisScreen.height - win.clientSize[1]) / 2]
         if not win._isFullScr:
             # add the necessary amount for second screen
             self.winHandle.set_location(int(win.pos[0] + thisScreen.x),

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -497,7 +497,7 @@ class Window():
 
         # parameters for transforming the overall view
         self.viewScale = val2array(viewScale)
-        if self.viewPos is not None and self.units is None:
+        if viewPos is not None and self.units is None:
             raise ValueError('You must define the window units to use viewPos')
         self.viewPos = val2array(viewPos, withScalar=False)
         self.viewOri = float(viewOri)


### PR DESCRIPTION
**Triple BFs**

One BF addresses the issues I reported in #6795, which turn out to come from an annoying shift of coordinate systems under macOS:
- pyglet `CocoaWindows` treats top left corner of the **shifted** main screen (i.e., x, y may not be 0) as the origin to determine the origin of the drawn window, and the positive direction is downward.
- Apple `NSWindow` however treats bottom left corner of the **unshifted** main screen as the origin to determine the origin of the drawn window, and the positive direction is upward.

This creates some mind-bending origin-shifts and offset calculations that remind me why I couldn't major in astrophysics... but after significant struggles I got it fixed!

Two bonus BFs:
1. we should use `viewPos` instead of `self.viewPos` when validating, since the latter isn't set yet.
2. `win.clientSize` returns normal large pixels when using Retina displays, so we shouldn't divide by 2 when setting default `win.pos` to the center of screen.