### PR TITLE
BF: Better error handling when getting recording from mic that's still recording

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -953,9 +953,10 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         """
         if self.isStarted:
-            raise AudioStreamError(
-                "Cannot get audio clip, recording was in progress. Be sure to "
-                "call `Microphone.stop` first.")
+            logging.warn(
+                "Cannot get audio clip while recording is in progress, so stopping recording now."
+            )
+            self.stop()
 
         return self._recording.getSegment()  # full recording
 


### PR DESCRIPTION
Tagging @mdcutone for review to make sure the hard error here isn't needed - does `stop` do anything asynchronous which we need to be wary of when calling immediately before a save?