### PR TITLE
ENH: Added error type for devices not found to make it easier to catch

### DIFF
--- a/psychopy/hardware/__init__.py
+++ b/psychopy/hardware/__init__.py
@@ -8,6 +8,7 @@ from psychopy import logging
 from . import eyetracker, listener
 from .manager import DeviceManager, deviceManager
 from .base import BaseDevice, BaseResponse, BaseResponseDevice
+from .exceptions import DeviceNotConnectedError
 
 try:
     from collections.abc import Iterable

--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -82,53 +82,6 @@ class BaseResponse:
         return json.dumps(message)
 
 
-class DeviceNotConnectedError(Exception):
-    """
-    Raised when a subclass of BaseDevice is initialised but the physical device it represents can't 
-    be found.
-
-    Parameters
-    ----------
-    msg : str
-        Message to display
-    deviceClass : type
-        Device class which the error came from
-    context : dict, optional
-        Dict of any additional information to store
-    """
-    def __init__(self, msg, deviceClass=None, context=None, *args):
-        # make exception
-        Exception.__init__(self, msg, *args)
-        # store device class
-        if deviceClass is not None and not isinstance(deviceClass, type):
-            deviceClass = type(deviceClass)
-        self.deviceClass = deviceClass
-        # store additional context
-        self.context = context
-    
-    def getJSON(self, asString=True):
-        """
-        Allow this type of error to be converted to JSON if requested.
-
-        Parameters
-        ----------
-        asString : bool, optional
-            Convert to a string or leave as a serializable dict? By default True
-        """
-        # construct message
-        message = {
-            'type': "device_not_connected_error",
-            'device_type': self.deviceClass.__name__,
-            'msg': str(self),
-            'context': self.context
-        }
-        # stringify if requested
-        if asString:
-            message = json.dumps(message)
-
-        return message
-
-
 class BaseDevice:
     """
     Base class for device interfaces, includes support for DeviceManager and adding listeners.

--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -82,6 +82,14 @@ class BaseResponse:
         return json.dumps(message)
 
 
+class DeviceNotConnectedError(Exception):
+    """
+    Raised when a subclass of BaseDevice is initialised but the physical device it represents can't 
+    be found.
+    """
+    pass
+
+
 class BaseDevice:
     """
     Base class for device interfaces, includes support for DeviceManager and adding listeners.

--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -86,8 +86,47 @@ class DeviceNotConnectedError(Exception):
     """
     Raised when a subclass of BaseDevice is initialised but the physical device it represents can't 
     be found.
+
+    Parameters
+    ----------
+    msg : str
+        Message to display
+    deviceClass : type
+        Device class which the error came from
+    context : dict, optional
+        Dict of any additional information to store
     """
-    pass
+    def __init__(self, msg, deviceClass=None, context=None, *args):
+        # make exception
+        Exception.__init__(self, msg, *args)
+        # store device class
+        if deviceClass is not None and not isinstance(deviceClass, type):
+            deviceClass = type(deviceClass)
+        self.deviceClass = deviceClass
+        # store additional context
+        self.context = context
+    
+    def getJSON(self, asString=True):
+        """
+        Allow this type of error to be converted to JSON if requested.
+
+        Parameters
+        ----------
+        asString : bool, optional
+            Convert to a string or leave as a serializable dict? By default True
+        """
+        # construct message
+        message = {
+            'type': "device_not_connected_error",
+            'device_type': self.deviceClass.__name__,
+            'msg': str(self),
+            'context': self.context
+        }
+        # stringify if requested
+        if asString:
+            message = json.dumps(message)
+
+        return message
 
 
 class BaseDevice:

--- a/psychopy/hardware/exceptions.py
+++ b/psychopy/hardware/exceptions.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 
 
 class DeviceNotConnectedError(Exception):
@@ -40,6 +41,37 @@ class DeviceNotConnectedError(Exception):
             'device_type': self.deviceClass.__name__,
             'msg': str(self),
             'context': self.context
+        }
+        # stringify if requested
+        if asString:
+            message = json.dumps(message)
+
+        return message
+
+
+class ManagedDeviceError(BaseException):
+    """
+    Exception arising from a managed device, which will include information about the device from
+    DeviceManager.
+    """
+    def __init__(self, msg, deviceName, traceback=None):
+        # create exception
+        BaseException.__init__(self, msg)
+        # store device name
+        self.deviceName = deviceName
+        # store traceback
+        if traceback is not None:
+            self.traceback = traceback
+        else:
+            self.traceback = self.__traceback__
+
+    def getJSON(self, asString=True):
+        tb = traceback.format_exception(type(self), self, self.traceback)
+        message = {
+            'type': "hardware_error",
+            'device': self.deviceName,
+            'msg': "".join(tb),
+            'context': getattr(self, "userdata", None)
         }
         # stringify if requested
         if asString:

