### PR TITLE
BF: Make it clearer that Slider labels/ticks can't be set each trial

### DIFF
--- a/psychopy/experiment/components/slider/__init__.py
+++ b/psychopy/experiment/components/slider/__init__.py
@@ -87,7 +87,7 @@ class SliderComponent(BaseVisualComponent):
         # = the usual as inherited from BaseVisual plus:
         self.params['ticks'] = Param(
                 ticks, valType='list', inputType="single", allowedTypes=[], categ='Basic',
-                updates='constant',
+                updates='constant', allowedUpdates=["constant"],
                 hint=_translate("Tick positions (numerical) on the scale, "
                                 "separated by commas"),
                 label=_translate("Ticks"))
@@ -107,7 +107,7 @@ class SliderComponent(BaseVisualComponent):
         )
         self.params['labels'] = Param(
                 labels, valType='list', inputType="single", allowedTypes=[], categ='Basic',
-                updates='constant',
+                updates='constant', allowedUpdates=["constant"],
                 hint=_translate("Labels for the tick marks on the scale, "
                                 "separated by commas"),
                 label=_translate("Labels"))
@@ -118,7 +118,7 @@ class SliderComponent(BaseVisualComponent):
         )
         self.params['granularity'] = Param(
                 granularity, valType='num', inputType="single", allowedTypes=[], categ='Basic',
-                updates='constant',
+                updates='constant', allowedUpdates=["constant"],
                 hint=_translate("Specifies the minimum step size "
                                 "(0 for a continuous scale, 1 for integer "
                                 "rating scale)"),


### PR DESCRIPTION
This doesn't change how they work, just displays the greyed out "updates" field with "constant" selected to be clear that these values are set when the Slider is created.

Eventually it would be good for Slider to be dynamically updatable, but that's more involved than we can do at this point in the release cycle (2025.2 maybe?)