### PR TITLE
FF: Reinstate audioWASAPIOnly pref (was overwritten)

### DIFF
--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -131,7 +131,9 @@
 # Settings for hardware
 [hardware]
     # LEGACY: choice of audio library
-    audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
+    audioLib = list(default=list('ptb', 'sounddevice', 'pyo', 'pygame'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # audio driver to use
     audioDriver = list(default=list('coreaudio', 'portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -131,7 +131,9 @@
 # Settings for hardware
 [hardware]
     # LEGACY: choice of audio library
-    audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
+    audioLib = list(default=list('ptb', 'sounddevice', 'pyo', 'pygame'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -131,7 +131,9 @@
 # Settings for hardware
 [hardware]
     # LEGACY: choice of audio library
-    audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
+    audioLib = list(default=list('ptb', 'sounddevice', 'pyo', 'pygame'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -131,7 +131,9 @@
 # Settings for hardware
 [hardware]
     # LEGACY: choice of audio library
-    audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
+    audioLib = list(default=list('ptb', 'sounddevice', 'pyo', 'pygame'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # audio driver to use
     audioDriver = list(default=list('Primary Sound','ASIO','Audigy'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -127,7 +127,9 @@
 # Settings for hardware
 [hardware]
     # LEGACY: choice of audio library
-    audioLib = list(default=list('PTB', 'sounddevice', 'pyo', 'pygame'))
+    audioLib = list(default=list('ptb', 'sounddevice', 'pyo', 'pygame'))
+    # exclude non-WASAPI audio devices
+    audioWASAPIOnly = boolean(default=True)
     # audio driver to use
     audioDriver = list(default=list('portaudio'))
     # audio device to use (if audioLib allows control)

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -87,7 +87,6 @@ thisLibName = None  # name of the library we are trying to load
 
 # selection and fallback mechanism for audio libraries
 for thisLibName in prefs.hardware['audioLib']:
-    print(thisLibName)
     # Tell the user we are trying to load the specifeid audio library
     logging.info(f"Trying to load audio library: {thisLibName}")
 
@@ -117,7 +116,6 @@ for thisLibName in prefs.hardware['audioLib']:
                 Sound = backend.SoundPTB
                 audioDriver = backend.audioDriver
             except Exception as err:
-                print(err)
                 failed.append(thisLibName)
                 continue
             else:

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -71,7 +71,7 @@ backend = None
 # These are the names that can be used in the prefs to specifiy audio libraries.
 # The available libraries are hard-coded at this point until we can overhaul
 # the sound library to be more modular.
-_audioLibs = ['PTB', 'sounddevice', 'pyo', 'pysoundcard', 'pygame']
+_audioLibs = ['ptb', 'sounddevice', 'pyo', 'pysoundcard', 'pygame']
 failed = []  # keep track of audio libs that failed to load
 
 # check if this is being imported on Travis/Github (has no audio card)
@@ -87,6 +87,7 @@ thisLibName = None  # name of the library we are trying to load
 
 # selection and fallback mechanism for audio libraries
 for thisLibName in prefs.hardware['audioLib']:
+    print(thisLibName)
     # Tell the user we are trying to load the specifeid audio library
     logging.info(f"Trying to load audio library: {thisLibName}")
 
@@ -115,7 +116,8 @@ for thisLibName in prefs.hardware['audioLib']:
                 from . import backend_ptb as backend
                 Sound = backend.SoundPTB
                 audioDriver = backend.audioDriver
-            except Exception:
+            except Exception as err:
+                print(err)
                 failed.append(thisLibName)
                 continue
             else:

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -50,7 +50,11 @@ else:
 
 # check if we should only use WAS host API (default is True on Windows)
 audioWASAPIOnly = False
-if sys.platform == 'win32' and prefs.hardware['audioWASAPIOnly']:
+try:
+    wasapiPref = prefs.hardware['audioWASAPIOnly']
+except KeyError:
+    wasapiPref = False
+if sys.platform == 'win32' and wasapiPref:
     audioWASAPIOnly = True
 
 # these will be used by sound.__init__.py


### PR DESCRIPTION
Was added in [this commit](https://github.com/psychopy/psychopy/commit/7a0b6cf40a378b6b1c2ba5733677e29d70a4128c) but only to the Windows.spec file, not to baseNoArch.spec, so the next time we made a change to prefs it was overwritten.