### PR TITLE
BF: Fonts in experiment folder weren't found when running locally

### DIFF
--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -662,6 +662,11 @@ def findFontFiles(folders=(), recursive=True):
             searchPaths = _OSXFontDirectories
         elif sys.platform.startswith('linux'):
             searchPaths = _X11FontDirectories
+    # make sure font paths is a list
+    if isinstance(searchPaths, tuple):
+        searchPaths = list(searchPaths)
+    # always look in the local directory
+    searchPaths.append(Path(".").absolute())
     # always look inside the app
     searchPaths.append(Path(prefs.paths['assets']) / "fonts")
     # always look in the user folder


### PR DESCRIPTION
Meant you couldn't add a font file to experiment folder and reference it (as you can online)