### PR TITLE
FF: Allow scripts to fetch the current Liaison server rather than creating a new one

### DIFF
--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -115,6 +115,27 @@ class WebSocketServer:
 			'liaison': (self, ['listRegisteredMethods', 'addLogFile', 'pingPong'])
 		}
 	
+	@classmethod
+	def fromPort(cls, host, port):
+		"""
+		Get/create a Liaison server from the given host:port strings.
+
+		Parameters
+		----------
+		host : string
+			the hostname, e.g. 'localhost'
+		port : int
+			the port number, e.g. 8001
+		"""
+		# create reference key
+		key = f"{host}:{port}"
+		# if there's a server running, return it
+		if key in host.servers:
+			return host.servers[key]
+		# otherwise create one
+		server = cls()
+		server.start(host=host, port=port)
+	
 	def addLogFile(self, file, loggingLevel=logging.INFO):
 		# actualize logging level
 		if isinstance(loggingLevel, str):

--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -270,7 +270,7 @@ class WebSocketServer:
 			the port number, e.g. 8001
 		"""
 		# store ref to self
-		WebSocketServer.servers[f"host:port"] = self
+		WebSocketServer.servers[f"{host}:{port}"] = self
 		# set the loop future on SIGTERM or SIGINT for clean interruptions:
 		loop = asyncio.get_running_loop()
 		loopFuture = loop.create_future()

--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -90,6 +90,8 @@ class WebSocketServer:
 	"""
 	A simple Liaison server, using WebSockets as communication protocol.
 	"""
+	# attribute to keep track of active servers
+	servers = {}
 
 	def __init__(self):
 		"""
@@ -267,6 +269,8 @@ class WebSocketServer:
 		port : int
 			the port number, e.g. 8001
 		"""
+		# store ref to self
+		WebSocketServer.servers[f"host:port"] = self
 		# set the loop future on SIGTERM or SIGINT for clean interruptions:
 		loop = asyncio.get_running_loop()
 		loopFuture = loop.create_future()

--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -130,8 +130,8 @@ class WebSocketServer:
 		# create reference key
 		key = f"{host}:{port}"
 		# if there's a server running, return it
-		if key in host.servers:
-			return host.servers[key]
+		if key in cls.servers:
+			return cls.servers[key]
 		# otherwise create one
 		server = cls()
 		server.start(host=host, port=port)

--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -19,6 +19,7 @@ import json
 import sys
 import traceback
 import logging as _logging
+import importlib.metadata
 from psychopy import logging
 from psychopy.localization import _translate
 
@@ -114,6 +115,9 @@ class WebSocketServer:
 		self._methods = {
 			'liaison': (self, ['listRegisteredMethods', 'addLogFile', 'pingPong'])
 		}
+		# register the Liaison-compatible classes defined in plugins
+		for ep in importlib.metadata.entry_points(group="psychopy.liaison"):
+			self.registerClass(ep.load(), ep.name)
 	
 	@classmethod
 	def fromPort(cls, host, port):


### PR DESCRIPTION
This means external applications can call a new script and have it map its classes to Liaison without having to create a new Liaison server just for it, like so:
```
from psychopy import liaison
server = liaison.WebSocketServer.servers[host]
```