### PR TITLE
RF!: Rather than specifying Mic latency mode, just specify whether or not to take exclusive control of it

### DIFF
--- a/psychopy/app/preferencesDlg.py
+++ b/psychopy/app/preferencesDlg.py
@@ -552,36 +552,6 @@ class PreferencesDlg(wx.Dialog):
                             labels=labels,
                             values=[i for i in range(len(labels))],
                             value=default, helpText=helpText)
-                # # audio latency mode for the PTB driver
-                elif prefName == 'audioLatencyMode':
-                    # get the labels from above
-                    labels = []
-                    for val, labl in audioLatencyLabels.items():
-                        labels.append(u'{}: {}'.format(val, labl))
-
-                    # get the options from the config file spec
-                    vals = thisSpec.replace("option(", "").replace("'", "")
-                    # item -1 is 'default=x' from spec
-                    vals = vals.replace(", ", ",").split(',')
-
-                    try:
-                        # set the field to the value in the pref
-                        default = int(thisPref)
-                    except ValueError:
-                        try:
-                            # use first if default not in list
-                            default = int(vals[-1].strip('()').split('=')[1])
-                        except (IndexError, TypeError, ValueError):
-                            # no default
-                            default = 0
-
-                    self.proPrefs.addEnumItem(
-                            sectionName,
-                            pLabel,
-                            prefName,
-                            labels=labels,
-                            values=[i for i in range(len(labels))],
-                            value=default, helpText=helpText)
                 # # option items are given a dropdown, current value is shown
                 # # in the box
                 elif thisSpec.startswith('option') or prefName == 'audioDevice':

--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -43,6 +43,7 @@ class MicrophoneComponent(BaseDeviceComponent):
                  stopType='duration (s)', stopVal=2.0,
                  startEstim='', durationEstim='',
                  channels='auto', device=None,
+                 exclusive=False,
                  sampleRate='DVD Audio (48kHz)', maxSize=24000,
                  outputType='default', speakTimes=False, trimSilent=False,
                  policyWhenFull='warn',
@@ -74,6 +75,7 @@ class MicrophoneComponent(BaseDeviceComponent):
             "device",
             "channels",
             "sampleRate",
+            "exclusive",
             "maxSize",
         ]
 
@@ -135,6 +137,14 @@ class MicrophoneComponent(BaseDeviceComponent):
                 "How many samples per second (Hz) to record at"
             ),
             direct=False
+        )
+        self.params['exclusive'] = Param(
+            exclusive, valType="code", inputType="bool", categ="Device",
+            label=_translate("Exclusive control"),
+            hint=_translate(
+                "Take exclusive control of the microphone, so other apps can't use it during your "
+                "experiment."
+            )
         )
         self.params['maxSize'] = Param(
             maxSize, valType='num', inputType="single", categ='Device',
@@ -327,6 +337,7 @@ class MicrophoneComponent(BaseDeviceComponent):
             "    deviceName=%(deviceLabel)s,\n"
             "    index=%(device)s,\n"
             "    maxRecordingSize=%(maxSize)s,\n"
+            "    exclusive=%(exclusive)s,\n"
         )
         if self.params['device'].val not in ("None", "", None):
             code += (

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -132,8 +132,6 @@
 [hardware]
     # LEGACY: choice of audio library
     audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
-    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
-    audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('coreaudio', 'portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -132,8 +132,6 @@
 [hardware]
     # LEGACY: choice of audio library
     audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
-    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
-    audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -132,8 +132,6 @@
 [hardware]
     # LEGACY: choice of audio library
     audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
-    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
-    audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -132,14 +132,10 @@
 [hardware]
     # LEGACY: choice of audio library
     audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
-    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
-    audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
     # audio device to use (if audioLib allows control)
     audioDevice = list(default=list('default'))
-    # exclude non-WASAPI audio devices
-    audioWASAPIOnly = boolean(default=True)
     # a list of parallel ports
     parallelPorts = list(default=list('0x0378', '0x03BC'))
     # The name of the Qmix pump configuration to use

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -128,8 +128,6 @@
 [hardware]
     # LEGACY: choice of audio library
     audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
-    # LEGACY: latency mode for PsychToolbox audio (3 is good for most applications. See
-    audioLatencyMode = option(0, 1, 2, 3, 4, default=3)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -33,18 +33,8 @@ except Exception:
 
 import numpy as np
 
-try:
-    defaultLatencyClass = int(prefs.hardware['audioLatencyMode'][0])
-except (TypeError, IndexError):  # maybe we were given a number instead
-    defaultLatencyClass = prefs.hardware['audioLatencyMode']
-"""vals in prefs.hardware['audioLatencyMode'] are:
-     {0:_translate('Latency not important'),
-      1:_translate('Share low-latency driver'),
-      2:_translate('Exclusive low-latency'),
-      3:_translate('Aggressive low-latency'),
-      4:_translate('Latency critical')}
-Based on help at http://psychtoolbox.org/docs/PsychPortAudio-Open
-"""
+
+defaultLatencyClass = 1
 # suggestedLatency = 0.005  ## Not currently used. Keep < 1 scr refresh
 
 if prefs.hardware['audioDriver']=='auto':

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -26,11 +26,13 @@ class Microphone:
             streamBufferSecs=2.0,
             maxRecordingSize=24000,
             policyWhenFull='warn',
-            audioLatencyMode=None,
+            exclusive=False,
             audioRunMode=0,
             name="mic",
             recordingFolder=Path.home(),
             recordingExt="wav",
+            # legacy
+            audioLatencyMode=None,
     ):
         # store name
         self.name = name
@@ -55,7 +57,7 @@ class Microphone:
                 streamBufferSecs=streamBufferSecs,
                 maxRecordingSize=maxRecordingSize,
                 policyWhenFull=policyWhenFull,
-                audioLatencyMode=audioLatencyMode,
+                exclusive=exclusive,
                 audioRunMode=audioRunMode
             )
         # set policy when full (in case device already existed)


### PR DESCRIPTION
Mirrors what we've done with Sound in #6953, and means that device exclusivity is defined per-mic rather than at a prefs level.

Potentially breaking change as it means removing a pref