### PR TITLE
Update installPsychoPy.py

### DIFF
--- a/installPsychoPy.py
+++ b/installPsychoPy.py
@@ -14,12 +14,11 @@ shortcuts, checking/recommending virtual envs etc.
 
 # Author: Jonathan Peirce, based on work of Flavio Bastos and Florian Osmani
 
-import os, sys
-import pathlib
-import subprocess
 import os
+import pathlib
+import platform
+import subprocess
 import sys
-import requests
 
 _linux_installer = None  # will be apt-get or yum depending on system
 
@@ -80,9 +79,9 @@ def apt_install(*packages):
     def find_package(package):
         # check pacakage name according to apt/yum
         packages_lookup = {
-            'python3-dev': {'apt':'libgtk-3-dev', 'yum':'gtk3-devel'},
+            'python3-dev': {'apt':'python3.' + str(sys.version_info[1]) + '-dev', 'yum':'gtk3-devel'},
             'libgtk-3-dev': {'apt':'libgtk-3-dev', 'yum':'gtk3-devel'},
-            'libwebkit2gtk-4.0-dev': {'apt':'libwebkit2gtk-4.0-dev', 'yum':'webkit2gtk3-devel'},
+            'libwebkit2gtk-4.0-dev': {'apt':'libwebkit2gtk-4.*-dev', 'yum':'webkit2gtk3-devel'},
             'libxcb-xinerama0': {'apt':'libxcb-xinerama0', 'yum':'libxcb-xinerama'},
             'libegl1-mesa-dev': {'apt':'libegl1-mesa-dev', 'yum':'mesa-libEGL-devel'},
         }


### PR DESCRIPTION
l. 17-21: removed import os, sys (imported individually some lines below) and import requests (not used; needs otherwise to be installed first) and sorted the modules alphabetically (to make it easier to keep track)
l. 82: added minor version number and correct to python3.xx-dev (you need to update yum which is incorrect too); adding the minor version ensures that there is no mismatch between the default Python version on the system and the Python version used for psychopy (e.g., when running in a venv)
l. 84: changing the minor version for libwebkit2gtk-4.x-dev into a placeholder (e.g., Ubuntu 24.04 comes with version libwebkit2gtk-4.1-dev, and the placeholder ensures that libwebkit2gtk-4.0-dev used in earlier versions is matched too, wxPython seems to install properly with either version).