### PR TITLE
ENH: Improvements to app launch speed

### DIFF
--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -8,22 +8,7 @@ from psychopy import logging
 from psychopy.experiment.components import (
     BaseComponent, BaseDeviceComponent, Param, _translate, getInitVals
 )
-from psychopy.sound.audiodevice import sampleRateQualityLevels
 from psychopy.tools import stringtools as st, systemtools as syst, audiotools as at
-
-
-_hasPTB = True
-try:
-    import psychtoolbox.audio as audio
-except (ImportError, ModuleNotFoundError):
-    logging.warning(
-        "The 'psychtoolbox' library cannot be loaded but is required for audio "
-        "capture (use `pip install psychtoolbox` to get it). Microphone "
-        "recording will be unavailable this session. Note that opening a "
-        "microphone stream will raise an error.")
-    _hasPTB = False
-# Get list of sample rates
-micSampleRates = {r[1]: r[0] for r in sampleRateQualityLevels.values()}
 
 
 class CameraComponent(BaseDeviceComponent):
@@ -370,11 +355,16 @@ class CameraComponent(BaseDeviceComponent):
             hint=msg,
             label=_translate("Channels"))
 
+        def getSampleRates():
+            return [r[0] for r in at.sampleRateQualityLevels.values()]
+        def getSampleRateLabels():
+            return [r[1] for r in at.sampleRateQualityLevels.values()]
         msg = _translate(
             "How many samples per second (Hz) to record at")
         self.params['micSampleRate'] = Param(
             sampleRate, valType='num', inputType="choice", categ='Audio',
-            allowedVals=list(micSampleRates),
+            allowedVals=getSampleRates,
+            allowedLabels=getSampleRateLabels,
             hint=msg, direct=False,
             label=_translate("Sample rate (hz)"))
 
@@ -417,8 +407,9 @@ class CameraComponent(BaseDeviceComponent):
         inits = getInitVals(self.params)
         self.setupMicNameInInits(inits)
         # --- setup mic ---
-        # substitute sample rate value for numeric equivalent
-        inits['micSampleRate'] = micSampleRates[inits['micSampleRate'].val]
+        # make sure mic sample rate is numeric
+        if inits['micSampleRate'].val in at.sampleRateLabels:
+            inits['micSampleRate'].val = at.sampleRateLabels[inits['micSampleRate'].val]
         # substitute channel value for numeric equivalent
         inits['micChannels'] = {'mono': 1, 'stereo': 2, 'auto': None}[self.params['micChannels'].val]
         # initialise mic device

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -38,6 +38,10 @@ class EyetrackerRecordComponent(BaseComponent):
         self.type = 'EyetrackerRecord'
         self.url = "https://www.psychopy.org/builder/components/eyetracker.html"
         self.exp.requirePsychopyLibs(['iohub', 'hardware'])
+        self.exp.requireImport(
+            importName="EyetrackerControl",
+            importFrom="psychopy.hardware.eyetracker"
+        )
 
         self.params['actionType'] = Param(
             actionType,
@@ -113,7 +117,7 @@ class EyetrackerRecordComponent(BaseComponent):
         inits = self.params
         # Make a controller object
         code = (
-            "%(name)s = hardware.eyetracker.EyetrackerControl(\n"
+            "%(name)s = EyetrackerControl(\n"
         )
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -409,7 +409,7 @@ class MicrophoneComponent(BaseDeviceComponent):
 
     def writeInitCodeJS(self, buff):
         inits = getInitVals(self.params)
-        inits['sampleRate'] = sampleRates[inits['sampleRate'].val]
+        inits['sampleRate'] = at.sampleRates[inits['sampleRate'].val]
         # Alert user if non-default value is selected for device
         if inits['device'].val != 'default':
             alert(5055, strFields={'name': inits['name'].val})

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -409,7 +409,9 @@ class MicrophoneComponent(BaseDeviceComponent):
 
     def writeInitCodeJS(self, buff):
         inits = getInitVals(self.params)
-        inits['sampleRate'] = at.sampleRates[inits['sampleRate'].val]
+        # make sure sample rate is numeric
+        if inits['sampleRate'].val in at.sampleRateLabels:
+            inits['sampleRate'].val = at.sampleRateLabels[inits['sampleRate'].val]
         # Alert user if non-default value is selected for device
         if inits['device'].val != 'default':
             alert(5055, strFields={'name': inits['name'].val})

--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -27,6 +27,10 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
         self.url = "https://psychopy.org/builder/components/eyetracker_calibration.html"
 
         self.exp.requirePsychopyLibs(['iohub', 'hardware'])
+        self.exp.requireImport(
+            importName="EyetrackerControl",
+            importFrom="psychopy.hardware.eyetracker"
+        )
 
         # Basic params
         self.order += [
@@ -252,7 +256,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
         # Make config object
         code = (
             "# define parameters for %(name)s\n"
-            "%(name)s = hardware.eyetracker.EyetrackerCalibration(win, \n"
+            "%(name)s = EyetrackerCalibration(win, \n"
         )
         buff.writeIndentedLines(code % inits)
         buff.setIndentLevel(1, relative=True)

--- a/psychopy/hardware/__init__.py
+++ b/psychopy/hardware/__init__.py
@@ -5,7 +5,6 @@ import sys
 import glob
 from itertools import chain
 from psychopy import logging
-from . import eyetracker, listener
 from .manager import DeviceManager, deviceManager
 from .base import BaseDevice, BaseResponse, BaseResponseDevice
 

--- a/psychopy/monitors/calibTools.py
+++ b/psychopy/monitors/calibTools.py
@@ -9,7 +9,7 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 from .calibData import wavelength_5nm, juddVosXYZ1976_5nm, cones_SmithPokorny
-from psychopy import __version__, logging, hardware
+from psychopy import __version__, logging
 
 try:
     import serial
@@ -1116,6 +1116,7 @@ def getRGBspectra(stimSize=0.3, winSize=(800, 600), photometer='COM1'):
         photom = photometer
     else:
         # setup photom
+        from psychopy import hardware
         photom = hardware.Photometer(photometer)
     if photom != None:
         havephotom = 1

--- a/psychopy/tools/audiotools.py
+++ b/psychopy/tools/audiotools.py
@@ -98,6 +98,9 @@ sampleRateQualityLevels = {
     4: (SAMPLE_RATE_96kHz, 'High-Def (96kHz)'),
     5: (SAMPLE_RATE_192kHz, 'Ultra High-Def (192kHz)')
 }
+sampleRateLabels = {
+    r[1]: r[0] for r in sampleRateQualityLevels.values()
+}
 
 # supported formats for loading and saving audio samples to file
 try:


### PR DESCRIPTION
Basically, avoiding importing heavy modules like `pschopy.sound` or `psychopy.hardware.eyetracker` on startup - instead importing them when needed