### PR TITLE
FF: Setting sound via a Static Component wasn't working in JS

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1002,6 +1002,8 @@ class BaseComponent:
                 # There is no setMarker_label or setMarker_value function in the eeg_marker object
                 # The marker label and value are set by the variables set in the dialogue
                 pass
+            elif paramName == "sound":
+                buff.writeIndented(f"{compName}.setValue({val}{loggingStr}){endStr}")
             else:
                 buff.writeIndented(f"{compName}.set{paramCaps}({val}{loggingStr}){endStr}\n")
 


### PR DESCRIPTION
In PsychoJS, the method to set a `Sound`'s sound from a value is `.setValue`, whereas in PsychoPy it's `.setSound`, and because the parameter is called `sound`, Builder will call `setSound` to set the param. I'd handled this in the Sound Component by manually replacing `setSound` with `setValue`, but if the param is set by a Static Component then this substitution is ignored and the same bug pops up.

This PR makes the same substitution in Static Component, but it's really a whack-a-mole fix - there could easily be another point where `setSound` is written that I couldn't predict. To fix this properly, this needs changing on the JS end:
https://github.com/psychopy/psychojs/pull/608