### PR TITLE
ENH: Add option to show mouse in pilot mode

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -1912,11 +1912,15 @@ class SettingsComponent:
         )
         buff.writeIndentedLines(code)
 
-        # show/hide pilot indicator
+        # post-init window adjustments for piloting mode
         code = (
-            "# show a visual indicator if we're in piloting mode\n"
-            "if PILOTING and prefs.piloting['showPilotingIndicator']:\n"
-            "    win.showPilotingIndicator()\n"
+            "if PILOTING:\n"
+            "    # show a visual indicator if we're in piloting mode\n"
+            "    if prefs.piloting['showPilotingIndicator']:\n"
+            "        win.showPilotingIndicator()\n"
+            "    # always show the mouse in piloting mode\n"
+            "    if prefs.piloting['forceMouseVisible']:\n"
+            "        win.mouseVisible = True\n"
         )
         buff.writeIndentedLines(code)
 

--- a/psychopy/preferences/Darwin.spec
+++ b/psychopy/preferences/Darwin.spec
@@ -147,6 +147,8 @@
 [piloting]
     # Prevent the experiment from being fullscreen when piloting
     forceWindowed = boolean(default=True)
+    # Always show the mouse when piloting
+    forceMouseVisible = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
     # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)

--- a/psychopy/preferences/FreeBSD.spec
+++ b/psychopy/preferences/FreeBSD.spec
@@ -147,6 +147,8 @@
 [piloting]
     # Prevent the experiment from being fullscreen when piloting
     forceWindowed = boolean(default=True)
+    # Always show the mouse when piloting
+    forceMouseVisible = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
     # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)

--- a/psychopy/preferences/Linux.spec
+++ b/psychopy/preferences/Linux.spec
@@ -147,6 +147,8 @@
 [piloting]
     # Prevent the experiment from being fullscreen when piloting
     forceWindowed = boolean(default=True)
+    # Always show the mouse when piloting
+    forceMouseVisible = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
     # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)

--- a/psychopy/preferences/Windows.spec
+++ b/psychopy/preferences/Windows.spec
@@ -147,6 +147,8 @@
 [piloting]
     # Prevent the experiment from being fullscreen when piloting
     forceWindowed = boolean(default=True)
+    # Always show the mouse when piloting
+    forceMouseVisible = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
     # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)

--- a/psychopy/preferences/baseNoArch.spec
+++ b/psychopy/preferences/baseNoArch.spec
@@ -143,6 +143,8 @@
 [piloting]
     # Prevent the experiment from being fullscreen when piloting
     forceWindowed = boolean(default=True)
+    # Always show the mouse when piloting
+    forceMouseVisible = boolean(default=True)
     # What window size to use when forced to windowed mode
     forcedWindowSize = list(default=list(800, 600))
     # How much output to include in the log file when piloting ('error' is fewest messages, 'debug' is most)


### PR DESCRIPTION
This is a bit feature-y but hopefully it's minor enough - essentially, I was trying to debug the textbox scrollbar and found it annoying that the mouse was hidden (which, to be fair, I had told it to be). I feel like when piloting, users will always want to see the mouse so they know where it is, even if the mouse needs to be hidden when running. So I thought it made sense to have a pref for it, and it's a tiny change.