### PR TITLE
NF: Allow Mic and Camera Components to be automatically saved when experiment data saves

### DIFF
--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -474,6 +474,8 @@ class CameraComponent(BaseDeviceComponent):
         code = (
             "# get camera object\n"
             "%(name)s = deviceManager.getDevice(%(deviceLabel)s)\n"
+            "# connect camera save method to experiment handler so it's called when data saves\n"
+            "thisExp.connectSaveMethod(%(name)s.save)\n"
         )
         buff.writeIndentedLines(code % inits)
 

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -410,6 +410,8 @@ class MicrophoneComponent(BaseDeviceComponent):
             "# tell the experiment handler to save this Microphone's clips if the experiment is "
             "force ended\n"
             "runAtExit.append(%(name)s.saveClips)\n"
+            "# connect camera save method to experiment handler so it's called when data saves\n"
+            "thisExp.connectSaveMethod(%(name)s.saveClips)\n"
         )
         buff.writeIndentedLines(code % inits)
 


### PR DESCRIPTION
This plays into the new Static param "saveData" - as it means when this is ticked, Mic and Camera Components will save their audio/video files during the static period too.