### PR TITLE
BF: Fixed incorrect func ref in `getAllJoysticks()`

### DIFF
--- a/psychopy/hardware/joystick/__init__.py
+++ b/psychopy/hardware/joystick/__init__.py
@@ -1189,7 +1189,7 @@ def getAllJoysticks():
         joy = Joystick(joysticks[0]['index'])
 
     """
-    return Joystick.getAllJoysticks()
+    return Joystick.getAvailableDevices()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #7391 