### PR TITLE
ENH: Run Microphone.saveClips in endExperiment

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -398,6 +398,9 @@ class MicrophoneComponent(BaseDeviceComponent):
             "    recordingFolder=%(name)sRecFolder,\n"
             "    recordingExt='%(outputType)s'\n"
             ")\n"
+            "# tell the experiment handler to save this Microphone's clips if the experiment is "
+            "force ended\n"
+            "runAtExit.append(%(name)s.saveClips)\n"
         )
         buff.writeIndentedLines(code % inits)
 

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -981,6 +981,8 @@ class SettingsComponent:
             "psychopyVersion = '%(version)s'\n"
             "expName = %(expName)s  # from the Builder filename that created this script\n"
             "expVersion = %(expVersion)s\n"
+            "# a list of functions to run when the experiment ends (starts off blank)\n"
+            "runAtExit = []\n"
         )
         buff.writeIndentedLines(code % params)
         # get info for this experiment
@@ -2116,6 +2118,9 @@ class SettingsComponent:
             "logging.console.setLevel(logging.WARNING)\n"
             "# mark experiment handler as finished\n"
             "thisExp.status = FINISHED\n"
+            "# run any 'at exit' functions\n"
+            "for fcn in runAtExit:\n"
+            "    fcn()\n"
         )
         if self.params['Save log file'].val:
             code += (

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -204,12 +204,16 @@ class AudioClip:
         """
         if codec is not None:
             AudioClip._checkCodecSupported(codec, raiseError=True)
-
+        # write file
         sf.write(
             filename,
             data=self._samples,
             samplerate=self._sampleRateHz,
             format=codec)
+        # log
+        logging.info(
+            f"Saved audio data to {filename}"
+        )
 
     # --------------------------------------------------------------------------
     # Tone and noise generation methods

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -11,6 +11,7 @@
 __all__ = ['Microphone']
 
 from pathlib import Path
+from psychopy import logging
 from psychopy.constants import NOT_STARTED
 from psychopy.hardware import DeviceManager
 from psychopy.tools.attributetools import logAttrib
@@ -215,6 +216,7 @@ class Microphone:
         """
         # iterate through all clips
         for tag in self.clips:
+            logging.info(f"Saving {len(self.clips[tag])} audio clips with tag {tag}")
             for i, clip in enumerate(self.clips[tag]):
                 # construct filename
                 filename = self.getClipFilename(tag, i)


### PR DESCRIPTION
Isn't an issue from Builder as when you finish an experiment the Python process closes anyway (triggering Microphone.__del__), but if you're using Session to run several experiments at once then Microphone.__del__ isn't called and Microphone.saveClips isn't called unless the experiment runs to completion. This PR means that anything which triggers `endExperiment` (i.e. pressing ESCAPE) will call Microphone.saveClips