### PR TITLE
BF: Fix default audio device not being found

### DIFF
--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -8,7 +8,7 @@ class SpeakerDevice(BaseDevice):
         profiles = self.getAvailableDevices()
 
         # if index is default (-1), setup a default device index
-        if not isinstance(index, (int, float)) or index < 0:
+        if not isinstance(index, (int, float)):
             index = profiles[0]['index']  # initialize as the first device
 
             # check if a default device is already set and update index
@@ -23,8 +23,8 @@ class SpeakerDevice(BaseDevice):
                         if profile['deviceName'] == defaultDevice:
                             index = profile['index']
 
-        available_index = [profile['index'] for profile in profiles]
-        if index < 0 or index not in available_index:
+        available_index = [profile['index'] for profile in profiles] + [-1]
+        if index not in available_index:
             logging.error("No speaker device found with index %d" % index)
 
         # store index
@@ -87,3 +87,21 @@ class SpeakerDevice(BaseDevice):
             devices.append(device)
 
         return devices
+
+    @staticmethod
+    def getSystemSpeaker():
+        """
+        Use psychtoolbox to work out what the operating system's default audio device is.
+        
+        Returns
+        -------
+        dict
+            Information about the found speaker.
+        """
+        import win32api
+        import win32con
+        import win32gui
+        import win32com.client
+        # make a media manager object
+        mgr = win32com.client.Dispatch("Windows.MediaDeviceManager")
+        return mgr.GetDefaultAudioCaptureDevice()

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -87,21 +87,3 @@ class SpeakerDevice(BaseDevice):
             devices.append(device)
 
         return devices
-
-    @staticmethod
-    def getSystemSpeaker():
-        """
-        Use psychtoolbox to work out what the operating system's default audio device is.
-        
-        Returns
-        -------
-        dict
-            Information about the found speaker.
-        """
-        import win32api
-        import win32con
-        import win32gui
-        import win32com.client
-        # make a media manager object
-        mgr = win32com.client.Dispatch("Windows.MediaDeviceManager")
-        return mgr.GetDefaultAudioCaptureDevice()

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -246,11 +246,28 @@ class _MasterStream(audio.Stream):
                       .format(device, mode+8, audioLatencyClass, sampleRate, channels))
                 raise e
             except Exception as e:
-                audio.Stream.__init__(self, mode=mode+8,
-                                      latency_class=audioLatencyClass,
-                                      freq=sampleRate,
-                                      channels=channels,
-                                      )
+                if deviceID == -1:
+                    # if default device doesn't setup from ptb, pick first device
+                    for device in audio.get_devices(device_type=13):
+                        logging.error(
+                            f"System default audio device failed to connect, so using first found "
+                            f"device: {device['DeviceName']}"
+                        )
+                        audio.Stream.__init__(
+                            self,mode=mode+8,
+                            device_id=device['DeviceIndex'],
+                            freq=device['DefaultSampleRate'],
+                            channels=device['NrOutputChannels']
+                        )
+                        break
+                else:
+                    # any other problem, try with no device ID
+                    audio.Stream.__init__(
+                        self, mode=mode+8,
+                        latency_class=audioLatencyClass,
+                        freq=sampleRate,
+                        channels=channels,
+                    )
 
                 if "there isn't any audio output device" in str(e):
                     print("Failed to load audio device:\n"


### PR DESCRIPTION
Prior to 2024.2.0, if your system audio output sample rate wasn't 48000 then initialising a Sound with default speaker raised an error, as ptb doesn't have a method of getting the system default speaker's sample rate; you can only initialise a speaker with -1 as the index. So with no way of asking "what is the sample rate of the system default speaker?" we're forced to just try to set it up with the default (48000), leading to an error if your speaker didn't match.

To get around this, rather than using an index of `-1` to initialise a stream, we simply got the first device found and used its parameters instead. Because we got the device's actual info from ptb, this meant it wouldn't error when initialising, so you'd at least have *a* speaker. The problem is that the first device found isn't necessarily the system audio, so some people are finding audio playing out of the wrong speaker when it's set to "default".

This solution attempts to retain ptb's default speaker behaviour (by passing it -1), but catching the error and resorting to using the first device found instead. This isn't ideal - if your system audio has a sample rate other than 48000 then you'll still find sound playing on the wrong device sometimes, and there's a lot of console spam (even if we catch errors raised by ptb, it'll still print to the console when it fails).

In the long run I think we need to find a way to identify the system default device and get its parameters *before* attempting to connect to it. I can't see a way to do that with ptb, but maybe we can use another audio system to get its system name and then match with ptb's indexes from that?

Fixes #6372