### PR TITLE
FF: Allow Liaison to accept `null`

### DIFF
--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -401,7 +401,7 @@ class WebSocketServer:
 					# try to parse json string
 					try:
 						arg = json.loads(arg)
-					except json.decoder.JSONDecodeError:
+					except (json.decoder.JSONDecodeError, TypeError):
 						pass
 					# if arg is a known property, get its value
 					arg = self.actualizeAttributes(arg)


### PR DESCRIPTION
If sent null from a JS client, Liaison will crash as `json.dumps(None)` raises a `TypeError` rather than a `json.decoder.JSONDecodeError` (which we catch)