--- a/psychopy/hardware/exceptions.py
+++ b/psychopy/hardware/exceptions.py
@@ -2,7 +2,7 @@ import json
 import traceback
 
 
-class DeviceNotConnectedError(Exception):
+class DeviceNotConnectedError(BaseException):
     """
     Raised when a subclass of BaseDevice is initialised but the physical device it represents can't 
     be found.
@@ -18,7 +18,7 @@ class DeviceNotConnectedError(Exception):
     """
     def __init__(self, msg, deviceClass=None, context=None, *args):
         # make exception
-        Exception.__init__(self, msg, *args)
+        BaseException.__init__(self, msg, *args)
         # store device class
         if deviceClass is not None and not isinstance(deviceClass, type):
             deviceClass = type(deviceClass)
@@ -40,6 +40,7 @@ class DeviceNotConnectedError(Exception):
             'type': "device_not_connected_error",
             'device_type': self.deviceClass.__name__,
             'msg': str(self),
+            'traceback': traceback.format_exception(type(self), self, self.__traceback__),
             'context': self.context
         }
         # stringify if requested
@@ -66,11 +67,11 @@ class ManagedDeviceError(BaseException):
             self.traceback = self.__traceback__
 
     def getJSON(self, asString=True):
-        tb = traceback.format_exception(type(self), self, self.traceback)
         message = {
             'type': "hardware_error",
             'device': self.deviceName,
-            'msg': "".join(tb),
+            'msg': str(self),
+            'traceback': traceback.format_exception(type(self), self, self.traceback),
             'context': getattr(self, "userdata", None)
         }
         # stringify if requested

--- a/psychopy/hardware/exceptions.py
+++ b/psychopy/hardware/exceptions.py
@@ -1,0 +1,48 @@
+import json
+
+
+class DeviceNotConnectedError(Exception):
+    """
+    Raised when a subclass of BaseDevice is initialised but the physical device it represents can't 
+    be found.
+
+    Parameters
+    ----------
+    msg : str
+        Message to display
+    deviceClass : type
+        Device class which the error came from
+    context : dict, optional
+        Dict of any additional information to store
+    """
+    def __init__(self, msg, deviceClass=None, context=None, *args):
+        # make exception
+        Exception.__init__(self, msg, *args)
+        # store device class
+        if deviceClass is not None and not isinstance(deviceClass, type):
+            deviceClass = type(deviceClass)
+        self.deviceClass = deviceClass
+        # store additional context
+        self.context = context
+    
+    def getJSON(self, asString=True):
+        """
+        Allow this type of error to be converted to JSON if requested.
+
+        Parameters
+        ----------
+        asString : bool, optional
+            Convert to a string or leave as a serializable dict? By default True
+        """
+        # construct message
+        message = {
+            'type': "device_not_connected_error",
+            'device_type': self.deviceClass.__name__,
+            'msg': str(self),
+            'context': self.context
+        }
+        # stringify if requested
+        if asString:
+            message = json.dumps(message)
+
+        return message

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -17,6 +17,7 @@ __all__ = [
 
 
 from psychopy.tools import systemtools as st
+from psychopy.hardware.exceptions import DeviceNotConnectedError
 from serial.tools import list_ports
 from psychopy import logging
 import atexit
@@ -241,8 +242,6 @@ class DeviceManager:
         BaseDevice
             Device created by the linked class init
         """
-        from psychopy.hardware.base import DeviceNotConnectedError
-        
         # if device class is an already registered alias, get the actual class str
         deviceClass = DeviceManager._resolveAlias(deviceClass)
         # get device class

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -17,47 +17,15 @@ __all__ = [
 
 
 from psychopy.tools import systemtools as st
-from psychopy.hardware.exceptions import DeviceNotConnectedError
+from psychopy.hardware.exceptions import DeviceNotConnectedError, ManagedDeviceError
 from serial.tools import list_ports
 from psychopy import logging
 import atexit
-import traceback
 import importlib
 import json
 from pathlib import Path
 
 __folder__ = Path(__file__).parent
-
-
-class ManagedDeviceError(BaseException):
-    """
-    Exception arising from a managed device, which will include information about the device from
-    DeviceManager.
-    """
-    def __init__(self, msg, deviceName, traceback=None):
-        # create exception
-        BaseException.__init__(self, msg)
-        # store device name
-        self.deviceName = deviceName
-        # store traceback
-        if traceback is not None:
-            self.traceback = traceback
-        else:
-            self.traceback = self.__traceback__
-
-    def getJSON(self, asString=True):
-        tb = traceback.format_exception(type(self), self, self.traceback)
-        message = {
-            'type': "hardware_error",
-            'device': self.deviceName,
-            'msg': "".join(tb),
-            'context': getattr(self, "userdata", None)
-        }
-        # stringify if requested
-        if asString:
-            message = json.dumps(message)
-
-        return message
 
 
 class DeviceManager:

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -16,6 +16,7 @@ __all__ = [
 ]
 
 
+from psychopy.hardware.base import DeviceNotConnectedError
 from psychopy.tools import systemtools as st
 from serial.tools import list_ports
 from psychopy import logging
@@ -248,6 +249,9 @@ class DeviceManager:
         try:
             # initialise device
             device = cls(*args, **kwargs)
+        except DeviceNotConnectedError as err:
+            # raise "not connected" errors as normal
+            raise err
         except Exception as err:
             # if initialization fails, generate a more informative ManagedDeviceError and return it
             raise ManagedDeviceError(

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -16,7 +16,6 @@ __all__ = [
 ]
 
 
-from psychopy.hardware.base import DeviceNotConnectedError
 from psychopy.tools import systemtools as st
 from serial.tools import list_ports
 from psychopy import logging
@@ -242,6 +241,8 @@ class DeviceManager:
         BaseDevice
             Device created by the linked class init
         """
+        from psychopy.hardware.base import DeviceNotConnectedError
+        
         # if device class is an already registered alias, get the actual class str
         deviceClass = DeviceManager._resolveAlias(deviceClass)
         # get device class

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -149,9 +149,10 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             # if there are none, error
             if not len(_devices):
                 raise DeviceNotConnectedError(_translate(
-                    "Could not choose default recording device as no recording "
-                    "devices are connected."
-                ))
+                        "Could not choose default recording device as no recording "
+                        "devices are connected."
+                    ), deviceClass=MicrophoneDevice
+                )
 
             # Try and get the best match which are compatible with the user's
             # specified settings.
