### PR TITLE
BF: moviepy import for window frame capture

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -2724,7 +2724,7 @@ class Window():
 
         if fileExt in ['.gif', '.mpg', '.mpeg', '.mp4', '.mov']:
             # lazy loading of moviepy.editor (rarely needed)
-            from moviepy.editor import ImageSequenceClip
+            from moviepy import ImageSequenceClip
             # save variety of movies with moviepy
             numpyFrames = []
             for frame in self.movieFrames:


### PR DESCRIPTION
moviepy namespace doesn't include moviepy.editor in newer version per [docs](https://zulko.github.io/moviepy/reference/reference/moviepy.html). 

Changed the import to get ImageSequenceClip directly from moviepy 