### PR TITLE
DOC: Remove beta sticker from various Components

### DIFF
--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -30,7 +30,7 @@ class CameraComponent(BaseDeviceComponent):
     version = "2022.2.0"
     iconFile = Path(__file__).parent / 'webcam.png'
     tooltip = _translate('Webcam: Record video from a webcam.')
-    beta = True
+    beta = False
     deviceClasses = ["psychopy.hardware.camera.Camera"]
 
     def __init__(

--- a/psychopy/experiment/components/eyetracker_record/__init__.py
+++ b/psychopy/experiment/components/eyetracker_record/__init__.py
@@ -21,7 +21,7 @@ class EyetrackerRecordComponent(BaseComponent):
     version = "2021.2.0"
     iconFile = Path(__file__).parent / 'eyetracker_record.png'
     tooltip = _translate('Start and / or Stop recording data from the eye tracker')
-    beta = True
+    beta = False
 
     def __init__(self, exp, parentName, name='etRecord',
                  startType='time (s)', startVal=0.0,

--- a/psychopy/experiment/components/form/__init__.py
+++ b/psychopy/experiment/components/form/__init__.py
@@ -23,7 +23,7 @@ class FormComponent(BaseVisualComponent):
     version = "2020.2.0"
     iconFile = Path(__file__).parent / 'form.png'
     tooltip = _translate('Form: a Psychopy survey tool')
-    beta = True
+    beta = False
 
     def __init__(self, exp, parentName,
                  name='form',

--- a/psychopy/experiment/components/roi/__init__.py
+++ b/psychopy/experiment/components/roi/__init__.py
@@ -18,7 +18,7 @@ class RegionOfInterestComponent(PolygonComponent):
     version = "2021.2.0"
     iconFile = Path(__file__).parent / 'eyetracker_roi.png'
     tooltip = _translate('Region Of Interest: Define a region of interest for use with eyetrackers')
-    beta = True
+    beta = False
 
     def __init__(self, exp, parentName, name='roi',
                  units='from exp settings',

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -18,7 +18,7 @@ class SerialOutComponent(BaseComponent):
     version = "2022.2.0"
     iconFile = Path(__file__).parent / 'serial.png'
     tooltip = _translate('Serial out: send signals from a serial port')
-    beta = True
+    beta = False
 
     def __init__(self, exp, parentName, name='serialPort',
                  startType='time (s)', startVal=0.0,

--- a/psychopy/experiment/components/textbox/__init__.py
+++ b/psychopy/experiment/components/textbox/__init__.py
@@ -19,7 +19,7 @@ class TextboxComponent(BaseVisualComponent):
     version = "2020.2.0"
     iconFile = Path(__file__).parent / 'textbox.png'
     tooltip = _translate('Textbox: present text stimuli but cooler')
-    beta = True
+    beta = False
 
     def __init__(self, exp, parentName, name='textbox',
                  # effectively just a display-value


### PR DESCRIPTION
The following Components have been out in the wild long enough that we can consider them out of beta:
- Camera
- Eyetracker Record
- Form
- Region Of Interest
- Serial Out
- Textbox