### PR TITLE
FF: skip ioHub event callback without server or PsychoPy window

### DIFF
--- a/psychopy/iohub/devices/mouse/linux2.py
+++ b/psychopy/iohub/devices/mouse/linux2.py
@@ -90,6 +90,10 @@ class Mouse(MouseDevice):
                 logged_time = currentSec()
                 event_array = event[0]
 
+                if self._iohub_server is None or self._iohub_server._psychopy_windows is None:
+                    # Do not report event if no ioHub server is running or no psychopy window is open
+                    return True
+
                 psychowins = self._iohub_server._psychopy_windows.keys()
                 report_all = self.getConfiguration().get('report_system_wide_events', True)
                 if report_all is False and psychowins and event_array[-1] not in psychowins:

--- a/psychopy/iohub/devices/mouse/win32.py
+++ b/psychopy/iohub/devices/mouse/win32.py
@@ -178,6 +178,11 @@ class Mouse(MouseDevice):
         if self.isReportingEvents():
             logged_time = currentSec()
             report_system_wide_events = self.getConfiguration().get('report_system_wide_events', True)
+
+            if self._iohub_server is None or self._iohub_server._psychopy_windows is None:
+                # Do not report event if no ioHub server is running or no psychopy window is open
+                return True
+
             pyglet_window_hnds = self._iohub_server._psychopy_windows.keys()
             if event.Window in pyglet_window_hnds:
                 pass


### PR DESCRIPTION
There is a very niche bug within ioHub at the end of an experiment on Windows. When the ioHub server itself has closed or the PsychoPy window has closed but the rest of close-down steps are still going, if users move the mouse at this moment, it triggers a Traceback error due to trying to access attributes from `None` type.

p.s. It's still a bug on Linux but the Linux implementation is wrapped by a `try` statement so does not lead to a crush of the processes.

This FF allows the `_nativeEventCallback` method to `return True` and ignore the event callback if no ioHub server or PsychoPy window is currently open. This fix allows both the ioHub server subprocess and PsychoPy main process to close out gracefully.