### PR TITLE
DOC: Correct zh_CN translation for user feedback message

### DIFF
--- a/psychopy/app/locale/zh_CN/LC_MESSAGE/messages.po
+++ b/psychopy/app/locale/zh_CN/LC_MESSAGE/messages.po
@@ -287,7 +287,7 @@ msgid ""
 msgstr ""
 "用于 Python 中的刺激生成和实验控制。\n"
 "PsychoPy 非常感谢您的反馈。 如果某项内容不能正常工作\n"
-"请让我们知道，练习psychopy-users@googlegroups.com"
+"请让我们知道，联系 psychopy-users@googlegroups.com"
 
 #: ../app/builder/builder.py:76 ../app/builder/localizedStrings.py:111
 msgid "Field"


### PR DESCRIPTION
This patch corrects translation from '练习' to '联系' for user feedback message.

- 练习 (liànxí): This word generally refers to "practice" or "exercise."
- 联系 (liánxì): This word means "contact" or "communication."

They share the same pinyin, so it's possible that this error was introduced when using a pinyin input method.