### PR TITLE
BF: Reset the global clock after a pause, otherwise onflip timing breaks

### DIFF
--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -753,7 +753,7 @@ class Routine(list):
             "    pauseExperiment(\n"
             "        thisExp=thisExp, \n"
             "        win=win, \n"
-            "        timers=[routineTimer], \n"
+            "        timers=[routineTimer, globalClock], \n"
             "        playbackComponents=[{playbackComponentsStr}]\n"
             "    )\n"
             "    # skip the frame we paused on\n"


### PR DESCRIPTION
Pulling into dev as pause is only really used by the mega keen beans who are using Session with threading to run experiments asynchronously