### PR TITLE
Correctly get the number of joystick devices

### DIFF
--- a/psychopy/experiment/components/joyButtons/__init__.py
+++ b/psychopy/experiment/components/joyButtons/__init__.py
@@ -132,7 +132,7 @@ class JoyButtonsComponent(BaseComponent):
         buff.writeIndentedLines(code % self.params)
 
         buff.setIndentLevel(+1, relative=True)
-        code = ("numJoysticks = joysticklib.getNumJoysticks()\n"
+        code = ("numJoysticks = len(joysticklib.Joystick.getAvailableDevices())\n"
                 "if numJoysticks > 0:\n")
         buff.writeIndentedLines(code % self.params)
 

--- a/psychopy/experiment/components/joystick/__init__.py
+++ b/psychopy/experiment/components/joystick/__init__.py
@@ -165,7 +165,7 @@ class JoystickComponent(BaseComponent):
         buff.writeIndentedLines(code % self.params)
 
         buff.setIndentLevel(+1, relative=True)
-        code = ("numJoysticks = joysticklib.getNumJoysticks()\n"
+        code = ("numJoysticks = len(joysticklib.Joystick.getAvailableDevices())\n"
                 "if numJoysticks > 0:\n")
         buff.writeIndentedLines(code % self.params)
 


### PR DESCRIPTION
The method `getNumJoysticks()` of the class `hardware.joystick` has been removed from file `psychopy/hardware/joystick/__init__.py` in commit edca46d4b15a91091339296734950f416e7e0124. However, the code in the file `experiment/components/joystick/__init__.py` (injection in the `_lastrun.py` file) has not been updated accordingly. This causes any experiment that includes the joystick component to fail, displaying the error message `No joystick/gamepad device found`. The commit in this PR seems to fix the problem.

It also resolves a similar issue in the `experiment.components.joyButtons` class.