### PR TITLE
FF: packages symlink only if the folder doesn't exist

### DIFF
--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -213,11 +213,11 @@ class Preferences:
                 userScripts = userPkgRoot / "bin"
 
                 # create symlinks to the python version agnostic directories
-                if not userPackages.is_symlink():
+                if not userPackages.exists():
                     userPackages.symlink_to(oldUserPackageRoot / "lib")
-                if not userInclude.is_symlink():
+                if not userInclude.exists():
                     userInclude.symlink_to(oldUserPackageRoot / "include")
-                if not userScripts.is_symlink():
+                if not userScripts.exists():
                     userScripts.symlink_to(oldUserPackageRoot / "bin")
 
             # reload userPkgRoot


### PR DESCRIPTION
We were testing if the folder was already a symlink but maybe it's already a folder

Not sure why but that occurred in our devops build