### PR TITLE
NF: Add option for custom calibration points in Eyetracker Calibration

### DIFF
--- a/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
+++ b/psychopy/experiment/routines/eyetracker_calibrate/__init__.py
@@ -16,6 +16,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
     def __init__(self, exp, name='calibration',
                  progressMode="time", targetDur=1.5, expandDur=1, expandScale=1.5,
                  movementAnimation=True, movementDur=1.0, targetDelay=1.0,
+                 useCustom=False, customTarget="",
                  innerFillColor='green', innerBorderColor='black', innerBorderWidth=2, innerRadius=0.0035,
                  fillColor='', borderColor="black", borderWidth=2, outerRadius=0.01,
                  colorSpace="rgb", units='from exp settings',
@@ -28,7 +29,7 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
 
         self.exp.requirePsychopyLibs(['iohub', 'hardware'])
         self.exp.requireImport(
-            importName="EyetrackerControl",
+            importName="EyetrackerCalibration",
             importFrom="psychopy.hardware.eyetracker"
         )
 
@@ -58,6 +59,8 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                      label=_translate("Text color"))
         # Target Params
         self.order += [
+            "useCustom",
+            "customTarget",
             "targetStyle",
             "fillColor",
             "borderColor",
@@ -69,6 +72,31 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
             "outerRadius",
             "innerRadius",
         ]
+
+        self.params['useCustom'] = Param(
+            useCustom, valType="code", inputType="bool", categ="Target",
+            label=_translate("Use custom?"),
+            hint=_translate(
+                "Check this box to use a custom stimulus as a calibration target, rather than "
+                "creating one from params."
+            ),
+            direct=False
+        )
+
+        self.params['customTarget'] = Param(
+            customTarget, valType="code", inputType="single", categ="Target",
+            label=_translate("Custom target"),
+            hint=_translate(
+                "Give the name of any visual Component to use it as a calibration target."
+            )
+        )
+        self.depends.append({
+            "dependsOn": 'useCustom',  # if...
+            "condition": "",  # meets...
+            "param": 'customTarget',  # then...
+            "true": "show",  # should...
+            "false": "hide",  # otherwise...
+        })
 
         self.params['innerFillColor'] = Param(innerFillColor,
                                      valType='color', inputType="color", categ='Target',
@@ -122,6 +150,27 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
                                      allowedVals=['from exp settings'], direct=False,
                                      hint=_translate("Units of dimensions for this stimulus"),
                                      label=_translate("Spatial units"))
