### PR TITLE
BF: Fix `AttributeError` accessing `PathDistribution.name` on Py39

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -437,7 +437,7 @@ def scanPlugins():
             if not ep.group.startswith("psychopy"):
                 continue
             # make sure we have an entry for this distribution
-            if sys.version.startswith("3.8"):
+            if sys.version.startswith("3.8") or sys.version.startswith("3.9"):
                 distName = dist.metadata['name']
             else:
                 distName = dist.name


### PR DESCRIPTION
Fixes an error that comes up when using Python 3.9 due to changes in `importlib` after Python 3.8 that affects how metadata is accessed