### PR TITLE
ENH: Allow plugin Components to specify themselves as hidden

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -76,9 +76,7 @@ from psychopy.scripts.psyexpCompile import generateScript
 
 # Components which are always hidden
 alwaysHidden = [
-    'SettingsComponent', 'RoutineSettingsComponent', 'UnknownComponent', 'UnknownRoutine',
-    'UnknownStandaloneRoutine', 'UnknownPluginComponent', 'BaseComponent', 'BaseStandaloneRoutine',
-    'BaseValidatorRoutine'
+    'BaseComponent', 'BaseStandaloneRoutine', 'BaseValidatorRoutine'
 ]
 
 
@@ -3248,6 +3246,9 @@ class ComponentsPanel(scrolledpanel.ScrolledPanel, handlers.ThemeMixin):
                         shown = False
                 # Check whether button is hidden by prefs
                 if name in prefs.builder['hiddenComponents'] + alwaysHidden:
+                    shown = False
+                # check whether comp/rt indicates itsef as hidden
+                if emt.hidden:
                     shown = False
                 # Check whether button refers to a future comp/rt
                 if hasattr(emt, "version"):

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -40,6 +40,8 @@ class BaseComponent:
     beta = False
     # what classes can validate this Component? Specify by name
     validatorClasses = []
+    # hide this Component in Builder view?
+    hidden = False
 
     def __init__(self, exp, parentName, name='',
                  startType='time (s)', startVal='',

--- a/psychopy/experiment/components/routineSettings/__init__.py
+++ b/psychopy/experiment/components/routineSettings/__init__.py
@@ -14,6 +14,8 @@ class RoutineSettingsComponent(BaseComponent):
     iconFile = Path(__file__).parent / 'routineSettings.png'
     tooltip = _translate('Settings for this Routine.')
     version = "2023.2.0"
+    # a Routine only has one RoutineSettingsComponent, so hide it from the Components panel
+    hidden = True
 
     def __init__(
             self, exp, parentName,

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -81,6 +81,8 @@ class SettingsComponent:
     plugin = None
     version = "0.0.0"
     beta = False
+    # an experiment only has one SettingsComponent, so hide it from the Components panel
+    hidden = True
 
     def __init__(
             self, parentName, exp, expName='', fullScr=True, runMode=0, rush=False,

--- a/psychopy/experiment/components/unknown/__init__.py
+++ b/psychopy/experiment/components/unknown/__init__.py
@@ -20,6 +20,8 @@ class UnknownComponent(BaseComponent):
     tooltip = _translate('Unknown: A component that is not known by the current '
                          'installed version of PsychoPy\n(most likely from the '
                          'future)')
+    # hide from the Components panel
+    hidden = True
 
     def __init__(self, exp, parentName, name='', compType="UnknownComponent"):
         self.exp = exp  # so we can access the experiment if necess

--- a/psychopy/experiment/components/unknownPlugin/__init__.py
+++ b/psychopy/experiment/components/unknownPlugin/__init__.py
@@ -18,6 +18,8 @@ class UnknownPluginComponent(BaseComponent):
     targets = ['PsychoPy']
     iconFile = Path(__file__).parent / 'unknownPlugin.png'
     tooltip = _translate('Unknown: A component which comes from a plugin which you do not have installed & activated.')
+    # hide from the Components panel
+    hidden = True
 
     def __init__(self, exp, parentName, name='', compType="UnknownPluginComponent"):
         self.exp = exp  # so we can access the experiment if necess

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -30,6 +30,8 @@ class BaseStandaloneRoutine:
     version = "0.0.0"
     # is it still in beta?
     beta = False
+    # hide this Component in Builder view?
+    hidden = False
 
     def __init__(self, exp, name='',
                  stopType='duration (s)', stopVal='',

--- a/psychopy/experiment/routines/unknown/__init__.py
+++ b/psychopy/experiment/routines/unknown/__init__.py
@@ -7,6 +7,8 @@ class UnknownRoutine(BaseStandaloneRoutine):
     targets = []
     iconFile = Path(__file__).parent / "unknown.png"
     tooltip = "Unknown routine"
+    # hide from the Components panel
+    hidden = True
 
     def __init__(self, exp, name=''):
         BaseStandaloneRoutine.__init__(self, exp, name=name)


### PR DESCRIPTION
Meaning e.g. the old CedrusButtonBoxComponent can exist, and be recognised by Builder when opening an old experiment with one in, but isn't shown in the Components panel (so users don't end up using it instead of the new ButtonBoxComponent)

This could also be achieved by adding
```
from psychopy.app.builder import builder
builder.alwaysHidden.append("CedrusButtonBoxComponent")
```
but importing `psychopy.app` in a Component opens up a whole can of worms which I'd rather avoid if possible