### PR TITLE
FF: suppress pip version check in package manager

### DIFF
--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -68,7 +68,6 @@ class EnvironmentManagerDlg(wx.Dialog):
 
         self.notebook.ChangeSelection(0)
 
-
     @staticmethod
     def getPackageVersionInfo(packageName):
         """Query packages for available versions.
@@ -278,10 +277,13 @@ class EnvironmentManagerDlg(wx.Dialog):
             )
         else:
             command.append('--user')
-        
+
         # add other options to the command
         command += ['--prefer-binary', '--no-input', '--no-color']
-            
+
+        # disable pip version check
+        command += ['--disable-pip-version-check']
+
         # write command to output panel
         self.output.writeCmd(" ".join(command))
         # append own name to extra
@@ -359,7 +361,7 @@ class EnvironmentManagerDlg(wx.Dialog):
         # write installation termination statement
         msg = "Installation complete"
         if 'pipname' in self.pipProcess.extra:
-            msg = f"Finished installing %(pipname)s" % self.pipProcess.extra
+            msg = "Finished installing %(pipname)s" % self.pipProcess.extra
         self.output.writeTerminus(msg)
 
         # if we have a plugin, write additional plugin information post-install
@@ -411,12 +413,12 @@ class EnvironmentManagerDlg(wx.Dialog):
         # refresh view
         pkgtools.refreshPackages()
         self.pluginMgr.updateInfo()
-    
+
     def onUninstallExit(self, pid, exitCode):
         # write installation termination statement
         msg = "Uninstall complete"
         if 'pipname' in self.pipProcess.extra:
-            msg = f"Finished uninstalling %(pipname)s" % self.pipProcess.extra
+            msg = "Finished uninstalling %(pipname)s" % self.pipProcess.extra
         self.output.writeTerminus(msg)
         # clear pip process
         self.pipProcess = None
@@ -435,7 +437,7 @@ class EnvironmentManagerDlg(wx.Dialog):
             # if they change their mind, cancel closing
             if dlg.ShowModal() == wx.ID_NO:
                 return
-        
+
         if evt is not None:
             evt.Skip()
 


### PR DESCRIPTION
As pip version progresses, the `pip` package shipped with PsychoPy will soon go out of date. This PR suppresses the warning message about pip version update in the package manager to make the output more relevant/succinct.