### PR TITLE
BF: Opening the same experiment in two Builder windows caused the prefs file to be saved wrong, leading to an error next time the app started

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -1063,7 +1063,11 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.appData['fileHistory'] = copy.copy(tmp[-fhMax:])
 
         # assign the data to this filename
-        self.appData['frames'][str(self.filename)] = frameData
+        if (
+            str(self.filename) not in self.appData['frames']
+            and str(self.filename) not in self.appData
+        ):
+            self.appData['frames'][str(self.filename)] = frameData
         # save the display data only for those frames in the history:
         tmp2 = {}
         for f in self.appData['frames']:


### PR DESCRIPTION
It's a quirk of the `contrib` module which we save/load the prefs file using - it only seems to allow 1 level of nesting dicts, so doing `self.appData['frames'][str(self.filename)]` saved in the file as if it were `self.appData[str(self.filename)]`. If you had the same experiment open twice, the first one would be saved in the prefs file, then the file would be reloaded, then when the second one saved it wouldn't recognise that the same file is already present because it's looking 1 level down from where the prefs file maxed out.

In the long term I think we should do away with `contrib` in favour of Python builtin `configparser`, but adding this check fixes the immediate problem