### PR TITLE
ENH: Allow numpy>=2.0

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -397,7 +397,7 @@ class Color:
         """If colour is printed, it will display its class and value.
         """
         if self.valid:
-            if self.named:
+            if isinstance(self.named, str):
                 return (f"<{self.__class__.__module__}."
                         f"{self.__class__.__name__}: {self.named}, "
                         f"alpha={self.alpha}>")

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -389,7 +389,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                     if val.startswith('[') and val.endswith(']'):
                         # val = eval('%s' %unicode(val.decode('utf8')))
                         val = eval(val)
-                elif type(val) == np.string_:
+                elif type(val) == np.bytes_:
                     val = str(val.decode('utf-8-sig'))
                     # if it looks like a list, convert it:
                     if val.startswith('[') and val.endswith(']'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     ]
     
 dependencies = [
-    "numpy<2.0",  # use numpy<1.24 for psychopy<2023.1
+    "numpy",  # use numpy<1.24 for psychopy<2023.1
     "scipy",
     "matplotlib",
     "pyglet == 1.4.11; platform_system == \"Windows\"",


### PR DESCRIPTION
I think it was only PTB that was holding it back? Eric Larson fixed it on the PTB side in https://github.com/kleinerm/Psychtoolbox-3/pull/276, and wheels with numpy 2 support were generated for 3.0.19.14 (https://github.com/aforren1/ptb-wheels/releases/tag/3.0.19.14).