### PR TITLE
ENH: Add function to get parameters from stimuli, which you can use to recreate it

### DIFF
--- a/psychopy/tests/test_visual/test_basevisual.py
+++ b/psychopy/tests/test_visual/test_basevisual.py
@@ -1,12 +1,35 @@
 import json
-from pathlib import Path
-
 import pytest
-from psychopy import visual, layout, event
-from psychopy import colors
-from psychopy.monitors import Monitor
 from copy import copy
+from pathlib import Path
+from psychopy import visual, layout, event, colors
+from psychopy.tools.stimulustools import serialize
+from psychopy.monitors import Monitor
 from psychopy.tests import utils
+
+
+class _TestSerializationMixin:
+    """
+    Tests that stimuli can be serialized and recreated from serialized form.
+    """
+    # placeholders for object and window
+    obj = None
+    win = None
+
+    def test_serialization(self):
+        # skip if we don't have an object
+        if self.obj is None or self.win is None:
+            pytest.skip()
+        # start by flipping the window
+        self.win.flip()
+        # serialize object
+        params = serialize(self.obj)
+        # replace ref to window
+        params['win'] = self.win
+        # recreate object from params
+        dupe = type(self.obj)(**params)
+        # delete duplicate
+        del dupe
 
 
 class _TestColorMixin:

--- a/psychopy/tests/test_visual/test_basevisual.py
+++ b/psychopy/tests/test_visual/test_basevisual.py
@@ -4,7 +4,7 @@ import importlib
 from copy import copy
 from pathlib import Path
 from psychopy import visual, layout, event, colors
-from psychopy.tools.stimulustools import serialize
+from psychopy.tools.stimulustools import serialize, actualize
 from psychopy.monitors import Monitor
 from psychopy.tests import utils
 
@@ -25,15 +25,12 @@ class _TestSerializationMixin:
         self.win.flip()
         # serialize object
         params = serialize(self.obj, includeClass=True)
-        # replace ref to window
+        # substitute win
         params['win'] = self.win
-        # get class
-        mod = importlib.import_module(params.pop('__module__'))
-        cls = getattr(mod, params.pop('__class__'))
-        # check class is the same as obj
-        assert isinstance(self.obj, cls)
         # recreate object from params
-        dupe = cls(**params)
+        dupe = actualize(params)
+        # check object is same class
+        assert isinstance(dupe, type(self.obj))
         # delete duplicate
         del dupe
 

--- a/psychopy/tests/test_visual/test_basevisual.py
+++ b/psychopy/tests/test_visual/test_basevisual.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import importlib
 from copy import copy
 from pathlib import Path
 from psychopy import visual, layout, event, colors
@@ -23,11 +24,16 @@ class _TestSerializationMixin:
         # start by flipping the window
         self.win.flip()
         # serialize object
-        params = serialize(self.obj)
+        params = serialize(self.obj, includeClass=True)
         # replace ref to window
         params['win'] = self.win
+        # get class
+        mod = importlib.import_module(params.pop('__module__'))
+        cls = getattr(mod, params.pop('__class__'))
+        # check class is the same as obj
+        assert isinstance(self.obj, cls)
         # recreate object from params
-        dupe = type(self.obj)(**params)
+        dupe = cls(**params)
         # delete duplicate
         del dupe
 

--- a/psychopy/tests/test_visual/test_button.py
+++ b/psychopy/tests/test_visual/test_button.py
@@ -1,9 +1,9 @@
 from psychopy import visual
-from psychopy.tests.test_visual.test_basevisual import _TestColorMixin
+from psychopy.tests.test_visual.test_basevisual import _TestColorMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 
 
-class TestButton(_TestColorMixin, _TestBoilerplateMixin):
+class TestButton(_TestColorMixin, _TestBoilerplateMixin, _TestSerializationMixin):
 
     @classmethod
     def setup_class(self):

--- a/psychopy/tests/test_visual/test_circle.py
+++ b/psychopy/tests/test_visual/test_circle.py
@@ -2,12 +2,12 @@ from pathlib import Path
 
 import pytest
 from psychopy import visual
