### PR TITLE
NF: Allow devices to listen for responses while frame loop is paused

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -2000,9 +2000,9 @@ class SettingsComponent:
         buff.writeIndentedLines(code)
 
     def writePauseCode(self, buff):
-        # Open function def
+        # open function def for pause
         code = (
-            'def pauseExperiment(thisExp, win=None, timers=[], playbackComponents=[]):\n'
+            'def pauseExperiment(thisExp, win=None, timers=[], playbackComponents=[], dispatchComponents=[]):\n'
             '    """\n'
             '    Pause this experiment, preventing the flow from advancing to the next routine until resumed.\n'
             '    \n'
@@ -2017,7 +2017,10 @@ class SettingsComponent:
             '        List of timers to reset once pausing is finished.\n'
             '    playbackComponents : list, tuple\n'
             '        List of any components with a `pause` method which need to be paused.\n'
-            '    """'
+            '    dispatchComponents : list, tuple\n'
+            '        List of any components with a `dispatchMessages` method which needs to be called while \n'
+            '        paused.\n'
+            '    """\n'
         )
         buff.writeIndentedLines(code)
         buff.setIndentLevel(+1, relative=True)
@@ -2051,6 +2054,9 @@ class SettingsComponent:
             "        endExperiment(thisExp, win=win)\n"
             )
         code += (
+            "    # dispatch messages on response components\n"
+            "    for comp in dispatchComponents:\n"
+            "        comp.device.dispatchMessages()\n"
             "    # sleep 1ms so other threads can execute\n"
             "    clock.time.sleep(0.001)\n"
             "# if stop was requested while paused, quit\n"
@@ -2064,8 +2070,7 @@ class SettingsComponent:
             "    timer.addTime(-pauseTimer.getTime())\n"
         )
         buff.writeIndentedLines(code % self.params)
-
-        # Exit function def
+        # exit function def
         buff.setIndentLevel(-1, relative=True)
         buff.writeIndentedLines("\n")
 

--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -283,6 +283,12 @@ class BaseResponseDevice(BaseDevice):
             'kwargs': kwargs
         })
     
+    def clearCallbacks(self):
+        """
+        Un-register all callbacks which have been registered to this device by `registerCallback`
+        """
+        self.callbacks = []
+    
     def checkCallbacks(self, message):
         """
         Check whether a received message should trigger any registered callback functions (see 

--- a/psychopy/hardware/button.py
+++ b/psychopy/hardware/button.py
@@ -12,6 +12,25 @@ class ButtonResponse(base.BaseResponse):
         base.BaseResponse.__init__(self, t=t, value=value)
         # store channel
         self.channel = channel
+    
+    def __eq__(self, other):
+        """
+        ButtonResponse will recognise itself as equal to either:
+        - A boolean which matches its value
+        - An integer which matches its channel
+        - Another ButtonResponse which matches its value and channel
+        """
+        # match another ButtonResponse with the same value and channel
+        if isinstance(other, ButtonResponse):
+            return other.value == self.value and other.channel == self.channel
+        # match a boolean to response
+        if isinstance(other, bool):
+            return other == self.value
+        # match an integer to channel
+        if isinstance(other, int):
+            return other == self.channel
+        
+        return False
 
 
 class BaseButtonGroup(base.BaseResponseDevice):


### PR DESCRIPTION
This is crucial for using `pauseExperiment` as it allows the experiment to be *un*paused when a key is pressed, owing to the `registerCallback` method of `ResponseDevice` (which executes a function, i.e. thisExp.resume, when it receives a particular response)