### PR TITLE
BF: Don't use SetFont on Linux

### DIFF
--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -397,13 +397,22 @@ class SingleLineCtrl(BaseParamCtrl):
         self.ctrl.Refresh()
     
     def styleCode(self):
-        # text becomes monospace if code
+        def _setFont(font):
+            # text becomes monospace if code
+            if sys.platform == "linux":
+                # have to go via SetStyle on Linux
+                style = wx.TextAttr(self.ctrl.GetForegroundColour(), font=font)
+                self.ctrl.SetStyle(0, len(self.GetValue()), style)
+            else:
+                # otherwise SetFont is fine
+                self.ctrl.SetFont(font)
+
         if self.isCode:
-            self.ctrl.SetFont(
+            _setFont(
                 fonts.CodeFont(bold=True).obj
             )
         else:
-            self.ctrl.SetFont(
+            _setFont(
                 fonts.AppFont().obj
             )
         self.ctrl.Refresh()

--- a/psychopy/app/builder/dialogs/paramCtrls.py
+++ b/psychopy/app/builder/dialogs/paramCtrls.py
@@ -402,7 +402,7 @@ class SingleLineCtrl(BaseParamCtrl):
             if sys.platform == "linux":
                 # have to go via SetStyle on Linux
                 style = wx.TextAttr(self.ctrl.GetForegroundColour(), font=font)
-                self.ctrl.SetStyle(0, len(self.GetValue()), style)
+                self.ctrl.SetStyle(0, len(self.ctrl.GetValue()), style)
             else:
                 # otherwise SetFont is fine
                 self.ctrl.SetFont(font)

--- a/psychopy/tests/test_app/conftest.py
+++ b/psychopy/tests/test_app/conftest.py
@@ -21,7 +21,6 @@ if Version(pytest.__version__) < Version('5'):
 
 
 # this method seems to work on at least Pytest 5.4+
-@pytest.mark.needs_wx
 @pytest.fixture(scope='session')
 def get_app(request):
 


### PR DESCRIPTION
I'd already fixed this way back in #5729 but when I reworked the param ctrls to make them work with DeviceManager I added calls to SetFont again without realising.