### PR TITLE
BF: Handle when allowedKeys is just 1 multi-character string (e.g. "return") online

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -395,9 +395,14 @@ class KeyboardComponent(BaseDeviceComponent):
             waitRelease = "false"
             if self.params['registerOn'] == "release":
                 waitRelease = "true"
-            code = ("let theseKeys = {name}.getKeys({{keyList: {keyStr}, waitRelease: {waitRelease}}});\n"
-                    "_{name}_allKeys = _{name}_allKeys.concat(theseKeys);\n"
-                    "if (_{name}_allKeys.length > 0) {{\n")
+            code = (
+                "let theseKeys = {name}.getKeys({{\n"
+                "  keyList: typeof {keyStr} === 'string' ? [{keyStr}] : {keyStr}, \n"
+                "  waitRelease: {waitRelease}\n"
+                "}});\n"
+                "_{name}_allKeys = _{name}_allKeys.concat(theseKeys);\n"
+                "if (_{name}_allKeys.length > 0) {{\n"
+            )
             buff.writeIndentedLines(
                 code.format(
                     name=self.params['name'],


### PR DESCRIPTION
Currently, supplying just `"return"` as allowed keys acts as if you'd supplied `["r", "e", "t", "u", "r", "n"]` and not `["return"]`

There's an easy workaround (just supply `["return"]` or `"return",`) but we should really just handle this use case.