### PR TITLE
FF: Periodic file saving was causing data files with same name to be overwritten

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -632,8 +632,12 @@ class ExperimentHandler(_ComparisonMixin):
         # handle default
         if fileName is None:
             fileName = self.dataFileName
+        # make filename iterable
+        if not isinstance(fileName, (list, tuple)):
+            fileName = [fileName]
         # queue collision
-        self._nextSaveCollision[fileName] = fileCollisionMethod
+        for thisFileName in fileName:
+            self._nextSaveCollision[thisFileName] = fileCollisionMethod
     
     def connectSaveMethod(self, fcn, *args, **kwargs):
         """
@@ -663,15 +667,19 @@ class ExperimentHandler(_ComparisonMixin):
         Work out from own settings how to save, then use the appropriate method (saveAsWideText, 
         saveAsPickle, etc.)
         """
-        savedName = None
+        savedNames = []
         if self.dataFileName not in ['', None]:
             if self.autoLog:
                 msg = 'Saving data for %s ExperimentHandler' % self.name
                 logging.debug(msg)
             if self.savePickle:
-                savedName = self.saveAsPickle(self.dataFileName)
+                savedNames.append(
+                    self.saveAsPickle(self.dataFileName)
+                )
             if self.saveWideText:
-                savedName = self.saveAsWideText(self.dataFileName + '.csv')
+                savedNames.append(
+                    self.saveAsWideText(self.dataFileName + '.csv')
+                )
         else:
             logging.warn(
                 "ExperimentHandler.save was called on an ExperimentHandler with no dataFileName set."
@@ -680,7 +688,7 @@ class ExperimentHandler(_ComparisonMixin):
         for profile in self.connectedSaveMethods:
             profile['fcn'](*profile['args'], **profile['kwargs'])
         
-        return savedName
+        return savedNames
 
     def saveAsWideText(self,
                        fileName,

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -852,22 +852,21 @@ class ExperimentHandler(_ComparisonMixin):
         savePickle = self.savePickle
         saveWideText = self.saveWideText
 
+        # append extension
+        if not fileName.endswith('.psydat'):
+            fileName += '.psydat'
+
         # check for queued collision methods if using default, fallback to rename
-        if fileCollisionMethod is None:
-            if fileCollisionMethod is None and fileName in self._nextSaveCollision:
-                fileCollisionMethod = self._nextSaveCollision.pop(fileName)
-            elif fileCollisionMethod is None:
-                fileCollisionMethod = "rename"
+        if fileCollisionMethod is None and fileName in self._nextSaveCollision:
+            fileCollisionMethod = self._nextSaveCollision.pop(fileName)
+        elif fileCollisionMethod is None:
+            fileCollisionMethod = "rename"
 
         self.savePickle = False
         self.saveWideText = False
 
         origEntries = self.entries
         self.entries = self.getAllEntries()
-
-        # otherwise use default location
-        if not fileName.endswith('.psydat'):
-            fileName += '.psydat'
 
         with openOutputFile(fileName=fileName, append=False,
                            fileCollisionMethod=fileCollisionMethod) as f:

--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -11,7 +11,7 @@ from psychopy import constants, clock
 from psychopy import logging
 from psychopy.data.trial import TrialHandler2
 from psychopy.tools.filetools import (openOutputFile, genDelimiter,
-                                      genFilenameFromDelimiter)
+                                      genFilenameFromDelimiter, handleFileCollision)
 from psychopy.localization import _translate
 from .utils import checkValidFilePath
 from .base import _ComparisonMixin
@@ -95,7 +95,7 @@ class ExperimentHandler(_ComparisonMixin):
         self.originPath = originPath
         self.savePickle = savePickle
         self.saveWideText = saveWideText
-        self.dataFileName = dataFileName
+        self.dataFileName = handleFileCollision(dataFileName, "rename")
         self.sortColumns = sortColumns
         self.thisEntry = {}
         self.entries = []  # chronological list of entries

--- a/psychopy/experiment/components/static/__init__.py
+++ b/psychopy/experiment/components/static/__init__.py
@@ -196,8 +196,8 @@ class StaticComponent(BaseComponent):
             if self.params['saveData']:
                 code = (
                     "# take the opportunity to save data file now (to be updated later)\n"
-                    "_%(name)sLastFileName = thisExp.save()\n"
-                    "thisExp.queueNextCollision('overwrite', fileName=_%(name)sLastFileName)\n"
+                    "_%(name)sLastFileNames = thisExp.save()\n"
+                    "thisExp.queueNextCollision('overwrite', fileName=_%(name)sLastFileNames)\n"
                 )
                 buff.writeIndentedLines(code % self.params)
             # start static

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -33,13 +33,26 @@ def handleFileCollision(fileName, fileCollisionMethod):
         raise IOError(msg % fileName)
     elif fileCollisionMethod == 'rename':
         rootName, extension = os.path.splitext(fileName)
-        matchingFiles = glob.glob("%s*%s" % (rootName, extension))
+        
+        # make extension iterable
+        if extension:
+            allowedExt = [extension]
+        else:
+            allowedExt = [
+                os.path.splitext(match)[1] for match in 
+                glob.glob("%s*" % rootName)
+            ]
+        # get extension (from options) with most files
+        nFiles = 0
+        for ext in allowedExt:
+            matchingFiles = glob.glob("%s*%s" % (rootName, ext))
+            nFiles = max(nFiles, len(matchingFiles))
 
         # Build the renamed string.
-        if not matchingFiles:
+        if not nFiles:
             fileName = "%s%s" % (rootName, extension)
         else:
-            fileName = "%s_%d%s" % (rootName, len(matchingFiles), extension)
+            fileName = "%s_%d%s" % (rootName, nFiles, extension)
 
         # Check to make sure the new fileName hasn't been taken too.
         if os.path.exists(fileName):


### PR DESCRIPTION
As file collision was being used to iterate filenames for multiple runs, this assumes that each file is saved only once per experiment run. As the Static Component can now save mid-experiment, this is no longer true, so we need to use that collision method to iterate filenames on creation of a new ExperimentHandler rather than on save.