### PR TITLE
FF: Coder wasn't reloading even if "Yes" was pressed on the reload dialog

### DIFF
--- a/psychopy/app/coder/coder.py
+++ b/psychopy/app/coder/coder.py
@@ -2022,7 +2022,7 @@ class CoderFrame(BaseAuiFrame, handlers.ThemeMixin):
                                 "Reload (without saving)?") % filename
             dlg = dialogs.MessageDialog(self, message=msg, type='Warning')
             dlg.Raise()
-            if dlg.ShowWindowModal() == wx.ID_YES:
+            if dlg.ShowModal() == wx.ID_YES:
                 self.statusBar.SetStatusText(_translate('Reloading file'))
                 self.fileReload(event,
                                 filename=self.currentDoc.filename,


### PR DESCRIPTION
Switching from ShowModal to ShowWindowModal (in #7111) meant that the returned value was never `wx.ID_YES` on Windows, as `ShowWindowModal` seems to always return `None` (I think this is a bug in wx), so for now it will have to remain globally modal.