### PR TITLE
FF: Fixes to photodiode validator

### DIFF
--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -267,7 +267,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
 
         # choose a clock to sync to according to component's params
         if "syncScreenRefresh" in stim.params and stim.params['syncScreenRefresh']:
-            clockStr = ""
+            clockStr = "clock=globalClock"
         else:
             clockStr = "clock=routineTimer"
         # sync component start/stop timers with validator clocks

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -180,8 +180,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
         if self.params['findThreshold']:
             code = (
                 "# find threshold for photodiode\n"
-                "if %(deviceLabelCode)s.getThreshold(channel=%(channel)s) is None:\n"
-                "    %(deviceLabelCode)s.findThreshold(win, channel=%(channel)s)\n"
+                "%(deviceLabelCode)s.findThreshold(win, channel=%(channel)s)\n"
             )
         else:
             code = (
@@ -192,8 +191,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
         if self.params['findDiode']:
             code = (
                 "# find position and size of photodiode\n"
-                "if %(deviceLabelCode)s.pos is None and %(deviceLabelCode)s.size is None and %(deviceLabelCode)s.units is None:\n"
-                "    %(deviceLabelCode)s.findPhotodiode(win, channel=%(channel)s)\n"
+                "%(deviceLabelCode)s.findPhotodiode(win, channel=%(channel)s)\n"
             )
             buff.writeOnceIndentedLines(code % inits)
 
@@ -298,7 +296,6 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
         """
         # get starting indent level
         startIndent = buff.indentLevel
-
         # validate start time
         code = (
             "# validate {name} start time\n"

--- a/psychopy/experiment/routines/photodiodeValidator/__init__.py
+++ b/psychopy/experiment/routines/photodiodeValidator/__init__.py
@@ -313,6 +313,7 @@ class PhotodiodeValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
             "        thisExp.addData('{name}.%(name)s.started', %(name)s.tStart)\n"
             "        thisExp.addData('%(name)s.startDelay', %(name)s.tStartDelay)\n"
             )
+        buff.writeIndentedLines(code.format(**stim.params) % self.params)
 
         # validate stop time
         code = (

--- a/psychopy/hardware/photodiode.py
+++ b/psychopy/hardware/photodiode.py
@@ -421,7 +421,7 @@ class BasePhotodiodeGroup(base.BaseResponseDevice):
         # set size/pos/units
         self.units = "norm"
         self.size = rect.size * 2
-        self.pos = rect.pos + rect.size / (-2, 2)
+        self.pos = rect.pos
 
         return (
             layout.Position(self.pos, units="norm", win=win),


### PR DESCRIPTION
When doing `findPhotodiode`, the result would be shifted so only a corner was on the actual diode. This is because previously we were manually adjusting for the Rect's anchor, but the previous code has changed so this is no longer needed & it's now overcorrected.