### PR TITLE
BF: Counterbalance Routine conditions file chooser wasn't updating the value properly

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -982,7 +982,7 @@ class TableCtrl(wx.TextCtrl, _ValidatorMixin, _HideMixin, _FileMixin):
         _wld = f"All Table Files({'*'+';*'.join(self.validExt)})|{'*'+';*'.join(self.validExt)}|All Files (*.*)|*.*"
         file = self.getFile(msg="Specify table file ...", wildcard=_wld)
         if file:
-            self.SetValue(file)
+            FileCtrl.setFile(self, file)
             self.validate(event)
 
 


### PR DESCRIPTION
TableCtrl wasn't triggering the correct event when a file was chosen, so the value wasn't updated unless the user went and edited the value in the text field after choosing it. While loops use the same control type, they handle this manually so it was only affecting Counterbalance Routine