### PR TITLE
NF: Add "rolling" Microphone mode live sampling for long periods

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -56,6 +56,7 @@ class MicrophoneComponent(BaseDeviceComponent):
                  channels='auto', device=None,
                  sampleRate='DVD Audio (48kHz)', maxSize=24000,
                  outputType='default', speakTimes=False, trimSilent=False,
+                 policyWhenFull='warn',
                  transcribe=False, transcribeBackend="none",
                  transcribeLang="en-US", transcribeWords="",
                  transcribeWhisperModel="base",
@@ -158,7 +159,21 @@ class MicrophoneComponent(BaseDeviceComponent):
             hint=msg,
             label=_translate("Output file type")
         )
-
+        self.params['policyWhenFull'] = Param(
+            policyWhenFull, valType="str", inputType="choice", categ="Data",
+            updates="set every repeat",
+            allowedVals=["warn", "roll", "error"],
+            allowedLabels=[
+                _translate("Discard incoming data"), 
+                _translate("Clear oldest data"), 
+                _translate("Raise error"),
+            ],
+            label=_translate("Full buffer policy"),
+            hint=_translate(
+                "What to do when we reach the max amount of audio data which can be safely stored "
+                "in memory?"
+            )
+        )
         msg = _translate(
             "Tick this to save times when the participant starts and stops speaking")
         self.params['speakTimes'] = Param(
@@ -417,15 +432,6 @@ class MicrophoneComponent(BaseDeviceComponent):
         """Write the code that will be called every frame"""
         inits = getInitVals(self.params)
         inits['routine'] = self.parentName
-
-        # If stop time is blank, substitute max stop
-        if self.params['stopVal'] in ('', None, -1, 'None'):
-            self.params['stopVal'].val = at.audioMaxDuration(
-                bufferSize=float(self.params['maxSize'].val) * 1000,
-                freq=float(sampleRates[self.params['sampleRate'].val])
-            )
-            # Show alert
-            alert(4125, strFields={'name': self.params['name'].val, 'stopVal': self.params['stopVal'].val})
 
         # Start the recording
         indented = self.writeStartTestCode(buff)

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -143,6 +143,7 @@ class MicrophoneComponent(BaseDeviceComponent):
         )
         self.params['maxSize'] = Param(
             maxSize, valType='num', inputType="single", categ='Device',
+            updates="set every repeat",
             label=_translate("Max recording size (kb)"),
             hint=_translate(
                 "To avoid excessively large output files, what is the biggest file size you are "

--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -53,11 +53,15 @@ class BaseResponse:
 
     def getJSON(self):
         import json
+        # get device profile
+        deviceProfile = None
+        if hasattr(self.device, "getDeviceProfile"):
+            deviceProfile = self.device.getDeviceProfile()
         # construct message as dict
         message = {
             'type': "hardware_response",
             'class': type(self).__name__,
-            'device': self.getDeviceName(),
+            'device': deviceProfile,
             'data': {}
         }
         # add all fields to "data"

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -817,9 +817,6 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         # figure out what to do with this other information
         audioData, absRecPosition, overflow, cStartTime = \
             self._stream.get_audio_data()
-        # log how many samples we got if debugging
-        if not len(audioData):
-            logging.debug(f"Polled samples from microphone {self.index} and none were returned")
 
         if overflow:
             logging.warning(

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -928,6 +928,10 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             If True, will clear the recording up until now after dispatching the volume. This is
             useful if you're just sampling volume and aren't wanting to store the recording.
         """
+        # if mic is not recording, there's nothing to dispatch
+        if not self.isStarted:
+            return
+        
         # poll the mic now
         self.poll()
         # create a response object

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1180,15 +1180,17 @@ class RecordingBuffer:
                     "Cannot write samples, recording buffer is full.")
             elif self._policyWhenFull == ('rolling', 'roll'):
                 # if policy is rolling, we clear the first half of the buffer
-                toSave = int(self._totalSamples / 2)
+                toSave = self._totalSamples - len(samples)
                 # get last 0.1s so we still have enough for volume measurement
                 savedSamples = self._recording._samples[-toSave:, :]
                 # log
-                logging.debug(
-                    f"Microphone buffer reached, as policy when full is 'roll'/'rolling' all but "
-                    f"the most recent {toSave} samples will be cleared to make room for new "
-                    f"samples."
-                )
+                if not self._warnedRecBufferFull:
+                    logging.warning(
+                        f"Microphone buffer reached, as policy when full is 'roll'/'rolling' the "
+                        f"oldest samples will be cleared to make room for new samples."
+                    )
+                    logging.flush()
+                self._warnedRecBufferFull = True
                 # clear samples
                 self._recording.clear()
                 # reassign saved samples

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -937,7 +937,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         # create a response object
         message = MicrophoneResponse(
             logging.defaultClock.getTime(),
-            self.getCurrentVolume()
+            self.getCurrentVolume(),
+            device=self,
         )
         # clear recording if requested (helps with continuous running)
         if clear and self.isRecBufferFull:

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -884,8 +884,6 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         audioData, absRecPosition, overflow, cStartTime = \
             self._stream.get_audio_data()
         
-        audioData = []
-        
         if len(audioData):
             # if we got samples, the device is awake, so stop figuring out if it's asleep
             self._possiblyAsleep = False

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -899,6 +899,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             self._isStarted = False
             # reopen
             self.reopen()
+            # start again
+            self.start()
 
         if overflow:
             logging.warning(

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -309,6 +309,27 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         self.listeners = []
     
     @property
+    def maxRecordingSize(self):
+        """
+        Until a file is saved, the audio data from a Microphone needs to be stored in RAM. To avoid 
+        a memory leak, we limit the amount which can be stored by a single Microphone object. The 
+        `maxRecordingSize` parameter defines what this limit is.
+
+        Parameters
+        ----------
+        value : int
+            How much data (in kb) to allow, default is 24mb (so 24,000kb)
+        """
+        return self._recording.maxRecordingSize
+    
+    @maxRecordingSize.setter
+    def maxRecordingSize(self, value):
+        # set size
+        self._recording.maxRecordingSize = value
+        # re-allocate
+        self._recording._allocRecBuffer()
+    
+    @property
     def policyWhenFull(self):
         """
         Until a file is saved, the audio data from a Microphone needs to be stored in RAM. To avoid 

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -96,6 +96,9 @@ class Microphone:
             obj=self, log=True, attrib="maxRecordingSize", value=value
         )
     setMaxRecordingSize.__doc__ == maxRecordingSize.__doc__
+
+    # the Builder param has a different name
+    setMaxSize = setMaxRecordingSize
     
     @property
     def policyWhenFull(self):

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -71,6 +71,33 @@ class Microphone:
         self.saveClips()
     
     @property
+    def maxRecordingSize(self):
+        """
+        Until a file is saved, the audio data from a Microphone needs to be stored in RAM. To avoid 
+        a memory leak, we limit the amount which can be stored by a single Microphone object. The 
+        `maxRecordingSize` parameter defines what this limit is.
+
+        Parameters
+        ----------
+        value : int
+            How much data (in kb) to allow, default is 24mb (so 24,000kb)
+        """
+        return self.device.maxRecordingSize
+    
+    @maxRecordingSize.setter
+    def maxRecordingSize(self, value):
+        # set size
+        self.device.maxRecordingSize = value
+    
+    def setMaxRecordingSize(self, value):
+        self.maxRecordingSize = value
+        # log
+        logAttrib(
+            obj=self, log=True, attrib="maxRecordingSize", value=value
+        )
+    setMaxRecordingSize.__doc__ == maxRecordingSize.__doc__
+    
+    @property
     def policyWhenFull(self):
         """
         Until a file is saved, the audio data from a Microphone needs to be stored in RAM. To avoid 

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -13,6 +13,7 @@ __all__ = ['Microphone']
 from pathlib import Path
 from psychopy.constants import NOT_STARTED
 from psychopy.hardware import DeviceManager
+from psychopy.tools.attributetools import logAttrib
 
 
 class Microphone:
@@ -56,6 +57,8 @@ class Microphone:
                 audioLatencyMode=audioLatencyMode,
                 audioRunMode=audioRunMode
             )
+        # set policy when full (in case device already existed)
+        self.device.policyWhenFull = policyWhenFull
         # setup clips and transcripts dicts
         self.clips = {}
         self.lastClip = None
@@ -66,6 +69,36 @@ class Microphone:
 
     def __del__(self):
         self.saveClips()
+    
+    @property
+    def policyWhenFull(self):
+        """
+        Until a file is saved, the audio data from a Microphone needs to be stored in RAM. To avoid 
+        a memory leak, we limit the amount which can be stored by a single Microphone object. The 
+        `policyWhenFull` parameter tells the Microphone what to do when it's reached that limit.
+
+        Parameters
+        ----------
+        value : str
+            One of:
+            - "ignore": When full, just don't record any new samples
+            - "warn": Same as ignore, but will log a warning
+            - "error": When full, will raise an error
+            - "rolling": When full, clears the start of the buffer to make room for new samples
+        """
+        return self.device.policyWhenFull
+    
+    @policyWhenFull.setter
+    def policyWhenFull(self, value):
+        return self.device.policyWhenFull
+    
+    def setPolicyWhenFull(self, value):
+        self.policyWhenFull = value
+        # log
+        logAttrib(
+            obj=self, log=True, attrib="policyWhenFull", value=value
+        )
+    setPolicyWhenFull.__doc__ = policyWhenFull.__doc__
 
     @property
     def recording(self):


### PR DESCRIPTION
This mode allows the mic to run for a long time without filling up memory as it deletes older samples as it goes. Not what you want if saved recordings are important, but very useful if you want e.g. to use the current volume of a mic in an experiment but don't care about the recording.