### PR TITLE
BF: Variables in Button Component callbacks weren't defined properly online

### DIFF
--- a/psychopy/experiment/components/button/__init__.py
+++ b/psychopy/experiment/components/button/__init__.py
@@ -350,7 +350,7 @@ class ButtonComponent(BaseVisualComponent):
         # Get callback from params
         callback = inits['callback']
         if inits['callback'].val not in [None, "None", "none", "undefined"]:
-            callback = translatePythonToJavaScript(str(callback))
+            callback = translatePythonToJavaScript(str(callback), namespace=None)
         else:
             callback = ""
 


### PR DESCRIPTION
Because the boilerplate code was detecting them in the callback code and defining them locally, it was overriding the global definition from the general experiment boilerplate code