### PR TITLE
ENH: Allow automatic resampling of audio files

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -55,7 +55,7 @@ inputDefaults = {
 # version" warnings
 legacyParams = [
     'lineColorSpace', 'borderColorSpace', 'fillColorSpace', 'foreColorSpace',  # 2021.1, we standardised colorSpace to be object-wide rather than param-specific
-    'Audio latency priority',  # from 2025.1, latency priority is handled by a combination of exclusivity and resampling settings
+    'Audio latency priority',  # from 2025.1, latency priority is handled by SpeakerDevice
 ]
 
 class Param():

--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -5,6 +5,7 @@
 # Copyright (C) 2002-2018 Jonathan Peirce (C) 2019-2024 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
 
+from pathlib import Path
 import numpy
 import copy
 from os import path
@@ -13,11 +14,16 @@ from psychopy.constants import (STARTED, PLAYING, PAUSED, FINISHED, STOPPED,
                                 NOT_STARTED, FOREVER)
 from psychopy.tools.filetools import pathToString, defaultStim, defaultStimRoot
 from psychopy.tools.audiotools import knownNoteNames, stepsFromA
-from psychopy.tools.attributetools import AttributeGetSetMixin
+from psychopy.tools.attributetools import AttributeGetSetMixin, attributeSetter
+from .exceptions import SoundFormatError, DependencyError
 from sys import platform
 from .audioclip import AudioClip
 from ..hardware import DeviceManager
 from ..preferences.preferences import prefs
+try:
+    import soundfile as sf
+except Exception:
+    raise DependencyError("soundfile not working")
 
 if platform == 'win32':
     mediaLocation = "C:\\Windows\\Media"
@@ -114,6 +120,9 @@ class _SoundBase(AttributeGetSetMixin):
     # def setVolume(self, newVol, log=True):
     # def _setSndFromFile(self, fileName):
     # def _setSndFromArray(self, thisArray):
+
+    autoLog = True
+    
     def setSound(self, value, secs=0.5, octave=4, hamming=True, log=True):
         """Set the sound to be played.
 
@@ -217,7 +226,22 @@ class _SoundBase(AttributeGetSetMixin):
             if log and self.autoLog:
                 logging.exp("Set %s sound=%s" % (self.name, value), obj=self)
             self.status = NOT_STARTED
+    
+    # alias channels, stereo and isStereo for the sake of the different backends
 
+    @attributeSetter
+    def channels(self, channels):
+        self.__dict__['channels'] = channels
+        self.__dict__['stereo'] = self.__dict__['isStereo'] = channels is None or channels > 1
+    
+    @attributeSetter
+    def stereo(self, stereo):
+        self.channels = 2 if stereo else 1
+    
+    @attributeSetter
+    def isStereo(self, stereo):
+        self.stereo = stereo
+        
     def _setSndFromNote(self, thisNote, secs, octave, hamming=True):
         # note name -> freq -> sound
         freqA = 440.0
@@ -241,6 +265,104 @@ class _SoundBase(AttributeGetSetMixin):
         if hamming and nSamples > 30:
             outArr = apodize(outArr, self.sampleRate)
         self._setSndFromArray(outArr)
+    
+    def _setSndFromFile(self, filename):
+        # alias default names (so it always points to default.png)
+        if filename in defaultStim:
+            filename = Path(prefs.paths['assets']) / defaultStim[filename]
+        self.sndFile = f = sf.SoundFile(filename)
+        self.sourceType = 'file'
+        self.sampleRate = f.samplerate
+        if self.channels == -1:  # if channels was auto then set to file val
+            self.channels = f.channels
+        fileDuration = float(len(f)) / f.samplerate  # needed for duration?
+        # process start time
+        if self.startTime and self.startTime > 0:
+            startFrame = self.startTime * self.sampleRate
+            self.sndFile.seek(int(startFrame))
+            self.t = self.startTime
+        else:
+            self.t = 0
+        # process stop time
+        if self.stopTime and self.stopTime > 0:
+            requestedDur = self.stopTime - self.t
+            self.duration = min(requestedDur, fileDuration)
+        else:
+            self.duration = fileDuration - self.t
+        # can now calculate duration in frames
+        self.durationFrames = int(round(self.duration * self.sampleRate))
+        # are we preloading or streaming?
+        if self.preBuffer == 0:
+            # no buffer - stream from disk on each call to nextBlock
+            pass
+        elif self.preBuffer == -1:
+            # full pre-buffer. Load requested duration to memory
+            sndArr = self.sndFile.read(
+                frames=int(self.sampleRate * self.duration))
+            self.sndFile.close()
+            self._setSndFromArray(sndArr)
+        self._channelCheck(
+            self.sndArr)  # Check for fewer channels in stream vs data array
+    
+    def _setSndFromArray(self, thisArray):
+        self.sndArr = numpy.asarray(thisArray).astype('float32')
+        if thisArray.ndim == 1:
+            self.sndArr.shape = [len(thisArray), 1]  # make 2D for broadcasting
+        if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
+            self.sndArr = self.sndArr.repeat(2, axis=1)
+        elif self.sndArr.shape[1] == 1:  # if channels in [-1,1] then pass
+            pass
+        else:
+            try:
+                self.sndArr.shape = [len(thisArray), 2]
+            except ValueError:
+                raise ValueError("Failed to format sound with shape {} "
+                                 "into sound with channels={}"
+                                 .format(self.sndArr.shape, self.channels))
+
+        # is this stereo?
+        if self.stereo == -1:  # auto stereo. Try to detect
+            if self.sndArr.shape[1] == 1:
+                self.stereo = 0
+            elif self.sndArr.shape[1] == 2:
+                self.stereo = 1
+            else:
+                raise IOError("Couldn't determine whether array is "
+                              "stereo. Shape={}".format(self.sndArr.shape))
+        # store details about array
+        self._nSamples = thisArray.shape[0]
+        self.sourceType = "array"
+
+        # catch when array is empty
+        if not len(self.sndArr):
+            logging.warning(
+                "Received a blank array for sound, playing nothing instead."
+            )
+            self.sndArr = numpy.zeros(shape=(self.blockSize, self.channels))
+
+        # create audio clip
+        clip = AudioClip(
+            samples=self.sndArr, 
+            sampleRateHz=self.sampleRate
+        )
+        # set from clip
+        self._setSndFromClip(clip)
+    
+    def _setSndFromClip(self, clip: AudioClip):
+        """
+        Set current sound from an AudioClip object. All other setSound methods eventually lead to 
+        this - they just transform the given sound (be it an array, file, note, etc.) to an 
+        AudioClip first.
+
+        Each subclass of _SoundBase (so each sound backend; ptb, pygame, etc.) will implement this 
+        method in their own way.
+
+        Parameters
+        ----------
+        clip : AudioClip
+            AudioClip object to set.
+        """
+        raise NotImplementedError()
 
     def _getDefaultSampleRate(self):
         """For backends this might depend on what streams are open"""

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -237,109 +237,17 @@ class SoundPTB(_SoundBase):
         self.loops = self._loopsRequested
         # start with the base class method
         _SoundBase.setSound(self, value, secs, octave, hamming, log)
-
-    def _setSndFromFile(self, filename):
-        # alias default names (so it always points to default.png)
-        if filename in ft.defaultStim:
-            filename = Path(prefs.paths['assets']) / ft.defaultStim[filename]
-        self.sndFile = f = sf.SoundFile(filename)
-        self.sourceType = 'file'
-        self.sampleRate = f.samplerate
-        if self.channels == -1:  # if channels was auto then set to file val
-            self.channels = f.channels
-        fileDuration = float(len(f)) / f.samplerate  # needed for duration?
-        # process start time
-        if self.startTime and self.startTime > 0:
-            startFrame = self.startTime * self.sampleRate
-            self.sndFile.seek(int(startFrame))
-            self.t = self.startTime
-        else:
-            self.t = 0
-        # process stop time
-        if self.stopTime and self.stopTime > 0:
-            requestedDur = self.stopTime - self.t
-            self.duration = min(requestedDur, fileDuration)
-        else:
-            self.duration = fileDuration - self.t
-        # can now calculate duration in frames
-        self.durationFrames = int(round(self.duration * self.sampleRate))
-        # are we preloading or streaming?
-        if self.preBuffer == 0:
-            # no buffer - stream from disk on each call to nextBlock
-            pass
-        elif self.preBuffer == -1:
-            # full pre-buffer. Load requested duration to memory
-            sndArr = self.sndFile.read(
-                frames=int(self.sampleRate * self.duration))
-            self.sndFile.close()
-            self._setSndFromArray(sndArr)
-        self._channelCheck(
-            self.sndArr)  # Check for fewer channels in stream vs data array
-
-    def _setSndFromArray(self, thisArray):
-
-        self.sndArr = np.asarray(thisArray).astype('float32')
-        if thisArray.ndim == 1:
-            self.sndArr.shape = [len(thisArray), 1]  # make 2D for broadcasting
-        if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
-            self.sndArr = self.sndArr.repeat(2, axis=1)
-        elif self.sndArr.shape[1] == 1:  # if channels in [-1,1] then pass
-            pass
-        else:
-            try:
-                self.sndArr.shape = [len(thisArray), 2]
-            except ValueError:
-                raise ValueError("Failed to format sound with shape {} "
-                                 "into sound with channels={}"
-                                 .format(self.sndArr.shape, self.channels))
-
-        # is this stereo?
-        if self.stereo == -1:  # auto stereo. Try to detect
-            if self.sndArr.shape[1] == 1:
-                self.stereo = 0
-            elif self.sndArr.shape[1] == 2:
-                self.stereo = 1
-            else:
-                raise IOError("Couldn't determine whether array is "
-                              "stereo. Shape={}".format(self.sndArr.shape))
-        self._nSamples = thisArray.shape[0]
-        if self.stopTime == -1:
-            self.duration = self._nSamples / float(self.sampleRate)
-        # set to run from the start:
-        self.seek(0)
-        self.sourceType = "array"
-
-        # catch when array is empty
-        if not len(self.sndArr):
-            logging.warning(
-                "Received a blank array for sound, playing nothing instead."
-            )
-            self.sndArr = np.zeros(shape=(self.blockSize, self.channels))
-
-        # create audio clip
-        clip = AudioClip(
-            samples=self.sndArr, 
-            sampleRateHz=self.sampleRate
-        )
-        # set from clip
-        self._setSndFromClip(clip)
     
     def _setSndFromClip(self, clip: AudioClip):
-        """
-        Set current sound from an AudioClip object. All other setSound methods eventually lead to 
-        this - they just transform the given sound to an AudioClip.
-
-        Parameters
-        ----------
-        clip : AudioClip
-            AudioClip object to set.
-        """
         # store clip
         self.clip = clip
         # resample the clip if needed and allowed
         if self.speaker.resample:
             if clip.sampleRateHz != self.speaker.sampleRateHz:
                 clip.resample(targetSampleRateHz=self.speaker.sampleRateHz)
+        # work out stop time
+        if self.stopTime == -1:
+            self.duration = clip.sample.shape[0] / clip.sampleRateHz
         # create/update track
         if  self.track:
             self.track.stop()
@@ -350,6 +258,8 @@ class SoundPTB(_SoundBase):
                 data=clip.samples,
                 volume=self.volume
             )
+        # seek to start
+        self.seek(0)
 
     def _channelCheck(self, array):
         """Checks whether stream has fewer channels than data. If True, ValueError"""

--- a/psychopy/sound/backend_pygame.py
+++ b/psychopy/sound/backend_pygame.py
@@ -172,6 +172,8 @@ class SoundPygame(_SoundBase):
             init()
             inits = mixer.get_init()
         self.sampleRate, self.format, self.isStereo = inits
+        self.startTime = 0
+        self.stopTime = secs
 
         if hamming:
             logging.warning("Hamming was requested using the 'pygame' sound "
@@ -285,9 +287,11 @@ class SoundPygame(_SoundBase):
             logging.error(msg % fileName)
             raise ValueError(msg % fileName)
 
-    def _setSndFromArray(self, thisArray):
-        # get a mixer.Sound object from an array of floats (-1:1)
+    def _setSndFromClip(self, clip):
+        self.clip = clip
+        thisArray = self.clip.samples
 
+        # get a mixer.Sound object from an array of floats (-1:1)
         # make stereo if mono
         if (self.isStereo == 2 and
                 (len(thisArray.shape) == 1 or

--- a/psychopy/sound/backend_pyo.py
+++ b/psychopy/sound/backend_pyo.py
@@ -18,7 +18,10 @@ try:
         get_input_devices,
         get_output_devices,
         getDevices,
-        SoundPyo)
+        SoundPyo,
+        pyoSndServer,
+        audioDriver,
+    )
 except (ModuleNotFoundError, ImportError):
     logging.error(
         "Support for the `pyo` audio backend is not available this session. "

--- a/psychopy/sound/backend_pysound.py
+++ b/psychopy/sound/backend_pysound.py
@@ -180,6 +180,8 @@ class SoundPySoundCard(_SoundBase):
         self.bufferSize = bufferSize
         self.volume = volume
 
+        self.channels = 2
+
         # try to create sound
         self._snd = None
         # distinguish the loops requested from loops actual because of
@@ -267,33 +269,13 @@ class SoundPySoundCard(_SoundBase):
         attributetools.setAttribute(self, 'volume', value, log, operation)
         return value  # this is returned for historical reasons
 
-    def _setSndFromFile(self, fileName):
-        # alias default names (so it always points to default.png)
-        if fileName in ft.defaultStim:
-            fileName = Path(prefs.paths['assets']) / ft.defaultStim[fileName]
-        # load the file
-        if not path.isfile(fileName):
-            msg = "Sound file %s could not be found." % fileName
-            logging.error(msg)
-            raise ValueError(msg)
-        self.fileName = fileName
-        # in case a tone with inf loops had been used before
-        self.loops = self.requestedLoops
-        try:
-            self.sndFile = sndfile.SoundFile(fileName)
-            sndArr = self.sndFile.read()
-            self.sndFile.close()
-            self._setSndFromArray(sndArr)
-
-        except Exception:
-            msg = "Sound file %s could not be opened using pysoundcard for sound."
-            logging.error(msg % fileName)
-            raise ValueError(msg % fileName)
-
-    def _setSndFromArray(self, thisArray):
+    def _setSndFromClip(self, clip):
         """For pysoundcard all sounds are ultimately played as an array so
         other setSound methods are going to call this having created an arr
         """
+        self.clip = clip
+        thisArray = self.clip.samples
+
         self._callbacks = _PySoundCallbackClass(sndInstance=self)
         if defaultOutput is not None and type(defaultOutput) != int:
             devs = getDevices()
@@ -307,7 +289,7 @@ class SoundPySoundCard(_SoundBase):
         self._stream = soundcard.Stream(samplerate=self.sampleRate,
                                         device=device,
                                         blocksize=self.bufferSize,
-                                        channels=1,
+                                        channels=self.channels,
                                         callback=self._callbacks.fillBuffer)
         self._snd = self._stream
         chansIn, chansOut = self._stream.channels
@@ -329,4 +311,5 @@ class SoundPySoundCard(_SoundBase):
         self._isPlaying = False
 
     def __del__(self):
-        self._stream.close()
+        if hasattr(self, "_stream"):
+            self._stream.close()


### PR DESCRIPTION
Two stages to this one:
- Very simple implementation allowing the ptb backend specifically to do auto resampling by having `_setSndFromArray` create an `AudioClip`, do the resampling, then setup the AudioSlave using that clip's `samples` (in a new `_setSndFromClip` method)
- Refactor to give all backends the same behaviour for processing files, arrays, notes, etc. into an AudioClip object (as nothing up to this point needs to be backend-specific), then have each backend implement a `_setSndFromClip` method (generally the same stuff as in `_setSndFromArray` but with `thisArray = clip.samples` at the beginning)