### PR TITLE
ENH: Replace default participant ID in pilot mode with "pilot"

### DIFF
--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -155,6 +155,8 @@
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting
     forceNonRush = boolean(default=True)
+    # Replace default participant ID with "pilot" when piloting
+    replaceParticipantID = boolean(default=True)
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -155,6 +155,8 @@
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting
     forceNonRush = boolean(default=True)
+    # Replace default participant ID with "pilot" when piloting
+    replaceParticipantID = boolean(default=True)
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -155,6 +155,8 @@
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting
     forceNonRush = boolean(default=True)
+    # Replace default participant ID with "pilot" when piloting
+    replaceParticipantID = boolean(default=True)
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -155,6 +155,8 @@
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting
     forceNonRush = boolean(default=True)
+    # Replace default participant ID with "pilot" when piloting
+    replaceParticipantID = boolean(default=True)
 
 # Settings for connections
 [connections]

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -151,6 +151,8 @@
     showPilotingIndicator = boolean(default=True)
     # Prevent experiment from enabling rush mode when piloting
     forceNonRush = boolean(default=True)
+    # Replace default participant ID with "pilot" when piloting
+    replaceParticipantID = boolean(default=True)
 
 # Settings for connections
 [connections]


### PR DESCRIPTION
Makes it easier to tell which data files were from you piloting and which were from genuine participants. Note that this only changes the default value (which initially appears in the expInfo dialog), not the final value.

Motivated by me struggling to remember which data files came from runs in pilot vs run mode while testing :P 