### PR TITLE
BF: Sound online was sometimes marked as already finished on second iteration of a loop

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -268,6 +268,12 @@ class SoundComponent(BaseDeviceComponent):
         stopVal = self.params['stopVal']
         if stopVal in ['', None, 'None']:
             stopVal = -1
+        
+        # never start a Routine marked as finished
+        code = (
+            "%(name)s.isFinished = false;"
+        )
+        buff.writeIndentedLines(code % self.params)
 
         if self.params['sound'].updates == 'set every repeat':
             buff.writeIndented("%(name)s.setValue(%(sound)s);\n" % self.params)


### PR DESCRIPTION
If the sound finished playing in the first iteration, it gets `isFinished = true`. If the Component reached its stop point, it gets `.status = FINISHED` (one referring to the sound itself, the second referring to the Sound Component). As with all Components, it gets `.status = NOT_STARTED` when the next iteration begins, but `.isFinished` is never set back to `false`. 

An example of an incongruency:
You have a Sound Component called `snd` with duration set to 5s, it plays a sound file which is 2s long. After 2s, the sound finishes and `snd.isFinished = true`. After 5s, the Component finishes and `snd.status = FINISHED`. Next iteration of the trials loop, `snd.status = NOT_STARTED` (correctly, as we haven't played anything yet), but `snd.isFinished = true` because that wasn't automatically reset.

This solution means that a Sound always starts a Routine with `isFinished = false`