### PR TITLE
FF: Handle when playing a stereo sound on mono speakers

### DIFF
--- a/psychopy/sound/_base.py
+++ b/psychopy/sound/_base.py
@@ -308,17 +308,6 @@ class _SoundBase(AttributeGetSetMixin):
         self.sndArr = numpy.asarray(thisArray).astype('float32')
         if thisArray.ndim == 1:
             self.sndArr.shape = [len(thisArray), 1]  # make 2D for broadcasting
-        if self.channels == 2 and self.sndArr.shape[1] == 1:  # mono -> stereo
-            self.sndArr = self.sndArr.repeat(2, axis=1)
-        elif self.sndArr.shape[1] == 1:  # if channels in [-1,1] then pass
-            pass
-        else:
-            try:
-                self.sndArr.shape = [len(thisArray), 2]
-            except ValueError:
-                raise ValueError("Failed to format sound with shape {} "
-                                 "into sound with channels={}"
-                                 .format(self.sndArr.shape, self.channels))
 
         # is this stereo?
         if self.stereo == -1:  # auto stereo. Try to detect

--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -968,18 +968,25 @@ class AudioClip:
             Mono version of this object.
 
         """
-        samples = np.atleast_2d(self._samples)  # enforce 2D
+        if self.channels == 1:
+            return self
+        # log
+        logging.debug(
+            "Converted audio clip from stereo to mono"
+        )
+        # enforce 2D
+        samples = np.atleast_2d(self._samples)
+        # reduce to mono
         if samples.shape[1] > 1:
             samplesMixed = np.atleast_2d(
                 np.sum(samples, axis=1, dtype=np.float32) / np.float32(2.)).T
         else:
             samplesMixed = samples.copy()
-
+        # create copy if requested
         if copy:
             return AudioClip(samplesMixed, self.sampleRateHz)
-
-        self._samples = samplesMixed  # overwrite
-
+        # otherwise change self
+        self._samples = samplesMixed
         return self
     
     def asStereo(self, copy=True):
@@ -1001,15 +1008,19 @@ class AudioClip:
         """
         if self.channels == 2:
             return self
-
-        samples = np.atleast_2d(self._samples)  # enforce 2D
+        # log
+        logging.debug(
+            "Converted audio clip from mono to stereo"
+        )
+        # enforce 2D
+        samples = np.atleast_2d(self._samples) 
+        # expand to stereo
         samples = np.hstack((samples, samples))
-
+        # create copy if requested
         if copy:
             return AudioClip(samples, self.sampleRateHz)
-
-        self._samples = samples  # overwrite
-
+        # otherwise change self
+        self._samples = samples
         return self
 
     def transcribe(self, engine='whisper', language='en-US', expectedWords=None,

--- a/psychopy/sound/backend_ptb.py
+++ b/psychopy/sound/backend_ptb.py
@@ -252,6 +252,11 @@ class SoundPTB(_SoundBase):
         # work out stop time
         if self.stopTime == -1:
             self.duration = clip.samples.shape[0] / clip.sampleRateHz
+        # handle stereo/mono
+        if self.speaker.channels > 1:
+            clip = clip.asStereo()
+        else:
+            clip = clip.asMono()
         # create/update track
         if  self.track:
             self.track.stop()


### PR DESCRIPTION
Uses the existing methods inside AudioClip, with a slight modification to not bother averaging if it's already mono. With this in place, the code to duplicate channels if given a mono sound for a stereo speaker is no longer needed (as _setSndFromArray calls _setSndFromClip)