### PR TITLE
NF: Add support for displaying plots with `ImageStim`

### DIFF
--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -327,10 +327,31 @@ class ImageStim(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin,
         """
         self.__dict__['image'] = self._imName = value
 
-        # If given a color array, get it in rgb1
-        if isinstance(value, colors.Color):
+        # handle a matplotlib object as image
+        if hasattr(value, 'canvas'):  # matplotlib figure
+            if hasattr(value.canvas, 'draw'):
+                value.canvas.draw()  # make sure the figure is drawn
+            figDPI = value.get_dpi()
+            figWidth = value.get_figwidth() * figDPI
+            figHeight = value.get_figheight() * figDPI
+            self._origSize = (int(figWidth), int(figHeight))
+            ncol, nrow = value.canvas.get_width_height()
+            value = numpy.flip(numpy.frombuffer(
+                value.canvas.tostring_argb(), dtype="uint8").reshape(
+                    int(nrow), int(ncol), 4), axis=0)
+            # value = value[..., [1, 2, 3, 0]]  # swizzle alpha channel
+            # discard alpha channel, keep RGB
+            value = value[..., 1:]
+            # convert to float32
+            value = numpy.ascontiguousarray(
+                value, dtype=numpy.float32) / 127.5 - 1
+            # pixFormat = GL.GL_RGBA
+        elif isinstance(value, colors.Color):
             value = value.render('rgb1')
+        else:
+            pass
 
+        # determine data type
         wasLumImage = self.isLumImage
         if type(value) != numpy.ndarray and value == "color":
             datatype = GL.GL_FLOAT


### PR DESCRIPTION
This PR adds support for showing plots with `ImageStim` within a PsychoPy session by accepting matplotlib figure objects as images. Setting the parameter `size=None` when initializing `ImageStim` renders the plot in its native resolution