### PR TITLE
FF: Assume not dark mode if on windows as wx windows doesn't use system dark mode

### DIFF
--- a/psychopy/app/_psychopyApp.py
+++ b/psychopy/app/_psychopyApp.py
@@ -419,7 +419,7 @@ class PsychoPyApp(wx.App, handlers.ThemeMixin):
 
         # get the system theme
         self._systemAppearance = wx.SystemSettings.GetAppearance()
-        self._isDarkMode = self._systemAppearance.IsDark()
+        self._isDarkMode = self._systemAppearance.IsDark() and not sys.platform == "win32"
 
         if showSplash:
             # show splash screen


### PR DESCRIPTION
We added a fix for the inverse problem (#5979) which queried the system darkmode setting and set text to white accordingly, but the problem is that wxPython ignores this system setting on Windows, so if your Windows machine is using dark windows, the text became white on a white background...

Solution is to ignore darkmode setting on Windows, for consistency with wxPython.