### PR TITLE
RF: Summary csv files from loops now have a _ between the filename and the loop name

### DIFF
--- a/docs/source/builder/settings.rst
+++ b/docs/source/builder/settings.rst
@@ -108,6 +108,9 @@ Save Excel file
 Save csv file (summaries)
     If this box is checked a summary file will be created with one row corresponding to the entire loop. If a keyboard response is used the mean and dtandard deviations of responses across trials will also be stored.
 
+.. note::
+   Up to 2024.2.4, the summary file naming convention is ``rf"{filename}{loop_name}.csv"``. From 2025.1.0 onwards, the new naming convention is ``rf"{filename}_{loop_name}.csv"`` to be consistent with uses of suffix throughout PsychoPy. If you are using analysis scripts based on versions prior to 2025.1.0, please be aware of this change and adjust file paths accordingly.
+
 Save csv file (trial-by-trial)
 	If this box is checked a comma separated variable (.csv) will be stored. Each trial will be stored as a new row.
 

--- a/psychopy/experiment/loops.py
+++ b/psychopy/experiment/loops.py
@@ -417,7 +417,7 @@ class TrialHandler(_BaseLoopHandler):
                         "    dataOut=['n','all_mean','all_std', 'all_raw'])\n")
                 buff.writeIndentedLines(code % self.params)
             if saveCSV:
-                code = ("%(name)s.saveAsText(filename + '%(name)s.csv', "
+                code = ("%(name)s.saveAsText(filename + '_%(name)s.csv', "
                         "delim=',',\n"
                         "    stimOut=params,\n"
                         "    dataOut=['n','all_mean','all_std', 'all_raw'])\n")
@@ -606,7 +606,7 @@ class StairHandler(_BaseLoopHandler):
                 buff.writeIndented(code % self.params)
             if self.exp.settings.params['Save csv file'].val:
                 code = ("%(name)s.saveAsText(filename + "
-                        "'%(name)s.csv', delim=',')\n")
+                        "'_%(name)s.csv', delim=',')\n")
                 buff.writeIndented(code % self.params)
 
     def getType(self):
@@ -865,7 +865,7 @@ class MultiStairHandler(_BaseLoopHandler):
                 code = "%(name)s.saveAsExcel(filename + '.xlsx')\n"
                 buff.writeIndented(code % self.params)
             if self.exp.settings.params['Save csv file'].val:
-                code = ("%(name)s.saveAsText(filename + '%(name)s.csv', "
+                code = ("%(name)s.saveAsText(filename + '_%(name)s.csv', "
                         "delim=',')\n")
                 buff.writeIndented(code % self.params)
 


### PR DESCRIPTION
This is super minor, but given the way duplicated files are renamed and how the session ID is appended to the rest of file name using underscores, I feel that the summary csv files should also use `_[loopName]` for naming. Totally fine and harmless if not worth changing.