### PR TITLE
PKG: can drop the version pin for h5py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ suggested = [
     "sounddevice",
     "pylsl>=1.16.1", # lab streaming layer for general connectivity
     "xlwt",  # writing excel files with pandas
-    "h5py<3.15.0",  # to read hdf5 files for analysis
+    "h5py",  # to read hdf5 files for analysis
     "tobii_research",
     "badapted>=0.0.3",
     "egi-pynetstation>=1.0.0",


### PR DESCRIPTION
h5py 3.15.0 wheels on macos were only released for macos 14+ whereas in h5py before 3.15 and from 3.15.1 onwards they correctly support macos 11+

This only affects the building/installing of the app (which on macos<14 will then try to build from source on that version of h5py)