### PR TITLE
BF: Added code to maintain external spectral calibration

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -262,6 +262,8 @@ class Color:
         self._renderCache = {}
         self.contrast = contrast if isinstance(contrast, (int, float)) else 1
         self.valid = False
+
+
         self.conematrix = conematrix
 
         # defined here but set later

--- a/psychopy/tools/colorspacetools.py
+++ b/psychopy/tools/colorspacetools.py
@@ -23,8 +23,42 @@ __all__ = ['srgbTF', 'rec709TF', 'cielab2rgb', 'cielch2rgb', 'dkl2rgb',
 import numpy
 from psychopy import logging
 from psychopy.tools.coordinatetools import sph2cart
+# Add a registry
+_active_cone_mats = {'lms': None, 'dkl': None}
+
+def _register_active_cone_matrices(lms_mat, dkl_mat):
+    """Called by Window to register calibrated cone matrices early."""
+    _active_cone_mats['lms'] = lms_mat
+    _active_cone_mats['dkl'] = dkl_mat
+
+def _get_active_cone_matrix(space: str):
+    return _active_cone_mats.get(space.lower())
 
 
+def _get_cone_matrix_from_default_window(space: str):
+    """
+    Try to extract LMS/DKL->RGB cone matrix from the current default PsychoPy window's monitor.
+    Returns a 3x3 or None. Safe no-op if no window/monitor is available.
+    """
+    try:
+        from psychopy.visual.window import _defaultWindow  # lazy import; avoid hard dependency at module import
+    except Exception:
+        return None
+
+    mon = getattr(_defaultWindow, 'monitor', None)
+    if mon is None:
+        return None
+
+    try:
+        if space == 'lms' and hasattr(mon, 'getLMS_RGB'):
+            return mon.getLMS_RGB()
+        if space == 'dkl' and hasattr(mon, 'getDKL_RGB'):
+            return mon.getDKL_RGB()
+    except Exception:
+        return None
+    return None
+
+    
 def unpackColors(colors):  # used internally, not exported by __all__
     """Reshape an array of color values to Nx3 format.
 
@@ -628,8 +662,14 @@ def lms2rgb(lms_Nx3, conversionMatrix=None):
 
     # its easier to use in the other orientation!
     lms_3xN = numpy.transpose(lms_Nx3)
-
+ # ...
     if conversionMatrix is None:
+        # Try matrices registered by Window
+        conversionMatrix = _get_active_cone_matrix('lms')
+        logging.info(f'Trying to get active cone matrix (lms): {conversionMatrix}')
+    if conversionMatrix is None:
+        # Original behaviour (keep the warning + default matrix)
+
         cones_to_rgb = numpy.asarray([
             # L        M        S
             [4.97068857, -4.14354132, 0.17285275],  # R

--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -15,6 +15,8 @@ import atexit
 from itertools import product
 from collections import deque
 
+from psychopy.tools import colorspacetools as ct
+
 from psychopy.contrib.lazy_import import lazy_import
 from psychopy import colors, event
 from psychopy.localization import _translate
@@ -372,6 +374,18 @@ class Window():
         else:
             self.monitor = monitor
 
+        # Register lms and dkl conversion matrices for colorspacetools to grab if it wants
+        # ARW 020825
+        try:
+            lms_mat = self.monitor.getLMS_RGB()
+        except Exception:
+            lms_mat = None
+        try:
+            dkl_mat = self.monitor.getDKL_RGB()
+        except Exception:
+            dkl_mat = None
+
+        ct._register_active_cone_matrices(lms_mat, dkl_mat)
         # otherwise monitor will just be a dict
         self.scrWidthCM = self.monitor.getWidth()
         self.scrDistCM = self.monitor.getDistance()


### PR DESCRIPTION
This may fix an issue with Psychopy ignoring custom LMS2RGB matrices.