### PR TITLE
BF: Parameters weren't being set on first frame in JS

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -501,6 +501,14 @@ class BaseComponent:
         buff.writeIndentedLines(code % params)
         buff.setIndentLevel(+1, relative=True)
 
+        if self.checkNeedToUpdate('set every frame'):
+            # write param updates for first frame (if needed)
+            code = (
+                "// update params\n"
+            )
+            buff.writeIndentedLines(code % params)
+            self.writeParamUpdatesJS(buff, 'set every frame')
+
         code = (f"// keep track of start time/frame for later\n"
                 f"{params['name']}.tStart = t;  // (not accounting for frame time here)\n"
                 f"{params['name']}.frameNStart = frameN;  // exact frame index\n\n")


### PR DESCRIPTION
Because they're set each frame that the stimulus is STARTED, they're not set on the first frame that it's drawn because the check for STARTED (and subsequent param setting) happens before STARTED is set that frame. This PR adds lines to set params when starting a Component as well as each frame it's active.