### PR TITLE
PKG: Automatically label PR's according to their title

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -22,3 +22,6 @@ changelog:
       labels:
         - "📓 docs & demos" 
         - "🔨 tests"
+    - title: "Other Changes"
+      labels:
+        - "*"

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -6,6 +6,8 @@ changelog:
     labels:
       - ignore-for-release
       - "📦 packaging" 
+      - "🔀 refactor"
+      - "🤖 sys admin"
     authors:
       - octocat
   categories:

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -9,15 +9,14 @@ changelog:
     authors:
       - octocat
   categories:
-    - title: New and Improved 🎉
+    - title: 🎉 New and improved
       labels:
-        - "🌟 enhancement" 
-    - title: 🐛 Bug Fixes
+        - "🌟 feature"
+        - "✨ enhancement"
+    - title: 🐛 Bug fixes
       labels:
         - "🐞 bug"
-    - title: "📓 Docs & Demos" 
+    - title: "📓 Docs, demos and testing" 
       labels:
         - "📓 docs & demos" 
-    - title: Other Changes
-      labels:
-        - "*"
+        - "🔨 tests"

--- a/.github/workflows/label_pull_requests.yaml
+++ b/.github/workflows/label_pull_requests.yaml
@@ -18,11 +18,21 @@ jobs:
       if: ${{ startsWith(github.event.pull_request.title, 'enh') }}
       with:
         labels: "✨ enhancement"
-    - name: "Enhancement"
+    - name: "Bug fix"
       uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.event.pull_request.title, 'bf') }}
       with:
         labels: "🐞 bug"
+    - name: "Feature fix"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'ff') }}
+      with:
+        labels: "ignore-for-release"
+    - name: "Refactor"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'rf') }}
+      with:
+        labels: "🔀 refactor"
     - name: "Docs & demos"
       uses: actions-ecosystem/action-add-labels@v1
       if: ${{ startsWith(github.event.pull_request.title, 'doc') }}
@@ -38,3 +48,8 @@ jobs:
       if: ${{ startsWith(github.event.pull_request.title, 'pkg') }}
       with:
         labels: "📦 packaging"
+    - name: "Systems admin"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'sys') }}
+      with:
+        labels: "🤖 sys admin"

--- a/.github/workflows/label_pull_requests.yaml
+++ b/.github/workflows/label_pull_requests.yaml
@@ -1,3 +1,5 @@
+# Commit tags are documented here: https://psychopy.org/developers/repository.html#psychopy-commit-messages
+
 name: "Apply labels to PR based on tags (BF, ENH, NF, etc.)"
 
 on:

--- a/.github/workflows/label_pull_requests.yaml
+++ b/.github/workflows/label_pull_requests.yaml
@@ -4,11 +4,13 @@ name: "Apply labels to PR based on tags (BF, ENH, NF, etc.)"
 
 on:
   pull_request:
-   types: [opened]
+   types: [opened, reopened]
 
 jobs:
   set-label:
     runs-on: "ubuntu-latest"
+    permissions:
+      pull-requests: write
     steps:
     - name: "New feature"
       uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/label_pull_requests.yaml
+++ b/.github/workflows/label_pull_requests.yaml
@@ -1,0 +1,40 @@
+name: "Apply labels to PR based on tags (BF, ENH, NF, etc.)"
+
+on:
+  pull_request:
+   types: [opened]
+
+jobs:
+  set-label:
+    runs-on: "ubuntu-latest"
+    steps:
+    - name: "New feature"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'nf') }}
+      with:
+        labels: "🌟 feature"
+    - name: "Enhancement"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'enh') }}
+      with:
+        labels: "✨ enhancement"
+    - name: "Enhancement"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'bf') }}
+      with:
+        labels: "🐞 bug"
+    - name: "Docs & demos"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'doc') }}
+      with:
+        labels: "📓 docs & demos"
+    - name: "Tests"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'test') }}
+      with:
+        labels: "🔨 tests"
+    - name: "Packaging"
+      uses: actions-ecosystem/action-add-labels@v1
+      if: ${{ startsWith(github.event.pull_request.title, 'pkg') }}
+      with:
+        labels: "📦 packaging"

--- a/.github/workflows/label_pull_requests.yaml
+++ b/.github/workflows/label_pull_requests.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   set-label:
     runs-on: "ubuntu-latest"
-    permissions:
-      pull-requests: write
+    permissions: write-all
     steps:
     - name: "New feature"
       uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
Currently `release.yml` categorises everything as "Other changes" unless we've manually gone and labelled it. This action checks for the tags from [our commit spec](https://psychopy.org/developers/repository.html#psychopy-commit-messages) and assigns the appropriate label when the PR is opened.