### PR TITLE
ENH: Better error catching when loading plugins

### DIFF
--- a/psychopy/experiment/plugins.py
+++ b/psychopy/experiment/plugins.py
@@ -1,3 +1,6 @@
+from psychopy import logging
+
+
 class PluginDevicesMixin:
     """
     Mixin for Components and Routines which adds behaviour to get parameters and values from
@@ -78,6 +81,10 @@ class DeviceBackend:
     deviceClasses = []
 
     def __init_subclass__(cls):
+        logging.debug(
+            f"Registered backend for {cls.component.__name__}: {cls.label} ({cls.key}) from "
+            f"{cls.__module__}:{cls.__name__}"
+        )
         # add class to list of backends for ButtonBoxComponent
         cls.component.backends = cls.component.backends.copy()
         cls.component.backends.append(cls)

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -784,6 +784,10 @@ def loadPlugin(plugin):
                     #     _failed_plugins_.append(plugin)
                     #
                     # return False
+            # log that we're loading the entry point
+            logging.debug(
+                f"Registering entry point {ep.value} (from {plugin}) to {ep.group}:{ep.name}"
+            )
             try:
                 ep = ep.load()  # load the entry point
 
@@ -792,26 +796,21 @@ def loadPlugin(plugin):
                     logging.warning(
                         "Plugin `{}` is being loaded from a zip file. This may "
                         "cause issues with the plugin's functionality.".format(plugin))
-
-            except ImportError as e:
-                logging.error(
-                    "Failed to load entry point `{}` of plugin `{}`. "
-                    "(`{}: {}`) "
-                    "Skipping.".format(str(ep), plugin, e.name, e.msg))
-
-                if plugin not in _failed_plugins_:
-                    _failed_plugins_.append(plugin)
-
-                return False
-            except Exception:  # catch everything else
-                logging.error(
-                    "Failed to load entry point `{}` of plugin `{}` for unknown"
-                    " reasons. Skipping.".format(str(ep), plugin))
+            except Exception as err:
+                # generic start of message
+                msg = f"Skipping entry point {ep.value} (from {plugin}) to {ep.group}:{ep.name}"
+                # append reason
+                if isinstance(err, ImportError):
+                    msg += f" as {ep.value} cannot be imported."
+                else:
+                    msg += f", reason: {err}"
+                # log message
+                logging.error(msg)
 
                 if plugin not in _failed_plugins_:
                     _failed_plugins_.append(plugin)
 
-                return False
+                continue
 
             # If we get here, the entry point is valid and we can safely add it
             # to PsychoPy's namespace.


### PR DESCRIPTION
Currently, because we use `return False` rather than `continue` when an entry point fails to load, if one entry point fails then none of the rest of the entry points for that plugin are registered. There also isn't any detail given, so the logs just look like:
```
ERROR Failed to load <entry point> from <plugin-name> for unknown reason. Skipping
```

This PR means that when an entry point fails, only that specific entry point is skipped, and we'll log the reason.