### PR TITLE
BF: Better handle (and warn about) deprecated color attributes

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -15,6 +15,45 @@ from functools import partialmethod
 from psychopy.tools.stringtools import CaseSwitcher
 
 
+class UndefinedType:
+    """
+    Represents a value which has not been defined - useful for distinguishing between something not 
+    being set and something being set to None.
+    """
+
+    instance = None
+
+    def __new__(cls):
+        """
+        There should only ever be one instance of UndefinedType
+        """
+        if cls.instance is None:
+            cls.instance = super(cls, cls).__new__(cls)
+        
+        return cls.instance
+    
+    def __eq__(self, other):
+        """
+        Comparing undefined by ``==`` should be the same as by ``is``
+        """
+        return self is other
+    
+    def __bool__(self):
+        """
+        When used as a boolean, undefined is always ``False``
+        """
+        return False
+
+    def __repr__(self):
+        """
+        Display as simply ``undefined`` when printed.
+        """
+        return "undefined"
+
+
+undefined = UndefinedType()
+
+
 class attributeSetter:
     """Makes functions appear as attributes. Takes care of autologging.
     """

--- a/psychopy/visual/circle.py
+++ b/psychopy/visual/circle.py
@@ -40,11 +40,6 @@ class Circle(Polygon):
     lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the circle's outline and fill. If `None`, a fully
         transparent color is used which makes the fill or outline invisible.
-    lineColorSpace, fillColorSpace : str
-        Colorspace to use for the outline and fill. These change how the
-        values passed to `lineColor` and `fillColor` are interpreted.
-        *Deprecated*. Please use `colorSpace` to set both outline and fill
-        colorspace. These arguments may be removed in a future version.
     pos : array_like
         Initial position (`x`, `y`) of the circle on-screen relative to the
         origin located at the center of the window or buffer in `units`
@@ -81,9 +76,6 @@ class Circle(Polygon):
         produces a smoother (less-pixelated) outline of the shape.
     draggable : bool
         Can this stimulus be dragged by a mouse click?
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These
-        arguments may be removed in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/circle.py
+++ b/psychopy/visual/circle.py
@@ -11,6 +11,7 @@ as a special case of a :class:`~psychopy.visual.Polygon`
 
 import psychopy  # so we can get the __path__
 
+from psychopy.tools.attributetools import undefined
 from psychopy.visual.polygon import Polygon
 
 
@@ -107,17 +108,14 @@ class Circle(Polygon):
 
     """
 
-    _defaultFillColor = "white"
-    _defaultLineColor = None
-
     def __init__(self,
                  win,
                  radius=.5,
                  edges="circle",
                  units='',
                  lineWidth=1.5,
-                 lineColor=False,
-                 fillColor=False,
+                 lineColor=None,
+                 fillColor="white",
                  colorSpace='rgb',
                  pos=(0, 0),
                  size=1.0,
@@ -134,9 +132,9 @@ class Circle(Polygon):
                  autoLog=None,
                  autoDraw=False,
                  # legacy
-                 color=False,
-                 fillColorSpace=None,
-                 lineColorSpace=None,
+                 color=undefined,
+                 fillColorSpace=undefined,
+                 lineColorSpace=undefined,
                  ):
 
         # what local vars are defined (these are the init params) for use by
@@ -152,9 +150,7 @@ class Circle(Polygon):
             units=units,
             lineWidth=lineWidth,
             lineColor=lineColor,
-            lineColorSpace=lineColorSpace,
             fillColor=fillColor,
-            fillColorSpace=fillColorSpace,
             pos=pos,
             size=size,
             anchor=anchor,
@@ -169,5 +165,9 @@ class Circle(Polygon):
             name=name,
             autoLog=autoLog,
             autoDraw=autoDraw,
+            colorSpace=colorSpace,
+            # legacy
             color=color,
-            colorSpace=colorSpace)
+            fillColorSpace=fillColorSpace,
+            lineColorSpace=lineColorSpace,
+        )

--- a/psychopy/visual/form.py
+++ b/psychopy/visual/form.py
@@ -8,6 +8,7 @@
 import copy
 import psychopy
 from psychopy.localization import _translate
+from psychopy.tools.attributetools import undefined
 from .text import TextStim
 from .rect import Rect
 from psychopy.data.utils import importConditions, listFromString
@@ -125,8 +126,8 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
                  autoLog=True,
                  depth=0,
                  # legacy
-                 color=None,
-                 foreColor=None
+                 color=undefined,
+                 foreColor=undefined
                  ):
 
         super(Form, self).__init__(win, units, autoLog=False)
@@ -149,9 +150,9 @@ class Form(BaseVisualStim, ContainerMixin, ColorMixin):
         self.itemColor = itemColor
         self.responseColor = responseColor
         self.markerColor = markerColor
-        if color:
+        if color is not undefined:
             self.foreColor = color
-        if foreColor:
+        if foreColor is not undefined:
             self.foreColor = color
 
         self.font = font or "Noto Sans"

--- a/psychopy/visual/grating.py
+++ b/psychopy/visual/grating.py
@@ -132,9 +132,6 @@ class GratingStim(BaseVisualStim, DraggingMixin, TextureMixin, ColorMixin,
         produces a smoother (less-pixelated) outline of the shape.
     draggable : bool
         Can this stimulus be dragged by a mouse click?
-    lineRGB, fillRGB: ArrayLike, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These arguments
-        may be removed in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -17,7 +17,7 @@ from psychopy import logging
 import numpy
 
 from psychopy.visual.shape import ShapeStim
-from psychopy.tools.attributetools import attributeSetter, setAttribute
+from psychopy.tools.attributetools import attributeSetter, setAttribute, undefined
 
 
 class Line(ShapeStim):
@@ -123,16 +123,13 @@ class Line(ShapeStim):
 
     """
 
