### PR TITLE
BF: Removed PyPI package search using no longer supported package

### DIFF
--- a/psychopy/app/plugin_manager/packages.py
+++ b/psychopy/app/plugin_manager/packages.py
@@ -4,7 +4,6 @@ import wx
 import os
 import sys
 import subprocess as sp
-from pypi_search import search as pypi
 
 from psychopy.app import utils
 from psychopy.app.themes import handlers, icons
@@ -277,19 +276,17 @@ class PackageListCtrl(wx.Panel):
         # Add column for latest version if we're actually searching
         self.ctrl.AppendColumn(_translate("Latest"))
         # Get packages from search
-        foundPackages = pypi.find_packages(self.searchCtrl.GetValue())
         # Populate
-        for pkg in foundPackages:
+        for pkg, version in installedPackages.items():
+            if pkg is None:
+                continue
             font = wx.Font()
-            if pkg['name'] in installedPackages:
+            if searchTerm in pkg:
                 # If installed, add row with value for installed version
-                item = self.ctrl.Append((pkg['name'], installedPackages[pkg['name']], pkg['version']))
+                item = self.ctrl.Append((pkg, version))
                 font = font.Bold()
-            else:
-                # Otherwise, add row with installed version blank
-                item = self.ctrl.Append((pkg['name'], "-", pkg['version']))
-            # Style new row according to install status
-            self.ctrl.SetItemFont(item, font)
+                # Style new row according to install status
+                self.ctrl.SetItemFont(item, font)
 
     def onAddFromFile(self, evt=None):
         # Create dialog to get package file location

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ dependencies = [
     "requests",
     "future",  # only to support legacy versions in useVersion
     # supporting plugins
-    "pypi-search>=1.2.1",
     "setuptools==70.3.0",  # py2app issues https://github.com/ronaldoussoren/py2app/issues/531
     # pavlovia connections
     "python-gitlab",


### PR DESCRIPTION
This PR removes the ability to search PyPI in the package manager. This feature was removed since the library that does it is no longer maintained. Search still works with locally installed packages. If users wish to install third party packages, they must use the PIP terminal. Plugin installations have not changed

Future versions of the software will download a package index from PyPI instead of querying the website, this will be added in the next point release