### PR TITLE
FF: Fix filename collision iterations

### DIFF
--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -37,7 +37,7 @@ def handleFileCollision(fileName, fileCollisionMethod):
         fileObj = Path(fileName)
         # use a glob star if we don't have an ext
         if not fileObj.suffix:
-            fileObj = fileObj.with_suffix(".*")
+            fileObj = fileObj.parent / (fileObj.stem + ".*")
         # get original file name
         rootName = fileObj.stem
         # get total number of sibling files to use as maximum for iteration
@@ -46,10 +46,10 @@ def handleFileCollision(fileName, fileCollisionMethod):
         i = 0
         while list(fileObj.parent.glob(fileObj.name)) and i < nSiblings:
             i += 1
-            fileObj = fileObj.with_stem(f"{rootName}_{i}")
+            fileObj = fileObj.parent / (f"{rootName}_{i}" + fileObj.suffix)
         # remove glob star from suffix if needed
         if fileObj.suffix == ".*":
-            fileObj = fileObj.with_suffix("")
+            fileObj = fileObj.parent / fileObj.stem
         # convert back to a string
         fileName = str(fileObj)
 

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -38,10 +38,11 @@ def handleFileCollision(fileName, fileCollisionMethod):
         if extension:
             allowedExt = [extension]
         else:
-            allowedExt = [
-                os.path.splitext(match)[1] for match in 
-                glob.glob("%s*" % rootName)
-            ]
+            allowedExt = []
+            for match in glob.glob("%s*" % rootName):
+                ext = os.path.splitext(match)[1]
+                if ext and ext not in allowedExt:
+                    allowedExt.append(ext)
         # get extension (from options) with most files
         nFiles = 0
         for ext in allowedExt:

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -9,6 +9,7 @@
 """
 import os
 import glob
+from pathlib import Path
 
 from psychopy import logging
 
@@ -32,28 +33,25 @@ def handleFileCollision(fileName, fileCollisionMethod):
                "fileCollisionMethod to overwrite.")
         raise IOError(msg % fileName)
     elif fileCollisionMethod == 'rename':
-        rootName, extension = os.path.splitext(fileName)
-        
-        # make extension iterable
-        if extension:
-            allowedExt = [extension]
-        else:
-            allowedExt = []
-            for match in glob.glob("%s*" % rootName):
-                ext = os.path.splitext(match)[1]
-                if ext and ext not in allowedExt:
-                    allowedExt.append(ext)
-        # get extension (from options) with most files
-        nFiles = 0
-        for ext in allowedExt:
-            matchingFiles = glob.glob("%s*%s" % (rootName, ext))
-            nFiles = max(nFiles, len(matchingFiles))
-
-        # Build the renamed string.
-        if not nFiles:
-            fileName = "%s%s" % (rootName, extension)
-        else:
-            fileName = "%s_%d%s" % (rootName, nFiles, extension)
+        # convert to a Path object
+        fileObj = Path(fileName)
+        # use a glob star if we don't have an ext
+        if not fileObj.suffix:
+            fileObj = fileObj.with_suffix(".*")
+        # get original file name
+        rootName = fileObj.stem
+        # get total number of sibling files to use as maximum for iteration
+        nSiblings = len(list(fileObj.parent.glob("*")))
+        # iteratively add numbers to the end until filename isn't taken
+        i = 0
+        while list(fileObj.parent.glob(fileObj.name)) and i < nSiblings:
+            i += 1
+            fileObj = fileObj.with_stem(f"{rootName}_{i}")
+        # remove glob star from suffix if needed
+        if fileObj.suffix == ".*":
+            fileObj = fileObj.with_suffix("")
+        # convert back to a string
+        fileName = str(fileObj)
 
         # Check to make sure the new fileName hasn't been taken too.
         if os.path.exists(fileName):


### PR DESCRIPTION
Rather than counting number of matches of the raw filename with iterative extensions, start out with the raw filename and iteratively extend it checking each time.

With the old method, if you had a data file called `myExperiment_participant1.csv` and another from another experiment called `myExperiment_participant1_v2.csv`, this would count as a file collision and so the iteration on both experiment data files would be higher than expected/necessary. The old method would, if given just `myExperiment_participant1` (without `.csv`) count all files with that name, so if you had a log file and a psydat too you'd get `myExperiment_participant1_3.csv` on your second call.

Plus `pathlib.Path` is generally easier to work with and more readable, so it's a win-win.