### PR TITLE
FF: Added `pyarrow` dependancy for `pandas`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dependencies = [
     'tables!=3.9.2',  # 3.9.2 crashes on Rosetta
     "packaging>=24.0",
     "moviepy",
+    "pyarrow"
 ]
 
 [project.optional-dependencies]  # This is optional dependencies


### PR DESCRIPTION
Adds the package `pyarrow` as a dependency, this is required by `pandas` in the future. Adding this package with suppress the following deprecation message from being logged:

```
  Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
  (to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
  but was not found to be installed on your system.
```