### PR TITLE
BF: Fixed loading ioHub settings from XML by device class name

### DIFF
--- a/psychopy/iohub/devices/deviceConfigValidation.py
+++ b/psychopy/iohub/devices/deviceConfigValidation.py
@@ -490,7 +490,8 @@ def validateDeviceConfiguration(
     """Validate the device configuration settings provided.
     """
     validation_module = importDeviceModule(relative_module_path)
-    validation_file_path = getSupportedConfigSettings(validation_module)
+    validation_file_path = getSupportedConfigSettings(
+        validation_module, deviceClassName=device_class_name)
 
     # use a default config if we can't get the YAML file
     if not os.path.exists(validation_file_path):

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -168,14 +168,13 @@ def getSupportedConfigSettings(moduleName, deviceClassName=None):
         fileName = 'supported_config_settings_{0}.yaml'.format(
             deviceClassName.lower())
         yamlFile = yamlRoot / pathlib.Path(moduleName.__file__).parent / fileName
-        if not yamlFile.exists():
-            raise FileNotFoundError(
-                "No config file found in module dir for: {0}".format(
-                    moduleName))
-        logging.debug(
-            "Found ioHub device configuration file: {0}".format(yamlFile))
-
-        return str(yamlFile)
+        if yamlFile.exists():
+            logging.debug(
+                "Found ioHub device configuration file: {0}".format(yamlFile))
+            return str(yamlFile)
+        logging.debug(("No configuration matching device class name '{0}' found in "
+                       "module dir {1}. Using default config file instead.").format(
+            deviceClassName, yamlRoot))
 
     # file name for yaml file name convention for single file
     yamlFile = yamlRoot / pathlib.Path('supported_config_settings.yaml')


### PR DESCRIPTION
Fixes #7299 by now using the device class name to determine the XML file path to lookup valid settings for the device.