### PR TITLE
BF: Avoid "untitled.psyexp does not exist" warning

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1030,10 +1030,8 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
             ok = self.checkSave()
             if not ok:
                 return False  # user cancelled
-        if self.filename is None:
-            frameData = self.appData['defaultFrame']
-        else:
-            frameData = dict(self.appData['defaultFrame'])
+        frameData = self.appData['defaultFrame']
+        if self.fileExists:
             self.appData['prevFiles'].append(self.filename)
 
             # get size and window layout info


### PR DESCRIPTION
If you closed Builder with nothing open (filename=untitled.psyexp, fileExists=False) then the filename still got added to `prevFiles` in app data, so when you next opened Builder it would try to open a nonexistant "untitled.psyexp" file and print a warning when it failed. The solution is to not store the filename if `fileExists=False`.