### PR TITLE
Backward compatibility for Dlg

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -240,9 +240,11 @@ class Dlg(QtWidgets.QDialog):
 
         Returns a handle to the field (but not to the label).
         """
-        # if not given a label, use key (sans-pipe syntax)
+        # if not given a label, mimics old Dlg behavior by creating a numeric key corresponding to order added, and
+        # uses whatever string was entered as key (sans-pipe syntax)
         if label is None:
             label, _ = util.parsePipeSyntax(key)
+            key = len(self.inputFieldNames) # current length before new entry added
 
         self.inputFieldNames.append(label)
         if choices:


### PR DESCRIPTION
If old gui.Dlg syntax is used for addField (i.e., no label provided), then the label is created from the key argument, and the dictionary key is just the list index of the field name.

This means that it supports the old behavior for both creating fields and accessing data from the Dlg (i.e., you can refer to it by list index in the order the fields were added, since the index is now just a numeric key for the relevant dict entry).

Addresses #6790 and #6781 