### PR TITLE
BF: Fixed camera recordings appending frames from previous recordings

### DIFF
--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -2137,7 +2137,7 @@ class Camera:
     #     """
     #     pass
 
-    def record(self):
+    def record(self, clearLastRecording=True):
         """Start recording frames.
 
         This function will start recording frames and audio (if available). The
@@ -2152,7 +2152,16 @@ class Camera:
         Warnings
         --------
         If a recording has been previously made without calling `save()` it will
-        be discarded if `record()` is called again.
+        be discarded if `record()` is called again unless 
+        `clearLastRecording=False`.
+
+        Parameters
+        ----------
+        clearLastRecording : bool
+            Clear the frame buffer before starting the recording. If `True`,
+            the frame buffer will be cleared before starting the recording. If
+            `False`, the frame buffer will be kept and new frames will be added
+            to the buffer. Default is `True`.
 
         """
         if self.isNotStarted:
@@ -2162,6 +2171,10 @@ class Camera:
                 "opening now. This is not recommended as it may incur a longer "
                 "than expected delay in the recording start time."
             )
+
+        # clear previous frames
+        if clearLastRecording:
+            self._captureFrames.clear()
         
         self._audioTrack = None
         self._lastFrame = None


### PR DESCRIPTION
PR fixes the `Camera.record()` method not clearing the frame storage array when called. This resulted in frames being appended from previous recordings. The parameter `clearPreviousRecording` was added to give users the option of using the current behaviour if desired