### PR TITLE
ENH: Include details about sample rate and channels in SpeakerDevice

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -118,8 +118,8 @@ class _SoundBase(AttributeGetSetMixin):
     def _parseSpeaker(self, speaker):
         from psychopy.hardware.speaker import SpeakerDevice
         # if already a SpeakerDevice, great!
-        if isinstance(device, SpeakerDevice):
-            return device
+        if isinstance(speaker, SpeakerDevice):
+            return speaker
         # if no device, populate from prefs
         if speaker is None:
             pref = prefs.hardware['audioDevice']

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -116,8 +116,12 @@ class _SoundBase(AttributeGetSetMixin):
     # def _setSndFromArray(self, thisArray):
 
     def _parseSpeaker(self, speaker):
+        from psychopy.hardware.speaker import SpeakerDevice
+        # if already a SpeakerDevice, great!
+        if isinstance(device, SpeakerDevice):
+            return device
+        # if no device, populate from prefs
         if speaker is None:
-            # if no device, populate from prefs
             pref = prefs.hardware['audioDevice']
             if isinstance(pref, (list, tuple)):
                 pref = pref[0]

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -386,7 +386,12 @@ class SoundPTB(_SoundBase):
 
     @stereo.setter
     def stereo(self, val):
+        # if auto, get from speaker
+        if val == -1:
+            val = self.speaker.channels > 1
+        # store value
         self.__dict__['stereo'] = val
+        # convert to n channels
         if val is True:
             self.__dict__['channels'] = 2
         elif val is False:


### PR DESCRIPTION
As each speaker reports its sample rate and number of channels, it makes much more sense for this to be stored in SpeakerDevice than for Sound to work it out each time. 

This also makes the bug where Sound initialised without specifying `stereo` breaks irrelevant - as if you specify a Sound without stereo, it works it out from the speaker.