### PR TITLE
BF: All unknown parameters were labelled "Plugin"

### DIFF
--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -744,7 +744,7 @@ class Experiment:
                         # don't warn people if we know it's OK (e.g. for params
                         # that have been removed
                         pass
-                    elif componentNode is not None and componentNode.get("plugin", False):
+                    elif componentNode is not None and componentNode.get("plugin", False) not in (False, "", "None", None):
                         # is param unrecognised because it's from a plugin?
                         params[name].categ = "Plugin"
                         params[name].plugin = componentNode.get("plugin", False)


### PR DESCRIPTION
Even ones not from a plugin. Reason being that we were checking for the *presence* of an attribute "plugin" in the XML node, not actually whether it was `None`