### PR TITLE
FF: Fix method when photodiode isn't found

### DIFF
--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -379,7 +379,7 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
             )
         # if we didn't get any responses at all, prompt to try again
         if not responsive:
-            handleNonResponse(label=label, rect=rect)
+            return handleNonResponse(label=label, rect=rect)
         # clear all the events created by this process
         self.state = [None] * self.channels
         self.dispatchMessages()


### PR DESCRIPTION
When a photodiode isn't found, we recalculate the threshold and tries again. However, I'd missed a `return` in this function, so it was running, in some cases finding the photodiode, and returning the *original* (failed) patch size, which was massive.