### PR TITLE
ENH: In Components from not installed plugins, add a button to get the plugin

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -91,7 +91,6 @@ jobs:
           brew install swig vlc portaudio portmidi liblo sdl2
         fi
         # install optional components
-        pip install psychopy-sounddevice psychopy-pyo psychopy-legacy-mic psychopy-connect psychopy-crs psychopy-emotiv psychopy-gammasci psychopy-mri-emulator
         pip install moviepy
 
 #    - name: test docs to pdf

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1564,8 +1564,8 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
     def openPluginManager(self, evt=None):
         dlg = psychopy.app.plugin_manager.dialog.EnvironmentManagerDlg(self)
         dlg.Show()
-        # Do post-close checks
-        dlg.onClose()
+        
+        return dlg
 
     def onPavloviaCreate(self, evt=None):
         if Path(self.filename).is_file():

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -28,9 +28,10 @@ from .dlgsConditions import DlgConditions
 from .dlgsCode import DlgCodeComponentProperties, CodeBox
 from .findDlg import BuilderFindDlg
 from . import paramCtrls
+from psychopy.app.utils import HyperLinkCtrl
 from psychopy import data, logging, exceptions
 from psychopy.localization import _translate
-from psychopy.tools import versionchooser as vc
+from psychopy.tools import versionchooser as vc, pkgtools
 from psychopy.alerts import alert
 from ...colorpicker import PsychoColorPicker
 from pathlib import Path
@@ -879,6 +880,7 @@ class _BaseParamsDlg(wx.Dialog):
         self.showAdvanced = showAdvanced
         self.order = element.order
         self.depends = element.depends
+        self.plugin = element.plugin
         self.data = []
         # max( len(str(self.params[x])) for x in keys )
         self.maxFieldLength = 10
@@ -907,11 +909,25 @@ class _BaseParamsDlg(wx.Dialog):
 
         self.mainSizer.Add(self.ctrls,  # ctrls is the notebook of params
                            proportion=1, flag=wx.EXPAND | wx.ALL, border=5)
+        # if element came from a plugin that's not installed, add button to open plugins dlg
+        self.pluginBtn = HyperLinkCtrl(
+            self, label=_translate("Requires plugin {}, click here to install.").format(self.plugin)
+        )
+        self.pluginBtn.Bind(wx.EVT_BUTTON, self.jumpToPlugin)
+        self.mainSizer.Add(self.pluginBtn, border=6, flag=wx.CENTER | wx.ALL)
+        # show/hide button according to whether the plugin is installed or not
+        self.pluginBtn.Show(
+            self.plugin not in (None, "None", "") and self.plugin not in dict(pkgtools.getInstalledPackages())
+        )
 
         self.SetSizerAndFit(self.mainSizer)
 
     def getParams(self):
         return self.ctrls.getParams()
+
+    def jumpToPlugin(self, evt):
+        dlg = self.frame.openPluginManager()
+        dlg.jumpToPlugin(self.plugin)
 
     def openMonitorCenter(self, event):
         self.app.openMonitorCenter(event)

--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -137,6 +137,22 @@ class EnvironmentManagerDlg(wx.Dialog):
         """
         return self.pipProcess is not None
 
+    def jumpToPlugin(self, name):
+        """
+        Jump to viewing a particular plugin.
+
+        Parameters
+        ----------
+        name : str
+            Package name for the plugin
+        """
+        # open the plugins panel
+        i = self.notebook.FindPage(self.pluginMgr)
+        self.notebook.ChangeSelection(i)
+        # search for plugin name
+        self.pluginMgr.pluginList.searchCtrl.SetValue(name)
+        self.pluginMgr.pluginList.search()
+
     def uninstallPackage(self, packageName):
         """Uninstall a package.
 

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -720,9 +720,10 @@ class Experiment:
                         # don't warn people if we know it's OK (e.g. for params
                         # that have been removed
                         pass
-                    elif componentNode is not None and componentNode.get("plugin") not in ("None", None):
-                        # don't warn people if comp/routine is from a plugin
-                        pass
+                    elif componentNode is not None and componentNode.get("plugin", False):
+                        # is param unrecognised because it's from a plugin?
+                        params[name].categ = "Plugin"
+                        params[name].plugin = componentNode.get("plugin", False)
                     elif paramNode.get('plugin', False):
                         # load plugin name if param is from a plugin
                         params[name].plugin = paramNode.get('plugin')

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -74,6 +74,9 @@ class SettingsComponent:
     targets = ['PsychoPy', 'PsychoJS']
     iconFile = Path(__file__).parent / 'settings.png'
     tooltip = _translate("Edit settings for this experiment")
+    plugin = None
+    version = "0.0.0"
+    beta = False
 
     def __init__(
             self, parentName, exp, expName='', fullScr=True, runMode=0, rush=False,


### PR DESCRIPTION
This should help with the confusion around "Unknown Plugin Component", by adding a link to the bottom of the actual Component dialog to get the plugin. When clicked, will open the plugin dialog with the search bar prepopulated - so if the plugin doesn't exist it'll just come up blank rather than erroring.

![image](https://github.com/user-attachments/assets/bc1a9101-1b97-49dd-825b-2bb6dafe7c59)