@@ -375,7 +376,9 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
         elif chosenDevice is None:
             # if no index match found, raise error
             raise DeviceNotConnectedError(
-                f"Could not find any audio recording device with index {index}"
+                f"Could not find any audio recording device with index {index}",
+                deviceClass=MicrophoneDevice,
+                context={'index': index, 'sampleRateHz': sampleRateHz, 'channels': channels}
             )
 
         return chosenDevice

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 from psychtoolbox import audio as audio
 from psychopy import logging as logging, prefs
-from psychopy.hardware.base import DeviceNotConnectedError
+from psychopy.hardware.exceptions import DeviceNotConnectedError
 from psychopy.localization import _translate
 from psychopy.constants import NOT_STARTED
 from psychopy.hardware import BaseDevice, BaseResponse, BaseResponseDevice

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -4,6 +4,7 @@ import time
 import numpy as np
 from psychtoolbox import audio as audio
 from psychopy import logging as logging, prefs
+from psychopy.hardware.base import DeviceNotConnectedError
 from psychopy.localization import _translate
 from psychopy.constants import NOT_STARTED
 from psychopy.hardware import BaseDevice, BaseResponse, BaseResponseDevice
@@ -147,7 +148,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             _devices = MicrophoneDevice.getDevices()
             # if there are none, error
             if not len(_devices):
