### PR TITLE
ENH: Allow non-WASAPI audio devices

### DIFF
--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -138,6 +138,8 @@
     audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
     # audio device to use (if audioLib allows control)
     audioDevice = list(default=list('default'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
     # The name of the Qmix pump configuration to use

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -56,6 +56,11 @@ if prefs.hardware['audioDevice']=='auto':
 else:
     audioDevice = prefs.hardware['audioDevice']
 
+# check if we should only use WAS host API (default is True on Windows)
+audioWASAPIOnly = False
+if sys.platform == 'win32' and prefs.hardware['audioWASAPIOnly']:
+    audioWASAPIOnly = True
+
 # these will be used by sound.__init__.py
 defaultInput = None
 defaultOutput = audioDevice
@@ -86,7 +91,7 @@ def getDevices(kind=None):
     kind can be None, 'input' or 'output'
     The dict keys are names, and items are dicts of properties
     """
-    if sys.platform == 'win32':
+    if audioWASAPIOnly:
         deviceTypes = 13  # only WASAPI drivers need apply!
     else:
         deviceTypes = None


### PR DESCRIPTION
We need to use ASIO drivers for a particular hardware soundcard, so I have compiled a custom pyaudio + psychtoolbox with ASIO support, but psychopy filters out non-WASAPI audio devices.

This adds a config option that on windows allows you to use ASIO (or WDM-KS if you would even want to).

The default for `prefs.hardware['audioWASAPIOnly']` is `True` for windows, `False` otherwise.

This isn't necessarily useful for anything outside of edge cases like ours, but I can imagine that more than one research group uses ASIO low-latency hardware with multi-channel output support.

On a separate note, if it's useful, I can make another PR with some modifications I made to `SoundPTB` to allow for an arbitrary number of output channels (not just mono or stereo), we use 3-channel output (left, right and a Manchester Encoded trigger channel to a trigger box).



