### PR TITLE
BF: Fix removing devices from listener loop

### DIFF
--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -327,9 +327,10 @@ class BaseResponseDevice(BaseDevice):
         bool
             True if completed successfully
         """
-        # remove listeners from loop
+        # remove self from listener loop
         for listener in self.listeners:
-            listener.loop.removeDevice(listener)
+            if self in listener.loop.devices:
+                listener.loop.removeDevice(self)
         # clear list
         self.listeners = []
 

--- a/psychopy/hardware/button.py
+++ b/psychopy/hardware/button.py
@@ -161,7 +161,7 @@ class KeyboardButtonBox(BaseButtonGroup):
 
     def isSameDevice(self, other):
         # all Keyboards are the same device
-        return True
+        return isinstance(other, (KeyboardButtonBox, dict))
 
 
 class ButtonBox:

--- a/psychopy/hardware/listener.py
+++ b/psychopy/hardware/listener.py
@@ -50,8 +50,11 @@ class ListenerLoop(threading.Thread):
             Device to remove
         """
         if device in self.devices:
+            logging.info(f"Removed from listener loop: {device}")
             i = self.devices.index(device)
             self.devices.pop(i)
+        else:
+            logging.error(f"Could not remove from listener loop: {device} not in {self.devices}")
 
     def start(self):
         """
@@ -211,12 +214,6 @@ class BaseListener:
             Message received.
         """
         raise NotImplementedError()
-
-    def __del__(self):
-        """
-        On deletion, remove self from loop.
-        """
-        loop.removeDevice(self)
 
 
 class PrintListener(BaseListener):

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -878,8 +878,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         )
         # get average volume
         rms = clip.rms() * 10
-        # adjust and round
-        rms = np.round(rms, decimals=3)
+        # round
+        rms = np.round(rms.astype(np.float64), decimals=3)
 
         return rms
 
@@ -954,6 +954,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         # dispatch to listeners
         for listener in self.listeners:
             listener.receiveMessage(message)
+        
+        return message
 
 
 class RecordingBuffer:


### PR DESCRIPTION
Was trying to remove the *listener* from the loop, not the *device*, so devices were remaining in it & continued being sampled after calling `clearListeners`