### PR TITLE
ENH: Allow overriding user preferences directory with PSYCHOPY_CONFIG_FOLDER environment variable

### DIFF
--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -95,9 +95,11 @@ depends on the type of the [files]:
     )
     # parse args
     args, startFilesRaw = argParser.parse_known_args(sys.argv)
-    
-    # setup prefs
+
+    # import app and prefs now that args have been parsed
     from psychopy.preferences import prefs
+    from psychopy.app import startApp, quitApp
+    # setup prefs
     prefs.getPaths(userDir=args.userDir)
     # insert fallbacks from prefs for unsupplied call args
     if args.showSplash is None:

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -19,9 +19,6 @@ import psychopy.locale_setup  # noqa
 
 
 def main():
-    from psychopy.app import startApp, quitApp
-    from psychopy.preferences import prefs
-
     # parser to process input arguments
     argParser = argparse.ArgumentParser(
         prog="PsychoPyApp", description=(
@@ -80,7 +77,7 @@ depends on the type of the [files]:
     )
     # add option to hide splash
     argParser.add_argument(
-        "--no-splash", dest="showSplash", action="store_false", default=prefs.app['showSplash'], help=(
+        "--no-splash", dest="showSplash", action="store_false", default=None, help=(
             "Suppresses splash screen"
         )
     )
@@ -90,8 +87,21 @@ depends on the type of the [files]:
             "Launches app with profiling to see what specific processes are taking up resources."
         )
     )
+    # add option to supply custom user directory
+    argParser.add_argument(
+        "--user-dir", dest="userDir", action="store", help=(
+            "Launches app with a custom location for the prefs folder."
+        )
+    )
     # parse args
     args, startFilesRaw = argParser.parse_known_args(sys.argv)
+    
+    # setup prefs
+    from psychopy.preferences import prefs
+    prefs.getPaths(userDir=args.userDir)
+    # insert fallbacks from prefs for unsupplied call args
+    if args.showSplash is None:
+        args.showSplash = prefs.app['showSplash']
     # pathify startFiles
     startFiles = None
     for thisFile in startFilesRaw:

--- a/psychopy/app/psychopyApp.py
+++ b/psychopy/app/psychopyApp.py
@@ -100,7 +100,7 @@ depends on the type of the [files]:
     from psychopy.preferences import prefs
     from psychopy.app import startApp, quitApp
     # setup prefs
-    prefs.getPaths(userDir=args.userDir)
+    prefs.loadAll(userDir=args.userDir)
     # insert fallbacks from prefs for unsupplied call args
     if args.showSplash is None:
         args.showSplash = prefs.app['showSplash']

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -101,7 +101,7 @@ class Preferences:
             print(msg % userCfg)
         self.loadAll()  # reloads, now getting all from .spec
 
