### PR TITLE
BF: Don't use `BeginBusyCursor` or `EndBusyCursor` on GTK/Linux

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -611,7 +611,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
                 ).format(thisFile, err))
 
         # if we started a busy cursor which never finished, finish it now
-        if wx.IsBusy():
+        if wx.IsBusy() and wx.Platform != '__WXGTK__':
             wx.EndBusyCursor()
 
         # send anonymous info to https://usage.psychopy.org
@@ -831,12 +831,14 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
                 version=self.version,
                 beta="beta" if self.beta else ""
             )
-            wx.BeginBusyCursor()
+            if wx.Platform != '__WXGTK__':
+                wx.BeginBusyCursor()
             self.coder = coder.CoderFrame(None, -1,
                                           title=title,
                                           files=fileList, app=self)
             self.updateWindowMenu()
-            wx.EndBusyCursor()
+            if wx.Platform != '__WXGTK__':
+                wx.EndBusyCursor()
         else:
             # set output window and standard streams
             self.coder.setOutputWindow(True)
@@ -853,7 +855,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
 
     def newBuilderFrame(self, event=None, fileName=None):
         # have to reimport because it is only local to __init__ so far
-        wx.BeginBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.BeginBusyCursor()
         from .builder.builder import BuilderFrame
         title = "PsychoPy Builder (v{version}{beta})".format(
             version=self.version,
@@ -866,7 +869,8 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
         self.builder.Raise()
         self.SetTopWindow(self.builder)
         self.updateWindowMenu()
-        wx.EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.EndBusyCursor()
 
         return self.builder
 
@@ -925,13 +929,15 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
             version=self.version,
             beta="beta" if self.beta else ""
         )
-        wx.BeginBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.BeginBusyCursor()
         self.runner = RunnerFrame(parent=None,
                                   id=-1,
                                   title=title,
                                   app=self)
         self.updateWindowMenu()
-        wx.EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.EndBusyCursor()
         return self.runner
 
     def OnDrop(self, x, y, files):

--- a/psychopy/app/coder/repl.py
+++ b/psychopy/app/coder/repl.py
@@ -349,7 +349,9 @@ class PythonREPLCtrl(wx.Panel, handlers.ThemeMixin):
             "Starting Python interpreter session, please wait ...\n")
 
         # setup the sub-process
-        wx.BeginBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.BeginBusyCursor()
+
         self._process = wx.Process(self)
         self._process.Redirect()
 
@@ -373,7 +375,8 @@ class PythonREPLCtrl(wx.Panel, handlers.ThemeMixin):
         self._lastTextPos = self.txtTerm.GetLastPosition()
         self.toolbar.update()
 
-        wx.EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.EndBusyCursor()
 
     def interrupt(self, evt=None):
         """Send a keyboard interrupt signal to the interpreter.

--- a/psychopy/app/runner/scriptProcess.py
+++ b/psychopy/app/runner/scriptProcess.py
@@ -16,6 +16,8 @@ __all__ = ['ScriptProcess']
 
 import os.path
 import sys
+
+import wx
 import psychopy.app.jobs as jobs
 from wx import BeginBusyCursor, EndBusyCursor, MessageDialog, ICON_ERROR, OK
 from psychopy.app.console import StdStreamDispatcher
@@ -156,7 +158,8 @@ class ScriptProcess:
             terminateCallback=self._onTerminateCallback
         )
 
-        BeginBusyCursor()  # visual feedback
+        if wx.Platform != '__WXGTK__':
+            BeginBusyCursor()  # visual feedback
 
         # start the subprocess
         workingDir, _ = os.path.split(fullPath)
@@ -186,7 +189,8 @@ class ScriptProcess:
                 event.Skip()
 
             self.scriptProcess = None  # reset
-            EndBusyCursor()
+            if wx.Platform != '__WXGTK__':
+                EndBusyCursor()
             return False
 
         self.focusOnExit = focusOnExit
@@ -351,7 +355,8 @@ class ScriptProcess:
                     self.app.runner.panel.ribbon.buttons['pypilot'].Enable()
                     self.app.runner.panel.ribbon.buttons['pystop'].Disable()
 
-        EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            EndBusyCursor()
 
 
 if __name__ == "__main__":

--- a/psychopy/app/stdout/stdOutRich.py
+++ b/psychopy/app/stdout/stdOutRich.py
@@ -107,7 +107,11 @@ class StdOutRich(wx.richtext.RichTextCtrl, _BaseErrorHandler, handlers.ThemeMixi
         }
 
     def onURL(self, evt=None):
-        wx.BeginBusyCursor()
+        """Open link in default browser."""
+
+        if wx.Platform != '__WXGTK__':
+            wx.BeginBusyCursor()
+
         try:
             if evt.String.startswith("http"):
                 webbrowser.open(evt.String)
@@ -121,7 +125,8 @@ class StdOutRich(wx.richtext.RichTextCtrl, _BaseErrorHandler, handlers.ThemeMixi
         except Exception as e:
             print("##### Could not open URL: {} #####\n".format(evt.String))
             print(e)
-        wx.EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.EndBusyCursor()
 
     def write(self, inStr, evt=None):
         self.MoveEnd()  # always 'append' text rather than 'writing' it
@@ -357,7 +362,8 @@ class ScriptOutputCtrl(StdOutRich, handlers.ThemeMixin):
 
     def onURL(self, evt):
         """Open link in default browser."""
-        wx.BeginBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.BeginBusyCursor()
         try:
             if evt.String.startswith("http"):
                 webbrowser.open(evt.String)
@@ -375,7 +381,8 @@ class ScriptOutputCtrl(StdOutRich, handlers.ThemeMixin):
         except Exception as e:
             print("##### Could not open URL: {} #####\n".format(evt.String))
             print(e)
-        wx.EndBusyCursor()
+        if wx.Platform != '__WXGTK__':
+            wx.EndBusyCursor()
 
     def clear(self, evt=None):
         self.Clear()


### PR DESCRIPTION
Fixes #7420 by making `BeginBusyCursor` or `EndBusyCursor` conditional to not be called on GTK/Linux installs