### PR TITLE
ENH: Add a keyboard shortcut (ALT+SHIFT+R) for "Reveal in file explorer"

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -323,7 +323,7 @@ class BuilderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.menuIDs.ID_REVEAL = wx.NewIdRef(count=1)
         menu.Append(
             self.menuIDs.ID_REVEAL,
-            _translate("Reveal in file explorer..."),
+            _translate("Reveal in file explorer...\t%s") % keys['revealFolder'],
             _translate("Open the folder containing this experiment in your system's file explorer")
         )
         self.Bind(wx.EVT_MENU, self.fileReveal, id=self.menuIDs.ID_REVEAL)

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -183,6 +183,8 @@
     save = string(default='Ctrl+S')
     # save a Builder or Coder file under a new name
     saveAs = string(default='Ctrl+Shift+S')
+    # reveal the folder containing the current Builder file
+    revealFolder = string(default='Alt+Shift+R')
     # Coder: print the file
     print = string(default='Ctrl+P')
     # close the Builder or Coder window

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -183,6 +183,8 @@
     save = string(default='Ctrl+S')
     # save a Builder or Coder file under a new name
     saveAs = string(default='Ctrl+Shift+S')
+    # reveal the folder containing the current Builder file
+    revealFolder = string(default='Alt+Shift+R')
     # Coder: print the file
     print = string(default='Ctrl+P')
     # close the Builder or Coder window

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -183,6 +183,8 @@
     save = string(default='Ctrl+S')
     # save a Builder or Coder file under a new name
     saveAs = string(default='Ctrl+Shift+S')
+    # reveal the folder containing the current Builder file
+    revealFolder = string(default='Alt+Shift+R')
     # Coder: print the file
     print = string(default='Ctrl+P')
     # close the Builder or Coder window

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -183,6 +183,8 @@
     save = string(default='Ctrl+S')
     # save a Builder or Coder file under a new name
     saveAs = string(default='Ctrl+Shift+S')
+    # reveal the folder containing the current Builder file
+    revealFolder = string(default='Alt+Shift+R')
     # Coder: print the file
     print = string(default='Ctrl+P')
     # close the Builder or Coder window

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -179,6 +179,8 @@
     save = string(default='Ctrl+S')
     # save a Builder or Coder file under a new name
     saveAs = string(default='Ctrl+Shift+S')
+    # reveal the folder containing the current Builder file
+    revealFolder = string(default='Alt+Shift+R')
     # Coder: print the file
     print = string(default='Ctrl+P')
     # close the Builder or Coder window


### PR DESCRIPTION
Chose ALT+SHIFT+R to mirror the equivalent shortcut in VS Code - open to alternatives though, and it's easy enough to change