### PR TITLE
RF: Interpret --builder, --coder, etc. arguments *before* restoring previous files / windows from prefs

### DIFF
--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -61,7 +61,8 @@ def startApp(
         safeMode=False, 
         startView=None,
         startFiles=None,
-        firstRun=False
+        firstRun=False,
+        profiling=False,
     ):
     """Start the PsychoPy GUI.
 
@@ -130,7 +131,8 @@ def startApp(
         safeMode=safeMode, 
         startView=startView,
         startFiles=startFiles,
-        firstRun=firstRun
+        firstRun=firstRun,
+        profiling=profiling,
     )
 
     # After the app is loaded, we hand off logging to the stream dispatcher

--- a/psychopy/app/__init__.py
+++ b/psychopy/app/__init__.py
@@ -55,7 +55,14 @@ class _Tee(object):
         sys.__stdout__.flush()
 
 
-def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
+def startApp(
+        showSplash=True, 
+        testMode=False, 
+        safeMode=False, 
+        startView=None,
+        startFiles=None,
+        firstRun=False
+    ):
     """Start the PsychoPy GUI.
 
     This function is idempotent, where additional calls after the app starts
@@ -117,7 +124,14 @@ def startApp(showSplash=True, testMode=False, safeMode=False, startView=None):
     # console.
     from psychopy.app._psychopyApp import PsychoPyApp
     _psychopyAppInstance = PsychoPyApp(
-        0, testMode=testMode, showSplash=showSplash, safeMode=safeMode, startView=startView)
+        0, 
+        testMode=testMode, 
+        showSplash=showSplash, 
+        safeMode=safeMode, 
+        startView=startView,
+        startFiles=startFiles,
+        firstRun=firstRun
+    )
 
     # After the app is loaded, we hand off logging to the stream dispatcher
     # using the provided log file path. The dispatcher will write out any log

--- a/psychopy/app/__main__.py
+++ b/psychopy/app/__main__.py
@@ -1,0 +1,3 @@
+from .psychopyApp import main
+
+main()

--- a/psychopy/app/__main__.py
+++ b/psychopy/app/__main__.py
@@ -1,3 +1,3 @@
-from .psychopyApp import main
+from psychopy.app.psychopyApp import main
 
 main()

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -588,6 +588,9 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
         # if specified as a single string, convert to list
         if isinstance(startView, str):
             startView = [startView]
+        # if last open frame was no frame, use all instead
+        if not startView:
+            startView = ["builder", "coder", "runner"]
         # create windows
         if "runner" in startView:
             self.showRunner()

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -523,13 +523,6 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             if self.prefs.builder['reloadPrevExp'] and ('prevFiles' in self.prefs.appData['builder']):
                 for thisFile in self.prefs.appData['builder']['prevFiles']:
                     startFiles.append(thisFile)
-            # get starting files from commandline args
-            for arg in sys.argv:
-                # skip calling script
-                if arg.endswith("psychopyApp.py"):
-                    continue
-                # add to start files
-                startFiles.append(thisFile)
         # open start files
         for thisFile in startFiles:
             # convert to file object & skip any which aren't paths

--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -19,8 +19,6 @@ import argparse
 
 from psychopy.app.themes import icons, colors, handlers
 
-profiling = False  # turning on will save profile files in currDir
-
 import psychopy
 from psychopy import prefs
 from packaging.version import Version
@@ -166,7 +164,7 @@ class _Showgui_Hack():
 class PsychoPyApp(wx.App, handlers.ThemeMixin):
     _called_from_test = False  # pytest needs to change this
 
-    def __init__(self, arg=0, testMode=False, startView=None, **kwargs):
+    def __init__(self, arg=0, testMode=False, startView=None, profiling=False, **kwargs):
         """With a wx.App some things get done here, before App.__init__
         then some further code is launched in OnInit() which occurs after
         """

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -83,6 +83,12 @@ depends on the type of the [file]:
             "Suppresses splash screen"
         )
     )
+    # add option to include app profiling
+    argParser.add_argument(
+        "--profiling", dest="profiling", action="store_true", help=(
+            "Launches app with profiling to see what specific processes are taking up resources."
+        )
+    )
     # treat any other args as filepaths
     argParser.add_argument(dest="startFiles", nargs="*", type=Path)
 
@@ -141,7 +147,8 @@ depends on the type of the [file]:
                 startView=args.startView, 
                 showSplash=args.showSplash, 
                 startFiles=args.startFiles,
-                firstRun=args.firstRun
+                firstRun=args.firstRun,
+                profiling=args.profiling
             )
     else:
         # start app
@@ -149,7 +156,8 @@ depends on the type of the [file]:
             startView=args.startView, 
             showSplash=args.showSplash, 
             startFiles=args.startFiles,
-            firstRun=args.firstRun
+            firstRun=args.firstRun,
+            profiling=args.profiling
         )
         quitApp()
 

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -84,7 +84,7 @@ depends on the type of the [file]:
         )
     )
     # treat any other args as filepaths
-    argParser.add_argument(dest="startFiles", nargs='+', type=Path)
+    argParser.add_argument(dest="startFiles", nargs="*", type=Path)
 
     args = argParser.parse_args(sys.argv)
 

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -128,9 +128,7 @@ depends on the type of the [file]:
         # Therefore `pythonw` often doesn't exist, and we can just use `python`.
         if PYTHONW != 'True' and os.path.isfile(pyw_exe):
             from psychopy import core
