### PR TITLE
RF: Make device params more compatible with JSON exports

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -1672,6 +1672,23 @@ class DeviceCtrl(ChoiceCtrl):
             self.deviceMgrBtn, border=6, flag=wx.EXPAND | wx.LEFT
         )
 
+    def populate(self):
+        self.choices = []
+        self.labels = []
+        for name, device in prefs.devices.items():
+            # get backends from allowedVals
+            for backend in self.param.allowedVals:
+                # if device is the correct type, include it
+                if isinstance(device, backend):
+                    self.choices.append(name)
+                    self.labels.append(name)
+        # apply to ctrl
+        self.ctrl.SetItems(self.labels)
+        # disable if param is readonly
+        self.ctrl.Enable(not self.param.readOnly)
+        # apply (or re-apply) selection
+        self.setValue(self.param.val)
+    
     def openDeviceManager(self, evt=None):
         from psychopy.app.deviceManager import DeviceManagerDlg
         # create dialog

--- a/psychopy/experiment/components/camera/__init__.py
+++ b/psychopy/experiment/components/camera/__init__.py
@@ -107,27 +107,10 @@ class CameraComponent(BaseDeviceComponent):
         self.order += [
             "deviceLabel"
         ]
-        # functions for getting device labels
-        def getMicDevices():
-            # start with default
-            devices = [("", _translate("Default"))]
-            # iterate through saved devices
-            for name, device in prefs.devices.items():
-                # if device is a microphone, include it
-                if isinstance(device, MicrophoneDeviceBackend):
-                    devices.append(
-                        (name, name)
-                    )
-            return devices
-        def getMicLabels():
-            return [device[1] for device in getMicDevices()]
-        def getMicValues():
-            return [device[0] for device in getMicDevices()]
         # label to refer to device by
         self.params['micDeviceLabel'] = Param(
             micDeviceLabel, valType="str", inputType="device", categ="Device",
-            allowedVals=getMicValues,
-            allowedLabels=getMicLabels,
+            allowedVals=[MicrophoneDeviceBackend],
             label=_translate("Microphone device"),
             hint=_translate(
                 "The named device from Device Manager to use for this Component."

--- a/psychopy/experiment/devices.py
+++ b/psychopy/experiment/devices.py
@@ -27,29 +27,10 @@ class DeviceMixin:
         self.order += [
             "deviceLabel"
         ]
-        # functions for getting device labels
-        def getDevices():
-            # start with default
-            devices = [("", _translate("Default"))]
-            # iterate through saved devices
-            for name, device in prefs.devices.items():
-                # iterate through backends for this Component
-                for backend in self.backends:
-                    # if device is the correct type, include it
-                    if isinstance(device, backend):
-                        devices.append(
-                            (name, name)
-                        )
-            return devices
-        def getLabels():
-            return [device[1] for device in getDevices()]
-        def getValues():
-            return [device[0] for device in getDevices()]
         # label to refer to device by
         self.params['deviceLabel'] = Param(
             defaultLabel, valType="device", inputType="device", categ="Device",
-            allowedVals=getValues,
-            allowedLabels=getLabels,
+            allowedVals=list(self.backends),
             label=_translate("Device"),
             hint=_translate(
                 "The named device from Device Manager to use for this Component."


### PR DESCRIPTION
Uses allowedValues to specify device backend classes rather than a local (non-serializable) method