-    _defaultFillColor = None
-    _defaultLineColor = "white"
-
     def __init__(self,
                  win,
                  start=(-.5, -.5),
                  end=(.5, .5),
                  units=None,
                  lineWidth=1.5,
-                 lineColor=False,
+                 lineColor="white",
                  colorSpace='rgb',
                  pos=(0, 0),
                  size=1.0,
@@ -147,11 +144,11 @@ class Line(ShapeStim):
                  autoLog=None,
                  autoDraw=False,
                  # legacy
-                 color=False,
-                 fillColor=False,
-                 lineColorSpace=None,
-                 lineRGB=False,
-                 fillRGB=False,
+                 color=undefined,
+                 fillColor=undefined,
+                 lineColorSpace=undefined,
+                 lineRGB=undefined,
+                 fillRGB=undefined,
                  ):
 
         """
@@ -170,9 +167,6 @@ class Line(ShapeStim):
             units=units,
             lineWidth=lineWidth,
             lineColor=lineColor,
-            lineColorSpace=None,
-            fillColor=None,
-            fillColorSpace=lineColorSpace,  # have these set to the same
             vertices=(start, end),
             anchor=anchor,
             closeShape=False,
@@ -184,13 +178,17 @@ class Line(ShapeStim):
             depth=depth,
             interpolate=interpolate,
             draggable=draggable,
-            lineRGB=lineRGB,
-            fillRGB=fillRGB,
             name=name,
             autoLog=autoLog,
             autoDraw=autoDraw,
+            colorSpace=colorSpace,
+            # legacy
             color=color,
-            colorSpace=colorSpace)
+            fillColor=fillColor,
+            lineColorSpace=lineColorSpace,
+            lineRGB=lineRGB,
+            fillRGB=fillRGB,
+        )
 
         del self._tesselVertices
 

--- a/psychopy/visual/line.py
+++ b/psychopy/visual/line.py
@@ -51,11 +51,6 @@ class Line(ShapeStim):
     lineColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the line. If `None`, a fully transparent color is used which
         makes the line invisible. *Deprecated* use `color` instead.
-    lineColorSpace : str or None
-        Colorspace to use for the line. These change how the values passed to
-        `lineColor` are interpreted. *Deprecated*. Please use `colorSpace` to
-        set the line colorspace. This arguments may be removed in a future
-        version.
     pos : array_like
         Initial translation (`x`, `y`) of the line on-screen relative to the
         origin located at the center of the window or buffer in `units`.
@@ -92,9 +87,6 @@ class Line(ShapeStim):
         smoother (less-pixelated) line.
     draggable : bool
         Can this stimulus be dragged by a mouse click?
-    lineRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `color` instead. This argument may be removed
-        in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -116,9 +116,6 @@ class Pie(BaseShapeStim):
 
     """
 
