### PR TITLE
BF: Handle when record of last open app windows is an invalid value (e.g. from old version)

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -532,6 +532,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if self.prefs.app['defaultView'] == 'all':
                 startView = ["builder", "coder", "runner"]
             elif self.prefs.app['defaultView'] == "last":
+                if self.prefs.appData['lastFrame'] == "both":
+                    self.prefs.appData['lastFrame'] = "builder-coder-runner"
                 startView = self.prefs.appData['lastFrame'].split("-")
             elif self.prefs.app['defaultView'] in ["builder", "coder", "runner"]:
                 startView = self.prefs.app['defaultView']

--- a/psychopy/app/appData.spec
+++ b/psychopy/app/appData.spec
@@ -1,5 +1,5 @@
 
-lastFrame = string(default='both')
+lastFrame = string(default='builder-coder-runner')
 skipVersion=string(default='')  #skipping any updates of this version
 tipIndex = integer(default=0)
 flowSize = integer(0,2,default=2)


### PR DESCRIPTION
Should fix #6812 (though I was unable to replicate the issue on Windows so please give this a try @aforren1 and let me know if it fixes the problem)