### PR TITLE
FF: Avoid "double bagging" Trial objects when converting to JSON

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -811,18 +811,27 @@ class Trial(dict):
             'data': {key: val for key, val in self.items()},
         }
     
-    def getJSON(self):
+    def getJSON(self, asString=False):
         """
         Serialize this Trial to a JSON format.
+
+        Parameters
+        ----------
+        asString : bool
+            If True, convert the returned object to a string. If False, keep as a dict.
 
         Returns
         -------
         str
             The results of Trial.getDict expressed as a JSON string
         """
-        return json.dumps(
-            self.getDict()
-        )
+        # get self as a dict
+        data = self.getDict()
+        # convert to string if requested
+        if asString:
+            data = json.dumps(data)
+        
+        return data
 
 
 class TrialHandler2(_BaseTrialHandler):


### PR DESCRIPTION
Converting to a string before sending to Liaison means that particularly complex data structures (so particularly long strings) get garbled in transit.