-    _defaultFillColor = None
-    _defaultLineColor = None
-
     def __init__(self,
                  win,
                  radius=.5,
@@ -127,8 +124,8 @@ class Pie(BaseShapeStim):
                  edges=32,
                  units='',
                  lineWidth=1.5,
-                 lineColor=False,
-                 fillColor=False,
+                 lineColor=None,
+                 fillColor=None,
                  pos=(0, 0),
                  size=1.0,
                  ori=0.0,

--- a/psychopy/visual/pie.py
+++ b/psychopy/visual/pie.py
@@ -48,11 +48,6 @@ class Pie(BaseShapeStim):
     lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the shape outline and fill. If `None`, a fully transparent
         color is used which makes the fill or outline invisible.
-    lineColorSpace, fillColorSpace : str
-        Colorspace to use for the outline and fill. These change how the
-        values passed to `lineColor` and `fillColor` are interpreted.
-        *Deprecated*. Please use `colorSpace` to set both outline and fill
-        colorspace. These arguments may be removed in a future version.
     pos : array_like
         Initial position (`x`, `y`) of the shape on-screen relative to
         the origin located at the center of the window or buffer in `units`.
@@ -85,9 +80,6 @@ class Pie(BaseShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These
-        arguments may be removed in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -10,7 +10,7 @@
 
 import psychopy  # so we can get the __path__
 from psychopy.visual.shape import ShapeStim
-from psychopy.tools.attributetools import attributeSetter, setAttribute
+from psychopy.tools.attributetools import attributeSetter, setAttribute, undefined
 from psychopy.tools import gltools as gt
 
 import numpy as np
@@ -107,9 +107,6 @@ class Polygon(ShapeStim):
         Can this stimulus be dragged by a mouse click?
 
     """
-
-    _defaultFillColor = "white"
-    _defaultLineColor = "white"
     _tesselMode = 'fan'  # fastest for regular/equilateral polygons
 
     def __init__(self,
@@ -118,8 +115,8 @@ class Polygon(ShapeStim):
                  radius=.5,
                  units='',
                  lineWidth=1.5,
-                 lineColor=False,
-                 fillColor=False,
+                 lineColor="white",
+                 fillColor="white",
                  pos=(0, 0),
                  size=1.0,
                  anchor=None,
@@ -134,11 +131,11 @@ class Polygon(ShapeStim):
                  autoDraw=False,
                  colorSpace='rgb',
                  # legacy
-                 color=False,
-                 fillColorSpace=None,
-                 lineColorSpace=None,
-                 lineRGB=False,
-                 fillRGB=False,
+                 color=undefined,
+                 fillColorSpace=undefined,
+                 lineColorSpace=undefined,
+                 lineRGB=undefined,
+                 fillRGB=undefined,
                  ):
 
         # what local vars are defined (these are the init params) for use by
@@ -157,9 +154,7 @@ class Polygon(ShapeStim):
             units=units,
             lineWidth=lineWidth,
             lineColor=lineColor,
-            lineColorSpace=lineColorSpace,
             fillColor=fillColor,
-            fillColorSpace=fillColorSpace,
             vertices=self.vertices,
             closeShape=True,
             pos=pos,
@@ -171,13 +166,17 @@ class Polygon(ShapeStim):
             depth=depth,
             interpolate=interpolate,
             draggable=draggable,
-            lineRGB=lineRGB,
-            fillRGB=fillRGB,
             name=name,
             autoLog=autoLog,
             autoDraw=autoDraw,
+            colorSpace=colorSpace,
+            # legacy
             color=color,
-            colorSpace=colorSpace)
+            fillColorSpace=fillColorSpace,
+            lineColorSpace=lineColorSpace,
+            lineRGB=lineRGB,
+            fillRGB=fillRGB,
+        )
 
     def _calcVertices(self):
         if self.edges == "circle":

--- a/psychopy/visual/polygon.py
+++ b/psychopy/visual/polygon.py
@@ -46,11 +46,6 @@ class Polygon(ShapeStim):
     lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or `None`
         Color of the shape's outline and fill. If `None`, a fully
         transparent color is used which makes the fill or outline invisible.
-    lineColorSpace, fillColorSpace : str
-        Colorspace to use for the outline and fill. These change how the
-        values passed to `lineColor` and `fillColor` are interpreted.
-        *Deprecated*. Please use `colorSpace` to set both outline and fill
-        colorspace. These arguments may be removed in a future version.
     pos : array_like
         Initial position (`x`, `y`) of the shape on-screen relative to the
         origin located at the center of the window or buffer in `units`.
@@ -85,9 +80,6 @@ class Polygon(ShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These
-        arguments may be removed in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -42,11 +42,6 @@ class Rect(BaseShapeStim):
     lineColor, fillColor : array_like, str, :class:`~psychopy.colors.Color` or None
         Color of the shape outline and fill. If `None`, a fully transparent
         color is used which makes the fill or outline invisible.
-    lineColorSpace, fillColorSpace : str
-        Colorspace to use for the outline and fill. These change how the
-        values passed to `lineColor` and `fillColor` are interpreted.
-        *Deprecated*. Please use `colorSpace` to set both outline and fill
-        colorspace. These arguments may be removed in a future version.
     pos : array_like
         Initial position (`x`, `y`) of the shape on-screen relative to
         the origin located at the center of the window or buffer in `units`.
@@ -79,9 +74,6 @@ class Rect(BaseShapeStim):
     interpolate : bool
         Enable smoothing (anti-aliasing) when drawing shape outlines. This
         produces a smoother (less-pixelated) outline of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These
-        arguments may be removed in a future version.
     name : str
         Optional name of the stimuli for logging.
     autoLog : bool

--- a/psychopy/visual/rect.py
+++ b/psychopy/visual/rect.py
@@ -12,7 +12,7 @@ import numpy as np
 
 import psychopy  # so we can get the __path__
 from psychopy.visual.shape import BaseShapeStim
-from psychopy.tools.attributetools import attributeSetter, setAttribute
+from psychopy.tools.attributetools import attributeSetter, setAttribute, undefined
 
 
 class Rect(BaseShapeStim):
@@ -109,17 +109,14 @@ class Rect(BaseShapeStim):
 
     """
 
-    _defaultFillColor = 'white'
-    _defaultLineColor = None
-
     def __init__(self,
                  win,
                  width=.5,
                  height=.5,
                  units='',
                  lineWidth=1.5,
-                 lineColor=False,
-                 fillColor=False,
+                 lineColor=None,
+                 fillColor='white',
                  colorSpace='rgb',
                  pos=(0, 0),
                  size=None,
@@ -134,11 +131,11 @@ class Rect(BaseShapeStim):
                  autoLog=None,
                  autoDraw=False,
                  # legacy
-                 color=None,
-                 lineColorSpace=None,
-                 fillColorSpace=None,
-                 lineRGB=False,
-                 fillRGB=False,
+                 color=undefined,
+                 lineColorSpace=undefined,
+                 fillColorSpace=undefined,
+                 lineRGB=undefined,
+                 fillRGB=undefined
                  ):
         # width and height attributes, these are later aliased with `size`
         self.__dict__['width'] = float(width)
@@ -161,9 +158,7 @@ class Rect(BaseShapeStim):
             units=units,
             lineWidth=lineWidth,
             lineColor=lineColor,
-            lineColorSpace=lineColorSpace,
             fillColor=fillColor,
-            fillColorSpace=fillColorSpace,
             vertices=vertices,
             closeShape=True,
             pos=pos,
@@ -175,13 +170,17 @@ class Rect(BaseShapeStim):
             depth=depth,
             interpolate=interpolate,
             draggable=draggable,
-            lineRGB=lineRGB,
-            fillRGB=fillRGB,
             name=name,
             autoLog=autoLog,
             autoDraw=autoDraw,
+            colorSpace=colorSpace,
+            # legacy
             color=color,
-            colorSpace=colorSpace)
+            lineColorSpace=lineColorSpace,
+            fillColorSpace=fillColorSpace,
+            lineRGB=lineRGB,
+            fillRGB=fillRGB
+        )
 
     def setSize(self, size, operation='', log=None):
         """Usually you can use 'stim.attribute = value' syntax instead,

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -574,16 +574,7 @@ class ShapeStim(BaseShapeStim):
         frame without the need to explicitly call the
         :py:meth:`~psychopy.visual.ShapeStim.draw` method.
     color : array_like, str, :class:`~psychopy.colors.Color` or None
-        Sets both the initial `lineColor` and `fillColor` of the shape.
-    lineRGB, fillRGB: array_like, :class:`~psychopy.colors.Color` or None
-        *Deprecated*. Please use `lineColor` and `fillColor`. These
-        arguments may be removed in a future version.
-    lineColorSpace, fillColorSpace : str
-        Colorspace to use for the outline and fill. These change how the
-        values passed to `lineColor` and `fillColor` are interpreted.
-        *Deprecated*. Please use `colorSpace` to set both outline and fill
-        colorspace. These arguments may be removed in a future version.
-
+        Synonymous with `fillColor`
     """
     # Author: Jeremy Gray, November 2015, using psychopy.contrib.tesselate
     _tesselMode = 'triangle'  # best for most shapes

