### PR TITLE
BF: Fix view and projection matrices not being applied before first flip

### DIFF
--- a/psychopy/visual/window.py
+++ b/psychopy/visual/window.py
@@ -625,7 +625,7 @@ class Window():
         self._projectionMatrixNeedsUpdate = True
         self._viewMatrixNeedsUpdate = True
 
-        self.setOrthographicView()
+        self.setDefaultView()  # initialize view/proj matrix
 
         # piloting indicator
         self._pilotingIndicator = None
@@ -822,13 +822,14 @@ class Window():
         settings.
         """
         if self._projectionMatrixNeedsUpdate:
-            widthOver2 = self.size[0] / 2.0
-            heightOver2 = self.size[1] / 2.0
-            self._projectionMatrix[:, :] = viewtools.orthoProjectionMatrix(
-                -widthOver2, widthOver2,    # -X, +X
-                -heightOver2, heightOver2,  # -Y, +Y
-                -1.0, 1.0,                  # -Z, +Z
-                dtype=numpy.float32)
+            # widthOver2 = self.size[0] / 2.0
+            # heightOver2 = self.size[1] / 2.0
+            # self._projectionMatrix[:, :] = viewtools.orthoProjectionMatrix(
+            #     -widthOver2, widthOver2,    # -X, +X
+            #     -heightOver2, heightOver2,  # -Y, +Y
+            #     -1.0, 1.0,                  # -Z, +Z
+            #     dtype=numpy.float32)
+            self._projectionMatrix[:, :] = numpy.identity(4, dtype=numpy.float32)
             self._projectionMatrixNeedsUpdate = False
 
     @property
@@ -2267,6 +2268,20 @@ class Window():
         if applyTransform:
             self.applyEyeTransform(clearDepth=clearDepth)
 
+    def setDefaultView(self, applyTransform=True, clearDepth=True):
+        """Set the projection and view matrix to PsychoPy's default.
+
+        This is the mode which is typically used for rendering 2D stimuli. It should
+        be called prior to rendering any 2D stimuli if the projection has been
+        changed.
+
+        """
+        self._updateViewMatrix()
+        self._updateProjectionMatrix()
+
+        if applyTransform:
+            self.applyEyeTransform(clearDepth=clearDepth)
+
     def setOrthographicView(self, applyTransform=True, clearDepth=True):
         """Set the projection and view matrix to render with orthographic view.
 
@@ -2290,8 +2305,16 @@ class Window():
             Clear the depth buffer.
 
         """
-        self._updateProjectionMatrix()
         self._updateViewMatrix()
+
+        widthOver2 = self.size[0] / 2.0
+        heightOver2 = self.size[1] / 2.0
+        self._projectionMatrix[:, :] = viewtools.orthoProjectionMatrix(
+            -widthOver2, widthOver2,    # -X, +X
+            -heightOver2, heightOver2,  # -Y, +Y
+            -1.0, 1.0,                  # -Z, +Z
+            dtype=numpy.float32)
+        self._projectionMatrix[:, :] = numpy.identity(4, dtype=numpy.float32)
 
         if applyTransform:
             self.applyEyeTransform(clearDepth=clearDepth)


### PR DESCRIPTION
Fixes the issue where visual stimuli appear incorrectly scaled prior to the first flip call. This was caused by the projection matrix for 2D rendering being incorrect until cleared and reset by a flip call. How the default ortho projection matrix is computed has been changed, no longer accounting for window dimensions since that's dealt with by the stimuli's vertex data container

I added method `setDefaultView()` to put matrices in the correct state for PsychoPy's 2D stim classes and now have `setOrthographicView` separate for those who wish to scale coordinates that way 