### PR TITLE
BF: Coder file modified dialog shouldn't block Builder

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1097,7 +1097,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.project = None
         self.ignoreErrors = False
         self.fileStatusLastChecked = time.time()
-        self.fileStatusCheckInterval = 5 * 60  # sec
+        self.fileStatusCheckInterval = 5  # sec
         self.showingReloadDialog = False
 
         # default window title string
@@ -2021,6 +2021,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
             msg = _translate("'%s' was modified outside of PsychoPy:\n\n"
                                 "Reload (without saving)?") % filename
             dlg = dialogs.MessageDialog(self, message=msg, type='Warning')
+            dlg.Raise()
             if dlg.ShowWindowModal() == wx.ID_YES:
                 self.statusBar.SetStatusText(_translate('Reloading file'))
                 self.fileReload(event,

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1097,7 +1097,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
         self.project = None
         self.ignoreErrors = False
         self.fileStatusLastChecked = time.time()
-        self.fileStatusCheckInterval = 5  # sec
+        self.fileStatusCheckInterval = 5 * 60  # sec
         self.showingReloadDialog = False
 
         # default window title string

--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -1963,27 +1963,12 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
                 if self._lastCaretPos != pos:
                     self.currentDoc.OnUpdateUI(evt=None)
                     self._lastCaretPos = pos
-            last = self.fileStatusLastChecked
-            interval = self.fileStatusCheckInterval
-            if time.time() - last > interval and not self.showingReloadDialog:
-                if not self.expectedModTime(self.currentDoc):
-                    self.showingReloadDialog = True
-                    filename = os.path.basename(self.currentDoc.filename)
-                    msg = _translate("'%s' was modified outside of PsychoPy:\n\n"
-                                     "Reload (without saving)?") % filename
-                    dlg = dialogs.MessageDialog(self, message=msg, type='Warning')
-                    if dlg.ShowModal() == wx.ID_YES:
-                        self.statusBar.SetStatusText(_translate('Reloading file'))
-                        self.fileReload(event,
-                                        filename=self.currentDoc.filename,
-                                        checkSave=False)
-                    self.showingReloadDialog = False
-                    self.statusBar.SetStatusText('')
-                    dlg.Destroy()
-                self.fileStatusLastChecked = time.time()
-                # Enable / disable save button
-                self.ribbon.buttons['save'].Enable(self.currentDoc.UNSAVED)
-                self.fileMenu.Enable(wx.ID_SAVE, self.currentDoc.UNSAVED)
+            # if file has been modified externally, show message
+            if (
+                time.time() - self.fileStatusLastChecked > self.fileStatusCheckInterval 
+                and not self.showingReloadDialog
+            ):
+                self.checkExternallyModified(event)
 
     def pageChanged(self, event):
         """Event called when the user switches between editor tabs."""
@@ -2022,21 +2007,32 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
             self.ribbon.buttons['pilotRunner'].Enable(isExp)
 
         self.statusBar.SetStatusText(fileType, 2)
-
-        # todo: reduce redundancy w.r.t OnIdle()
+        # check for external modified
+        self.checkExternallyModified(event)
+    
+    def checkExternallyModified(self, event=None):
+        """
+        Check whether the current file has been modified externally, and show a message dialog if 
+        so.
+        """
         if not self.expectedModTime(self.currentDoc):
+            self.showingReloadDialog = True
             filename = os.path.basename(self.currentDoc.filename)
             msg = _translate("'%s' was modified outside of PsychoPy:\n\n"
-                             "Reload (without saving)?") % filename
+                                "Reload (without saving)?") % filename
             dlg = dialogs.MessageDialog(self, message=msg, type='Warning')
-            if dlg.ShowModal() == wx.ID_YES:
+            if dlg.ShowWindowModal() == wx.ID_YES:
                 self.statusBar.SetStatusText(_translate('Reloading file'))
                 self.fileReload(event,
                                 filename=self.currentDoc.filename,
                                 checkSave=False)
-                self.setFileModified(False)
+            self.showingReloadDialog = False
             self.statusBar.SetStatusText('')
             dlg.Destroy()
+        self.fileStatusLastChecked = time.time()
+        # Enable / disable save button
+        self.ribbon.buttons['save'].Enable(self.currentDoc.UNSAVED)
+        self.fileMenu.Enable(wx.ID_SAVE, self.currentDoc.UNSAVED)
 
     # def pluginManager(self, evt=None, value=True):
     #     """Show the plugin manager frame."""


### PR DESCRIPTION
Showing the "File was modified outside PsychoPy..." dialog as modal (blocks user from doing anything while it's open) makes sense for Coder, but because it was fully modal it blocks Builder and Runner too when it doesn't need to.

Unfortunately, `ShowWindowModal` only works on Mac - on Windows it behaves the same as `ShowModal`, but I think it makes sense to go with the one which at least works on one OS.

I've also made it so the dialog is pushed to the front upon opening, so that the user at least knows it's there (it's annoying when Builder pings at you and you don't know why)