### PR TITLE
ENH: ensure window focus for the first `win.flip()` with pyglet backend on Windows OS

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1881,7 +1881,7 @@ class SettingsComponent:
             "    # if not given a window to setup, make one\n"
             "    win = visual.Window(\n"
             "        size=_winSize, fullscr=_fullScr, screen=%(screenNumber)s,\n"
-            "        winType=%(winType)s, allowStencil=%(allowStencil)s,\n"
+            "        winType=%(winType)s, allowGUI=%(allowGUI)s, allowStencil=%(allowStencil)s,\n"
             "        monitor=%(Monitor)s, color=%(color)s, colorSpace=%(colorSpace)s,\n"
             "        backgroundImage=%(backgroundImg)s, backgroundFit=%(backgroundFit)s,\n"
             "        blendMode=%(blendMode)s, useFBO=%(useFBO)s,\n"
@@ -1913,12 +1913,6 @@ class SettingsComponent:
             "    expInfo['frameRate'] = %(frameRate)s\n"
             )
             buff.writeIndentedLines(code % params)
-
-        # Show/hide mouse according to param
-        code = (
-            "win.mouseVisible = %s\n"
-        )
-        buff.writeIndentedLines(code % allowGUI)
 
         # Reset splash message
         code = (

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1885,7 +1885,7 @@ class SettingsComponent:
             "        monitor=%(Monitor)s, color=%(color)s, colorSpace=%(colorSpace)s,\n"
             "        backgroundImage=%(backgroundImg)s, backgroundFit=%(backgroundFit)s,\n"
             "        blendMode=%(blendMode)s, useFBO=%(useFBO)s,\n"
-            "        units=%(Units)s, \n"
+            "        units=%(Units)s,\n"
             "        checkTiming=False  # we're going to do this ourselves in a moment\n"
             "    )\n"
             "else:\n"

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -337,6 +337,7 @@ class Flow(list):
                 "logging.setDefaultClock(globalClock)\n"
                 "# routine timer to track time remaining of each (possibly non-slip) routine\n"
                 "routineTimer = core.Clock()\n"
+                "win.winHandle.activate()  # set window to foreground to prevent losing focus\n"
                 "win.flip()  # flip window to reset last flip timer\n"
                 "# store the exact time the global clock started\n"
                 "expInfo['expStart'] = data.getDateStr(\n"

--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -41,7 +41,7 @@ class Flow(list):
         loopStack = [currentList]
         for thisEntry in self:
             if thisEntry.getType() == 'LoopInitiator':
-                currentList.append(thisEntry.loop) # this loop is child of current
+                currentList.append(thisEntry.loop)  # this loop is child of current
                 loopDict[thisEntry.loop] = []  # and is (current) empty list awaiting children
                 currentList = loopDict[thisEntry.loop]
                 loopStack.append(loopDict[thisEntry.loop])  # update the list of loops (for depth)
@@ -140,7 +140,6 @@ class Flow(list):
                 # right-click in GUI)
                 del self[id]
 
-
     def integrityCheck(self):
         """Check that the flow makes sense together and check each component"""
 
@@ -168,7 +167,7 @@ class Flow(list):
                     if not hasattr(field, 'label'):
                         continue  # no problem, no warning
                     if (field.label.lower() in ['text', 'customize'] or
-                            not field.valType in ('str', 'code')):
+                            field.valType not in ('str', 'code')):
                         continue
                     if (isinstance(field.val, str) and
                             field.val != field.val.strip()):
@@ -204,7 +203,7 @@ class Flow(list):
             # non-redundant, order unknown
             print('\n  '.join(list(set(warnings))))
 
-    def writePreCode(self,script):
+    def writePreCode(self, script):
         """Write the code that comes before the Window is created
         """
         script.writeIndentedLines("\n# Start Code - component code to be "
@@ -343,7 +342,7 @@ class Flow(list):
                 "expInfo['expStart'] = data.getDateStr(\n"
                 "    format='%Y-%m-%d %Hh%M.%S.%f %z', fractionalSecondDigits=6\n"
                 ")\n"
-        )
+                )
         script.writeIndentedLines(code)
         # run-time code
         for entry in self:
