### PR TITLE
FF: Mic was registering as asleep when it was actually stopped

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -674,7 +674,8 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         if self._stream is None:
             raise AudioStreamError("Stream not ready.")
-
+        # reset timer for possibly asleep
+        self._possiblyAsleep = False
         # reset the recording buffer
         self._recording = []
         self._totalSamples = 0


### PR DESCRIPTION
Because the check for asleep is "if we didn't get data this poll, and it's been 1s since we last got data", it meant if you stopped the mic and started it again after more than 1s, it would think it had gone to sleep. This essentially changes the check to "if we didn't get data at this poll, and it's been 1s since we last got data *or since we started sampling*"