### PR TITLE
BF: Better handle when stimulus stop validation fails

### DIFF
--- a/psychopy/alerts/alertsCatalogue/4160.yaml
+++ b/psychopy/alerts/alertsCatalogue/4160.yaml
@@ -1,0 +1,25 @@
+
+code: 4160
+cat: Timing validation
+msg: Cannot validate stop time for `{name}` as it stops on final frame of Routine
+
+# The following are typically used for online help pages, and support reStructured Text.
+label: Cannot validate stop time if stimulus ends on final frame
+
+synopsis: |
+  Timing validation works by asking a light/sound sensor, on the frame *after* a stimulus started/stopped, when it detected a stimulus start/stopping. If a stimulus ends on the final frame of a Routine, then there isn't a frame after so its stop time can't be validated.
+
+details: |
+  The timeline of a validation is as follows:
+
+  * Stimulus is asked to start/stop
+  * Frame loops
+  * Validation device is asked when it detected a stimulus starting/stopping
+
+  If the frame on which a stimulus is asked to stop is the final frame of a Routine, then there is no subsequent frame for the validator to be asked on. This means that your validated stop time will be `None`.
+
+solutions: |
+  This may be fine! You may only be interested in validating the stimulus' start time. If so, you can ignore this alert. If you do want stop time validation however, the Routine will need to be at least 1 frame longer than the validated stimulus.
+
+versions: |
+  All

--- a/psychopy/alerts/alertsCatalogue/alertCategories.yaml
+++ b/psychopy/alerts/alertsCatalogue/alertCategories.yaml
@@ -47,6 +47,9 @@
     4120: Component stop duration with no start time
     4125: Microphone given no stop duration
     4130: Static Component given infinite stop time
+    4150: 
+      cat: Timing validation
+      4160: Validating stop time on final frame
   4200:
     cat: Code component syntax
     4205: Python syntax error

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1228,6 +1228,25 @@ class BaseComponent:
         indent = validator.writeEachFrameValidationCode(buff, stim=self)
         # if validation code indented the buffer, dedent
         buff.setIndentLevel(-indent, relative=True)
+    
+    def writeRoutineEndValidationCode(self, buff):
+        """
+        Write Routine stop code to validate this stimulus against the specified validator.
+
+        Parameters
+        ----------
+        buff : StringIO
+            String buffer to write code to.
+        """
+        # get validator
+        validator = self.getValidator()
+        # if there is no validator, don't write any code
+        if validator is None:
+            return
+        # if there is a validator, write its code
+        indent = validator.writeRoutineEndValidationCode(buff, stim=self)
+        # if validation code indented the buffer, dedent
+        buff.setIndentLevel(-indent, relative=True)
 
     def getFullDocumentation(self, fmt="rst"):
         """

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -1191,6 +1191,22 @@ class BaseComponent:
                 if comp.name == name:
                     return comp
 
+    def endsWithRoutine(self):
+        """
+        Does this Component end along with the Routine (i.e. on the final frame)?
+        """
+        # if there's no Routine, then this doesn't apply
+        if self.getRoutine() is None:
+            return
+        # if it has the same stop time as the Routine, then yes it does
+        if self.getStartAndDuration()[1] == self.getRoutine().getMaxTime()[0]:
+            return True
+        # if the Routine times out before this Component ends, then yes it does
+        if self.getStartAndDuration()[1] >= self.getRoutine().settings.getDuration()[0]:
+            return True
+        # otherwise, assume no
+        return False
+    
     def writeRoutineStartValidationCode(self, buff):
         """
         WWrite Routine start code to validate this stimulus against the specified validator.
@@ -1370,6 +1386,9 @@ class BaseComponent:
     @property
     def name(self):
         return self.params['name'].val
