### PR TITLE
ENH: Improve coverage of documentation by having attributeSetters inherit docs

### DIFF
--- a/psychopy/tools/attributetools.py
+++ b/psychopy/tools/attributetools.py
@@ -58,12 +58,19 @@ class attributeSetter:
     """Makes functions appear as attributes. Takes care of autologging.
     """
 
-    def __init__(self, func, doc=None):
+    def __init__(self, func):
         self.func = func
-        if doc is not None:
-            self.__doc__ = doc
-        else:
-            self.__doc__ = func.__doc__
+        self.__doc__ = func.__doc__
+    
+    def __set_name__(self, owner: type, name: str):
+        # if we already have docs, no further action needed
+        if self.__doc__ is not None:
+            return
+        # inherit docs from first base class which has any for this method
+        for base in owner.__bases__:
+            if hasattr(base, name) and getattr(base, name).__doc__ is not None:
+                self.__doc__ = getattr(base, name).__doc__
+                break
 
     def __set__(self, obj, value):
         newValue = self.func(obj, value)


### PR DESCRIPTION
There's several `attributeSetter` decorated methods in the API which appear to not have docstrings (if you do e.g. `print(TextBox2.ori.__doc__)`, you'll get `None`) even though they're just overloads of a parent class's documented function (e.g. `print(BaseVisualStim.__doc__)` shows documentation). 

This PR fixes gaps in our docs coverage by allowing overloaded `attributeSetter` methods to inherit documentation from the equivalent method in a parent class (only when documentation isn't otherwise supplied). This substitution happens on import (`__set_name__` is called when a method is assigned to an attribute in a class, when the class is defined) so doesn't affect performance at runtime but is still detected by sphinx autodoc (which imports objects to obtain their docstrings, triggering this substitution)

I've removed the existing implementation for specifying docs on an attributeSetter because I couldn't find any instance of it being used in the library, and it isn't actually possible to use alongside the `@` syntax of decorators (you'd have to manually do `ori = attributeSetter(ori, doc=BaseVisualStim.ori.__doc__)` after defining a regular method for it to work)