### PR TITLE
BF: If ioHub keypress made with only key code, use value for key name

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -151,6 +151,8 @@ class KeyPress(BaseResponse):
             else:
                 self.name = keyNames[code]
         elif KeyboardDevice._backend == 'iohub':
+            if name is None:
+                name = code
             self.name = name
         # get value
         value = self.name


### PR DESCRIPTION
Pushing to dev as this only affects keypresses made via `makeResponse` - from the keyboard itself, ioHub supplies a value for `name`.