### PR TITLE
Fix SyntaxError due to docstring

### DIFF
--- a/psychopy/tools/stringtools.py
+++ b/psychopy/tools/stringtools.py
@@ -251,7 +251,7 @@ class CaseSwitcher:
 
 
 def wrap(value, chars, delim=r"\s|-"):
-    """
+    r"""
     Wrap a string at a number of characters.
 
     Parameters


### PR DESCRIPTION
Syntax error here:

```
.venv/lib/python3.10/site-packages/psychopy/data/__init__.py:14: in <module>
    from .counterbalance import Counterbalancer
.venv/lib/python3.10/site-packages/psychopy/data/counterbalance.py:2: in <module>
    from psychopy.tools.attributetools import attributeSetter
.venv/lib/python3.10/site-packages/psychopy/tools/attributetools.py:15: in <module>
    from psychopy.tools.stringtools import CaseSwitcher
E     File "/home/runner/work/gemini/gemini/.venv/lib/python3.10/site-packages/psychopy/tools/stringtools.py", line 254
E       """
E       ^^^
E   SyntaxError: invalid escape sequence '\-'
```