### PR TITLE
BF: Clear listeners when closing a MicrophoneDevice

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -782,6 +782,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         session.
 
         """
+        self.clearListeners()
         self._stream.close()
         logging.debug('Stream closed')
 


### PR DESCRIPTION
Otherwise the listener will continue requesting data from a buffer which no longer exists