### PR TITLE
NF: Automatic microphone polling

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -713,9 +713,17 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
                 initBarrier.wait()  # wait for stream to start
                 while not self._pollStopEvent.is_set():
                     with self._pollDataLock:
-                        # put data into the sample queue, this will be 
-                        self._sampleQueue.put_nowait(
-                            (self._stream.get_audio_data()))
+                        audioData, absRecPosition, overflow, cStartTime = \
+                            self._stream.get_audio_data()
+                        
+                        # Note - In cases where there is no audio data, it is 
+                        # likely that the mic is not fully started yet. This 
+                        # can happen if the `start` command is called with
+                        # `waitForStart=False`.
+                        if audioData:
+                            # put data into the sample queue, this will be 
+                            self._sampleQueue.put_nowait(
+                                (self._stream.get_audio_data()))
 
                     time.sleep(pollInterval)
                 

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -92,7 +92,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         `poll()` manually when `autoPolling` is `True` will still work, updating
         the recording buffer with the latest samples.
     pollInterval : float or None
-        Interval at which to poll the stream. Should be less than than 
+        Interval at which to poll the stream. Should be less than 
         `streamBufferSecs`. If `None`, the interval will be set to half the
         stream buffer size (`streamBufferSecs`). Default is `None`.
 

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -715,6 +715,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
                 microphone object will then retrieve the data from the queue.types
                 
                 """
+                pollInterval = self._pollInterval
                 while not self._pollStopEvent.is_set():
                     with self._pollDataLock:
                         audioData, absRecPosition, overflow, cStartTime = \
@@ -724,7 +725,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
                         self._sampleQueue.put(
                             (audioData, absRecPosition, overflow, cStartTime))
 
-                    time.sleep(0.5)  # less the stream buffer size will suffice
+                    time.sleep(pollInterval)  # less the stream buffer size will suffice
 
             self._pollStopEvent.clear()  # reset
             self._pollThread = threading.Thread(target=pollThread)


### PR DESCRIPTION
This PR allows the microphone to poll asynchronously by getting samples using a background thread. When `autoPolling=True`, the background thread will get samples at a rate specified by `pollInterval`. This value just needs to be less than the stream buffer size to prevent samples from being missed.  Calls to `poll()` in existing scripts will still work as they always have. However, the user never actually needs to call `poll()` explicitly when `autoPolling` is enabled, as the stream buffer is effectively infinite and all data is contains will be automatically written to the recording buffer when the stream is stopped.

This also has the benefit of keeping the audio stream alive if the device drivers tend to timeout and go into an inactive state.