### PR TITLE
BF: Fix packaging issue with metapensiero

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -71,6 +71,7 @@ jobs:
         pip install wheel
         pip install six  # for configobj and wxpython
         pip install attrdict3  # used by wxpython setup
+        pip install git+https://gitlab.com/peircej/metapensiero.pj  # git install of metapensiero for translation
         python ./building/plat_custom_installs.py
 
         pip install pdm

--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -12,7 +12,7 @@ import re
 try:
     from metapensiero.pj.api import translates
 except ImportError:
-    pass  # metapensiero not installed
+    translates = None # metapensiero not installed
 
 import astunparse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
     "gitpython",
     "cryptography",  # for sshkeys
     # psychoJS conversions
-    "javascripthon @ git+https://gitlab.com/peircej/metapensiero.pj",  # until fixes dukpy depend
     "astunparse",
     "esprima",
     "jedi >= 0.16",


### PR DESCRIPTION
Fixes #7393

Installs metapensiero to the plugins folder from within the app, rather than listing it as a dependency - as PyPi wasn't allowing us to publish with a `git+` dependency