### PR TITLE
FF: allow PipeReader to read from overflowBuffer promptly

### DIFF
--- a/psychopy/app/jobs.py
+++ b/psychopy/app/jobs.py
@@ -101,7 +101,14 @@ class PipeReader(Thread):
     @property
     def isAvailable(self):
         """Are there bytes available to be read (`bool`)?"""
-        return self._queue.full()
+        if self._queue.full():
+            return True
+        elif self._overflowBuffer:  # have leftover bytes
+            self._queue.put("".join(self._overflowBuffer))
+            self._overflowBuffer = []  # clear the overflow buffer
+            return True
+        else:
+            return False
 
     def read(self):
         """Read all bytes enqueued by the thread coming off the pipe. This is


### PR DESCRIPTION
Right now if `stdout` gets crowded by multiple printouts, the `_overflowBuffer` will catch them during the `PipeReader.run()` method. However, the for-loop of `self._fdpipe.readline` is dependent on new lines being added to the pipe. This means leftover bytes from the `_overflowBuffer` won't print out correctly to the runner stdout panel until the next message is printed, which could be never - so they only get printed at termination of the experiment.

This commit adds the ability to put the leftover bytes from `_overflowBuffer` into `_queue` as soon as the `_queue` is freed up, by coupling it into the `isAvailable()` method. This behavior is much smoother, without adding much blocking, and is consistent with what the existing comment in `PipeReader.run()` says:

```
# Put bytes into buffer if the queue hasn't been emptied quick
# enough. These bytes will be passed along once the queue has
# space.
```