### PR TITLE
BF: Save unfinished mic recordings if the experiment is ended by e.g. pressing escape

### DIFF
--- a/psychopy/sound/microphone.py
+++ b/psychopy/sound/microphone.py
@@ -219,6 +219,8 @@ class Microphone:
         clear : bool
             If True, clips will be removed from this object once saved to files.
         """
+        # bank just in case there's any unfinished clips
+        self.bank(tag="unfinished", transcribe=False)
         # iterate through all clips
         for tag in self.clips:
             logging.info(f"Saving {len(self.clips[tag])} audio clips with tag {tag}")


### PR DESCRIPTION
We're already called `saveClips`, but `saveClips` doesn't call `bank` so only finished recordings (i.e. the Component had finished its recording and called `bank`) were saved.

If there's no unfinished clips, then `bank` does nothing, so we can afford to call this on every call to `saveClips` and it seems the best bet to catch the most use cases.