### PR TITLE
BF: Fix confusing message on Sound when given a variable

### DIFF
--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -79,7 +79,7 @@ class SoundComponent(BaseDeviceComponent):
         hnt = _translate("A sound can be a note name (e.g. A or Bf), a number"
                          " to specify Hz (e.g. 440) or a filename")
         self.params['sound'] = Param(
-            sound, valType='str', inputType="soundFile", allowedTypes=[], updates='constant', categ='Basic',
+            sound, valType='str', inputType="soundFile", allowedTypes=[], updates='set every repeat', categ='Basic',
             allowedUpdates=['set every repeat'],
             hint=hnt,
             label=_translate("Sound"))


### PR DESCRIPTION
Even though the only allowed values for the "sound" param's updates is "set every repeat", the value for its updates was "constant", so there would be a warning about using a variable name that didn't apply.