-    def getPaths(self):
+    def getPaths(self, userDir=None):
         """Get the paths to various directories and files used by PsychoPy.
 
         If the paths are not found, they are created. Usually, this is only
@@ -139,24 +139,25 @@ class Preferences:
             # if there isn't an app folder at all then this is a lib-only psychopy
             # so don't try to load app prefs etc
             NO_APP = True
+        # get user dir
+        if userDir is not None and os.path.isdir(userDir):
+            self.paths['userPrefsDir'] = join(
+                userDir, '.psychopy3'
+            )
+        elif sys.platform == 'win32':
+            self.paths['userPrefsDir'] = join(
+                os.environ['APPDATA'], 'psychopy3'
+            )
+        else:
+            self.paths['userPrefsDir'] = join(
+                os.environ['HOME'], '.psychopy3'
+            )
+        # get system-appropriate spec file
         if sys.platform == 'win32':
             self.paths['prefsSpecFile'] = join(prefSpecDir, 'Windows.spec')
-            self.paths['userPrefsDir'] = join(os.environ['APPDATA'],
-                                              'psychopy3')
         else:
             self.paths['prefsSpecFile'] = join(
                 prefSpecDir, platform.system() + '.spec')
-            # Check for override of config folder via environment variable (PSYCHOPY_CONFIG_FOLDER)
-            # and set user preferences directory accordingly; otherwise, use default location.
-            config_folder_override = os.environ.get('PSYCHOPY_CONFIG_FOLDER')
-            if (config_folder_override and os.path.isdir(config_folder_override)
-                    and os.access(config_folder_override, os.R_OK | os.W_OK)):
-                self.paths['userPrefsDir'] = join(
-                    config_folder_override, '.psychopy3')
-            else:
-                self.paths['userPrefsDir'] = join(
-                    os.environ['HOME'], '.psychopy3')
-
         # directory for files created by the app at runtime needed for operation
         self.paths['userCacheDir'] = join(self.paths['userPrefsDir'], 'cache')
 

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -144,10 +144,13 @@ class Preferences:
             self.paths['userPrefsDir'] = join(os.environ['APPDATA'],
                                               'psychopy3')
         else:
-            self.paths['prefsSpecFile'] = join(prefSpecDir,
-                                               platform.system() + '.spec')
-            self.paths['userPrefsDir'] = join(os.environ['HOME'],
-                                              '.psychopy3')
+            self.paths['prefsSpecFile'] = join(prefSpecDir, platform.system() + '.spec')
+            config_folder_override = os.environ.get('PSYCHOPY_CONFIG_FOLDER')
+            if config_folder_override and os.path.isdir(config_folder_override) and os.access(config_folder_override, os.R_OK | os.W_OK):
+                self.paths['userPrefsDir'] = join(config_folder_override, '.psychopy3')
+            else:
+                self.paths['userPrefsDir'] = join(os.environ['HOME'],
+                                    '.psychopy3')
 
         # directory for files created by the app at runtime needed for operation
         self.paths['userCacheDir'] = join(self.paths['userPrefsDir'], 'cache')

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -71,7 +71,7 @@ class Preferences:
         self.paths = {}  # this will remain a dictionary
         self.keys = {}  # does not remain a dictionary
 
-        self.getPaths()
+        # Only call loadAll, which will handle getPaths
         self.loadAll()
         # setting locale is now handled in psychopy.localization.init
         # as called upon import by the app
@@ -277,9 +277,10 @@ class Preferences:
                     Path(self.paths['themes']) / file.name
                 )
 
-    def loadAll(self):
+    def loadAll(self, userDir=None):
         """Load the user prefs and the application data
         """
+        self.getPaths(userDir=userDir)
         self._validator = validate.Validator()
 
         # note: self.paths['userPrefsDir'] gets set in loadSitePrefs()

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -144,13 +144,18 @@ class Preferences:
             self.paths['userPrefsDir'] = join(os.environ['APPDATA'],
                                               'psychopy3')
         else:
-            self.paths['prefsSpecFile'] = join(prefSpecDir, platform.system() + '.spec')
+            self.paths['prefsSpecFile'] = join(
+                prefSpecDir, platform.system() + '.spec')
+            # Check for override of config folder via environment variable (PSYCHOPY_CONFIG_FOLDER)
+            # and set user preferences directory accordingly; otherwise, use default location.
             config_folder_override = os.environ.get('PSYCHOPY_CONFIG_FOLDER')
-            if config_folder_override and os.path.isdir(config_folder_override) and os.access(config_folder_override, os.R_OK | os.W_OK):
-                self.paths['userPrefsDir'] = join(config_folder_override, '.psychopy3')
+            if (config_folder_override and os.path.isdir(config_folder_override)
+                    and os.access(config_folder_override, os.R_OK | os.W_OK)):
+                self.paths['userPrefsDir'] = join(
+                    config_folder_override, '.psychopy3')
             else:
-                self.paths['userPrefsDir'] = join(os.environ['HOME'],
-                                    '.psychopy3')
+                self.paths['userPrefsDir'] = join(
+                    os.environ['HOME'], '.psychopy3')
 
         # directory for files created by the app at runtime needed for operation
         self.paths['userCacheDir'] = join(self.paths['userPrefsDir'], 'cache')


### PR DESCRIPTION
This pull request changes `psychopy/preferences/preferences.py` to let users override PsychoPy’s config folder by setting `PSYCHOPY_CONFIG_FOLDER`. The new logic checks that the override exists and is readable/writable. It currently applies only to non‑Windows systems (it would be easy to enable on Windows, I’m just not sure if we want to). It works with:

```bash
export PSYCHOPY_CONFIG_FOLDER=/path/to/config
psychopy
```

but the `monitors` subfolder still defaults to `~/.psychopy3/monitors`. The code doesn’t issue a message on invalid/succesfull overrides. Adding one could be a useful follow‑up.