### PR TITLE
ENH: Allow for infinite duration audio recording

### DIFF
--- a/psychopy/sound/audioclip.py
+++ b/psychopy/sound/audioclip.py
@@ -577,6 +577,8 @@ class AudioClip:
         self._samples = np.ascontiguousarray(
             np.vstack((self._samples, other.samples)),
             dtype=np.float32)
+        
+        self._duration = len(self.samples) / float(self.sampleRateHz)
 
         return self
 


### PR DESCRIPTION
This PR removes the requirement to pre-allocate a buffer for audio recording samples. The `maxRecordingSize` parameter when set to `-1` or `None` will allow the microphone to record continuously until stopped. Audio samples are stored as fragments and concatenated only when the recording is retrieved. A separate algorithm is used to access the last few samples across fragments very quickly for the real-time `getCurrentVolume()` function.
