### PR TITLE
FF: Remove unecessary log from listener loop

### DIFF
--- a/psychopy/hardware/listener.py
+++ b/psychopy/hardware/listener.py
@@ -143,7 +143,6 @@ class ListenerLoop(threading.Thread):
                     device.dispatchMessages()
             # if there are no more devices attached, stop
             if not len(self.devices):
-                logging.info("Ending listener loop as there are no devices")
                 self._active = False
             # sleep for 10ms
             time.sleep(self.refreshRate)


### PR DESCRIPTION
With this in place, if you run an experiment from Session with a listener active, you get this log every 0.1s because the logging loop isn't dead (_alive=False), it's just paused dispatching (_active=False).