### PR TITLE
BF: Make output of Dlg.show backwards compatible with older versions

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -8,6 +8,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 import importlib
 from psychopy import logging, data
+from psychopy.tools.arraytools import IndexDict
 from . import util
 
 haveQt = False  # until we confirm otherwise
@@ -167,7 +168,7 @@ class Dlg(QtWidgets.QDialog):
         self.inputFields = []
         self.inputFieldTypes = {}
         self.inputFieldNames = []
-        self.data = {}
+        self.data = IndexDict()
         self.irow = 0
         self.pos = pos
         # QtWidgets.QToolTip.setFont(QtGui.QFont('SansSerif', 10))

--- a/psychopy/gui/wxgui.py
+++ b/psychopy/gui/wxgui.py
@@ -15,6 +15,8 @@ import os
 from psychopy.localization import _translate
 from packaging.version import Version
 
+from psychopy.tools.arraytools import IndexDict
+
 OK = wx.ID_OK
 
 thisVer = Version(wx.__version__)
@@ -282,10 +284,9 @@ class DlgFromDict(Dlg):
         # app = ensureWxApp() done by Dlg
         super().__init__(title)
 
-        if copyDict:
-            self.dictionary = dictionary.copy()
-        else:
-            self.dictionary = dictionary
+        self.copyDict = copyDict
+        self.originalDictionary = dictionary
+        self.dictionary = IndexDict(dictionary)
 
         self._keys = list(self.dictionary.keys())
 
@@ -319,6 +320,11 @@ class DlgFromDict(Dlg):
         if self.OK:
             for n, thisKey in enumerate(self._keys):
                 self.dictionary[thisKey] = self.data[n]
+            # if not copying dict, set values in-place
+            if not self.copyDict:
+                self.originalDictionary[thisKey] = self.data[thisKey]
+            
+            return self.dictionary
 
 
 def fileSaveDlg(initFilePath="", initFileName="",

--- a/psychopy/tests/test_tools/test_arraytools.py
+++ b/psychopy/tests/test_tools/test_arraytools.py
@@ -200,7 +200,7 @@ class TestIndexDict:
             {'set': (1, "pqr"), 'get': (1, "pqr")},
             # set by explicit key not yet in array
             {'set': ('newKey', "stu"), 'get': ('newKey', "stu")},
-            {'set': ('newKey', "stu"), 'get': (5, "stu")},
+            {'set': ('newKey', "stu"), 'get': (4, "stu")},
             # set by positional index not yet in array (should treat as explicit key)
             {'set': (6, "stu"), 'get': (6, "stu")},
         ]
@@ -227,9 +227,9 @@ class TestIndexDict:
         """
         cases = [
             # index bigger than array
-            (4, KeyError, "4 should be out of bounds, but got {}")
+            (4, KeyError, "4 should be out of bounds, but got {}"),
             # key not in array
-            ('lalala', KeyError, "There shouldn't be a value for 'lalala', but got {}")
+            ('lalala', KeyError, "There shouldn't be a value for 'lalala', but got {}"),
         ]
         for i, errType, msg in cases:
             try:

--- a/psychopy/tests/test_tools/test_arraytools.py
+++ b/psychopy/tests/test_tools/test_arraytools.py
@@ -199,10 +199,10 @@ class TestIndexDict:
             {'set': (1, "pqr"), 'get': ('someOtherKey', "def")},
             {'set': (1, "pqr"), 'get': (1, "pqr")},
             # set by explicit key not yet in array
-            {'set': ('newKey', "stu"), 'get': ('newKey', "stu")}
-            {'set': ('newKey', "stu"), 'get': (5, "stu")}
+            {'set': ('newKey', "stu"), 'get': ('newKey', "stu")},
+            {'set': ('newKey', "stu"), 'get': (5, "stu")},
             # set by positional index not yet in array (should treat as explicit key)
-            {'set': (6, "stu"), 'get': (6, "stu")}
+            {'set': (6, "stu"), 'get': (6, "stu")},
         ]
         # iterate through cases
         for case in cases:

--- a/psychopy/tests/test_tools/test_arraytools.py
+++ b/psychopy/tests/test_tools/test_arraytools.py
@@ -220,7 +220,7 @@ class TestIndexDict:
                 f"{repr(self.data[geti])}"
             )
     
-    def check_key_error(self):
+    def test_key_error(self):
         """
         Check that supplying an invalid key/index to an IndexDict still errors like a normal 
         dict/list

--- a/psychopy/tools/arraytools.py
+++ b/psychopy/tools/arraytools.py
@@ -21,6 +21,53 @@ import numpy
 import ctypes
 
 
+class IndexDict(dict):
+    """
+    A dict which allows for keys to be accessed by index as well as by key. Can be initialised 
+    from a dict, or from a set of keyword arguments.
+
+    Example
+    -------
+    ```
+    data = IndexDict({
+        'someKey': "abc",
+        'someOtherKey': "def",
+        'anotherOne': "ghi",
+        1: "jkl",
+    })
+    # using a numeric index will return the value for the key at that position
+    print(data[0])  # prints: abc
+    # ...unless that number is already a key
+    print(data[1])  # prints: jkl
+    ```
+    """
+    def __init__(self, arr=None, **kwargs):
+        # initialise dict
+        dict.__init__(self)
+        # if given no dict, use a blank one
+        if arr is None:
+            arr = {}
+        # if given a dict, update kwargs with it
+        kwargs.update(arr)
+        # set every key
+        for key, value in kwargs.items():
+            dict.__setitem__(self, key, value)
+    
+    def __getitem__(self, key):
+        # if key is a valid numeric index not present as a normal key, get matching key
+        if isinstance(key, int) and key < len(self) and key not in self:
+            return list(self.values())[key]
+        # index like normal
+        return dict.__getitem__(self, key)
+    
+    def __setitem__(self, key, value):
+        # if key is a valid numeric index not present as a normal key, get matching key
+        if isinstance(key, int) and key < len(self) and key not in self:
+            key = list(self.keys())[key]
+        # set like normal
+        return dict.__setitem__(self, key, value)
+
+
 def createXYs(x, y=None):
     """Create an Nx2 array of XY values including all combinations of the
     x and y values provided.


### PR DESCRIPTION
Implementing the class discussed in #6806, allowing data returned from Dlg.show to be indexed by either keys (as in a dict) or indices (as in a list). In situations where there's conflict, i.e. where one of the keys in the dict is explicitly states as an integer, the explicit key takes priority over the positional index. I've added some tests to be extra sure it's behaving as expected.

Flagging @jfkominsky to give this a look over, if you could pull down the branch and give it a try with your scripts that would be great

Fixes #6781 and #6790