### PR TITLE
BF: Fixed `Mouse.getPos()` returning `float64` typed objects instead of `float`

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -678,10 +678,7 @@ class Mouse:
 
         self.lastPos = self._pix2windowUnits(lastPosPix)
 
-        if self.lastPos is None:
-            return None
-
-        return [float(self.lastPos[0]), float(self.lastPos[1])]
+        return self.lastPos
 
     def mouseMoved(self, distance=None, reset=False):
         """Determine whether/how far the mouse has moved.

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -678,7 +678,7 @@ class Mouse:
 
         self.lastPos = self._pix2windowUnits(lastPosPix)
 
-        return copy.copy(self.lastPos)
+        return [float(self.lastPos[0]), float(self.lastPos[1])]
 
     def mouseMoved(self, distance=None, reset=False):
         """Determine whether/how far the mouse has moved.

--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -678,6 +678,9 @@ class Mouse:
 
         self.lastPos = self._pix2windowUnits(lastPosPix)
 
+        if self.lastPos is None:
+            return None
+
         return [float(self.lastPos[0]), float(self.lastPos[1])]
 
     def mouseMoved(self, distance=None, reset=False):

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -420,8 +420,8 @@ class MouseComponent(BaseComponent):
 
         elif self.params['saveMouseState'].val != 'never':
             mouseCode = ("x, y = {name}.getPos()\n"
-                    "{name}.x.append(x)\n"
-                    "{name}.y.append(y)\n"
+                    "{name}.x.append(float(x))\n"
+                    "{name}.y.append(float(y))\n"
                     "buttons = {name}.getPressed()\n"
                     "{name}.leftButton.append(buttons[0])\n"
                     "{name}.midButton.append(buttons[1])\n"

--- a/psychopy/tests/test_experiment/test_components/test_MouseComponent.py
+++ b/psychopy/tests/test_experiment/test_components/test_MouseComponent.py
@@ -28,24 +28,24 @@ class TestMouseComponent(BaseComponentTests):
         saveMouseStateCases = [
             {'val': "final",
              'want': [f"thisExp.addData('{comp.name}.x', x)"],  # should contain code for adding final value of x
-             'avoid': [f"{comp.name}.x.append(x)"]},  # should not contain code to update testMouse.x in frame loop
+             'avoid': [f"{comp.name}.x.append(float(x))"]},  # should not contain code to update testMouse.x in frame loop
             {'val': "on click",
              'want': [f"thisExp.addData('{comp.name}.x', {comp.name}.x)",  # should add testMouse.x at the end
-                      f"{comp.name}.x.append(x)"],  # should contain code to update testMouse.x in frame loop
+                      f"{comp.name}.x.append(float(x))"],  # should contain code to update testMouse.x in frame loop
              'avoid': [f"thisExp.addData('{comp.name}.x', x)"]},  # should not add final value of x
             {'val': "on valid click",
              'want': [f"thisExp.addData('{comp.name}.x', {comp.name}.x)",  # should add testMouse.x at the end
-                      f"{comp.name}.x.append(x)",  # should contain code to update testMouse.x in frame loop
+                      f"{comp.name}.x.append(float(x))",  # should contain code to update testMouse.x in frame loop
                       "if gotValidClick:"],  # should check for valid clicks
              'avoid': [f"thisExp.addData('{comp.name}.x', x)"]},  # should not add final value of x
             {'val': "every frame",
              'want': [f"thisExp.addData('{comp.name}.x', {comp.name}.x)",  # should add testMouse.x at the end
-                      f"{comp.name}.x.append(x)"],  # should contain code to update testMouse.x in frame loop
+                      f"{comp.name}.x.append(float(x))"],  # should contain code to update testMouse.x in frame loop
              'avoid': [f"thisExp.addData('{comp.name}.x', x)"]},  # should not add final value of x
             {'val': "never",
              'want': [],
              'avoid': [f"thisExp.addData('{comp.name}.x', {comp.name}.x)",  # should not add testMouse.x at the end
-                       f"{comp.name}.x.append(x)",  # should not contain code to update testMouse.x in frame loop
+                       f"{comp.name}.x.append(float(x))",  # should not contain code to update testMouse.x in frame loop
                        f"thisExp.addData('{comp.name}.x', x)"]},  # should not add final value of x]},
         ]
         forceEndRoutineOnPressCases = [


### PR DESCRIPTION
Mouse coordinates are now once again returned as builtin Python `float` types instead of NumPy `float64` objects. This mainly affected how values were written to the data file, appearing as `np.float64(<value>)` instead of just the value.