### PR TITLE
BF!: Only search for experiment fonts in specific subfolders, to avoid slow searching

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -1043,7 +1043,11 @@ class FontCtrl(SingleLineCtrl):
         from psychopy.tools.fontmanager import FontManager, MissingFontError
         fm = FontManager()
         # check whether the font is installed
-        installed = fm.getFontsMatching(self.getValue(), fallback=False)
+        if self.element and hasattr(self.element, "exp") and self.element.exp.filename:
+            currentDir = Path(self.element.exp.filename).parent
+        else:
+            currentDir = Path(".")
+        installed = fm.getFontsMatching(self.getValue(), fallback=False, currentDir=currentDir)
         # if not installed, ask the user whether to download from Google Fonts
         if not installed:
             # create dialog

--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -672,7 +672,7 @@ def findFontFiles(folders=(), recursive=True, currentDir=Path(".")):
     # if local directory has a /fonts or /assets subdirectory, search those
     for localSubdir in (
         currentDir / "fonts",
-        currentDir / "assets"
+        currentDir / "assets" / "fonts"
     ):
         if localSubdir.is_dir():
             searchPaths.append(localSubdir.absolute())

--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -641,13 +641,17 @@ class TextureGlyph:
             return 0
 
 
-def findFontFiles(folders=(), recursive=True):
+def findFontFiles(folders=(), recursive=True, currentDir=Path(".")):
     """Search for font files in the folder (or system folders)
 
     Parameters
     ----------
     folders: iterable
         folders to search. If empty then search typical system folders
+    recursive : bool
+        If True, recursively search within subfolders
+    currentDir : pathlib.Path
+        Path to use as current directory when making paths absolute
 
     Returns
     -------
@@ -665,14 +669,13 @@ def findFontFiles(folders=(), recursive=True):
     # make sure font paths is a list
     if isinstance(searchPaths, tuple):
         searchPaths = list(searchPaths)
-    # always look in the local directory, unless it's inside PsychoPy itself
-    thisDir = Path(".").absolute()
-    if all((
-        thisDir not in Path(prefs.paths['psychopy']).parents,
-        thisDir != Path(prefs.paths['psychopy']),
-        Path(prefs.paths['psychopy']) not in thisDir.parents,
-    )):
-        searchPaths.append(thisDir)
+    # if local directory has a /fonts or /assets subdirectory, search those
+    for localSubdir in (
+        currentDir / "fonts",
+        currentDir / "assets"
+    ):
+        if localSubdir.is_dir():
+            searchPaths.append(localSubdir.absolute())
     # always look inside the app
     searchPaths.append(Path(prefs.paths['assets']) / "fonts")
     # always look in the user folder
@@ -797,14 +800,14 @@ class FontManager():
         return self.fontStyles
 
     def getFontsMatching(self, fontName, bold=False, italic=False,
-                         fontStyle=None, fallback=True):
+                         fontStyle=None, fallback=True, currentDir=Path(".")):
         """
         Returns the list of FontInfo instances that match the provided
         fontName and style information. If no matching fonts are
         found, None is returned.
         """
-        if not self._fontInfos:
-            self.updateFontInfo()
+        if not self._fontInfos or currentDir != Path("."):
+            self.updateFontInfo(currentDir=currentDir)
         if type(fontName) != bytes:
             fontName = bytes(fontName, sys.getfilesystemencoding())
         # Convert value of "bold" to a numeric font weight
@@ -971,10 +974,10 @@ class FontManager():
 
         return glFont
 
-    def updateFontInfo(self, monospaceOnly=False):
+    def updateFontInfo(self, monospaceOnly=False, currentDir=Path(".")):
         self._fontInfos.clear()
         del self.fontStyles[:]
-        fonts_found = findFontFiles()
+        fonts_found = findFontFiles(currentDir=currentDir)
         self.addFontFiles(fonts_found, monospaceOnly)
 
     def booleansFromStyleName(self, style):


### PR DESCRIPTION
Fixes #7244

Searching for fonts in the experiment folder can cause some significant slowdown if you have a lot of data or very large stimuli, so this PR limits the scope of experiment folder font searching to just two subfolders: `/fonts` and `/assets/fonts`.

This is a breaking change for anyone specifically relying on the 2025.1.n behaviour where fonts can be anywhere in the experiment folder, so we'll need to be clear about this in the 2025.2.0 release notes, but hopefully this is a very small subset of users.