### PR TITLE
BF: Silence unnecessary "ERROR" log in Polygon

### DIFF
--- a/psychopy/experiment/components/polygon/__init__.py
+++ b/psychopy/experiment/components/polygon/__init__.py
@@ -296,8 +296,7 @@ class PolygonComponent(BaseVisualComponent):
         # make a util.Color object for non-transparent
         for key in ("fillColor", "lineColor"):
             if inits[key].val != "undefined":
-                inits[key].val = "new util.Color(%s)" % inits[key]
-                inits[key].valType = "code"
+                inits[key] = "new util.Color(%s)" % inits[key]
         # add other params
         code += (
             "  ori: {ori}, \n"


### PR DESCRIPTION
The crux of the problem was that (as of #6865) the init param for Polygon's fill and line colors had a value which was already translated to JS. It needs to be so as the JS transpiler can't detect a color from just the value given (how would it know the difference between $[1, 1, 1] being white in RGB vs being an array of three 1s?), but setting the value here meant that when the param was stringified it was translated again. Doing so wasn't harmful to the output as, upon failing, it returned the value unchanged, but when it fails it logs a confusing error message.

This PR fixes this by, rather than setting the *value* of the param to be the translated string, replaces the param with a simple string.

In the long term, we should really make the various color attributes of PsychoJS objects create their own `util.Color` object when set (like how the equivalent objects work in PsychoPy), so that this translation isn't needed. But for now, this silences the error without changing the output.