### PR TITLE
BF: Coder was always opening with psychopyApp.py open

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -542,7 +542,11 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             startView = [startView]
         
         # get files to open from commandline args
-        for arg in sys.argv:
+        for argn, arg in enumerate(sys.argv):
+            # first argument is calling script, ignore it
+            if argn < 1:
+                continue
+            # subsequent arguments are files to open
             if arg.endswith(".psyexp"):
                 exps.append(arg)
             if arg.endswith(".py"):

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1237,7 +1237,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # take files from arguments and append the previously opened files
         filename = ""
         if files not in [None, [], ()]:
-            for filename in set(files):
+            for filename in files:
                 if not os.path.isfile(filename):
                     continue
                 self.setCurrentDoc(filename, keepHidden=True)

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1237,7 +1237,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         # take files from arguments and append the previously opened files
         filename = ""
         if files not in [None, [], ()]:
-            for filename in files:
+            for filename in set(files):
                 if not os.path.isfile(filename):
                     continue
                 self.setCurrentDoc(filename, keepHidden=True)


### PR DESCRIPTION
Reason being that when we check the calling arguments for any filenames, we don't exclude the first arg, which will be the script which was called (i.e. psychopyApp.py)