### PR TITLE
BF: Fix TrialHander2's __eq__ error at staircase in loop

### DIFF
--- a/psychopy/data/trial.py
+++ b/psychopy/data/trial.py
@@ -1002,7 +1002,12 @@ class TrialHandler2(_BaseTrialHandler):
         # We want to ignore the RNG object when doing the comparison.
         self_copy = copy.deepcopy(self)
         other_copy = copy.deepcopy(other)
-        del self_copy._rng, other_copy._rng
+        
+        # Only delete _rng if it exists
+        if hasattr(self_copy, '_rng'):
+            del self_copy._rng
+        if hasattr(other_copy, '_rng'):
+            del other_copy._rng
 
         result = super(TrialHandler2, self_copy).__eq__(other_copy)
         return result


### PR DESCRIPTION
When I tried to use a staircase loop in a loop, I encountered this error. 
`self.loopsUnfinished` in `if loopHandler in self.loopsUnfinished:`, is an empty array, so it caused an AttributeError.
So I fixed it to check for the existence of _rng before doing `del`.

![experiment overview](https://github.com/user-attachments/assets/c9b46223-1fab-4692-8fb8-56291a2be1e9)

```
Traceback (most recent call last):
  File "F:\Research\psychopy_demos\Design Templates\psychophysicsStaircase\psychophysicsStaircase_lastrun.py", line 945, in <module>
    run(
  File "F:\Research\psychopy_demos\Design Templates\psychophysicsStaircase\psychophysicsStaircase_lastrun.py", line 616, in run
    for thisTrial in trials:
  File "F:\Development\psychopy\psychopy\data\staircase.py", line 395, in __next__
    self._terminate()
  File "F:\Development\psychopy\psychopy\data\base.py", line 106, in _terminate
    exp.loopEnded(self)
  File "F:\Development\psychopy\psychopy\data\experiment.py", line 154, in loopEnded
    if loopHandler in self.loopsUnfinished:
  File "F:\Development\psychopy\psychopy\data\trial.py", line 1005, in __eq__
    del self_copy._rng, other_copy._rng
AttributeError: _rng
```