### PR TITLE
BF: restrict glob matching to rename pattern in handleFileCollision()

### DIFF
--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -33,7 +33,7 @@ def handleFileCollision(fileName, fileCollisionMethod):
                "fileCollisionMethod to overwrite.")
         raise IOError(msg % fileName)
     elif fileCollisionMethod == 'rename':
-        rootName, extension = os.path.splitext(fileName)
+        rootName, extension = os.path.splitext(os.path.normpath(fileName))
         matchingFiles = glob.glob("%s*%s" % (rootName, extension))
 
         # Keep only files matching the specific pattern used in renaming

--- a/psychopy/tools/fileerrortools.py
+++ b/psychopy/tools/fileerrortools.py
@@ -9,6 +9,7 @@
 """
 import os
 import glob
+import re
 
 from psychopy import logging
 
@@ -34,6 +35,10 @@ def handleFileCollision(fileName, fileCollisionMethod):
     elif fileCollisionMethod == 'rename':
         rootName, extension = os.path.splitext(fileName)
         matchingFiles = glob.glob("%s*%s" % (rootName, extension))
+
+        # Keep only files matching the specific pattern used in renaming
+        pattern = rf"{re.escape(rootName)}(_\d+)?{re.escape(extension)}$"
+        matchingFiles = [f for f in matchingFiles if re.match(pattern, f)]
 
         # Build the renamed string.
         if not matchingFiles:


### PR DESCRIPTION
Otherwise trial summary files also match into the pattern of `rootName*extension` and creates confusing counter in the renamed files. This additional use of regular expression can avoid that behavior.