-from .test_basevisual import _TestColorMixin, _TestUnitsMixin
+from .test_basevisual import _TestColorMixin, _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from .. import utils
 
 
-class TestCircle(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin):
+class TestCircle(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
 
     @classmethod
     def setup_class(self):

--- a/psychopy/tests/test_visual/test_form.py
+++ b/psychopy/tests/test_visual/test_form.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from pandas import DataFrame
 
-from psychopy.tests.test_visual.test_basevisual import _TestColorMixin
+from psychopy.tests.test_visual.test_basevisual import _TestColorMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy.visual.window import Window
 from psychopy.visual.form import Form
@@ -19,7 +19,7 @@ from tempfile import mkdtemp
 import numpy as np
 
 
-class Test_Form(_TestColorMixin, _TestBoilerplateMixin):
+class Test_Form(_TestColorMixin, _TestBoilerplateMixin, _TestSerializationMixin):
     """Test suite for Form component"""
 
     def setup_class(self):

--- a/psychopy/tests/test_visual/test_image.py
+++ b/psychopy/tests/test_visual/test_image.py
@@ -1,12 +1,12 @@
 from pathlib import Path
 
 from psychopy import visual, colors, core
-from .test_basevisual import _TestUnitsMixin
+from .test_basevisual import _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy.tests import utils
 import pytest
 
-class TestImage(_TestUnitsMixin, _TestBoilerplateMixin):
+class TestImage(_TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
     """
     Test that images render as expected. Note: In BaseVisual tests, image colors will look different than
     seems intuitive as foreColor will be set to `"blue"`.

--- a/psychopy/tests/test_visual/test_progress.py
+++ b/psychopy/tests/test_visual/test_progress.py
@@ -1,11 +1,11 @@
 from psychopy import visual
-from .test_basevisual import _TestColorMixin, _TestUnitsMixin
+from .test_basevisual import _TestColorMixin, _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy.tests import utils
 from pathlib import Path
 
 
-class TestProgress(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin):
+class TestProgress(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
 
     @classmethod
     def setup_class(cls):

--- a/psychopy/tests/test_visual/test_roi.py
+++ b/psychopy/tests/test_visual/test_roi.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from .test_basevisual import _TestUnitsMixin
+from .test_basevisual import _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy import visual, core
 
 
-class TestROI(_TestUnitsMixin, _TestBoilerplateMixin):
+class TestROI(_TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
 
     def setup_method(self):
         self.win = visual.Window([128,128], pos=[50,50], units="pix", allowGUI=False, autoLog=False)

--- a/psychopy/tests/test_visual/test_shape.py
+++ b/psychopy/tests/test_visual/test_shape.py
@@ -1,11 +1,11 @@
 import pytest
 from psychopy import visual
-from .test_basevisual import _TestColorMixin, _TestUnitsMixin
+from .test_basevisual import _TestColorMixin, _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 
 
 
-class TestShape(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin):
+class TestShape(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
 
     @classmethod
     def setup_class(self):

--- a/psychopy/tests/test_visual/test_slider.py
+++ b/psychopy/tests/test_visual/test_slider.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from psychopy.tests import utils
-from psychopy.tests.test_visual.test_basevisual import _TestColorMixin
+from psychopy.tests.test_visual.test_basevisual import _TestColorMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy.visual.window import Window
 from psychopy.visual.slider import Slider
@@ -15,7 +15,7 @@ from numpy import array_equal
 import random
 
 
-class Test_Slider(_TestColorMixin, _TestBoilerplateMixin):
+class Test_Slider(_TestColorMixin, _TestBoilerplateMixin, _TestSerializationMixin):
     def setup_class(self):
 
         # Make a Window

--- a/psychopy/tests/test_visual/test_target.py
+++ b/psychopy/tests/test_visual/test_target.py
@@ -1,7 +1,7 @@
 from psychopy import visual, layout
-from .test_basevisual import _TestColorMixin, _TestUnitsMixin
+from .test_basevisual import _TestColorMixin, _TestUnitsMixin, _TestSerializationMixin
 
-class TestTarget(_TestUnitsMixin):
+class TestTarget(_TestUnitsMixin, _TestSerializationMixin):
     # Pixel which is the border color
     borderPoint = (0, 55)
     borderUsed = True

--- a/psychopy/tests/test_visual/test_textbox.py
+++ b/psychopy/tests/test_visual/test_textbox.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from psychopy import layout
 from psychopy.alerts._errorHandler import _BaseErrorHandler
-from psychopy.tests.test_visual.test_basevisual import _TestColorMixin, _TestUnitsMixin
+from psychopy.tests.test_visual.test_basevisual import _TestColorMixin, _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
 from psychopy.visual import Window
 from psychopy.visual import TextBox2
@@ -17,7 +17,7 @@ from psychopy.tests import utils
 
 
 @pytest.mark.textbox
-class Test_textbox(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin):
+class Test_textbox(_TestColorMixin, _TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
     def setup_method(self):
         self.win = Window((128, 128), pos=(50, 50), monitor="testMonitor", allowGUI=False, autoLog=False)
         self.error = _BaseErrorHandler()

--- a/psychopy/tests/test_visual/test_window.py
+++ b/psychopy/tests/test_visual/test_window.py
@@ -1,12 +1,29 @@
+import importlib
 from copy import copy
 from pathlib import Path
 
 from psychopy import visual, colors
 from psychopy.tests import utils
 from psychopy.tests.test_visual.test_basevisual import _TestColorMixin
+from psychopy.tools.stimulustools import serialize
 from psychopy import colors
 
 class TestWindow:
+    def test_serialization(self):
+        # make window
+        win = visual.Window()
+        # serialize window
+        params = serialize(win, includeClass=True)
+        # get class
+        mod = importlib.import_module(params.pop('__module__'))
+        cls = getattr(mod, params.pop('__class__'))
+        # check class is Window
+        assert isinstance(win, cls)
+        # recreate win from params
+        dupe = cls(**params)
+        # delete duplicate
+        dupe.close()
+
     def test_background_image_fit(self):
         _baseCases = [
             # no fitting

--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -9,6 +9,7 @@
 """
 
 import numpy
+import inspect
 from psychopy import logging
 from functools import partialmethod
 from psychopy.tools.stringtools import CaseSwitcher
@@ -44,6 +45,17 @@ class attributeSetter:
         #        origin[1], origin[3].__repr__())))  # long
         '''
         return newValue
+    
+    def serialize(self):
+        """
+        If an attributeSetter is received by serializer as an attribute, return the default value or 
+        None
+        """
+        defaults = inspect.getargspec(self.func).defaults
+        if defaults:
+            return defaults[0]
+        else:
+            return None
 
     def __repr__(self):
         return repr(self.__getattribute__)

--- a/psychopy/tools/stimulustools.py
+++ b/psychopy/tools/stimulustools.py
@@ -5,6 +5,13 @@ For example, lists of styles for Form/Slider, so that these static values
 can be quickly imported from here rather than importing `psychopy.visual` (which is slow)
 """
 
+import inspect
+import json
+import numpy as np
+from psychopy import logging
+from psychopy.tools.attributetools import attributeSetter
+
+
 formStyles = {
     'light': {
         'fillColor': [0.89, 0.89, 0.89],
@@ -26,3 +33,106 @@ formStyles = {
 
 sliderStyles = ['slider', 'rating', 'radio', 'scrollbar', 'choice']
 sliderStyleTweaks = ['labels45', 'triangleMarker']
+
+
+class SerializationError(Exception):
+    """
+    Error raised when serialize is called on a value which is not serializable.
+    """
+    pass
+
+
+def serialize(obj):
+    """
+    Get a JSON string representation of this stimulus, useful for recreating it in a different 
+    process. Will attempt to create a dict based on the object's `__init__` method, so that this 
+    can be used to create a new copy of the object. Attributes which are themselves serializable 
+    will be recursively serialized.
+
+    Parameters
+    ----------
+    obj : object
+        Object to serialize.
+    
+    Raises
+    ------
+    SerializationError
+        If the object is not already serialized and cannot be serialized.
+    
+    Returns
+    -------
+    str
+        Either a dict, or a JSON string of a dict, representing the object.
+    """
+    # handle numpy types
+    if isinstance(obj, np.integer):
+        obj = int(obj)
+    elif isinstance(obj, np.floating):
+        obj = float(obj)
+    elif isinstance(obj, np.ndarray):
+        obj = obj.tolist()
+    # if an array, serialize items
+    if isinstance(obj, (list, tuple)):
+        return [serialize(val) for val in obj]
+    if isinstance(obj, dict):
+        return {serialize(key): serialize(val) for key, val in obj.items()}
+    # if already json serializable, return as is
+    try:
+        json.dumps(obj)
+    except TypeError:
+        pass
+    except:
+        # if we got something other than a TypeError, substitute None
+        return None
+    else:
+        return obj
+    # if object defines its own serialization, use it
+    if hasattr(obj, "serialize"):
+        return obj.serialize()
+    
+    def _getAttr(obj, param):
+        """
+        Get serialized attribute value.
+        """
+        got = False
+        # if param looks to be stored in an attribute, add it
+        if hasattr(obj, param):
+            got = True
+            value = getattr(obj, param)
+        # if we have a get method for param, get its value
+        getParam = "get" + param[0].upper() + param[1:]
+        if hasattr(obj, getParam):
+            got = True
+            value = getattr(obj, getParam)()
+        # if we couldn't get a value, raise an error
+        if not got:
+            raise SerializationError(f"Could not get value for {type(obj).__name__}.{param}")
+
+        return serialize(value)
+    
+    # start off with an empty dict
+    arr = {}
+    # get init args
+    initArgs = inspect.getargspec(obj.__init__)
+    # if there are variable args, raise an error
+    if initArgs.varargs:
+        raise SerializationError("Cannot serialize object with variable args.")
+    # how many init args are required?
+    nReq = len(initArgs.args) - len(initArgs.defaults)
+    # get required params
+    for param in initArgs.args[:nReq]:
+        # skip self
+        if param == "self":
+            continue
+        # get attribute
+        arr[param] = _getAttr(obj, param)
+    # get optional params
+    for param in initArgs.args[nReq:]:
+        # get attribute, but don't worry if it fails
+        try:
+            arr[param] = _getAttr(obj, param)
+        except SerializationError:
+            pass
+    
+    return arr
+

--- a/psychopy/tools/stimulustools.py
+++ b/psychopy/tools/stimulustools.py
@@ -42,7 +42,7 @@ class SerializationError(Exception):
     pass
 
 
-def serialize(obj):
+def serialize(obj, includeClass=True):
     """
     Get a JSON string representation of this stimulus, useful for recreating it in a different 
     process. Will attempt to create a dict based on the object's `__init__` method, so that this 
@@ -53,6 +53,9 @@ def serialize(obj):
     ----------
     obj : object
         Object to serialize.
+    includeClass : bool
+        If True, serialized output will include a field `__class__` with the full path of the 
+        object's class.
     
     Raises
     ------
@@ -61,8 +64,8 @@ def serialize(obj):
     
     Returns
     -------
-    str
-        Either a dict, or a JSON string of a dict, representing the object.
+    dict
+        Dict representing the, if not already serializable.
     """
     # handle numpy types
     if isinstance(obj, np.integer):
@@ -108,7 +111,7 @@ def serialize(obj):
         if not got:
             raise SerializationError(f"Could not get value for {type(obj).__name__}.{param}")
 
-        return serialize(value)
+        return serialize(value, includeClass=False)
     
     # start off with an empty dict
     arr = {}
@@ -133,6 +136,11 @@ def serialize(obj):
             arr[param] = _getAttr(obj, param)
         except SerializationError:
             pass
+    
+    # add class
+    if includeClass:
+        arr['__class__'] = type(obj).__name__
+        arr['__module__'] = type(obj).__module__
     
     return arr
 

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -139,11 +139,13 @@ class PygletBackend(BaseBackend):
             win.stereo = False
 
         if sys.platform == 'darwin' and not win.useRetina and pyglet.version >= "1.3":
-            raise ValueError(
+            logging.warn(
                 "As of PsychoPy 1.85.3 OSX windows should all be set to "
                 "`useRetina=True` (or remove the argument). Pyglet 1.3 appears "
                 "to be forcing us to use retina on any retina-capable screen "
-                "so setting to False has no effect.")
+                "so setting to False has no effect."
+            )
+            win.useRetina = True
 
         # window framebuffer configuration
         bpc = backendConf.get('bpc', (8, 8, 8))


### PR DESCRIPTION
The main use of this is ioHub - because it runs in a separate process, we can't pass object handles directly, so have to recreate any stimuli. Making all stimuli serializable means we can pass a JSON string between processes and use it to recreate the stimulus on the other end, meaning *any* stimulus is then able to use used in calibration/validation, not just TargetStim.