### PR TITLE
BF: DlgFromDict was erroneously adding keys when given "order" or "fixed"

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -371,8 +371,10 @@ class Dlg(QtWidgets.QDialog):
         """Adds a field to the dialog box (like addField) but the field cannot
         be edited. e.g. Display experiment version.
         """
-        return self.addField(key, label, initial, color, choices, tip,
-                             enabled=False)
+        return self.addField(
+            key=key, label=label, initial=initial, color=color, choices=choices, tip=tip, 
+            enabled=False
+        )
 
     def addReadmoreCtrl(self):
         line = ReadmoreCtrl(self, label=_translate("Configuration fields..."))

--- a/psychopy/gui/util.py
+++ b/psychopy/gui/util.py
@@ -9,19 +9,9 @@ def makeDisplayParams(expInfo, sortKeys=True, labels=None, tooltips=None, fixed=
         labels = {}
     if tooltips is None:
         tooltips = {}
-    # convert fixed list to pipe syntax
-    if fixed is not None:
-        if isinstance(fixed, str):
-            fixed = [fixed]
-        for key in fixed:
-            if key in expInfo:
-                expInfo[f"{key}|fix"] = expInfo.pop(key)
-    # convert order list to pipe syntax
-    if order is not None:
-        for key in order:
-            i = order.index(key)
-            if key in expInfo:
-                expInfo[f"{key}|{i}"] = expInfo.pop(key)
+    # make sure fixed is a list
+    if isinstance(fixed, str):
+        fixed = [fixed]    
     # get keys as a list
     keys = list(expInfo)
     # sort alphabetically if requested
@@ -43,11 +33,17 @@ def makeDisplayParams(expInfo, sortKeys=True, labels=None, tooltips=None, fixed=
         tip = ""
         if key in tooltips:
             tip = tooltips[key]
-        # work out index
+        # work out index from flags
         i = None
         for flag in flags:
-            if flag.isnumeric():
-                i = int(flag)
+                if flag.isnumeric():
+                    i = int(flag)
+        # if given, manually set order should override flags
+        if order is not None and key in order:
+            i = order.index(key)
+        # work out fixed
+        if "fix" not in flags and fixed is not None and key in fixed:
+            flags.append("fix")
         # construct display param
         param = {
             'key': key,

--- a/psychopy/gui/util.py
+++ b/psychopy/gui/util.py
@@ -36,8 +36,8 @@ def makeDisplayParams(expInfo, sortKeys=True, labels=None, tooltips=None, fixed=
         # work out index from flags
         i = None
         for flag in flags:
-                if flag.isnumeric():
-                    i = int(flag)
+            if flag.isnumeric():
+                i = int(flag)
         # if given, manually set order should override flags
         if order is not None and key in order:
             i = order.index(key)


### PR DESCRIPTION
Fixes #6808

The cause of the bug was that I'd tried to use pipe syntax where possible to avoid doing the same thing twice in different places, but this meant adding characters to the dict keys in the case of order and fixed when we didn't need to.