### PR TITLE
BF: Slashes in project names were causing Pavlovia sync to error

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -1109,9 +1109,11 @@ class PavloviaProject(dict):
         elif localFiles:
             # get project name
             if "/" in self.stringId:
-                _, projectName = self.stringId.split("/")
+                _, projectName = self.stringId.split("/", maxsplit=1)
             else:
                 projectName = self.stringId
+            # remove extra / from project name
+            projectName = projectName.replace("/", "")
             # ask user if they want to clone to a subfolder
             msg = _translate(
                     "Folder '{localRoot}' is not empty, use '{localRoot}/{projectName}' instead?"
@@ -1477,7 +1479,9 @@ def getProject(filename):
     # If already found, return
     if (knownProjects is not None) and (path in knownProjects) and ('idNumber' in knownProjects[path]):
         # Make sure we are logged in
-        nameSpace, projectName = path.split("/")
+        nameSpace, projectName = path.split("/", maxsplit=1)
+        # remove extra slashes from project name
+        projectName = projectName.replace("/", "")
         # Try to log in if not logged in
         if not session.user:
             if nameSpace in knownUsers:
@@ -1523,7 +1527,9 @@ def getProject(filename):
                     # Remove .git
                     namespaceName = namespaceName.replace(".git", "")
                     # Split to get namespace
-                    nameSpace, projectName = namespaceName.split('/')
+                    nameSpace, projectName = namespaceName.split("/", maxsplit=1)
+                    # remove extra slashes from project name
+                    projectName = projectName.replace("/", "")
                     # Get current session
                     pavSession = getCurrentSession()
                     # Try to log in if not logged in

--- a/psychopy/tests/test_visual/test_roi.py
+++ b/psychopy/tests/test_visual/test_roi.py
@@ -1,4 +1,7 @@
 import numpy as np
+import pytest
+
+from psychopy.tests import utils
 
 from .test_basevisual import _TestUnitsMixin, _TestSerializationMixin
 from psychopy.tests.test_experiment.test_component_compile_python import _TestBoilerplateMixin
@@ -57,6 +60,9 @@ class TestROI(_TestUnitsMixin, _TestBoilerplateMixin, _TestSerializationMixin):
         assert not self.obj.isLookedIn, f"ROI returning True for isLookedIn when not looked at."
 
     def test_look_at_away(self):
+        # skip speed tests under vm
+        if utils.RUNNING_IN_VM:
+            pytest.skip()
         # Define some look times to simulate
         looks = np.array([
             [0.1, 0.2],


### PR DESCRIPTION
If the project was originally synced via Builder then this never happens - as Builder strips any extraneous `/` from the name on creation. However, if the project was cloned via url in command line and the url had a `/` at the end, the project then couldn't be opened in Builder.