### PR TITLE
BF: Dollar label wasn't showing for some params

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -283,7 +283,7 @@ class SingleLineCtrl(BaseParamCtrl):
         )
         # show/hide dollar according to valType
         self.dollarLbl.Show(
-            self.param.valType in ("code", "extendedCode")
+            self.param.valType in ("code", "extendedCode", "num", "list", "int", "fixedList")
         )
         # add value ctrl
         self.ctrl = wx.TextCtrl(


### PR DESCRIPTION
Because there's a lot more valTypes (which I'm not 100% sure we need) than code and extendedCode, the dollar label in Builder wasn't showing for some of them.