### PR TITLE
BF: if PsychoPy version includes "postN" then strip from PsychoJS version number

### DIFF
--- a/psychopy/tools/versionchooser.py
+++ b/psychopy/tools/versionchooser.py
@@ -202,7 +202,7 @@ def getPsychoJSVersionStr(currentVersion, preferredVersion=''):
         # e.g. 2021.1.0 not 2021.1.0.dev3
         useVerStr = '.'.join(useVerStr.split('.')[:3])
     # PsychoJS doesn't have additional rc1 or dev1 releases
-    for versionSuffix in ["rc", "dev", "a", "b"]:
+    for versionSuffix in ["rc", "dev", "post", "a", "b"]:
         if versionSuffix in useVerStr:
             useVerStr = useVerStr.split(versionSuffix)[0]
 


### PR DESCRIPTION
Originally we only expected to use `rcN`, `aN`, `bN`, `devN` tags but recently we used `postN` which broke the PsychoJS experiments