### PR TITLE
FF: Looking for fonts in local folder (#7142) caused recursion problems when local folder was the library root

### DIFF
--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -665,8 +665,14 @@ def findFontFiles(folders=(), recursive=True):
     # make sure font paths is a list
     if isinstance(searchPaths, tuple):
         searchPaths = list(searchPaths)
-    # always look in the local directory
-    searchPaths.append(Path(".").absolute())
+    # always look in the local directory, unless it's inside PsychoPy itself
+    thisDir = Path(".").absolute()
+    if all((
+        thisDir not in Path(prefs.paths['psychopy']).parents,
+        thisDir != Path(prefs.paths['psychopy']),
+        Path(prefs.paths['psychopy']) not in thisDir.parents,
+    )):
+        searchPaths.append(thisDir)
     # always look inside the app
     searchPaths.append(Path(prefs.paths['assets']) / "fonts")
     # always look in the user folder


### PR DESCRIPTION
I'm not 100% sure why (I would have thought it would just look inside the library and find them), but doing a recursive glob on the psychopy library folder would take a very long time to execute. Possibly because it was waiting for access to .py files which were in use?

In any case, the purpose of looking in the local folder is to find fonts in the experiment folder - which will never be inside the psychopy library. So it's best to avoid adding the local dir if it's inside psychopy.