### PR TITLE
BF: If a Mic was never started, it would error on saving recording

### DIFF
--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1036,14 +1036,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         """
         if self.recordingEmpty:
-            return AudioClip(
-                np.zeros(
-                    (self._sampleRateHz, self.channels),
-                    dtype=np.float32, 
-                    order='C'
-                ),
-                sampleRateHz=self._sampleRateHz
-            )
+            return None
         
         self._mergeAudioFragments()  # merge audio fragments
 

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1036,7 +1036,14 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         """
         if self.recordingEmpty:
-            return None
+            return AudioClip(
+                np.zeros(
+                    (self._sampleRateHz, self.channels),
+                    dtype=np.float32, 
+                    order='C'
+                ),
+                sampleRateHz=self._sampleRateHz
+            )
         
         self._mergeAudioFragments()  # merge audio fragments
 

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -283,8 +283,16 @@ class Microphone:
             self.scripts[tag] = []
 
         # append current recording to clip list according to tag
-        self.lastClip = self.getRecording()
-        self.clips[tag].append(self.lastClip)
+        lastClip = self.getRecording()
+        if lastClip is not None:
+            self.lastClip = lastClip
+            self.clips[tag].append(lastClip)
+        else:
+            # if no recording, return the correct number of items
+            if transcribe:
+                return None, None
+            else:
+                return None
 
         # synonymise null values
         nullVals = (


### PR DESCRIPTION
Because `.bank` is called by Builder whether or not the Component actually started (so whether or not the recording is empty) - but calling `bank` on a mic with an empty recording means that `mic.clips` gets a `None` appended. Fix is to instead store an empty AudioClip.