### PR TITLE
BF: Fix erronious alert when using any local transcriber

### DIFF
--- a/psychopy/experiment/components/microphone/__init__.py
+++ b/psychopy/experiment/components/microphone/__init__.py
@@ -462,9 +462,7 @@ class MicrophoneComponent(BaseDeviceComponent):
             inits['transcribeBackend'].val = None
         # Warn user if their transcriber won't work locally
         if inits['transcribe'].val:
-            if  self.params['transcribeBackend'].val in self.localTranscribers:
-                inits['transcribeBackend'].val = self.localTranscribers[self.params['transcribeBackend'].val]
-            else:
+            if  self.params['transcribeBackend'].val not in self.localTranscribers.values():
                 default = list(self.localTranscribers.values())[0]
                 alert(4610, strFields={"transcriber": inits['transcribeBackend'].val, "default": default})
         # Store recordings from this routine


### PR DESCRIPTION
Basically, we were checking for the key in `localTranscriebrs` rather than the value, so it was always behaving as if an invalid transcriber was chosen & was showing an unnecessary alert.

Fixes #7192