### PR TITLE
FF: fix startView across OS platforms that opens psychopyApp.py

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -546,8 +546,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if arg.endswith(".psyexp"):
                 exps.append(arg)
             if arg.endswith(".py"):
-                if sys.platform == 'darwin' and arg.endswith("psychopyApp.py"):
-                    # in wx4 on mac this is called erroneously by App.__init__
+                if arg.endswith("psychopyApp.py"):
+                    # this is called erroneously when starting standalone app
                     continue
                 else:
                     scripts.append(arg)


### PR DESCRIPTION
Same fix as #6789. I found out today that this issue of automatically opening `psychopyApp.py` is happening on Windows standalone app as well. I'm not sure what is trying to open `psychopyApp.py` when launching the app, but this FF commit can at least make the `startView` setting in preference work correctly and not always open Coder view due to the `psychopyApp.py`.