### PR TITLE
BF: Linux iohub keyboard relative import error

### DIFF
--- a/psychopy/iohub/devices/mouse/linux2.py
+++ b/psychopy/iohub/devices/mouse/linux2.py
@@ -6,7 +6,8 @@
 from ctypes import cdll
 
 from . import MouseDevice
-from .. import Keyboard, Computer, Device, xlib
+from .. import Computer, Device, xlib
+from ..keyboard import Keyboard
 from ...constants import MouseConstants
 from ...errors import print2err, printExceptionDetailsToStdErr
 


### PR DESCRIPTION
When running psychopy on linux, using the iohub mouse device results in an importerror:

```text
ImportError: cannot import name 'Keyboard' from 'psychopy.iohub.devices'
```

This fixes the import error by aligning the linux mouse device variant to the other OS variants.

