### PR TITLE
Fix Pavlovia sync errors due to git config settings

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1217,7 +1217,7 @@ class PavloviaProject(dict):
             config.set_value("user", "name", self.session.user['name'])
         if config.get_value("pull", "rebase", default=-100) == -100:
             config.set_value("pull", "rebase", False)
-        if config.get_value("pull", "rebase", default=-100) == -100:
+        if config.get_value("http", "postBuffer", default=-100) == -100:
             config.set_value("http", "postBuffer", 524288000)
         config.release()  # saves the changes (not needed if using `with config_writer() as config`)
 

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1211,7 +1211,8 @@ class PavloviaProject(dict):
         # set the local config
         config = self.repo.config_writer()
         # set config values if the user hasn't set them already
-        # the -100 hack is because ConfigParser.get_value allows setting 
+        # the -100 hack is because ConfigParser.get_value allows setting a default
+        # but doing try...except on its custom errors is annoying!
         if config.get_value("user", "email", default=-100) == -100:
             config.set_value("user", "email", self.session.user['email'])
             config.set_value("user", "name", self.session.user['name'])

--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1208,12 +1208,18 @@ class PavloviaProject(dict):
         None
         """
         localConfig = self.repo.git.config(l=True, local=True)  # list local
-        if self.session.user['email'] in localConfig:
-            return  # we already have it set up so can return
         # set the local config
-        with self.repo.config_writer() as config:
+        config = self.repo.config_writer()
+        # set config values if the user hasn't set them already
+        # the -100 hack is because ConfigParser.get_value allows setting 
+        if config.get_value("user", "email", default=-100) == -100:
             config.set_value("user", "email", self.session.user['email'])
             config.set_value("user", "name", self.session.user['name'])
+        if config.get_value("pull", "rebase", default=-100) == -100:
+            config.set_value("pull", "rebase", False)
+        if config.get_value("pull", "rebase", default=-100) == -100:
+            config.set_value("http", "postBuffer", 524288000)
+        config.release()  # saves the changes (not needed if using `with config_writer() as config`)
 
     def fork(self, to=None):
         # Sub in current user if none given


### PR DESCRIPTION
Fixes 2 errors depending on local settings:
```
error: RPC failed; HTTP 500 curl 22 The requested URL returned error: 500
send-pack: unexpected disconnect while reading sideband packet
fatal: the remote end hung up unexpectedly
```
when trying to upload a large repo in one go. This is fixed by setting http.postbuffer to a large value

and
```
git.exc.GitCommandError: Cmd('C:\Program Files\PsychoPy\MinGit\cmd\git.exe') failed due to: exit code(128)
  cmdline: C:\Program Files\PsychoPy\MinGit\cmd\git.exe pull https://oauth2:*****@gitlab.pavlovia.org/Consultancy/moon_task master
  stderr: 'warning: redirecting to https://gitlab.pavlovia.org/Consultancy/moon_task.git/
 * branch            master     -> FETCH_HEAD
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
From https://gitlab.pavlovia.org/Consultancy/moon_task
hint: your next pull:
hint:
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
```
caused by pull when a merge rule hasn't yet been set (git used to default to no rebase automatically)