### PR TITLE
PKG: fix dukpy dependency with custom javascripthon

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
     "freetype-py",
     "python-bidi",
     "arabic-reshaper",
-    "javascripthon",
     "websockets",  # new in 2023.2 for session.py
     # for the app
     "wxPython >= 4.1.1",
@@ -69,7 +68,7 @@ dependencies = [
     "gitpython",
     "cryptography",  # for sshkeys
     # psychoJS conversions
-    "javascripthon>=0.12",
+    "git+https://gitlab.com/peircej/metapensiero.pj",  # until fixes dukpy depend
     "astunparse",
     "esprima",
     "jedi >= 0.16",


### PR DESCRIPTION
I've fixed this in my fork of metapensiero (javascripthon) and [submitted the PR](https://gitlab.com/metapensiero/metapensiero.pj/-/merge_requests/37) but until that gets accepted we should install my branch