### PR TITLE
TEST: Remove tests of deprecated color setters

### DIFF
--- a/psychopy/tests/test_visual/test_basevisual.py
+++ b/psychopy/tests/test_visual/test_basevisual.py
@@ -292,25 +292,25 @@ class _TestColorMixin:
 
                 # Test old color space setters
                 # foreColorSpace
-                self.obj.foreColorSpace = space
-                assert self.obj.colorSpace == space
-                self.obj.foreColorSpace = 'named'
-                # fillColorSpace
-                self.obj.fillColorSpace = space
-                assert self.obj.colorSpace == space
-                self.obj.fillColorSpace = 'named'
-                # backColorSpace
-                self.obj.backColorSpace = space
-                assert self.obj.colorSpace == space
-                self.obj.backColorSpace = 'named'
-                # borderColorSpace
-                self.obj.borderColorSpace = space
-                assert self.obj.colorSpace == space
-                self.obj.borderColorSpace = 'named'
-                # lineColorSpace
-                self.obj.lineColorSpace = space
-                assert self.obj.colorSpace == space
-                self.obj.lineColorSpace = 'named'
+                # self.obj.foreColorSpace = space
+                # assert self.obj.colorSpace == space
+                # self.obj.foreColorSpace = 'named'
+                # # fillColorSpace
+                # self.obj.fillColorSpace = space
+                # assert self.obj.colorSpace == space
+                # self.obj.fillColorSpace = 'named'
+                # # backColorSpace
+                # self.obj.backColorSpace = space
+                # assert self.obj.colorSpace == space
+                # self.obj.backColorSpace = 'named'
+                # # borderColorSpace
+                # self.obj.borderColorSpace = space
+                # assert self.obj.colorSpace == space
+                # self.obj.borderColorSpace = 'named'
+                # # lineColorSpace
+                # self.obj.lineColorSpace = space
+                # assert self.obj.colorSpace == space
+                # self.obj.lineColorSpace = 'named'
 
 
 class _TestUnitsMixin:


### PR DESCRIPTION
Removes tests for deprecated color and colorspace setters in `test_basevisual.py` which clog up logging in the test suite. An alternative fix would be to show the warning once per session if we wish to keep the tests