### PR TITLE
DOC: Fix mistake in FormComponent documentation

### DIFF
--- a/docs/source/builder/components/form.rst
+++ b/docs/source/builder/components/form.rst
@@ -36,7 +36,7 @@ Items : A csv / xlsx file **To get started, we recommend selecting the "Open/Cre
     *itemWidth*
         The question width between 0 : 1
     *type*
-        The type of rating e.g., 'choice', 'rating', 'slider', 'free-text'
+        The type of rating e.g., 'choice', 'rating', 'slider', 'free text'
     *responseWidth*
         The question width between 0 : 1
     *options*


### PR DESCRIPTION
Update documentation to correctly show that the FormComponent accepts a type of `free text` rather than `free-text`

Addresses issue: https://github.com/psychopy/psychopy/issues/6452