### PR TITLE
BF: Use the same validation for experiment name as we use for Component names

### DIFF
--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -115,7 +115,7 @@ class ParamCtrls():
                     vc.availableVersions(local=False), wx.__version__)
                 param.allowedVals = (options + [''] + versions)
 
-        if param.inputType == "single":
+        if param.inputType in ("single", "name"):
             # Create single line string control
             self.valueCtrl = paramCtrls.SingleLineCtrl(
                 parent, 
@@ -258,7 +258,7 @@ class ParamCtrls():
             self.valueCtrl.Disable()  # visible but can't be changed
 
         # add a Validator to the valueCtrl
-        if fieldName == "name":
+        if param.inputType == "name":
             self.valueCtrl.SetValidator(NameValidator())
         elif param.inputType in ("single", "multi"):
             # only want anything that is valType code, or can be with $

--- a/psychopy/app/builder/validators.py
+++ b/psychopy/app/builder/validators.py
@@ -380,7 +380,12 @@ class NameValidator(BaseValidator):
         else:
             namespace = parent.frame.exp.namespace
             used = namespace.exists(newName)
-            sameAsOldName = bool(newName == parent.params['name'].val)
+            # get fieldName
+            if control.Name:
+                fieldName = control.Name
+            else:
+                fieldName = "name"
+            sameAsOldName = bool(newName == parent.params[fieldName].val)
             if used and not sameAsOldName:
                 # NOTE: formatted string literal doesn't work with _translate().
                 # So, we have to call format() after _translate() is applied.

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -26,7 +26,7 @@ from packaging.version import Version
 
 import psychopy
 from psychopy import data, __version__, logging
-from psychopy.tools import filetools as ft
+from psychopy.tools import filetools as ft, stringtools as st
 from .components.resourceManager import ResourceManagerComponent
 from .components.static import StaticComponent
 from .exports import IndentingBuffer, NameSpace
@@ -215,7 +215,7 @@ class Experiment:
 
     @name.setter
     def name(self, value):
-        self.settings.params['expName'].val = value
+        self.settings.params['expName'].val = st.makeValidVarName(value)
 
     @property
     def eyetracking(self):

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -67,7 +67,7 @@ class BaseComponent:
         msg = _translate(
             "Name of this Component (alphanumeric or _, no spaces)")
         self.params['name'] = Param(name,
-            valType='code', inputType="single", categ='Basic',
+            valType='code', inputType="name", categ='Basic',
             hint=msg,
             label=_translate("Name"))
 

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -164,7 +164,7 @@ class SettingsComponent:
             'Experiment info',
         ]
         self.params['expName'] = Param(
-            expName, valType='str', inputType="single", categ='Basic',
+            expName, valType='str', inputType="name", categ='Basic',
             hint=_translate(
                 "Name of the entire experiment (taken by default from the filename on save)"
             ),

--- a/psychopy/tests/test_experiment/test_components/test_base_components.py
+++ b/psychopy/tests/test_experiment/test_components/test_base_components.py
@@ -237,8 +237,11 @@ class BaseComponentTests:
             pytest.skip()
         # Make minimal experiment just for this test
         comp, rt, exp = self.make_minimal_experiment()
-        # Write experiment and check that component is written
+        # write experiment
         pyScript = exp.writeScript(target="PsychoPy")
+        # delete references to exp name (as it will contain the Component name)
+        pyScript = pyScript.replace(exp.name, "EXPERIMENT_NAME")
+        # check that Component is present only when it should be
         if "PsychoPy" in type(comp).targets:
             assert comp.name in pyScript, (
                 f"{type(comp).__name__} not found in compiled Python script when enabled and PsychoPy in targets."
@@ -260,8 +263,11 @@ class BaseComponentTests:
 
         # disable component then do same tests but assert not present
         comp.params['disabled'].val = True
-
+        # write experiment
         pyScript = exp.writeScript(target="PsychoPy")
+        # delete references to exp name (as it will contain the Component name)
+        pyScript = pyScript.replace(exp.name, "EXPERIMENT_NAME")
+        # check that Component is present only when it should be
         if "PsychoPy" in type(comp).targets:
             assert comp.name not in pyScript, (
                 f"{type(comp).__name__} found in compiled Python script when disabled but PsychoPy in targets."


### PR DESCRIPTION
Avoids e.g. setting experiment name to be blank and generating files just called `.js` and `.py`