### PR TITLE
BF: ExperimentHandler not saving extraInfo to wide text

### DIFF
--- a/psychopy/data/experiment.py
+++ b/psychopy/data/experiment.py
@@ -200,7 +200,7 @@ class ExperimentHandler(_ComparisonMixin):
     def _getExtraInfo(self):
         """Get the names and vals from the extraInfo dict (if it exists)
         """
-        if type(self.extraInfo) != dict:
+        if not isinstance(self.extraInfo, dict):
             names = []
             vals = []
         else:
@@ -680,7 +680,7 @@ class ExperimentHandler(_ComparisonMixin):
         for thisLoop in self.loopsUnfinished:
             self.updateEntryFromLoop(thisLoop)
         # add the extraInfo dict to the data
-        if type(self.extraInfo) == dict:
+        if isinstance(self.extraInfo, dict):
             this.update(self.extraInfo)
         self.entries.append(this)
         # add new entry with its


### PR DESCRIPTION
I recently updated my PsychoPy, and noticed the `ExperimentHandler` was no longer saving the fields in the `extraInfo` dictionary to the wide text/csv file. I think this is due to a recent change where the `extraInfo` gets stored as PsychoPy's new `IndexDict` object. This was causing checks for the type of the `extraInfo` object to fail, as it isn't a normal Python dictionary any more. Seeing as `IndexDict` inherits from `dict`, just changing the checks to use `isinstance` rather than `type == dict` seems to fix the problem.