### PR TITLE
TEST: Don't install plugins in test suite

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -91,7 +91,6 @@ jobs:
           brew install swig vlc portaudio portmidi liblo sdl2
         fi
         # install optional components
-        pip install psychopy-sounddevice psychopy-pyo psychopy-legacy-mic psychopy-connect psychopy-crs psychopy-emotiv psychopy-gammasci psychopy-mri-emulator
         pip install moviepy
 
 #    - name: test docs to pdf


### PR DESCRIPTION
Doing so creates a situation where the test suite can suddenly start failing because of a change in a plugin. Plugins should be tested in their own test suites.