### PR TITLE
BF: clamp StairHandler intensity when step size is negative

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -413,9 +413,7 @@ class StairHandler(_BaseTrialHandler):
             self._nextIntensity *= 10.0**self.stepSizeCurrent
         elif self.stepType == 'lin':
             self._nextIntensity += self.stepSizeCurrent
-        # check we haven't gone out of the legal range
-        if (self.maxVal is not None) and (self._nextIntensity > self.maxVal):
-            self._nextIntensity = self.maxVal
+        self._clampIntensity()
         self.correctCounter = 0
 
     def _intensityDec(self):
@@ -427,10 +425,15 @@ class StairHandler(_BaseTrialHandler):
             self._nextIntensity /= 10.0**self.stepSizeCurrent
         elif self.stepType == 'lin':
             self._nextIntensity -= self.stepSizeCurrent
+        self._clampIntensity()
         self.correctCounter = 0
-        # check we haven't gone out of the legal range
+
+    def _clampIntensity(self):
+        """Clamp the next intensity to min/max bounds regardless of step direction."""
         if (self.minVal is not None) and (self._nextIntensity < self.minVal):
             self._nextIntensity = self.minVal
+        if (self.maxVal is not None) and (self._nextIntensity > self.maxVal):
+            self._nextIntensity = self.maxVal
 
     def saveAsText(self, fileName,
                    delim=None,

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -424,6 +424,26 @@ class TestStairHandler(_BaseTestStairHandler):
         s_loaded = fromFile(path)
         assert s == s_loaded
 
+    def test_negative_step_clamped_to_min(self):
+        """Regression: negative stepSizes must still respect minVal."""
+        stairs = data.StairHandler(
+            startVal=0,
+            minVal=0,
+            maxVal=10,
+            stepType="lin",
+            stepSizes=-1,
+            nTrials=5,
+        )
+
+        seen = []
+        for trial_val in stairs:
+            seen.append(trial_val)
+            stairs.addResponse(0)  # force “increase” path, which subtracts here
+            if len(seen) >= 5:
+                break
+
+        assert all(val >= 0 for val in seen)
+
 
 class TestQuestHandler(_BaseTestStairHandler):
     """


### PR DESCRIPTION
Fixes #7188

## Summary
- enforce `StairHandler` min/max clamping regardless of step direction, covering negative step sizes
- add regression test to ensure negative `stepSizes` with `minVal` do not drop below bounds

## Testing
- python -m pytest psychopy/tests/test_data/test_StairHandlers.py::TestStairHandler::test_negative_step_clamped_to_min