### PR TITLE
ENH: Add "update" button to plugin dialog if plugin version isn't the latest

### DIFF
--- a/psychopy/app/plugin_manager/dialog.py
+++ b/psychopy/app/plugin_manager/dialog.py
@@ -203,7 +203,7 @@ class EnvironmentManagerDlg(wx.Dialog):
         global NEEDS_RESTART  # flag as needing a restart
         NEEDS_RESTART = True
 
-    def installPackage(self, packageName, version=None, extra=None):
+    def installPackage(self, packageName, version=None, extra=None, forceReinstall=None):
         """Install a package.
 
         Calling this will invoke a `pip` command which will install the
@@ -229,18 +229,21 @@ class EnvironmentManagerDlg(wx.Dialog):
         # add version if given
         if version is not None:
             packageName += f"=={version}"
+        # if forceReinstall is None, work out from version
+        if forceReinstall is None:
+            forceReinstall = version is not None
         # use package tools to install
         self.pipProcess = pkgtools.installPackage(
             packageName,
             upgrade=version is None,
-            forceReinstall=version is not None,
+            forceReinstall=forceReinstall,
             awaited=False,
             outputCallback=self.output.writeStdOut,
             terminateCallback=self.onInstallExit,
             extra=extra,
         )
 
-    def installPlugin(self, pluginInfo, version=None):
+    def installPlugin(self, pluginInfo, version=None, forceReinstall=None):
         """Install a package.
 
         Calling this will invoke a `pip` command which will install the
@@ -266,7 +269,8 @@ class EnvironmentManagerDlg(wx.Dialog):
             version=version,
             extra={
                 'pluginInfo': pluginInfo
-            }
+            },
+            forceReinstall=forceReinstall
         )
 
     def uninstallPlugin(self, pluginInfo):


### PR DESCRIPTION
As the necessary functionality is all in pkgtools already this seems like low hanging fruit - hopefully this will reduce the perceived bugginess of plugins as users will be able to see when they don't have the latest version (and, hopefully, if their bug is already fixed, they'll just update and see it work)