### PR TITLE
FF: Allow Liaison methods to be registered via entry points

### DIFF
--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -19,6 +19,7 @@ import json
 import sys
 import traceback
 import logging as _logging
+import importlib.metadata
 from psychopy import logging
 from psychopy.localization import _translate
 
@@ -112,6 +113,9 @@ class WebSocketServer:
 		self._methods = {
 			'liaison': (self, ['listRegisteredMethods', 'addLogFile', 'pingPong'])
 		}
+		# register the Liaison-compatible classes defined in plugins
+		for ep in importlib.metadata.entry_points(group="psychopy.liaison"):
+			self.registerClass(ep.load(), ep.name)
 	
 	def addLogFile(self, file, loggingLevel=logging.INFO):
 		# actualize logging level


### PR DESCRIPTION
Because scripts need to run in a subprocess, they don't have access to instances anyway, so #7003 wasn't really working. This way around it allows classes to be registered with the WebSocketServer class *before* it's initialised, so instead of running a script to interact with Liaison, you can connect a class to the Liaison class to be initialised in the main process.