### PR TITLE
ENH: Define "PILOTING" online as well as locally

### DIFF
--- a/psychopy/app/runner/runner.py
+++ b/psychopy/app/runner/runner.py
@@ -693,7 +693,7 @@ class RunnerPanel(wx.Panel, ScriptProcess, handlers.ThemeMixin):
         # start server
         self.startServer(htmlPath, port=port)
         # open experiment
-        webbrowser.open("http://localhost:{}".format(port))
+        webbrowser.open("http://localhost:{}?__pilotToken=local".format(port))
         # log experiment open
         print(
             f"##### Running PsychoJS task from {htmlPath} on port {port} #####\n"

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1156,6 +1156,7 @@ class SettingsComponent:
         code = ("\n// store info about the experiment session:\n"
                 "let expName = '%s';  // from the Builder filename that created this script\n"
                 "let expInfo = %s;\n"
+                "let PILOTING = util.getUrlParameters().has('__pilotToken');\n"
                 "\n" % (jsFilename, expInfoStr))
         buff.writeIndentedLines(code)
 


### PR DESCRIPTION
`PILOTING` is `true` if there's a `__pilotToken` supplied in the url and `false` otherwise. When piloting locally, `__pilotToken` is now supplied (given a placeholder value of `"local"` as it doesn't do anything locally).

Basically, this means any code the user writes in Builder to check for the `PILOTING` constant will get the same value online.