+        # hide all target params if using custom
+        for thisParam in (
+            "targetStyle",
+            "fillColor",
+            "borderColor",
+            "innerFillColor",
+            "innerBorderColor",
+            "colorSpace",
+            "borderWidth",
+            "innerBorderWidth",
+            "outerRadius",
+            "innerRadius",
+            "units",
+        ):
+            self.depends.append({
+                "dependsOn": 'useCustom',  # if...
+                "condition": "",  # meets...
+                "param": thisParam,  # then...
+                "true": "hide",  # should...
+                "false": "show",  # otherwise...
+            })
 
         # Animation Params
         self.order += [
@@ -234,24 +283,30 @@ class EyetrackerCalibrationRoutine(BaseStandaloneRoutine):
 
         BaseStandaloneRoutine.writeMainCode(self, buff)
 
-        # Make target
+        # make target
         code = (
             "# define target for %(name)s\n"
-            "%(name)sTarget = visual.TargetStim(win, \n"
         )
-        buff.writeIndentedLines(code % inits)
-        buff.setIndentLevel(1, relative=True)
-        code = (
-                "name='%(name)sTarget',\n"
-                "radius=%(outerRadius)s, fillColor=%(fillColor)s, borderColor=%(borderColor)s, lineWidth=%(borderWidth)s,\n"
-                "innerRadius=%(innerRadius)s, innerFillColor=%(innerFillColor)s, innerBorderColor=%(innerBorderColor)s, innerLineWidth=%(innerBorderWidth)s,\n"
-                "colorSpace=%(colorSpace)s, units=%(units)s\n"
-        )
-        buff.writeIndentedLines(code % inits)
-        buff.setIndentLevel(-1, relative=True)
-        code = (
-            ")"
-        )
+        if self.params['useCustom']:
+            code += (
+                "%(name)sTarget = %(customTarget)s\n"
+            )
+        else:
+            code += (
+                "%(name)sTarget = visual.TargetStim(win, \n"
+                "    name='%(name)sTarget',\n"
+                "    radius=%(outerRadius)s, \n"
+                "    fillColor=%(fillColor)s, \n"
+                "    borderColor=%(borderColor)s, \n"
+                "    lineWidth=%(borderWidth)s, \n"
+                "    innerRadius=%(innerRadius)s, \n"
+                "    innerFillColor=%(innerFillColor)s, \n"
+                "    innerBorderColor=%(innerBorderColor)s, \n"
+                "    innerLineWidth=%(innerBorderWidth)s,\n"
+                "    colorSpace=%(colorSpace)s, \n"
+                "    units=%(units)s\n"
+                ")\n"
+            )
         buff.writeIndentedLines(code % inits)
         # Make config object
         code = (

--- a/psychopy/iohub/devices/eyetracker/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/__init__.py
@@ -6,6 +6,7 @@ from .. import Device, ioDeviceError
 from ...constants import DeviceConstants, EyeTrackerConstants
 from . import hw
 from ...errors import print2err
+from psychopy.tools.stimulustools import serialize, actualize
 
 
 class EyeTrackerDevice(Device):
@@ -268,25 +269,16 @@ class EyeTrackerDevice(Device):
         dict
             Dict describing the given Calibration object
         """
+        targetAttributes = serialize(calib.target, includeClass=True)
+        # target animation
+        targetAttributes['animate'] = {
+            'enable': calib.movementAnimation,
+            'expansion_ratio': calib.expandScale,
+            'contract_only': calib.expandScale == 1,
+        }
+        
         return {
-            'target_attributes': {
-                # target outer circle
-                'outer_diameter': calib.target.radius * 2,
-                'outer_stroke_width': calib.target.outer.lineWidth,
-                'outer_fill_color': getattr(calib.target.outer._fillColor, calib.colorSpace) if calib.target.outer._fillColor else getattr(calib.target.win._color, calib.colorSpace),
-                'outer_line_color': getattr(calib.target.outer._borderColor, calib.colorSpace) if calib.target.outer._borderColor else getattr(calib.target.win._color, calib.colorSpace),
-                # target inner circle
-                'inner_diameter': calib.target.innerRadius * 2,
-                'inner_stroke_width': calib.target.inner.lineWidth,
-                'inner_fill_color': getattr(calib.target.inner._borderColor, calib.colorSpace) if calib.target.inner._borderColor else getattr(calib.target.win._color, calib.colorSpace),
-                'inner_line_color': getattr(calib.target.inner._borderColor, calib.colorSpace) if calib.target.inner._borderColor else getattr(calib.target.win._color, calib.colorSpace),
-                # target animation
-                'animate':{
-                    'enable': calib.movementAnimation,
-                    'expansion_ratio': calib.expandScale,
-                    'contract_only': calib.expandScale == 1,
-                },
-            },
+            'target_attributes': targetAttributes,
             'type': calib.targetLayout,
             'randomize': calib.randomisePos,
             'auto_pace': calib.progressMode == "time",

--- a/psychopy/iohub/devices/eyetracker/calibration/procedure.py
+++ b/psychopy/iohub/devices/eyetracker/calibration/procedure.py
@@ -12,6 +12,7 @@ from psychopy.iohub.constants import EventConstants as EC
 from psychopy.iohub.devices.keyboard import KeyboardInputEvent
 from psychopy.iohub.errors import print2err
 from psychopy.constants import PLAYING
+from psychopy.tools.stimulustools import serialize, actualize
 
 currentTime = Computer.getTime
 
@@ -182,10 +183,7 @@ class BaseCalibrationProcedure:
         if self._calibration_args.get('target_type') == 'CIRCLE_TARGET':
             setDefaultCalibrationTarget()
         else:
-            self.targetStim = createCustomCalibrationStim(self.window, self._calibration_args)
-            if self.targetStim is None:
-                # Error creating custom stim, so use default target stim type
-                setDefaultCalibrationTarget()
+            actualize(self._calibration_args.get('target_attributes'))
 
         self.originalTargetSize = self.targetStim.size
         self.targetClassHasPlayPause = hasattr(self.targetStim, 'play') and hasattr(self.targetStim, 'pause')

--- a/psychopy/iohub/devices/eyetracker/calibration/procedure.py
+++ b/psychopy/iohub/devices/eyetracker/calibration/procedure.py
@@ -47,7 +47,11 @@ class BaseCalibrationProcedure:
         self._lastCalibrationOK = False
         self._device_config = self._eyetracker.getConfiguration()
         display = self._eyetracker._display_device
-        updateSettings(self._device_config.get('calibration'), calibration_args)
+        # apply calibration args to defaults
+        self._device_config['calibration'].update(calibration_args)
+        # get target attributes (ignore default keys as args can vary)
+        self._device_config['calibration']['target_attributes'] = calibration_args['target_attributes']
+        # use modified default config for calibration args
         self._calibration_args = self._device_config.get('calibration')
         unit_type = self.getCalibSetting('unit_type')
         if unit_type is None:
@@ -155,35 +159,15 @@ class BaseCalibrationProcedure:
         color_type = self.getCalibSetting('color_type')
         unit_type = self.getCalibSetting('unit_type')
 
-        def setDefaultCalibrationTarget():
-            # convert sizes to stimulus units
-            radiusPix = self.getCalibSetting(['target_attributes', 'outer_diameter']) / 2
-            radiusObj = layout.Size(radiusPix, units=unit_type, win=self.window)
-            radius = getattr(radiusObj, unit_type)[1]
-            innerRadiusPix = self.getCalibSetting(['target_attributes', 'inner_diameter']) / 2
-            innerRadiusObj = layout.Size(innerRadiusPix, units=unit_type, win=self.window)
-            innerRadius = getattr(innerRadiusObj, unit_type)[1]
-            # make target
-            self.targetStim = visual.TargetStim(
-                self.window, name="CP", style="circles",
-                radius=radius,
-                fillColor=self.getCalibSetting(['target_attributes', 'outer_fill_color']),
-                borderColor=self.getCalibSetting(['target_attributes', 'outer_line_color']),
-                lineWidth=self.getCalibSetting(['target_attributes', 'outer_stroke_width']),
-                innerRadius=innerRadius,
-                innerFillColor=self.getCalibSetting(['target_attributes', 'inner_fill_color']),
-                innerBorderColor=self.getCalibSetting(['target_attributes', 'inner_line_color']),
-                innerLineWidth=self.getCalibSetting(['target_attributes', 'inner_stroke_width']),
-                pos=(0, 0),
-                units=unit_type,
-                colorSpace=color_type,
-                autoLog=False
-            )
-
-        if self._calibration_args.get('target_type') == 'CIRCLE_TARGET':
-            setDefaultCalibrationTarget()
-        else:
-            actualize(self._calibration_args.get('target_attributes'))
+        # get attributes to create target
+        targetAttrs = self._calibration_args.get('target_attributes').copy()
+        # sanitize for creating
+        if "animate" in targetAttrs:
+            targetAttrs.pop("animate")
+        if "win" in targetAttrs:
+            targetAttrs['win'] = self.window
+        
+        self.targetStim = actualize(targetAttrs)
 
         self.originalTargetSize = self.targetStim.size
         self.targetClassHasPlayPause = hasattr(self.targetStim, 'play') and hasattr(self.targetStim, 'pause')


### PR DESCRIPTION
- The EyetrackerCalibration object can now take any visual stimulus as its `target` parameter, not just a TargetStim (thanks to the `serialize` and `actualize` methods from #6801)
- The Eyetracker Calibration Routine in Builder now has a checkbox "use custom" in its Target tab, if ticked it gives a textbox in which you just put the name of the visual Component you want to use as a calibration point

Here's it in action, using an ImageComponent with `default.png` in its `image` param (using MouseGaze backend):

https://github.com/user-attachments/assets/6e034f8a-59e9-4830-b95a-d67a240f1ece