### PR TITLE
RF: Use a dedicated param ctrl for choosing validators

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -1759,3 +1759,21 @@ class DeviceCtrl(ChoiceCtrl):
                     prefs.devices[device.name] = device
                     prefs.devices.save()
                     self.populate()
+
+
+class ValidatorCtrl(ChoiceCtrl):
+    inputType = "validator"
+    
+    def populate(self):
+        # if we don't have an element, leave unpopulated (we should always have an element for validator ctrls)
+        if self.element is None:
+            return
+        # get choices and labels from element's validator methods
+        self.choices = self.element.getAllValidatorRoutines(attr="vals")
+        self.labels = self.element.getAllValidatorRoutines(attr="labels")
+        # apply to ctrl
+        self.ctrl.SetItems(self.labels)
+        # disable if param is readonly
+        self.ctrl.Enable(not self.param.readOnly)
+        # apply (or re-apply) selection
+        self.setValue(self.param.val)

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1593,9 +1593,8 @@ class BaseVisualComponent(BaseComponent):
 
         # --- Testing ---
         self.params['validator'] = Param(
-            validator, valType="code", inputType="choice", categ="Testing",
-            allowedVals=self.getAllValidatorRoutineVals,
-            allowedLabels=self.getAllValidatorRoutineLabels,
+            validator, valType="code", inputType="validator", categ="Testing",
+            allowedVals=self.validatorClasses,
             label=_translate("Validate with..."),
             hint=_translate(
                 "Name of validator Component/Routine to use to check the timing of this stimulus."

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -127,9 +127,8 @@ class SoundComponent(BaseDeviceComponent):
 
         # --- Testing ---
         self.params['validator'] = Param(
-            validator, valType="code", inputType="choice", categ="Testing",
-            allowedVals=self.getAllValidatorRoutineVals,
-            allowedLabels=self.getAllValidatorRoutineLabels,
+            validator, valType="code", inputType="validator", categ="Testing",
+            allowedVals=self.validatorClasses,
             label=_translate("Validate with..."),
             hint=_translate(
                 "Name of validator Component/Routine to use to check the timing of this stimulus."

--- a/psychopy/experiment/devices.py
+++ b/psychopy/experiment/devices.py
@@ -63,7 +63,7 @@ class DeviceBackend:
     # icon to use for this backend (relative to current file path, leave as None for no icon)
     icon = None
     # class of the device which this backend corresponds to
-    deviceClass = "psychopy.hardware.base.BaseDevice"
+    deviceClass = None
 
     plugin = None
       
@@ -100,6 +100,8 @@ class DeviceBackend:
         profile = {
             '__class__': f"{cls.__module__}:{cls.__qualname__}",
             '__name__': cls.__name__,
+            'label': cls.backendLabel,
+            'device': cls.deviceClass,
             'plugin': cls.plugin,
             'profile': {},
             'params': {}
@@ -120,6 +122,12 @@ class DeviceBackend:
             )
 
         return profile
+    
+    @classmethod
+    def getAvailableDevices(cls):
+        from psychopy.hardware import DeviceManager
+
+        return DeviceManager.getAvailableDevices(cls.deviceClass)
     
     def getParams(self):
         """
@@ -270,7 +278,10 @@ class DeviceBackend:
                 allBackends.append(cls)
 
         return allBackends
-        
+    
+    @staticmethod
+    def getBackendProfiles():
+        return [cls.getTemplateJSON() for cls in DeviceBackend.getAllBackends()]
     
     def writeBaseDeviceCode(self, buff, close=False):
         """


### PR DESCRIPTION
This is for compatibility with Svelte - currently, validators are listed by calling `self.getAllValidatorRoutines`, but when interacting via a websocket there isn't necessarily the context of `self` so the method fails.

Now, instead of needing the class context, the param supplies the relevant validator classes in `allowedVals` (which is the part of `self` that's needed to list relevant validators) so that the front end has the necessary data to handle it.