### PR TITLE
ENH: Copy MicrophoneDevice.reopen in Microphone

### DIFF
--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -202,6 +202,9 @@ class Microphone:
     def close(self):
         return self.device.close()
 
+    def reopen(self):
+        return self.device.reopen()
+
     def poll(self):
         return self.device.poll()
 


### PR DESCRIPTION
This matters because PsychoJS doesn't have a MicrophoneDevice, so this will make it simpler to auto-translate when PsychoJS.Microphone gets a reopen method