### PR TITLE
FF: Fix error when opening the Add Device dialog on Mac

### DIFF
--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -2791,12 +2791,15 @@ class StandaloneRoutineCanvas(scrolledpanel.ScrolledPanel):
         for name, routine in routines.items():
             if routine == self.routine:
                 # Update the routine dict keys to use the current name for this routine
-                self.frame.exp.routines[self.routine.params['name'].val] = self.frame.exp.routines.pop(name)
+                self.frame.exp.routines[self.routine.name] = self.frame.exp.routines.pop(name)
+                # update experiment namespace
+                self.frame.exp.namespace.remove(name)
+                self.frame.exp.namespace.add(self.routine.name)
         # Redraw the flow panel
         self.frame.flowPanel.canvas.draw()
         # Rename this page
         page = self.frame.routinePanel.GetPageIndex(self)
-        self.frame.routinePanel.SetPageText(page, self.routine.params['name'].val)
+        self.frame.routinePanel.SetPageText(page, self.routine.name)
         # Update save button
         self.frame.setIsModified(True)
 

--- a/psychopy/app/builder/builder.py
+++ b/psychopy/app/builder/builder.py
@@ -30,6 +30,7 @@ from wx.lib import platebtn
 from wx.html import HtmlWindow
 
 import psychopy.app.plugin_manager.dialog
+from .dialogs.paramCtrls import EVT_PARAM_CHANGED
 from .validators import WarningManager
 from ..pavlovia_ui import sync, PavloviaMiniBrowser
 from ..pavlovia_ui.project import ProjectFrame
@@ -2759,6 +2760,7 @@ class StandaloneRoutineCanvas(scrolledpanel.ScrolledPanel):
         # Setup categ notebook
         self.warnings = WarningManager(self)
         self.ctrls = ParamNotebook(self, experiment=self.frame.exp, element=routine)
+        self.ctrls.Bind(EVT_PARAM_CHANGED, self.updateExperiment)
         self.paramCtrls = self.ctrls.paramCtrls
         self.sizer.Add(self.ctrls, border=12, proportion=1, flag=wx.ALIGN_CENTER | wx.TOP)
         # Make buttons

--- a/psychopy/app/builder/dialogs/__init__.py
+++ b/psychopy/app/builder/dialogs/__init__.py
@@ -478,6 +478,8 @@ class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
         def addParam(self, name, param):
             # Make ctrl
             self.ctrls[name] = ParamCtrls(self.dlg, param.label, param, self, name)
+            # Bind change event
+            self.ctrls[name].valueCtrl.Bind(paramCtrls.EVT_PARAM_CHANGED, self.emitChangeEvent)
             # Add value ctrl
             _flag = wx.EXPAND | wx.ALL
             if hasattr(self.ctrls[name].valueCtrl, '_szr'):
@@ -589,6 +591,9 @@ class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
                 if isinstance(self.dlg, wx.Dialog):
                     self.dlg.Fit()
                 self.Refresh()
+        
+        def emitChangeEvent(self, evt): 
+            wx.PostEvent(self, evt)
 
         def doValidate(self, event=None):
             self.Validate()
@@ -629,8 +634,13 @@ class ParamNotebook(wx.Notebook, handlers.ThemeMixin):
         for categ, params in paramsByCateg.items():
             page = self.CategoryPage(self, self.parent, params, categ=categ)
             self.paramCtrls.update(page.ctrls)
+            # Bind change event
+            page.Bind(paramCtrls.EVT_PARAM_CHANGED, self.emitChangeEvent)
             # Add page to notebook
             self.AddPage(page, _translate(categ))
+    
+    def emitChangeEvent(self, evt): 
+        wx.PostEvent(self, evt)
 
     def checkDepends(self, event=None):
         """

--- a/psychopy/app/deviceManager/addDialog.py
+++ b/psychopy/app/deviceManager/addDialog.py
@@ -1,4 +1,3 @@
-import threading
 from psychopy.app.deviceManager.utils import DeviceImageList
 from psychopy.app.builder.dialogs.paramCtrls import EVT_PARAM_CHANGED, ParamCtrl
 from psychopy.app.builder.validators import WarningManager
@@ -169,10 +168,7 @@ class AddDeviceDlg(wx.Dialog):
             wx event triggering this call
         """
         # populate
-        threading.Thread(
-            target=self.populate,
-            daemon=True
-        ).start()
+        self.populate()
         # unbind
         if evt.EventType == wx.EVT_IDLE.typeId:
             self.Unbind(wx.EVT_IDLE)

--- a/psychopy/experiment/_experiment.py
+++ b/psychopy/experiment/_experiment.py
@@ -980,6 +980,9 @@ class Experiment:
                     if paramNode.tag == "Param":
                         for key, val in paramNode.items():
                             name = paramNode.get("name")
+                            # "device" valType was introduced in 2025.2.0 and should always override saved valType
+                            if key == "valType" and routine.params[name].valType == "device":
+                                continue
                             if name in routine.params:
                                 setattr(routine.params[name], key, val)
                 # Add routine to experiment

--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -384,6 +384,8 @@ def getInitVals(params, target="PsychoPy"):
         elif name == 'allowedKeys':
             inits[name].val = "[]"
             inits[name].valType = 'code'
+        elif name == "deviceLabel":
+            inits[name].valType = "device"
         else:
             # if not explicitly handled, default to None
             inits[name].val = "None"

--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -610,16 +610,22 @@ class CameraDevice(BaseDevice):
                     'pixels': 0,
                     'frameRate': 0
                 }
-                minFrameRate = max(30, min([cam.frameRate for cam in allCams]))
+                bestResolution = None
+                minFrameRate = max(28, min([cam.frameRate for cam in allCams]))
                 for cam in allCams:
                     # summarise spec of this cam
                     current = {
                         'pixels': cam.frameSize[0] * cam.frameSize[1],
                         'frameRate': cam.frameRate
                     }
+                    # store best frame rate as a fallback
+                    if bestResolution is None or current['pixels'] > lastBest['pixels']:
+                        bestResolution = cam
                     # if it's better than the last, set it as the only cam
                     if current['pixels'] > lastBest['pixels'] and current['frameRate'] >= minFrameRate:
                         cams = [cam]
+                # if no cameras meet frame rate requirement, use one with best resolution
+                cams = [bestResolution]
             # iterate through all (possibly filtered) cameras
             for cam in cams:
                 # construct a dict profile from the CameraInfo object


### PR DESCRIPTION
`getAvailableDevices` *really* doesn't like running in a secondary thread, but only on Mac (it seg faults the whole app). I was running it in a thread so that the UI wouldn't freeze up while devices were loading, but it looks like that's sadly unavoidable.