### PR TITLE
DOC: Redirect dead links in Components section

### DIFF
--- a/docs/extensions/redirect/__init__.py
+++ b/docs/extensions/redirect/__init__.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+
+class redirect(nodes.Element):
+    tagname = "meta"
+    local_attributes = ("http-equiv", "content")
+
+    def __init__(self, url):
+        nodes.Element.__init__(
+            self,
+            attributes={
+                'http-equiv': "refresh",
+                'content': f"0; url={url}"
+            }
+        )
+
+
+class PreviousDirective(SphinxDirective):
+    """
+    Indicates the target page as the former location of the current page. On compile, will create a 
+    .html file in that location which redirects to the document containing the directive.
+    """
+
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        # get target to redirect to
+        to_raw = self.get_source_info()[0]
+        # get document to redirect from
+        from_raw = self.env.relfn2path(self.content[0])[0]
+        # add redirect
+        add_redirect(
+            self.env, 
+            from_raw=from_raw, 
+            to_raw=to_raw
+        )
+
+        return []
+
+
+class RedirectDirective(SphinxDirective):
+    """
+    Indicates the target page as the new location of the current page. On compile, will create a 
+    redirect element in the file containing the directive which links to the target page.
+    """
+    has_content = True
+
+    def run(self):
+        self.assert_has_content()
+        # get target to redirect to
+        to_raw = self.env.relfn2path(self.content[0])[0]
+        # get document to redirect from
+        from_raw = self.get_source_info()[0]
+        # add redirect
+        add_redirect(
+            self.env, 
+            from_raw=from_raw, 
+            to_raw=to_raw
+        )
+
+        return []
+
+
+def add_redirect(env, from_raw, to_raw):
+    """
+    Add a redirect from one location to another.
+
+    Parameters
+    ----------
+    env : sphinx.environment.BuildEnvironment
+        The current Sphinx build environment
+    from_raw : str
+        Raw content pointing to the document to redirect from
+    to_raw : str
+        Raw content pointing to the document to redirect to
+    """
+    # make sure environment has a value for redirects
+    if not hasattr(env, 'redirects'):
+        env.redirects = []
+    # get document to redirect from
+    from_doc = env.path2doc(from_raw)
+    # get url to redirect to
+    if to_raw.startswith("https:"):
+        # if it's an external url, point to it as is
+        to_url = to_raw
+    else:
+        # otherwise get a relative link
+        to_doc = env.path2doc(to_raw)
+        to_url = f"/{to_doc}"
+    # append to list of redirects
+    env.redirects.append(
+        (from_doc, to_url)
+    )
+
+    
+def create_redirect_pages(app):
+    """
+    Creates the redirect pages specified in `app.env.redirects` - indended for use as an event 
+    callback for the `html-collect-pages` event.
+    """
+    # make sure environment has a value for redirects
+    if not hasattr(app.env, 'redirects'):
+        app.env.redirects = []
+    # get path of template for a redirect page
+    templatename = str((Path(__file__).parent / "redirect.html").absolute())
+    # start off with no new pages
+    pages = []
+    # add a new page for every redirect
+    for from_doc, to_url in app.env.redirects:
+        print(f"Creating redirect from {from_doc} to {to_url}.")
+        # add parameters from given links
+        pages.append(
+            (from_doc, {'url': to_url}, templatename)
+        )
+    
+    return pages
+
+
+def setup(app):
+    # add directives
+    directives.register_directive('previous', PreviousDirective)
+    directives.register_directive('redirect', RedirectDirective)
+    # connect event callback
+    app.connect('html-collect-pages', create_redirect_pages)
+
+    return {
+        'version': '0.1',
+        'env_version': 1,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/docs/extensions/redirect/redirect.html
+++ b/docs/extensions/redirect/redirect.html
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url={{ url }}" />

--- a/docs/source/builder/components/ApertureComponent.rst
+++ b/docs/source/builder/components/ApertureComponent.rst
@@ -234,4 +234,6 @@ Validate with...
 
 .. seealso::
 	
-	API reference for :class:`~psychopy.visual.Aperture`    
+	API reference for :class:`~psychopy.visual.Aperture`
+
+.. previous:: aperture.rst

--- a/docs/source/builder/components/ApertureComponent.rst
+++ b/docs/source/builder/components/ApertureComponent.rst
@@ -236,4 +236,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.Aperture`
 
-.. previous:: aperture.rst
+.. redirect-from:: aperture.rst

--- a/docs/source/builder/components/BrushComponent.rst
+++ b/docs/source/builder/components/BrushComponent.rst
@@ -161,4 +161,4 @@ Validate with...
 .. seealso::
     API reference for :class:`~psychopy.visual.Brush`
 
-.. previous:: brush.rst
+.. redirect-from:: brush.rst

--- a/docs/source/builder/components/BrushComponent.rst
+++ b/docs/source/builder/components/BrushComponent.rst
@@ -160,3 +160,5 @@ Validate with...
 
 .. seealso::
     API reference for :class:`~psychopy.visual.Brush`
+
+.. previous:: brush.rst

--- a/docs/source/builder/components/ButtonBoxComponent.rst
+++ b/docs/source/builder/components/ButtonBoxComponent.rst
@@ -174,4 +174,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
 
-.. previous:: cedrusResponseBox.rst
+.. redirect-from:: cedrusResponseBox.rst

--- a/docs/source/builder/components/ButtonBoxComponent.rst
+++ b/docs/source/builder/components/ButtonBoxComponent.rst
@@ -173,4 +173,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component
     Disable this Component
-    
+
+.. previous:: cedrusResponseBox.rst

--- a/docs/source/builder/components/ButtonComponent.rst
+++ b/docs/source/builder/components/ButtonComponent.rst
@@ -320,3 +320,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.ButtonStim`
+
+.. previous:: button.rst

--- a/docs/source/builder/components/ButtonComponent.rst
+++ b/docs/source/builder/components/ButtonComponent.rst
@@ -321,4 +321,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.ButtonStim`
 
-.. previous:: button.rst
+.. redirect-from:: button.rst

--- a/docs/source/builder/components/CameraComponent.rst
+++ b/docs/source/builder/components/CameraComponent.rst
@@ -216,4 +216,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
     
-.. previous:: camera.rst
+.. redirect-from:: camera.rst

--- a/docs/source/builder/components/CameraComponent.rst
+++ b/docs/source/builder/components/CameraComponent.rst
@@ -216,3 +216,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
     
+.. previous:: camera.rst

--- a/docs/source/builder/components/CodeComponent.rst
+++ b/docs/source/builder/components/CodeComponent.rst
@@ -143,4 +143,4 @@ Selected contents of `the numpy library and numpy.random <http://docs.scipy.org/
 
 - np.______: Many math-related features are available through the complete numpy libraries, which are available within psychopy builder scripts as 'np.'. For example, you could use `np.hanning(3)` or `np.random.poisson(10, 10)` in a code component.
 
-.. previous:: code.rst
+.. redirect-from:: code.rst

--- a/docs/source/builder/components/CodeComponent.rst
+++ b/docs/source/builder/components/CodeComponent.rst
@@ -142,3 +142,5 @@ Selected contents of `the numpy library and numpy.random <http://docs.scipy.org/
 - `average()`, `sqrt()`, `std()`: For average (mean), square root, and standard deviation, respectively. **Note:** Be sure that the numpy standard deviation formula is the one you want!
 
 - np.______: Many math-related features are available through the complete numpy libraries, which are available within psychopy builder scripts as 'np.'. For example, you could use `np.hanning(3)` or `np.random.poisson(10, 10)` in a code component.
+
+.. previous:: code.rst

--- a/docs/source/builder/components/CounterbalanceRoutine.rst
+++ b/docs/source/builder/components/CounterbalanceRoutine.rst
@@ -102,4 +102,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Routine
     Disable this Routine
-    
+
+.. previous:: counterbalanceComponent.rst

--- a/docs/source/builder/components/CounterbalanceRoutine.rst
+++ b/docs/source/builder/components/CounterbalanceRoutine.rst
@@ -103,4 +103,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Routine
     Disable this Routine
 
-.. previous:: counterbalanceComponent.rst
+.. redirect-from:: counterbalanceComponent.rst

--- a/docs/source/builder/components/DotsComponent.rst
+++ b/docs/source/builder/components/DotsComponent.rst
@@ -307,3 +307,5 @@ Validate with...
 .. seealso::
     
     API reference for :class:`~psychopy.visual.DotStim`
+
+.. previous:: dots.rst

--- a/docs/source/builder/components/DotsComponent.rst
+++ b/docs/source/builder/components/DotsComponent.rst
@@ -308,4 +308,4 @@ Validate with...
     
     API reference for :class:`~psychopy.visual.DotStim`
 
-.. previous:: dots.rst
+.. redirect-from:: dots.rst

--- a/docs/source/builder/components/EyetrackerCalibrationRoutine.rst
+++ b/docs/source/builder/components/EyetrackerCalibrationRoutine.rst
@@ -198,4 +198,4 @@ Disable Routine
 	
 	API reference for :class:`~psychopy.hardware.eyetracker.EyetrackerCalibration`
 
-.. previous:: eyetracker_calibration.rst
+.. redirect-from:: eyetracker_calibration.rst

--- a/docs/source/builder/components/EyetrackerCalibrationRoutine.rst
+++ b/docs/source/builder/components/EyetrackerCalibrationRoutine.rst
@@ -197,4 +197,5 @@ Disable Routine
 .. seealso::
 	
 	API reference for :class:`~psychopy.hardware.eyetracker.EyetrackerCalibration`
-    
+
+.. previous:: eyetracker_calibration.rst

--- a/docs/source/builder/components/EyetrackerRecordComponent.rst
+++ b/docs/source/builder/components/EyetrackerRecordComponent.rst
@@ -147,4 +147,4 @@ Disable Component
 	
 	API reference for :class:`~psychopy.iohub.devices.eyetracker.hw.mouse.EyeTracker`
 
-.. previous:: eyetracker_record.rst
+.. redirect-from:: eyetracker_record.rst

--- a/docs/source/builder/components/EyetrackerRecordComponent.rst
+++ b/docs/source/builder/components/EyetrackerRecordComponent.rst
@@ -20,7 +20,7 @@ Here the available options are:
 If you are developing your eye-tracking paradigm out-of-lab we recommend using *MouseGaze* which will simulate eye movement
 responses through monitoring your mouse cursor and buttons to simulate movements and blinks.
 
-The resulting eye-movement coordinates are stored and accessible through calling `etRecord.pos` where `etRecord corresponds
+The resulting eye-movement coordinates are stored and accessible through calling `etRecord.pos` where `etRecord` corresponds
 to the name of the eye-tracking record component, you can set something (e.g. a polygon) to be in the same location as
 the current "look" by setting the position field to :code:`etRecord.pos` and setting the field to update on **every frame**
 When running an eye tracking study, you can optionally save the data in hdf5 format through selecting this option in the
@@ -146,3 +146,5 @@ Disable Component
 .. seealso::
 	
 	API reference for :class:`~psychopy.iohub.devices.eyetracker.hw.mouse.EyeTracker`
+
+.. previous:: eyetracker_record.rst

--- a/docs/source/builder/components/EyetrackerValidationRoutine.rst
+++ b/docs/source/builder/components/EyetrackerValidationRoutine.rst
@@ -217,3 +217,5 @@ Disable Routine
 .. seealso::
 	
 	API reference for :class:`~psychopy.hardware.eyetracker.EyetrackerCalibration`
+
+.. previous:: eyetracker_validation.rst

--- a/docs/source/builder/components/EyetrackerValidationRoutine.rst
+++ b/docs/source/builder/components/EyetrackerValidationRoutine.rst
@@ -218,4 +218,4 @@ Disable Routine
 	
 	API reference for :class:`~psychopy.hardware.eyetracker.EyetrackerCalibration`
 
-.. previous:: eyetracker_validation.rst
+.. redirect-from:: eyetracker_validation.rst

--- a/docs/source/builder/components/FormComponent.rst
+++ b/docs/source/builder/components/FormComponent.rst
@@ -305,4 +305,5 @@ Validate with...
 .. seealso::
 
 	API reference for :class:`~psychopy.visual.Form`
-    
+
+.. previous:: form.rst

--- a/docs/source/builder/components/FormComponent.rst
+++ b/docs/source/builder/components/FormComponent.rst
@@ -306,4 +306,4 @@ Validate with...
 
 	API reference for :class:`~psychopy.visual.Form`
 
-.. previous:: form.rst
+.. redirect-from:: form.rst

--- a/docs/source/builder/components/GratingComponent.rst
+++ b/docs/source/builder/components/GratingComponent.rst
@@ -307,4 +307,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.GratingStim`
 
-.. previous:: grating.rst
+.. redirect-from:: grating.rst

--- a/docs/source/builder/components/GratingComponent.rst
+++ b/docs/source/builder/components/GratingComponent.rst
@@ -306,3 +306,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.GratingStim`
+
+.. previous:: grating.rst

--- a/docs/source/builder/components/ImageComponent.rst
+++ b/docs/source/builder/components/ImageComponent.rst
@@ -279,4 +279,4 @@ Validate with...
 
 	API reference for :class:`~psychopy.visual.ImageStim`
 
-.. previous:: image.rst
+.. redirect-from:: image.rst

--- a/docs/source/builder/components/ImageComponent.rst
+++ b/docs/source/builder/components/ImageComponent.rst
@@ -278,3 +278,5 @@ Validate with...
 .. seealso::
 
 	API reference for :class:`~psychopy.visual.ImageStim`
+
+.. previous:: image.rst

--- a/docs/source/builder/components/JoyButtonsComponent.rst
+++ b/docs/source/builder/components/JoyButtonsComponent.rst
@@ -153,4 +153,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component
     Disable this Component
-    
+
+.. previous:: joyButtons.rst

--- a/docs/source/builder/components/JoyButtonsComponent.rst
+++ b/docs/source/builder/components/JoyButtonsComponent.rst
@@ -154,4 +154,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
 
-.. previous:: joyButtons.rst
+.. redirect-from:: joyButtons.rst

--- a/docs/source/builder/components/JoystickComponent.rst
+++ b/docs/source/builder/components/JoystickComponent.rst
@@ -204,4 +204,4 @@ Disable Component
 
     API reference for :mod:`~psychopy.hardware.Joystick`
 
-.. previous:: joystick.rst
+.. redirect-from:: joystick.rst

--- a/docs/source/builder/components/JoystickComponent.rst
+++ b/docs/source/builder/components/JoystickComponent.rst
@@ -203,3 +203,5 @@ Disable Component
 .. seealso::
 
     API reference for :mod:`~psychopy.hardware.Joystick`
+
+.. previous:: joystick.rst

--- a/docs/source/builder/components/KeyboardComponent.rst
+++ b/docs/source/builder/components/KeyboardComponent.rst
@@ -173,3 +173,5 @@ Disable Component
 .. seealso::
 
     API reference for :doc:`psychopy.hardware.keyboard>`
+
+.. previous:: keyboard.rst

--- a/docs/source/builder/components/KeyboardComponent.rst
+++ b/docs/source/builder/components/KeyboardComponent.rst
@@ -174,4 +174,4 @@ Disable Component
 
     API reference for :doc:`psychopy.hardware.keyboard>`
 
-.. previous:: keyboard.rst
+.. redirect-from:: keyboard.rst

--- a/docs/source/builder/components/MicrophoneComponent.rst
+++ b/docs/source/builder/components/MicrophoneComponent.rst
@@ -310,4 +310,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component
     Disable this Component
-    
+
+.. previous:: microphone.rst

--- a/docs/source/builder/components/MicrophoneComponent.rst
+++ b/docs/source/builder/components/MicrophoneComponent.rst
@@ -311,4 +311,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
 
-.. previous:: microphone.rst
+.. redirect-from:: microphone.rst

--- a/docs/source/builder/components/MouseComponent.rst
+++ b/docs/source/builder/components/MouseComponent.rst
@@ -190,4 +190,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component
     Disable this Component
-    
+
+.. previous:: mouse.rst

--- a/docs/source/builder/components/MouseComponent.rst
+++ b/docs/source/builder/components/MouseComponent.rst
@@ -191,4 +191,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component
     Disable this Component
 
-.. previous:: mouse.rst
+.. redirect-from:: mouse.rst

--- a/docs/source/builder/components/MovieComponent.rst
+++ b/docs/source/builder/components/MovieComponent.rst
@@ -260,4 +260,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.MovieStim`
 
-.. previous:: movie.rst
+.. redirect-from:: movie.rst

--- a/docs/source/builder/components/MovieComponent.rst
+++ b/docs/source/builder/components/MovieComponent.rst
@@ -259,3 +259,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.MovieStim`
+
+.. previous:: movie.rst

--- a/docs/source/builder/components/PanoramaComponent.rst
+++ b/docs/source/builder/components/PanoramaComponent.rst
@@ -213,4 +213,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.Panorama`
 
-.. previous:: panorama.rst
+.. redirect-from:: panorama.rst

--- a/docs/source/builder/components/PanoramaComponent.rst
+++ b/docs/source/builder/components/PanoramaComponent.rst
@@ -212,4 +212,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.Panorama`
-    
+
+.. previous:: panorama.rst

--- a/docs/source/builder/components/ParallelOutComponent.rst
+++ b/docs/source/builder/components/ParallelOutComponent.rst
@@ -160,4 +160,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component 
     Disable this Component
-    
+
+.. previous:: parallelout.rst

--- a/docs/source/builder/components/ParallelOutComponent.rst
+++ b/docs/source/builder/components/ParallelOutComponent.rst
@@ -161,4 +161,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component 
     Disable this Component
 
-.. previous:: parallelout.rst
+.. redirect-from:: parallelout.rst

--- a/docs/source/builder/components/PavloviaSurveyRoutine.rst
+++ b/docs/source/builder/components/PavloviaSurveyRoutine.rst
@@ -94,4 +94,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Routine 
     Disable this Routine
 
-.. previous:: advanced_survey.rst
+.. redirect-from:: advanced_survey.rst

--- a/docs/source/builder/components/PavloviaSurveyRoutine.rst
+++ b/docs/source/builder/components/PavloviaSurveyRoutine.rst
@@ -93,4 +93,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Routine 
     Disable this Routine
-    
+
+.. previous:: advanced_survey.rst

--- a/docs/source/builder/components/PolygonComponent.rst
+++ b/docs/source/builder/components/PolygonComponent.rst
@@ -300,4 +300,5 @@ Validate with...
 	API reference for :class:`~psychopy.visual.Polygon`
 	API reference for :class:`~psychopy.visual.Rect`
 	API reference for :class:`~psychopy.visual.ShapeStim`
-    
+
+.. previous:: polygon.rst

--- a/docs/source/builder/components/PolygonComponent.rst
+++ b/docs/source/builder/components/PolygonComponent.rst
@@ -301,4 +301,4 @@ Validate with...
 	API reference for :class:`~psychopy.visual.Rect`
 	API reference for :class:`~psychopy.visual.ShapeStim`
 
-.. previous:: polygon.rst
+.. redirect-from:: polygon.rst

--- a/docs/source/builder/components/ProgressComponent.rst
+++ b/docs/source/builder/components/ProgressComponent.rst
@@ -248,4 +248,4 @@ Validate with...
 
 	API reference for :class:`~psychopy.visual.Progress`
 
-.. previous:: progressbar.rst
+.. redirect-from:: progressbar.rst

--- a/docs/source/builder/components/ProgressComponent.rst
+++ b/docs/source/builder/components/ProgressComponent.rst
@@ -247,4 +247,5 @@ Validate with...
 .. seealso::
 
 	API reference for :class:`~psychopy.visual.Progress`
-    
+
+.. previous:: progressbar.rst

--- a/docs/source/builder/components/RegionOfInterestComponent.rst
+++ b/docs/source/builder/components/RegionOfInterestComponent.rst
@@ -259,4 +259,5 @@ Validate with...
 
 Debug mode 
     In debug mode, the ROI is drawn in red. Use this to see what area of the screen is in the ROI.
-    
+
+.. previous:: eyetracker_ROI.rst

--- a/docs/source/builder/components/RegionOfInterestComponent.rst
+++ b/docs/source/builder/components/RegionOfInterestComponent.rst
@@ -260,4 +260,4 @@ Validate with...
 Debug mode 
     In debug mode, the ROI is drawn in red. Use this to see what area of the screen is in the ROI.
 
-.. previous:: eyetracker_ROI.rst
+.. redirect-from:: eyetracker_ROI.rst

--- a/docs/source/builder/components/ResourceManagerComponent.rst
+++ b/docs/source/builder/components/ResourceManagerComponent.rst
@@ -161,4 +161,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component 
     Disable this Component
 
-.. previous:: resource_manager.rst
+.. redirect-from:: resource_manager.rst

--- a/docs/source/builder/components/ResourceManagerComponent.rst
+++ b/docs/source/builder/components/ResourceManagerComponent.rst
@@ -160,4 +160,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component 
     Disable this Component
-    
+
+.. previous:: resource_manager.rst

--- a/docs/source/builder/components/SerialOutComponent.rst
+++ b/docs/source/builder/components/SerialOutComponent.rst
@@ -172,4 +172,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component 
     Disable this Component
 
-.. previous:: serialout.rst
+.. redirect-from:: serialout.rst

--- a/docs/source/builder/components/SerialOutComponent.rst
+++ b/docs/source/builder/components/SerialOutComponent.rst
@@ -171,4 +171,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component 
     Disable this Component
-    
+
+.. previous:: serialout.rst

--- a/docs/source/builder/components/SliderComponent.rst
+++ b/docs/source/builder/components/SliderComponent.rst
@@ -307,3 +307,6 @@ Validate with...
 .. seealso::
 
     API reference for :class:`~psychopy.visual.Slider`
+
+.. previous:: ratingscale.rst
+.. previous:: slider.rst

--- a/docs/source/builder/components/SliderComponent.rst
+++ b/docs/source/builder/components/SliderComponent.rst
@@ -308,4 +308,4 @@ Validate with...
 
     API reference for :class:`~psychopy.visual.Slider`
 
-.. previous:: slider.rst
+.. redirect-from:: slider.rst

--- a/docs/source/builder/components/SliderComponent.rst
+++ b/docs/source/builder/components/SliderComponent.rst
@@ -308,5 +308,4 @@ Validate with...
 
     API reference for :class:`~psychopy.visual.Slider`
 
-.. previous:: ratingscale.rst
 .. previous:: slider.rst

--- a/docs/source/builder/components/SoundComponent.rst
+++ b/docs/source/builder/components/SoundComponent.rst
@@ -176,4 +176,5 @@ Disable Component
 
 Validate with... 
     Name of the Validator Routine to use to check the timing of this stimulus. Options are generated live, so will vary according to your setup.
-    
+
+.. previous:: sound.rst

--- a/docs/source/builder/components/SoundComponent.rst
+++ b/docs/source/builder/components/SoundComponent.rst
@@ -177,4 +177,4 @@ Disable Component
 Validate with... 
     Name of the Validator Routine to use to check the timing of this stimulus. Options are generated live, so will vary according to your setup.
 
-.. previous:: sound.rst
+.. redirect-from:: sound.rst

--- a/docs/source/builder/components/StaticComponent.rst
+++ b/docs/source/builder/components/StaticComponent.rst
@@ -139,3 +139,5 @@ Disable Component
 .. seealso::
 
     API reference for :class:`~psychopy.clock.StaticPeriod`
+
+.. previous:: static.rst

--- a/docs/source/builder/components/StaticComponent.rst
+++ b/docs/source/builder/components/StaticComponent.rst
@@ -140,4 +140,4 @@ Disable Component
 
     API reference for :class:`~psychopy.clock.StaticPeriod`
 
-.. previous:: static.rst
+.. redirect-from:: static.rst

--- a/docs/source/builder/components/TextComponent.rst
+++ b/docs/source/builder/components/TextComponent.rst
@@ -255,4 +255,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.TextStim`
 
-.. previous:: text.rst
+.. redirect-from:: text.rst

--- a/docs/source/builder/components/TextComponent.rst
+++ b/docs/source/builder/components/TextComponent.rst
@@ -254,4 +254,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.TextStim`
-    
+
+.. previous:: text.rst

--- a/docs/source/builder/components/TextboxComponent.rst
+++ b/docs/source/builder/components/TextboxComponent.rst
@@ -372,4 +372,4 @@ Validate with...
 	
 	API reference for :class:`~psychopy.visual.TextBox`
 
-.. previous:: textbox.rst
+.. redirect-from:: textbox.rst

--- a/docs/source/builder/components/TextboxComponent.rst
+++ b/docs/source/builder/components/TextboxComponent.rst
@@ -371,3 +371,5 @@ Validate with...
 .. seealso::
 	
 	API reference for :class:`~psychopy.visual.TextBox`
+
+.. previous:: textbox.rst

--- a/docs/source/builder/components/VariableComponent.rst
+++ b/docs/source/builder/components/VariableComponent.rst
@@ -156,4 +156,5 @@ Tools for testing, debugging and checking the performance of this Component.
 
 Disable Component 
     Disable this Component
-    
+
+.. previous:: variable.rst

--- a/docs/source/builder/components/VariableComponent.rst
+++ b/docs/source/builder/components/VariableComponent.rst
@@ -157,4 +157,4 @@ Tools for testing, debugging and checking the performance of this Component.
 Disable Component 
     Disable this Component
 
-.. previous:: variable.rst
+.. redirect-from:: variable.rst

--- a/docs/source/builder/components/index.rst
+++ b/docs/source/builder/components/index.rst
@@ -48,7 +48,7 @@ If you do want the parameters of a stimulus to be evaluated by code in this way 
 .. _numpy.random.rand(): http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.rand.html#numpy.random.rand
 .. _numpy: http://numpy.scipy.org/
 
-.. previous::
+.. redirect::
    reward.rst > https://github.com/psychopy/psychopy-labeotech
    ratingscale.rst > https://psychopy.github.io/psychopy-legacy/builder/components/RatingScaleComponent/
    pump.rst > https://github.com/psychopy/psychopy-qmix

--- a/docs/source/builder/components/index.rst
+++ b/docs/source/builder/components/index.rst
@@ -47,3 +47,14 @@ If you do want the parameters of a stimulus to be evaluated by code in this way 
 .. _Python: http://www.python.org
 .. _numpy.random.rand(): http://docs.scipy.org/doc/numpy/reference/generated/numpy.random.rand.html#numpy.random.rand
 .. _numpy: http://numpy.scipy.org/
+
+.. previous::
+   reward.rst > https://github.com/psychopy/psychopy-labeotech
+   ratingscale.rst > https://psychopy.github.io/psychopy-legacy/builder/components/RatingScaleComponent/
+   pump.rst > https://github.com/psychopy/psychopy-qmix
+   patch.rst > https://psychopy.github.io/psychopy-legacy/builder/components/PatchComponent/
+   ioLabs.rst > https://psychopy.github.io/psychopy-iolabs/builder/components/IoLabsButtonBox/
+   emotiv_record.rst > https://psychopy.github.io/psychopy-emotiv/emotiv_record.html
+   emotiv_marking.rst > https://psychopy.github.io/psychopy-emotiv/emotiv_marking.html
+   cedrusResponseBox.rst > https://psychopy.github.io/psychopy-cedrus/builder/components/CedrusButtonBoxComponent/
+   

--- a/docs/source/builder/googleSpeech.rst
+++ b/docs/source/builder/googleSpeech.rst
@@ -52,4 +52,4 @@ Steps
 .. warning:: 
 	Remember to check that your accounts billing information stays up to date. Even if you haven't done enough recordings to warrant a large payment, if a card on your billing account expires this will invalidate the JSON key and raise a "billing" error in |PsychoPy|.
 
-.. previous:: ./components/googleSpeech.rst
+.. redirect-from:: ./components/googleSpeech.rst

--- a/docs/source/builder/googleSpeech.rst
+++ b/docs/source/builder/googleSpeech.rst
@@ -51,3 +51,5 @@ Steps
 
 .. warning:: 
 	Remember to check that your accounts billing information stays up to date. Even if you haven't done enough recordings to warrant a large payment, if a card on your billing account expires this will invalidate the JSON key and raise a "billing" error in |PsychoPy|.
+
+.. previous:: ./components/googleSpeech.rst

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,6 +17,7 @@ import pathlib
 import json
 
 docs_folder = pathlib.Path(__file__).parent.parent
+extensions_folder = docs_folder / "extensions"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -25,17 +26,24 @@ docs_folder = pathlib.Path(__file__).parent.parent
 
 # -- General configuration -----------------------------------------------------
 
+# Add custom extensions folder to the path
+sys.path.append(str(extensions_folder.resolve()))
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.todo',
-              'sphinx.ext.coverage',
-              'sphinx.ext.mathjax',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.intersphinx',
-              'sphinx.ext.viewcode',
-              'sphinx_design', 'sphinx_copybutton']
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.autosummary',
+  'sphinx.ext.todo',
+  'sphinx.ext.coverage',
+  'sphinx.ext.mathjax',
+  'sphinx.ext.napoleon',
+  'sphinx.ext.intersphinx',
+  'sphinx.ext.viewcode',
+  'sphinx_design', 
+  'sphinx_copybutton',
+  'redirect'
+]
 
 autoclass_content = 'both'
 autosummary_generate = True


### PR DESCRIPTION
Uses sphinx directives to handle redirects means we can point to an internal reference, same as if we'd used `:ref:` or something. This means when we rename a file, it's super easy to maintain a redirect to it - just put `.. redirect-from:: oldFileName.rst` in the new file.