### PR TITLE
BF: Distinguish between a trial that's been skipped and a trial that's currently skipping

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -8,7 +8,7 @@ import copy
 import numpy as np
 import pandas as pd
 
-from psychopy import logging
+from psychopy import logging, constants
 from psychopy.tools.filetools import (openOutputFile, genDelimiter,
                                       genFilenameFromDelimiter)
 from .utils import importConditions
@@ -756,6 +756,8 @@ class Trial(dict):
         self.thisRepN = thisRepN
         self.thisTrialN = thisTrialN
         self.thisIndex = thisIndex
+        # add status
+        self.status = constants.NOT_STARTED
         # data for this trial
         if data is None:
             data = {}
@@ -1242,6 +1244,8 @@ class TrialHandler2(_BaseTrialHandler):
                 f"Skipping to the last upcoming trial."
             )
             n = len(self.upcomingTrials)
+        # mark as skipping so routines end
+        self.thisTrial.status = constants.STOPPING
         # before iterating, add "skipped" to data
         self.addData("skipped", True)
         # iterate n times (-1 to account for current trial)
@@ -1274,8 +1278,8 @@ class TrialHandler2(_BaseTrialHandler):
                 f"elapsed. Rewinding to the first trial."
             )
             n = len(self.elapsedTrials)
-        # mark current trial as skipped so it ends
-        self.addData("skipped", True)
+        # mark current trial as skipping so it ends
+        self.thisTrial.status = constants.STOPPING
         # start with no trials
         rewound = [self.thisTrial]
         # pop the last n values from elapsed trials

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -913,10 +913,10 @@ class SettingsComponent:
         buff.write(
             "from psychopy import %s\n" % ', '.join(psychopyImports) +
             "from psychopy.tools import environmenttools\n"
-            "from psychopy.constants import (NOT_STARTED, STARTED, PLAYING,"
-            " PAUSED,\n"
-            "                                STOPPED, FINISHED, PRESSED, "
-            "RELEASED, FOREVER, priority)\n\n"
+            "from psychopy.constants import (\n"
+            "    NOT_STARTED, STARTED, PLAYING, PAUSED, STOPPED, STOPPING, FINISHED, PRESSED, \n"
+            "    RELEASED, FOREVER, priority\n"
+            ")\n\n"
             "import numpy as np  # whole numpy lib is available, "
             "prepend 'np.'\n"
             "from numpy import (%s,\n" % ', '.join(_numpyImports[:7]) +

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -216,8 +216,14 @@ class TrialHandler(_BaseLoopHandler):
         # then run the trials loop
         code = "\nfor %s in %s:\n"
         buff.writeIndentedLines(code % (self.thisName, self.params['name']))
-        # fetch parameter info from conditions
         buff.setIndentLevel(1, relative=True)
+        # mark current trial as started
+        code = (
+            "if hasattr(%(thisName)s, 'status'):\n"
+            "    %(thisName)s.status = STARTED\n"
+        )
+        buff.writeIndentedLines(code % {'thisName': self.thisName})
+        # fetch parameter info from conditions
         code = (
             "currentLoop = %(name)s\n"
             "thisExp.timestampOnFlip(win, 'thisRow.t', format=globalClock.format)\n"
@@ -345,6 +351,12 @@ class TrialHandler(_BaseLoopHandler):
         )
 
     def writeLoopEndCode(self, buff):
+        # mark current trial as finished at end of each iteration
+        code = (
+            "if hasattr(%(thisName)s, 'status'):\n"
+            "    %(thisName)s.status = FINISHED\n"
+        )
+        buff.writeIndentedLines(code % {'thisName': self.thisName})
         # Just within the loop advance data line if loop is whole trials
         if self.params['isTrials'].val == True:
             buff.writeIndentedLines(

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -700,7 +700,7 @@ class Routine(list):
             loop = self.exp.flow._loopList[-1]
             code = (
                 "# if trial has changed, end Routine now\n"
-                "if hasattr({thisName}, 'skipped') and {thisName}.skipped:\n"
+                "if hasattr({thisName}, 'status') and {thisName}.status == STOPPING:\n"
                 "    continueRoutine = False\n"
             ).format(thisName=loop.thisName)
             buff.writeIndentedLines(code)

--- a/psychopy/tests/test_misc/test_clock.py
+++ b/psychopy/tests/test_misc/test_clock.py
@@ -6,6 +6,7 @@ import numpy as np
 from psychopy.clock import wait, StaticPeriod, CountdownTimer
 from psychopy.visual import Window
 from psychopy.tools import systemtools
+from psychopy.tests import skip_under_vm
 
 
 def test_StaticPeriod_finish_on_time():
@@ -36,6 +37,7 @@ def test_StaticPeriod_recordFrameIntervals():
     win.close()
 
 
+@skip_under_vm
 def test_StaticPeriod_screenHz():
     """Test if screenHz parameter is respected, i.e., if after completion of the
     StaticPeriod, 1/screenHz seconds are still remaining, so the period will

--- a/psychopy/tests/test_misc/test_event.py
+++ b/psychopy/tests/test_misc/test_event.py
@@ -95,6 +95,7 @@ class _baseTest():
         event._onPygletMouseRelease(0, 0, LEFT | MIDDLE | RIGHT, None, emulated=True)
         assert not any(event.mouseButtons)
 
+    @skip_under_vm
     def test_mouse_clock(self):
         x, y = 0, 0
         scroll_x, scroll_y = 1, 1


### PR DESCRIPTION
Otherwise TrialHandler2.rewindTrials will skip the trial you were on when you rewound once it gets back to it, because it's now marked as skipped. We need to distinguished between "this has been skipped before" and "this needs to end its Routines"