### PR TITLE
BF: Fix routine clock resetting in JS

### DIFF
--- a/psychopy/clock.py
+++ b/psychopy/clock.py
@@ -332,14 +332,18 @@ class Clock(MonotonicClock):
         self._epochTimeAtLastReset -= t
 
     def add(self, t):
-        """DEPRECATED: use .addTime() instead
+        """
+        DEPRECATED: use .addTime() instead
 
         This function adds time TO THE BASE (t0) which, counterintuitively,
         reduces the apparent time on the clock
         """
-        logging.warning("DEPRECATED: Clock.add() is deprecated in favor of .addTime() due to "
-                        "the counterintuitive design (it added time to the baseline, which "
-                        "reduced the values returned from getTime()")
+        psychopy.logging.log(msg=(
+            "Clock.add() is deprecated in favor of .addTime() due to the counterintuitive design "
+            "(it added time to the baseline, which reduced the values returned from getTime() )"
+            ),
+            level=psychopy.logging.DEPRECATION
+        )
         self._timeAtLastReset += t
         self._epochTimeAtLastReset += t
 

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -824,7 +824,6 @@ class Routine(list):
         code = ("TrialHandler.fromSnapshot(snapshot); // ensure that .thisN vals are up to date\n\n"
                 "//--- Prepare to start Routine '%(name)s' ---\n"
                 "t = 0;\n"
-                "%(name)sClock.reset(); // clock\n"
                 "frameN = -1;\n"
                 "continueRoutine = true; // until we're told otherwise\n"
                 % self.params)
@@ -1008,9 +1007,9 @@ class Routine(list):
         if useNonSlip:
             code = (
                 "if (%(name)sMaxDurationReached) {{\n"
-                "    routineTimer.add(%(name)sMaxDuration);\n"
+                "    %(name)sClock.add(%(name)sMaxDuration);\n"
                 "}} else {{\n"
-                "    routineTimer.add(-{:f});\n"
+                "    %(name)sClock.add({:f});\n"
                 "}}\n"
             ).format(maxTime)
             buff.writeIndented(code % self.params)


### PR DESCRIPTION
When using nonslip timing, the nonslip duration was being subtracted from the routineTimer rather than the <routine name>Clock (in Python these are one and the same, in JS the routineTimer is a CountdownTimer), meaning nonslip Routines were causing the following Routine to be skipped by messing up its timer.

It's also worth noting that `Clock.add` in JS works the opposite to `Clock.addTime` in Python - adding time to the clock reduces the value of `getTime` (as it adds the time to `_lastResetTime`)