### PR TITLE
FF: Send Liaison message when experiment starts via Session

### DIFF
--- a/psychopy/session.py
+++ b/psychopy/session.py
@@ -1070,6 +1070,14 @@ class Session:
         ).format(key=key, expInfo=expInfo))
         # reset session clock
         self.experimentClock.reset()
+        # send start event to liaison
+        if self.liaison is not None:
+            self.sendToLiaison({
+                    'type': "experiment_status",
+                    'name': thisExp.name,
+                    'status': constants.STARTED,
+                    'expInfo': expInfo
+                })
         # Run this experiment
         try:
             self.experiments[key].run(


### PR DESCRIPTION
@alexOpenScience this should allow you to detect experiment (assessment) starts :) Message will look like:
```
{
    'type': "experiment_status",
    'name': <assessment name>,
    'status': 1,
    'expInfo': {<exp info array>}
}
```

(`status = 1` is what identifies it as a start rather than a pause/stop/etc.)