### PR TITLE
PKG: pin zope.event to v 5.1 for py2app gevent issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "psychtoolbox<3.0.20; platform_machine!='arm64'",
     # for iohub
     "pywinhook; platform_system == \"Windows\"",
+    "zope.event==5.0",  # py2app+gevent complains about zope.event 5.1
     "gevent",
     "MeshPy",
     "psutil",


### PR DESCRIPTION
zope.event ==5.1 we get an error during py2app that gevent requireqs zope.event which can't be found