### PR TITLE
NF: Allow loop to be paused on next iteration as well as immediately

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -172,6 +172,8 @@ class TrialHandler(_BaseTrialHandler):
 
         self.originPath, self.origin = self.getOriginPathAndFile(originPath)
         self._exp = None  # the experiment handler that owns me!
+        # starting status
+        self.status = constants.NOT_STARTED
 
     def __iter__(self):
         return self

--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -1202,6 +1202,31 @@ class Session:
             )
         
         return trials
+    
+    def pauseLoop(self):
+        """
+        Pause the current loop of the current experiment. Note that this will not take effect until 
+        the loop would next iterate.
+
+        Returns
+        -------
+        bool or None
+            True if the operation completed successfully
+        """
+        # warn and return failed if no experiment is running
+        if self.currentExperiment is None:
+            logging.warn(_translate(
+                "Could not pause loop as there is no experiment running."
+            ))
+            return False
+        # warn and return failed if not in a loop
+        if self.currentExperiment.currentLoop is self.currentExperiment:
+            logging.warn(_translate(
+                "Could not pause loop as the current experiment is not in a loop."
+            ))
+            return False
+        # pause loop
+        self.currentExperiment.currentLoop.status = constants.PAUSED
 
     def pauseExperiment(self):
         """


### PR DESCRIPTION
Works by the distinction between the current trial and the TrialHandler - if the current trial is paused, pause immediately, if the TrialHandler is paused, pause on iteration