-            cmd = [pyw_exe, __file__]
-            if '--no-splash' in sys.argv:
-                cmd.append('--no-splash')
+            cmd = [pyw_exe] + sys.argv
 
             stdout, stderr = core.shellCall(cmd,
                                             env=dict(env, PYTHONW='True'),
@@ -139,7 +137,12 @@ depends on the type of the [file]:
             print(stderr, file=sys.stderr)
             sys.exit()
         else:
-            start_app()
+            startApp(
+                startView=args.startView, 
+                showSplash=args.showSplash, 
+                startFiles=args.startFiles,
+                firstRun=args.firstRun
+            )
     else:
         # start app
         _ = startApp(

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -89,10 +89,18 @@ depends on the type of the [file]:
             "Launches app with profiling to see what specific processes are taking up resources."
         )
     )
-    # treat any other args as filepaths
-    argParser.add_argument(dest="startFiles", nargs="*", type=Path)
-
-    args = argParser.parse_args(sys.argv)
+    # parse args
+    args, startFilesRaw = argParser.parse_known_args(sys.argv)
+    # pathify startFiles
+    startFiles = []
+    for thisFile in startFilesRaw:
+        try:
+            startFiles.append(Path(thisFile))
+        except:
+            print(
+                "Could not interpret {} as a path.".format(thisFile)
+            )
+            continue
 
     # run files directly if requested
     if args.direct:
@@ -146,7 +154,7 @@ depends on the type of the [file]:
             startApp(
                 startView=args.startView, 
                 showSplash=args.showSplash, 
-                startFiles=args.startFiles,
+                startFiles=startFiles,
                 firstRun=args.firstRun,
                 profiling=args.profiling
             )
@@ -155,7 +163,7 @@ depends on the type of the [file]:
         _ = startApp(
             startView=args.startView, 
             showSplash=args.showSplash, 
-            startFiles=args.startFiles,
+            startFiles=startFiles,
             firstRun=args.firstRun,
             profiling=args.profiling
         )

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -25,13 +25,13 @@ def main():
     # parser to process input arguments
     argParser = argparse.ArgumentParser(
         prog="PsychoPyApp", description=(
-"""Starts the PsychoPy3 application.
+"""Starts the PsychoPy application.
 
-Usage:  python PsychoPy.py [options] [file]
+Usage:  python psychopy.app [options] [files]
 
 Without options or files provided this starts PsychoPy using prefs to
-decide on the view(s) to open.  If optional [file] is provided action
-depends on the type of the [file]:
+decide on the view(s) to open.  If optional [files] is provided action
+depends on the type of the [files]:
 
  Python script 'file.py' -- opens coder
 

--- a/psychopy/tests/data/test_basic_run.py
+++ b/psychopy/tests/data/test_basic_run.py
@@ -1,0 +1,1 @@
+print("SUCCESS")

--- a/psychopy/tests/test_app/test_command_line.py
+++ b/psychopy/tests/test_app/test_command_line.py
@@ -1,0 +1,65 @@
+"""
+Test that PsychoPy can be initialised from the command line with all API options
+"""
+import sys
+import time
+from pathlib import Path
+from psychopy import core
+from psychopy.tests import utils
+        
+
+def test_version_query():
+    """
+    Check that we can call the PsychoPy app with -v to get the version
+    """
+    from psychopy import __version__ as ppyVersion
+    cases = [
+        "-v",
+        "--version",
+    ]
+    for case in cases:
+        stderr = core.shellCall(
+            [sys.executable, "-m", "psychopy.app", case],
+            stderr=True
+        )
+        assert ppyVersion in "\n".join(stderr)
+
+
+def test_help_query():
+    """
+    Check that we can call the PsychoPy app with -h to get the help text
+    """
+    cases = [
+        "-h",
+        "--help",
+    ]
+    for case in cases:
+        stderr = core.shellCall(
+            [sys.executable, "-m", "psychopy.app", case],
+            stderr=True
+        )
+        assert "PsychoPy" in "\n".join(stderr)
+
+
+def test_direct_run():
+    """
+    Check that we can directly run files by invoking psychopy.app with -x
+    """
+    cases = [
+        {'tag': "-x", 'files': [str(Path(utils.TESTS_DATA_PATH) / "ghost_stroop.psyexp")]},
+        {'tag': "-x", 'files': [str(Path(utils.TESTS_DATA_PATH) / "test_basic_run.py")]},
+        {'tag': "-x", 'files': [
+            str(Path(utils.TESTS_DATA_PATH) / "ghost_stroop.psyexp"),
+            str(Path(utils.TESTS_DATA_PATH) / "test_basic_run.py")
+        ]},
+    ]
+    # include --direct too
+    for case in cases.copy():
+        case['tag'] = "--direct"
+        cases.append(case)
+    # run all cases
+    for case in cases:
+        stderr = core.shellCall(
+            [sys.executable, "-m", "psychopy.app", case['tag']] + case['files'],
+            stderr=True
+        )


### PR DESCRIPTION
Fixes #6914, as now we only reopen files/frames from the last time the app was opened if not actively told to open a specific frame.

This slipped through because we have arg parsing happening manually in multiple locations, so I moved it all to `psychopy.app.psychopyApp:main` and used Python's `argparse` handler as it's more robust than us manually iterating through `sys.argv`.