--- a/psychopy/visual/shape.py
+++ b/psychopy/visual/shape.py
@@ -22,11 +22,12 @@ from psychopy import logging
 # (JWP has no idea why!)
 # from psychopy.tools.monitorunittools import cm2pix, deg2pix
 from psychopy.tools.attributetools import (attributeSetter,  # logAttrib,
-                                           setAttribute)
+                                           setAttribute, undefined)
 from psychopy.tools import gltools as gt
 from psychopy.visual.basevisual import (
     BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin, WindowMixin
 )
+from psychopy.colors import Color
 # from psychopy.visual.helpers import setColor
 import psychopy.visual
 
@@ -113,15 +114,12 @@ class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
 
     """
 
-    _defaultFillColor = None
-    _defaultLineColor = "black"
-
     def __init__(self,
                  win,
                  units='',
                  lineWidth=1.5,
-                 lineColor=False, # uses False in place of None to distinguish between "not set" and "transparent"
-                 fillColor=False, # uses False in place of None to distinguish between "not set" and "transparent"
+                 lineColor="black",
+                 fillColor=None,
                  colorSpace='rgb',
                  vertices=((-0.5, 0), (0, +0.5), (+0.5, 0)),
                  closeShape=True,
@@ -138,11 +136,11 @@ class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
                  autoLog=None,
                  autoDraw=False,
                  # legacy
-                 color=False,
-                 lineRGB=False,
-                 fillRGB=False,
-                 fillColorSpace=None,
-                 lineColorSpace=None
+                 color=undefined,
+                 lineRGB=undefined,
+                 fillRGB=undefined,
+                 fillColorSpace=undefined,
+                 lineColorSpace=undefined,
                  ):
         """ """  # all doc is in the attributes
         # what local vars are defined (these are the init params) for use by
@@ -161,34 +159,34 @@ class BaseShapeStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
         self.lineWidth = lineWidth
         self.interpolate = interpolate
 
+        # handle legacy fill color attributes
+        if color is not undefined:
+            fillColor = color
+        if fillColorSpace is not undefined:
+            logging.warning(
+                "fillColorSpace parameter is deprecated. Please use colorSpace instead."
+            )
+            fillColor = Color(fillColor, space=fillColorSpace)
+        if fillRGB is not undefined:
+            logging.warning(
+                "fillRGB parameter is deprecated. Please use lineColor and colorSpace instead"
+            )
+            fillColor = Color(fillColor, space="rgb")
+        # handle legacy border color attributes
+        if lineColorSpace is not undefined:
+            logging.warning(
+                "lineColorSpace parameter is deprecated. Please use colorSpace instead."
+            )
+            lineColor = Color(lineColor, space=lineColorSpace)
+        if lineRGB is not undefined:
+            logging.warning(
+                "lineRGB parameter is deprecated. Please use lineColor and colorSpace instead"
+            )
+            lineColor = Color(lineColor, space="rgb")
         # Appearance
         self.colorSpace = colorSpace
-        if fillColor is not False:
-            self.fillColor = fillColor
-        elif color is not False:
-            # Override fillColor with color if not set
-            self.fillColor = color
-        else:
-            # Default to None if neither are set
-            self.fillColor = self._defaultFillColor
-        if lineColor is not False:
-            self.lineColor = lineColor
-        elif color is not False:
-            # Override lineColor with color if not set
-            self.lineColor = color
-        else:
-            # Default to black if neither are set
-            self.lineColor = self._defaultLineColor
-        if lineRGB is not False:
-            # Override with RGB if set
-            logging.warning("Use of rgb arguments to stimuli are deprecated."
-                            " Please use color and colorSpace args instead")
-            self.setLineColor(lineRGB, colorSpace='rgb', log=None)
-        if fillRGB is not False:
-            # Override with RGB if set
-            logging.warning("Use of rgb arguments to stimuli are deprecated."
-                            " Please use color and colorSpace args instead")
-            self.setFillColor(fillRGB, colorSpace='rgb', log=None)
+        self.fillColor = fillColor
+        self.lineColor = lineColor
         self.contrast = contrast
         if opacity is not None:
             self.opacity = opacity
@@ -613,39 +611,45 @@ class ShapeStim(BaseShapeStim):
                  autoLog=None,
                  autoDraw=False,
                  # legacy
-                 color=False,
-                 lineRGB=False,
-                 fillRGB=False,
-                 fillColorSpace=None,
-                 lineColorSpace=None
+                 color=undefined,
+                 lineRGB=undefined,
+                 fillRGB=undefined,
+                 fillColorSpace=undefined,
+                 lineColorSpace=undefined
                  ):
 
         # what local vars are defined (init params, for use by __repr__)
         self._initParamsOrig = dir()
         self._initParamsOrig.remove('self')
 
-        super(ShapeStim, self).__init__(win,
-                                        units=units,
-                                        lineWidth=lineWidth,
-                                        colorSpace=colorSpace,
-                                        lineColor=lineColor,
-                                        lineColorSpace=lineColorSpace,
-                                        fillColor=fillColor,
-                                        fillColorSpace=fillColorSpace,
-                                        vertices=None,  # dummy verts
-                                        closeShape=self.closeShape,
-                                        pos=pos,
-                                        size=size,
-                                        anchor=anchor,
-                                        ori=ori,
-                                        opacity=opacity,
-                                        contrast=contrast,
-                                        depth=depth,
-                                        interpolate=interpolate,
-                                        draggable=draggable,
-                                        name=name,
-                                        autoLog=False,
-                                        autoDraw=autoDraw)
+        super(ShapeStim, self).__init__(
+            win,
+            units=units,
+            lineWidth=lineWidth,
+            colorSpace=colorSpace,
+            lineColor=lineColor,
+            fillColor=fillColor,
+            vertices=None,  # dummy verts
+            closeShape=self.closeShape,
+            pos=pos,
+            size=size,
+            anchor=anchor,
+            ori=ori,
+            opacity=opacity,
+            contrast=contrast,
+            depth=depth,
+            interpolate=interpolate,
+            draggable=draggable,
+            name=name,
+            autoLog=False,
+            autoDraw=autoDraw,
+            # legacy
+            color=color,
+            lineRGB=lineRGB,
+            fillRGB=fillRGB,
+            fillColorSpace=fillColorSpace,
+            lineColorSpace=lineColorSpace
+        )
 
         self.closeShape = closeShape
         self.windingRule = windingRule


### PR DESCRIPTION
Core changes:
- Rather than relying on `False` to distinguish between "not set" and "set as None", I've made a dedicated constant for it (`undefined`, a singleton instance of `UndefinedType`) 
- At the BaseShapeLevel, if any of the legacy attributes are not `undefined`, warn the user and list the correct attribute