### PR TITLE
BF: Stop all playback Components (Sound, Movie, etc.) when experiment ends

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -2177,6 +2177,10 @@ class SettingsComponent:
         buff.setIndentLevel(+1, relative=True)
         # Write code to end experiment
         code = (
+            "# stop any playback components\n"
+            "if thisExp.currentRoutine is not None:\n"
+            "    for comp in thisExp.currentRoutine.getPlaybackComponents():\n"
+            "        comp.stop()\n"
             "if win is not None:\n"
             "    # remove autodraw from all current components\n"
             "    win.clearAutoDraw()\n"


### PR DESCRIPTION
We hadn't noticed as, usually, the Python process ends when an experiment does, but using Session means this becomes an issue