@@ -402,13 +401,14 @@ class Flow(list):
                 "\n"
                 "const flowScheduler = new Scheduler(psychoJS);\n"
                 "const dialogCancelScheduler = new Scheduler(psychoJS);\n"
-                "psychoJS.scheduleCondition(function() { return (psychoJS.gui.dialogComponent.button === 'OK'); }, flowScheduler, dialogCancelScheduler);\n"
+                "psychoJS.scheduleCondition(function() { return (psychoJS.gui.dialogComponent.button === 'OK'); },"
+                "flowScheduler, dialogCancelScheduler);\n"
                 "\n")
         script.writeIndentedLines(code)
 
         code = ("// flowScheduler gets run if the participants presses OK\n"
-               "flowScheduler.add(updateInfo); // add timeStamp\n"
-               "flowScheduler.add(experimentInit);\n")
+                "flowScheduler.add(updateInfo); // add timeStamp\n"
+                "flowScheduler.add(experimentInit);\n")
         script.writeIndentedLines(code)
         loopStack = []
         for thisEntry in self:

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -3331,7 +3331,12 @@ class Window():
         GL.glClear(GL.GL_DEPTH_BUFFER_BIT)
         return True
 
-    @attributeSetter
+    @property
+    def mouseVisible(self):
+        """Returns the visibility of the mouse cursor."""
+        return self.backend.mouseVisible
+
+    @mouseVisible.setter
     def mouseVisible(self, visibility):
         """Sets the visibility of the mouse cursor.
 
@@ -3345,7 +3350,6 @@ class Window():
 
         """
         self.backend.setMouseVisibility(visibility)
