### PR TITLE
ENH: Set experiment start time and name in run function

### DIFF
--- a/psychopy/experiment/flow.py
+++ b/psychopy/experiment/flow.py
@@ -274,6 +274,11 @@ class Flow(list):
         code = (
             "# mark experiment as started\n"
             "thisExp.status = STARTED\n"
+            "# update experiment info\n"
+            "expInfo['date'] = data.getDateStr()\n"
+            "expInfo['expName'] = expName\n"
+            "expInfo['expVersion'] = expVersion\n"
+            "expInfo['psychopyVersion'] = psychopyVersion\n"
             "# make sure window is set to foreground to prevent losing focus\n"
             "win.winHandle.activate()\n"
             "# make sure variables created by exec are available globally\n"


### PR DESCRIPTION
Means that start time reflects when the `run` function was called, not when the script was interpreted.

From Builder, the only difference is that start time is now after device setup rather than before, so should still be broadly similar to before. From Session, this means start time reflects when the experiment actually ran rather than when it was imported, which could be a substantial difference in time.