### PR TITLE
BF: Use expanding lists to avoid index errors with buttonboxes and sensors

### DIFF
--- a/psychopy/hardware/button.py
+++ b/psychopy/hardware/button.py
@@ -1,6 +1,7 @@
 from psychopy import logging, constants, core
 from psychopy.hardware import base, DeviceManager, keyboard
 from psychopy.localization import _translate
+from psychopy.tools.arraytools import ExpandingList
 
 
 class ButtonResponse(base.BaseResponse):
@@ -48,7 +49,7 @@ class BaseButtonGroup(base.BaseResponseDevice):
         # store number of channels
         self.channels = channels
         # attribute in which to store current state
-        self.state = [None] * channels
+        self.state = ExpandingList([None] * channels)
 
         # start off with a status
         self.status = constants.NOT_STARTED

--- a/psychopy/hardware/lightsensor.py
+++ b/psychopy/hardware/lightsensor.py
@@ -3,6 +3,7 @@ from psychopy.hardware import base, DeviceManager
 from psychopy.localization import _translate
 from psychopy.hardware import keyboard
 # for legacy compatability, import VisualValidator and VisualValidationError here
+from psychopy.tools.arraytools import ExpandingList
 from psychopy.validation.visual import VisualValidator, VisualValidationError
 
 
@@ -26,9 +27,9 @@ class BaseLightSensorGroup(base.BaseResponseDevice):
         # store number of channels
         self.channels = channels
         # attribute in which to store current state
-        self.state = [False] * channels
+        self.state = ExpandingList([False] * channels)
         # set initial threshold
-        self.threshold = [None] * channels
+        self.threshold = ExpandingList([None] * channels)
         if threshold is None:
             threshold = 0.5
         self.setThreshold(threshold, channel=list(range(channels)))

--- a/psychopy/hardware/soundsensor.py
+++ b/psychopy/hardware/soundsensor.py
@@ -3,6 +3,7 @@ from psychopy import constants, core, sound, logging
 from psychopy.hardware import base, DeviceManager
 from psychopy.localization import _translate
 from psychopy.hardware import keyboard
+from psychopy.tools.arraytools import ExpandingList
 
 
 class SoundSensorResponse(base.BaseResponse):
@@ -24,9 +25,9 @@ class BaseSoundSensorGroup(base.BaseResponseDevice):
         # store number of channels
         self.channels = channels
         # attribute in which to store current state
-        self.state = [False] * channels
+        self.state = ExpandingList([False] * channels)
         # set initial threshold
-        self.threshold = [None] * channels
+        self.threshold = ExpandingList([None] * channels)
         self.setThreshold(threshold, channel=list(range(channels)))
     
     def findThreshold(self, speaker, channel=None, samplingWindow=0.5):

--- a/psychopy/tests/test_tools/test_arraytools.py
+++ b/psychopy/tests/test_tools/test_arraytools.py
@@ -130,6 +130,36 @@ def test_AliasDict():
     assert "1" not in params.aliases
 
 
+def test_expandingList():
+    cases = [
+        # getting index out of range should return None
+        {'array': [1, 2, 3], 'get': {'index': 4, 'ans': None}},
+        # valid indices should return the same as normal
+        {'array': [1, 2, 3], 'get': {'index': 1, 'ans': 2}},
+        {'array': [1, 2, 3], 'get': {'index': -1, 'ans': 3}},
+        # setting index out of range should fill with None
+        {'array': [1, 2, 3], 'set': {'index': 5, 'value': 4, 'ans': [1, 2, 3, None, None, 4]}},
+        # valid indices should set the same as normal
+        {'array': [1, 2, 3], 'set': {'index': 1, 'value': 4, 'ans': [1, 4, 3]}},
+        {'array': [1, 2, 3], 'set': {'index': -1, 'value': 4, 'ans': [1, 2, 4]}},
+    ]
+    # try each case
+    for case in cases:
+        # make array for this case
+        arr = at.ExpandingList(case['array'])
+        # test getting...
+        if "get" in case:
+            assert arr[case['get']['index']] == case['get']['ans'], (
+                f"Expected value at index {case['get']['index']} of expanding list {arr} to be {case['get']['ans']}, but got {arr[case['get']['index']]}"
+            )
+        # test setting
+        if "set" in case:
+            arr[case['set']['index']] = case['set']['value']
+            assert all([x == y for x, y in zip(arr, case['set']['ans'])]), (
+                f"Expected expanding list {case['array']} to be {case['set']['ans']} after setting index {case['set']['index']} to {case['set']['value']}, but got {arr}"
+            )
+
+
 class TestIndexDict:
     def setup_method(self):
         self.recreateData()

--- a/psychopy/tools/arraytools.py
+++ b/psychopy/tools/arraytools.py
@@ -504,6 +504,43 @@ def createLumPattern(patternType, res, texParams=None, maskParams=None):
     return intensity
 
 
+class ExpandingList(list):
+    """
+    Almost identical to a regular list, but if a value is set out of range, the list expands (and 
+    fills with None) to accommodate. Also returns None when an out of range value is requested.
+    """
+    def __setitem__(self, key, value):
+        try:
+            # try to set as normal
+            return list.__setitem__(self, key, value)
+        except IndexError as err:
+            # if index isn't an integer, something else has gone on
+            if not isinstance(key, int):
+                raise err
+            # if index is an out of range negative, behave as normal
+            if key < 0:
+                raise err
+            # if index out of range, expand list to fit...
+            for _ in range(key + 1 - len(self)):
+                self.append(None)
+            # ..then try again
+            return list.__setitem__(self, key, value)
+    
+    def __getitem__(self, key):
+        try:
+            # try to get as normal
+            return list.__getitem__(self, key)
+        except IndexError as err:
+            # if index isn't an integer, something else has gone on
+            if not isinstance(key, int):
+                raise err
+            # if index is an out of range negative, behave as normal
+            if key < 0:
+                raise err
+            # if it's just out of range, return None
+            return None
+
+
 class AliasDict(dict):
     """
     Similar to a dict, but with the option to alias certain keys such that they always have the same value.


### PR DESCRIPTION
Currently we're relying on the user supplying the correct number of channels for a device (number of buttons for button box, number of sensors for light/sound sensor). If we receive a message from the device with an index higher than the number of channels, we get an index error.

This PR means that the lists storing states for these channels can expand as needed, and blank space will be filled with None.