### PR TITLE
Fix error using QtWidgets for info dlg in PyQt5 (most using PyQt6)

### DIFF
--- a/psychopy/gui/qtgui.py
+++ b/psychopy/gui/qtgui.py
@@ -175,16 +175,25 @@ class Dlg(QtWidgets.QDialog):
 
         # set always stay on top
         if alwaysOnTop:
-            self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
+            if hasattr(Qt.WindowType, 'WindowStaysOnTopHint'):
+                self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
 
         # add buttons for OK and Cancel
-        buttons = QtWidgets.QDialogButtonBox.StandardButton.Ok | QtWidgets.QDialogButtonBox.StandardButton.Cancel
-        self.buttonBox = QtWidgets.QDialogButtonBox(buttons, parent=self)
+        if hasattr(QtWidgets.QDialogButtonBox.StandardButton, 'Ok'):
+            # PyQt6 upwards?
+            okBtn = QtWidgets.QDialogButtonBox.StandardButton.Ok
+            cancelBtn = QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        else:
+            # e.g. PyQt5
+            okBtn = QtWidgets.QDialogButtonBox.Ok
+            cancelBtn = QtWidgets.QDialogButtonBox.Cancel
+            
+        self.buttonBox = QtWidgets.QDialogButtonBox(okBtn | cancelBtn, parent=self)
         self.buttonBox.accepted.connect(self.accept)
         self.buttonBox.rejected.connect(self.reject)
         # store references to OK and CANCEL buttons
-        self.okBtn = self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
-        self.cancelBtn = self.buttonBox.button(QtWidgets.QDialogButtonBox.StandardButton.Cancel)
+        self.okBtn = self.buttonBox.button(okBtn)
+        self.cancelBtn = self.buttonBox.button(cancelBtn)
 
         if style:
             raise RuntimeWarning("Dlg does not currently support the "


### PR DESCRIPTION
For 6 we need QtWidgets.QDialogButtonBox.StandardButton.Ok For 5 we need QtWidgets.QDialogButtonBox.Ok

For 6 we have Qt.WindowType.WindowStaysOnTopHint
For 5 ?