### PR TITLE
BF: Update TextStim after setting opacity to trigger a re-render

### DIFF
--- a/psychopy/visual/text.py
+++ b/psychopy/visual/text.py
@@ -244,7 +244,18 @@ class TextStim(BaseVisualStim, DraggingMixin, ForeColorMixin, ContainerMixin):
                 GL.glDeleteLists(self._listID, 1)
             except (ImportError, ModuleNotFoundError, TypeError, GL.lib.GLException):
                 pass  # if pyglet no longer exists
+    
+    @property
+    def opacity(self):
+        return BaseVisualStim.opacity.fget(self)
 
+    @opacity.setter
+    def opacity(self, value):
+        # do base setting
+        BaseVisualStim.opacity.fset(self, value)
+        # trigger update
+        self._needSetText = True
+    
     @attributeSetter
     def height(self, height):
         """The height of the letters (Float/int or None = set default).


### PR DESCRIPTION
Otherwise the attribute is updated but the render calculations aren't re-done, so text doesn't actually update its opacity until the next time `setText` is called.

Fixes #6998