### PR TITLE
DOCS: adding svg->pdf conversion for pdf files

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,8 +42,8 @@ extensions = [
   'sphinx.ext.viewcode',
   'sphinx_design', 
   'sphinx_copybutton',
-  'redirect'
-]
+  'redirect',
+  'sphinxcontrib.inkscapeconverter' # part of sphinxcontrib-svg2pdfconverter
 
 autoclass_content = 'both'
 autosummary_generate = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,11 @@ tests = [
 ]
 docs = [
     "sphinx",
+    "jinja2",
     "sphinx-design",
     "sphinx-copybutton",
-    "jinja2",
-    "psychopy-sphinx-theme"
+    "sphinxcontrib.svg2pdfconverter",  # requires inkscape
+    "psychopy-sphinx-theme",
 ]
 building = [
     "bdist-mpkg>=0.5.0; platform_system == \"Darwin\"",


### PR DESCRIPTION
This commit adds dependency on
- `sphinxcontrib-svg2pdfconverter` for anyone building docs in any format
- inkscape (and above) for anyone buliding the pdf, and add inscape/bin to system path