### PR TITLE
BF: Prevent crash if locale is not supported by the system

### DIFF
--- a/psychopy/locale_setup.py
+++ b/psychopy/locale_setup.py
@@ -28,4 +28,14 @@ if macVer:
         from psychopy import prefs
         if not prefs.app['locale']:
             prefs.app['locale'] = u'en_US'
-        locale.setlocale(locale.LC_ALL, str(prefs.app['locale']) + '.UTF-8')
+        
+        # set the requested locale
+        reqLocale = str(prefs.app['locale'])
+        reqLocale += '.UTF-8'
+        try:
+            locale.setlocale(locale.LC_ALL, reqLocale)
+        except locale.Error:
+            # locale not found, use en_US.UTF-8
+            locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
+            print('Warning: locale {} not found, using en_US.UTF-8'.format(
+                reqLocale))


### PR DESCRIPTION
Fixes a crash that occurs when setting the interpreter locale on MacOS if the locale is invalid on the system. It will default to en_US in such cases