-        self.__dict__['mouseVisible'] = visibility
 
     def setMouseVisible(self, visibility, log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -750,13 +750,17 @@ class Window():
     def setViewPos(self, value, log=True):
         setAttribute(self, 'viewPos', value, log=log)
 
-    @attributeSetter
+    @property
+    def fullscr(self):
+        """Return whether the window is in fullscreen mode."""
+        return self._isFullScr
+
+    @fullscr.setter
     def fullscr(self, value):
         """Set whether fullscreen mode is `True` or `False` (not all backends
         can toggle an open window).
         """
         self.backend.setFullScr(value)
-        self.__dict__['fullscr'] = value
         self._isFullScr = value
 
     @attributeSetter


### PR DESCRIPTION
Alright, round two of mouse visibility PRs (first one was #6465). Hopefully this time the annoying mouse is gone for good.

Previously there was a buggy `draggable()` event that caused visible mouse despite correct settings of `showMouse` and `fullScreen`. #6465 fixed it, and the mouse visibility is behaving correctly on macOS since then. Yesterday I started testing on Windows laptops and was horrified by the visible mouse again on standalone PsychoPy via builder. 

After some digging, I've fixed the issues around this. Here's a breakdown of the commits, which also improve how `mouseVisible` and `fullscr` attributes are stored in `window.Window()`.

1. **Avoid using `__dict__[ATTRIBUTE_NAME]` along with `@attributeSetter def ATTRIBUTE_NAME(self)`.** This setup has a dangerous wobbly attribute type for `ATTRIBUTE_NAME`. Before `self.ATTRIBUTE_NAME = xxx` is called, querying `self. ATTRIBUTE_NAME` returns an attributeSetter method; while after the attribute is set, it returns the actual attribute. This makes type setting and downstream usage of `self.ATTRIBUTE_NAME` unreliable since the attribute is not guaranteed to be set before called. It is better to use `@property` + `@ATTRIBUTE_NAME.setter def ATTRIBUTE_NAME(self)` to provide the same API without the problematic mutable type behavior. b6025f72e415ba90a53dddd765799c66345c1c9c and 4a99206261c17257b74fd73e880fddc8d64d90b2 implement this for `mouseVisible` and `fullscr`. In addition, since `Window()` always has a backend that has a `mouseVisible` attribute already, it's better to have `Window.mouseVisible` return `self.backend.mouseVisible` directly instead of keeping another attribute variable around, which may go out of sync with the backend `mouseVisible` if something goes wrong and makes it difficult to debug.
2. **Use `allowGUI` param to `Window` constructor.** There appears to be some adhoc code added to attempt to set mouse visibility when generating scripts from builder. Since the `allowGUI` parameter is available and accepted to `window.Window()`, we should use that instead of the extra manual `win.mouseVisible = allowGUI`. This keeps the `win.allowGUI` relevant and avoids confusing syntax. This is done by d052c89c9f75c5457a2821d8f32a88c310dfa4c7.
3. **Fix a root cause of losing focus that led to the visible mouse on Windows OS with `pyglet` backend.** I'm guessing that `win.mouseVisible = allowGUI` was added because people found that passing `allowGUI=False` into `window.Window()` didn't hide the mouse. But clearly manually setting `win.mouseVisible = allowGUI` doesn't work either unless it is called every frame on Windows OS using the `pyglet` backend with `Win32Window` window type. 
 
The core of this problem is a bit complicated: After instantiating the backend and the `Win32Window` handle, the `_hwnd` has lost its foreground status by the time it gets to the very first `win.flip()` call that does not have anything in `._to_draw()`. This is due to the additional process started during starting ioHub server. This causes the PsychoPy window to temporarily obtain focus via `setCurrent()` during `win.flip()` and immediately lose the focus after, regardless of whether `win` is on focus before this `win.flip()` call. Therefore, now the PsychoPy screen has lost focus despite still being visible. 

Due to the way `pyglet` `Win32Window` updates `_mouse_platform_visible` using a sequence of `or` statements:
```
platform_visible = (self._mouse_visible and
                    not self._exclusive_mouse and
                    (not self._mouse_cursor.gl_drawable or self._mouse_cursor.hw_drawable)) or \
                   (not self._mouse_in_window or
                    not self._has_focus)
``` 
, the mouse now stays visible, since the window no longer has focus.

_UPDATE: this problem only affects very few people. If your mouse is not visible when experiment starts, you are probably fine!_ **This is actually a very vulnerable behavior beyond the annoying visible mouse**, unless _users have always clicked mouse at least once on the PsychoPy screen_ to force grab focus and bring it to foreground from the OS level before doing anything else. Since I'm running without a mouse, this causes the focus to stay on the builder view. And sadly I'm using the `spacebar` to advance through PsychoPy screens, but now the keypress is double registered to the builder view, which maps to "Run Experiment" - so as I'm running a PsychoPy task, it silently spawned another experiment behind the screen... Similarly spacebar and any other keypress could cause unwanted consequences in this situation due to the messed up focus, including clearing the Runner output panel, etc., etc.

There are many different ways to fix this issue, but the cleanest solution only requires one extra line of code before the `win.flip()` and is provided in b295a8988992fd0175711106d9d71054e53d3cf7. 

4. a860c69a20ab65f2119247e76e36e40c8bf9eb13 and c1992f509ba8129bc7aa5ee6f5aa9926dc085f14 provide harmless code styling fixes following PEP8.

------------------------
@peircej @TEParsons I think this is a critical PR that should be pushed out soonish, since it can impact people using Standalone PsychoPy via builder on Windows OS, unless they have developed the "good" habit of clicking the PsychoPy window every time they start an experiment. I unfortunately found that the lost focus issue could sometimes result in missing the first keyboard press on each new screen, and only the second keypress gets registered (with the first keypress gaining focus temporarily but losing it immediately after). This issue will impact logged behavioral outputs, so it'll be good to fix.