### PR TITLE
FF: PsychoJS boilerplate was specifying files by name rather than relative path

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -1198,10 +1198,6 @@ class Experiment:
             else:
                 thisFile['rel'] = filePath
                 thisFile['abs'] = os.path.normpath(join(srcRoot, filePath))
-                if "/" in filePath:
-                    thisFile['name'] = filePath.split("/")[-1]
-                else:
-                    thisFile['name'] = filePath
                 if len(thisFile['abs']) <= 256 and os.path.isfile(thisFile['abs']):
                     return thisFile
 


### PR DESCRIPTION
I think this is a holdover from [when we were first supporting default stim online](https://github.com/TEParsons/psychopy/commit/254580da978eed5b371525f5518d43880cca577d) - before we added an if statement specifically for them. It was previously harmless as the relative path was used in place of a name if one was present, but I had to change that when [adding support for faceapi](https://github.com/psychopy/psychopy/pull/7018/commits/a8a7777e4b6d739dd9e9a2c97fca073c9e966a26) as faceapi is a non-default-stim which needs a different name to its relative path, which meant any stimuli with a relative path more complex than just its name wasn't found. Because we handle default stim separately now, this line is obsolete for its original purpose & with the face api changes is actively harmful, so removing it is the right way to go I think.