+    
+    def getRoutine(self):
+        return self.exp.routines.get(self.parentName, None)
 
     @name.setter
     def name(self, value):

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -451,6 +451,25 @@ class BaseValidatorRoutine(BaseDeviceRoutine):
         """
         # this method should be overloaded when subclassing!
         return 0
+    
+    def writeEachFrameValidationCode(self, buff, stim):
+        """
+        Write Routine stop code to validate this stimulus against the specified validator.
+
+        Parameters
+        ----------
+        buff : StringIO
+            String buffer to write code to.
+        stim : BaseComponent
+            Stimulus to validate
+
+        Returns
+        -------
+        int
+            Change in indentation level after writing
+        """
+        # this method should be overloaded when subclassing!
+        return 0
 
 
 class Routine(list):
@@ -826,6 +845,7 @@ class Routine(list):
                 '        thisComponent.setAutoDraw(False)\n')
         buff.writeIndentedLines(code % self.params)
         for event in self:
+            event.writeRoutineEndValidationCode(buff)
             event.writeRoutineEndCode(buff)
 
         if useNonSlip:

--- a/psychopy/experiment/routines/audioValidator/__init__.py
+++ b/psychopy/experiment/routines/audioValidator/__init__.py
@@ -167,6 +167,9 @@ class AudioValidatorRoutine(BaseDeviceRoutine):
             )
         buff.writeIndentedLines(code.format(**stim.params) % self.params)
 
+        # if stimulus ends with the Routine, raise an alert
+        if stim.endsWithRoutine():
+            alert(4160, strFields={'name': stim.name})
         # validate stop time
         code = (
             "# validate {name} stop time\n"
@@ -192,6 +195,8 @@ class AudioValidatorRoutine(BaseDeviceRoutine):
             "%(name)s.status = FINISHED\n"
         )
         buff.writeIndentedLines(code % self.params)
+
+        return 0
 
     def findConnectedStimuli(self):
         # list of linked components

--- a/psychopy/experiment/routines/audioValidator/__init__.py
+++ b/psychopy/experiment/routines/audioValidator/__init__.py
@@ -114,6 +114,7 @@ class AudioValidatorRoutine(BaseDeviceRoutine):
             clockStr = "clock=routineTimer"
         # sync component start/stop timers with validator clocks
         code = (
+            f"%(name)s.status = NOT_STARTED\n"
             f"# synchronise device clock for %(name)s with Routine timer\n"
             f"%(name)s.resetTimer({clockStr})\n"
         )
@@ -184,6 +185,13 @@ class AudioValidatorRoutine(BaseDeviceRoutine):
 
         # return change in indent level
         return buff.indentLevel - startIndent
+
+    def writeRoutineEndValidationCode(self, buff, stim):
+        # end validator after Routine is finished
+        code = (
+            "%(name)s.status = FINISHED\n"
+        )
+        buff.writeIndentedLines(code % self.params)
 
     def findConnectedStimuli(self):
         # list of linked components

--- a/psychopy/experiment/routines/visualValidator/__init__.py
+++ b/psychopy/experiment/routines/visualValidator/__init__.py
@@ -237,6 +237,7 @@ class VisualValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
             clockStr = "clock=routineTimer"
         # sync component start/stop timers with validator clocks
         code = (
+            f"%(name)s.status = NOT_STARTED\n"
             f"# synchronise device clock for %(name)s with Routine timer\n"
             f"%(name)s.resetTimer({clockStr})\n"
         )
@@ -313,6 +314,13 @@ class VisualValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
 
         # return change in indent level
         return buff.indentLevel - startIndent
+    
+    def writeRoutineEndValidationCode(self, buff, stim):
+        # end validator after Routine is finished
+        code = (
+            "%(name)s.status = FINISHED\n"
+        )
+        buff.writeIndentedLines(code % self.params)
 
     def findConnectedStimuli(self):
         # list of linked components

--- a/psychopy/experiment/routines/visualValidator/__init__.py
+++ b/psychopy/experiment/routines/visualValidator/__init__.py
@@ -296,6 +296,9 @@ class VisualValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
             )
         buff.writeIndentedLines(code.format(startAttr=startAttr, **stim.params) % self.params)
 
+        # if stimulus ends with the Routine, raise an alert
+        if stim.endsWithRoutine():
+            alert(4160, strFields={'name': stim.name})
         # validate stop time
         code = (
             "# validate {name} stop time\n"
@@ -321,6 +324,8 @@ class VisualValidatorRoutine(BaseValidatorRoutine, PluginDevicesMixin):
             "%(name)s.status = FINISHED\n"
         )
         buff.writeIndentedLines(code % self.params)
+
+        return 0
 
     def findConnectedStimuli(self):
         # list of linked components


### PR DESCRIPTION
When a stimulus ends on the final frame of a Routine, its stop time can't be validated as there's no frame after display has ended on which to query the validation device. This PR handles this more cleanly by:
- Resetting the validator's status so the data file gets `None` rather than a confusing negative value (as validation is attempted on the next repeat)
- Adding an alert explaining the situation when a validated Component has the same end time as its Routine