### PR TITLE
FF: Handle when a MicrophoneVoiceKeyEmulator shares a device with a MicrophoneDevice

### DIFF
--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -149,8 +149,11 @@ class DeviceManager:
         type
             Class pointed to by deviceClass
         """
+        # if already a class, return as is
+        if isinstance(deviceClass, type):
+            return deviceClass
+        # resolve "any" flags to BaseDevice
         if deviceClass in (None, "*"):
-            # resolve "any" flags to BaseDevice
             deviceClass = "psychopy.hardware.base.BaseDevice"
         # get package and class names from deviceClass string
         parts = deviceClass.split(".")

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1036,14 +1036,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         """
         if self.recordingEmpty:
-            return AudioClip(
-                np.zeros(
-                    (self._sampleRateHz, self.channels),
-                    dtype=np.float32, 
-                    order='C'
-                ),
-                sampleRateHz=self._sampleRateHz
-            )
+            return None
         
         self._mergeAudioFragments()  # merge audio fragments
 

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1036,7 +1036,14 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
 
         """
         if self.recordingEmpty:
-            return None
+            return AudioClip(
+                np.zeros(
+                    (self._sampleRateHz, self.channels),
+                    dtype=np.float32, 
+                    order='C'
+                ),
+                sampleRateHz=self._sampleRateHz
+            )
         
         self._mergeAudioFragments()  # merge audio fragments
 

--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -283,8 +283,16 @@ class Microphone:
             self.scripts[tag] = []
 
         # append current recording to clip list according to tag
-        self.lastClip = self.getRecording()
-        self.clips[tag].append(self.lastClip)
+        lastClip = self.getRecording()
+        if lastClip is not None:
+            self.lastClip = lastClip
+            self.clips[tag].append(lastClip)
+        else:
+            # if no recording, return the correct number of items
+            if transcribe:
+                return None, None
+            else:
+                return None
 
         # synonymise null values
         nullVals = (


### PR DESCRIPTION
Previous implementation was failing to recognise when a MicrophoneDevice was already created, so MicrophoneVoiceKeyEmulator was creating duplicate objects and causing errors by accessing the same mic in multiple ptb streams. This implementation catches when a device already exists and uses the same MicrophoneDevice object.