### PR TITLE
Mic-fixes-and-hot-recording

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -131,7 +131,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             maxRecordingSize=-1,
             policyWhenFull='warn',
             exclusive=False,
-            audioRunMode=0,
+            audioRunMode=1,
             # legacy
             audioLatencyMode=None,
         ):

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -291,7 +291,7 @@ elif hasattr(backend, 'defaultOutput'):
             deviceNames = sorted(devices.keys())
         else:
             deviceNames = sorted(devices)
-        if dev not in getDevices(kind='output'):
+        if dev not in devices:
             logging.warn(
                 u"Requested audio device '{}' that is not available on "
                 "this hardware. The 'audioDevice' preference should be one of "

--- a/psychopy/sound/__init__.py
+++ b/psychopy/sound/__init__.py
@@ -286,8 +286,12 @@ elif hasattr(backend, 'defaultOutput'):
     if dev == 'default' or systemtools.isVM_CI():
         pass  # do nothing
     elif getDevices is not None:
+        devices = getDevices(kind='output')
+        if type(devices) is dict:
+            deviceNames = sorted(devices.keys())
+        else:
+            deviceNames = sorted(devices)
         if dev not in getDevices(kind='output'):
-            deviceNames = sorted(getDevices(kind='output').keys())
             logging.warn(
                 u"Requested audio device '{}' that is not available on "
                 "this hardware. The 'audioDevice' preference should be one of "


### PR DESCRIPTION
A small number of devices (ClearOne, we're looking at you) send the device to sleep if they don't receive any polling for a few secs. Then when we try to make a new recording they error.

Using Psychtoolbox audioRunMode setting allows us to keep the mic "hot" and ready to record. It may consume more system resources but fewer errors and lower latencies (no start-up time)