### PR TITLE
PKG: pin gevent to 2.5.1

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-13, ubuntu-22.04]
-        python-version: ['3.8', '3.10']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # for iohub
     "pywinhook; platform_system == \"Windows\"",
     "zope.event==5.0",  # py2app+gevent complains about zope.event 5.1
-    "gevent==2.5.1",  # macos wheels for >2.5.1 are py3.12 only
+    "gevent==25.5.1",  # macos wheels for >2.5.1 are py3.12 only
     "MeshPy",
     "psutil",
     "pyzmq>=22.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # for iohub
     "pywinhook; platform_system == \"Windows\"",
     "zope.event==5.0",  # py2app+gevent complains about zope.event 5.1
-    "gevent",
+    "gevent==2.5.1",  # macos wheels for >2.5.1 are py3.12 only
     "MeshPy",
     "psutil",
     "pyzmq>=22.2.1",


### PR DESCRIPTION
macos wheels for gevent>2.5.1 are py3.12 only