-                raise AudioInvalidCaptureDeviceError(_translate(
+                raise DeviceNotConnectedError(_translate(
                     "Could not choose default recording device as no recording "
                     "devices are connected."
                 ))
@@ -373,8 +374,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             chosenDevice = fallbackDevice
         elif chosenDevice is None:
             # if no index match found, raise error
-            raise KeyError(
-                f"Could not find any device with index {index}"
+            raise DeviceNotConnectedError(
+                f"Could not find any audio recording device with index {index}"
             )
 
         return chosenDevice

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -16,7 +16,7 @@ from psychopy import logging
 import serial
 from psychopy.tools import systemtools as st
 from psychopy.tools.attributetools import AttributeGetSetMixin
-from .base import BaseDevice
+from .base import BaseDevice, DeviceNotConnectedError
 
 
 def _findPossiblePorts():
@@ -175,7 +175,7 @@ class SerialDevice(BaseDevice, AttributeGetSetMixin):
             global ports
             ports[port] = self
         else:
-            raise ConnectionError(
+            raise DeviceNotConnectedError(
                 f"Failed to connect to device on {port}, this device is likely to have "
                 f"been disconnected, or the port is in use by another application."
             )

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -17,7 +17,8 @@ import serial
 from psychopy.localization import _translate
 from psychopy.tools import systemtools as st
 from psychopy.tools.attributetools import AttributeGetSetMixin
-from .base import BaseDevice, DeviceNotConnectedError
+from .base import BaseDevice
+from psychopy.hardware.exceptions import DeviceNotConnectedError
 
 
 def _findPossiblePorts():

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -14,6 +14,7 @@ import time
 
 from psychopy import logging
 import serial
+from psychopy.localization import _translate
 from psychopy.tools import systemtools as st
 from psychopy.tools.attributetools import AttributeGetSetMixin
 from .base import BaseDevice, DeviceNotConnectedError
@@ -175,9 +176,12 @@ class SerialDevice(BaseDevice, AttributeGetSetMixin):
             global ports
             ports[port] = self
         else:
-            raise DeviceNotConnectedError(
-                f"Failed to connect to device on {port}, this device is likely to have "
-                f"been disconnected, or the port is in use by another application."
+            raise DeviceNotConnectedError(_translate(
+                    f"Failed to connect to device on {port}, this device is likely to have "
+                    f"been disconnected, or the port is in use by another application."
+                ),
+                deviceClass=SerialDevice,
+                context={'port': port}
             )
         # we aren't in a time-critical period so flush messages
         logging.flush()

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -1,4 +1,5 @@
 from psychopy.hardware import BaseDevice, DeviceManager
+from psychopy.hardware.base import DeviceNotConnectedError
 from psychopy.sound import setDevice, getDevices, backend
 from psychopy.tools import systemtools as st
 from psychopy import logging
@@ -22,6 +23,10 @@ class SpeakerDevice(BaseDevice):
         
         # get all playback devices
         profiles = st.getAudioPlaybackDevices()
+        if not len(profiles):
+            raise DeviceNotConnectedError(
+                "No audio output devices connected."
+            )
 
         # if index is default, get default
         if index in (-1, None):

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -25,7 +25,7 @@ class SpeakerDevice(BaseDevice):
         profiles = st.getAudioPlaybackDevices()
         if not len(profiles):
             raise DeviceNotConnectedError(
-                "No audio output devices connected."
+                "No audio output devices connected.", deviceClass=SpeakerDevice
             )
 
         # if index is default, get default

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -1,5 +1,5 @@
 from psychopy.hardware import BaseDevice, DeviceManager
-from psychopy.hardware.base import DeviceNotConnectedError
+from psychopy.hardware.exceptions import DeviceNotConnectedError
 from psychopy.sound import setDevice, getDevices, backend
 from psychopy.tools import systemtools as st
 from psychopy import logging

--- a/psychopy/tests/test_liaison/test_Liaison.py
+++ b/psychopy/tests/test_liaison/test_Liaison.py
@@ -272,4 +272,4 @@ class TestLiaison:
         # make sure error looks correct in JSON format
         result = self.protocol.messages[-1]
         assert result['type'] == "hardware_error"
-        assert "psychopy.hardware.manager.ManagedDeviceError" in result['msg']
+        assert "psychopy.hardware.exceptions.ManagedDeviceError" in result['msg']

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -318,7 +318,8 @@ class Rift(window.Window):
 
         if not libovr.isHmdConnected():
             raise DeviceNotConnectedError(
-                "Cannot find any connected HMD, check connections and try again."
+                "Cannot find any connected HMD, check connections and try again.",
+                deviceClass=Rift
             )
 
         # create a VR session, do some initial configuration

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -42,7 +42,7 @@ import ctypes
 import numpy as np
 import pyglet.gl as GL
 from psychopy.visual import window
-from psychopy.hardware.base import DeviceNotConnectedError
+from psychopy.hardware.exceptions import DeviceNotConnectedError
 from psychopy import platform_specific, logging, core
 from psychopy.tools.attributetools import setAttribute
 

--- a/psychopy/visual/rift.py
+++ b/psychopy/visual/rift.py
@@ -42,6 +42,7 @@ import ctypes
 import numpy as np
 import pyglet.gl as GL
 from psychopy.visual import window
+from psychopy.hardware.base import DeviceNotConnectedError
 from psychopy import platform_specific, logging, core
 from psychopy.tools.attributetools import setAttribute
 
@@ -316,8 +317,9 @@ class Rift(window.Window):
                                "exiting.")
 
         if not libovr.isHmdConnected():
-            raise RuntimeError("Cannot find any connected HMD, check " +
-                               "connections and try again.")
+            raise DeviceNotConnectedError(
+                "Cannot find any connected HMD, check connections and try again."
+            )
 
         # create a VR session, do some initial configuration
         initResult = libovr.initialize()  # removed logging callback


### PR DESCRIPTION
Makes it easier to distinguish between the requested device not being connected and initialisation failing for other reasons