### PR TITLE
remove announcement of past workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@
 
 ---
 
-**Announcement!!**
-
-We are excited to announce that PsychoPy will be hosting a 3-day in-person code-sprint at the University of Nottingham from 15-17 April 2024. The code sprint will be an opportunity for us to get together in person and improve PsychoPy/JS. Anyone who would like to attend will need to fill out the [online application](https://run.pavlovia.org/pavlovia/survey/?surveyId=171ed328-d5ea-4819-83dc-9ba00ef5683b) by 31 January 2024. Those selected will be notified by the end of February.
-
----
-
 PsychoPy is an open-source package for creating experiments in behavioral science. It aims to provide a single package that is:
 
 * precise enough for psychophysics


### PR DESCRIPTION
Event is last year, so we can remove it