### PR TITLE
FF: Remove remote package indexing

### DIFF
--- a/psychopy/app/plugin_manager/packageIndex.py
+++ b/psychopy/app/plugin_manager/packageIndex.py
@@ -69,7 +69,7 @@ def refreshPackageIndex(fetch=False):
             logging.error(f"Error refreshing package index: {error}")
             print(f"Error: {error}")
 
-        logging.info("Package index refreshed successfully.")
+        logging.info("Package index refreshed successfully. You may now open the Plugin Manager.")
     except sp.CalledProcessError as e:
         logging.error(f"Error refreshing package index: {e}")
     except FileNotFoundError:

--- a/psychopy/app/plugin_manager/packageIndex.py
+++ b/psychopy/app/plugin_manager/packageIndex.py
@@ -29,10 +29,21 @@ def refreshPackageIndex(fetch=False):
     _isIndexing = True
     scriptDir = prefs.paths['scripts']
 
+    # ensure we have an `appCache` directory
+    appCacheDir = os.path.join(
+        prefs.paths['userPrefsDir'], 'cache', 'appCache')
+    try:
+        os.makedirs(appCacheDir, exist_ok=True)
+    except OSError as err:
+        if err.errno != os.errno.EEXIST:
+            logging.error(f"Error creating directory {appCacheDir}: {err}")
+            raise
+
     # Construct the command to run the script
     _cmd = [
         sys.executable, 
         os.path.normpath(os.path.join(scriptDir, 'psychopy-pkgutil.py')),
+        '--quiet',
         '--app-pref-dir', prefs.paths['userPrefsDir'],
         'update']
     _cmd += ['--fetch'] if fetch else []
@@ -41,10 +52,10 @@ def refreshPackageIndex(fetch=False):
     try:
         headerText = ' Updating package index '
         headerText = headerText.center(80, '=')
-        print(headerText)
+        # print(headerText)
 
         env = os.environ.copy()
-        print(f"Running command: {' '.join(_cmd)}")
+        # print(f"Running command: {' '.join(_cmd)}")
 
         proc = sp.Popen(_cmd, 
                         stdout=sp.PIPE, 
@@ -119,7 +130,6 @@ def downloadPluginAssets(fetch=False):
     
     headerText = ' Downloading plugin icons '
     headerText = headerText.center(80, '=')
-    print(headerText)
     
     for iconUrl in pluginIconsURLs:
         # get the icon file name from URL
@@ -129,10 +139,10 @@ def downloadPluginAssets(fetch=False):
 
         # check if we already have a copy of the icon
         if os.path.exists(iconPath) and not fetch:
-            print(f"Plugin icon already exists at {iconPath}")
+            # print(f"Plugin icon already exists at {iconPath}")
             continue
 
-        print(f"Downloading plugin icon from {iconUrl} to {iconPath}")
+        # print(f"Downloading plugin icon from {iconUrl} to {iconPath}")
 
         import requests
 
@@ -147,7 +157,7 @@ def downloadPluginAssets(fetch=False):
                     file.write(chunk)
                     wx.YieldIfNeeded()
 
-            print(f"Plugin icon downloaded successfully to {iconPath}")
+            # print(f"Plugin icon downloaded successfully to {iconPath}")
         except requests.exceptions.RequestException as e:
             logging.error(f"Error downloading plugin icon: {e}")
         except IOError as e:

--- a/psychopy/app/plugin_manager/packages.py
+++ b/psychopy/app/plugin_manager/packages.py
@@ -187,14 +187,14 @@ class PackageListCtrl(wx.Panel):
 
         self.rootUserPackages = self.ctrl.AppendItem(self.ctrl.GetRootItem(), _translate("User Packages"))
         self.rootSystemPackages = self.ctrl.AppendItem(self.ctrl.GetRootItem(), _translate("System Packages"))  
-        self.rootRemotePackages = self.ctrl.AppendItem(self.ctrl.GetRootItem(), _translate("Available Packages"))
+        # self.rootRemotePackages = self.ctrl.AppendItem(self.ctrl.GetRootItem(), _translate("Available Packages"))
 
         self.ctrl.SetItemText(self.rootUserPackages, _translate("User Packages"))
         self.ctrl.SetItemText(self.rootSystemPackages, _translate("System Packages"))
-        self.ctrl.SetItemText(self.rootRemotePackages, _translate("Available Packages"))
+        # self.ctrl.SetItemText(self.rootRemotePackages, _translate("Available Packages"))
         self.ctrl.SetItemData(self.rootUserPackages, PACKAGE_STATUS_INVALID)
         self.ctrl.SetItemData(self.rootSystemPackages, PACKAGE_STATUS_INVALID)
-        self.ctrl.SetItemData(self.rootRemotePackages, PACKAGE_STATUS_INVALID)
+        # self.ctrl.SetItemData(self.rootRemotePackages, PACKAGE_STATUS_INVALID)
         self.ctrl.SetColumnWidth(0, 200)
         self.ctrl.SetColumnWidth(1, 100)
 
@@ -336,7 +336,7 @@ class PackageListCtrl(wx.Panel):
 
     def refresh(self, evt=None):
         # get states of items
-        rootRemoteWasExpanded = self.ctrl.IsExpanded(self.rootRemotePackages)
+        # BrootRemoteWasExpanded = self.ctrl.IsExpanded(self.rootRemotePackages)
         rootUserWasExpanded = self.ctrl.IsExpanded(self.rootUserPackages)
         rootSystemWasExpanded = self.ctrl.IsExpanded(self.rootSystemPackages)
 
@@ -350,24 +350,24 @@ class PackageListCtrl(wx.Panel):
         self.rootSystemPackages = self.ctrl.AppendItem(
             self.ctrl.GetRootItem(), _translate("System Packages"))  
         self.ctrl.SetItemData(self.rootSystemPackages, PACKAGE_STATUS_INVALID)
-        self.rootRemotePackages = self.ctrl.AppendItem(
-            self.ctrl.GetRootItem(), _translate("Available Packages"))
-        self.ctrl.SetItemData(
-            self.rootRemotePackages, PACKAGE_STATUS_INVALID)
+        # self.rootRemotePackages = self.ctrl.AppendItem(
+        #     self.ctrl.GetRootItem(), _translate("Available Packages"))
+        # self.ctrl.SetItemData(
+        #    self.rootRemotePackages, PACKAGE_STATUS_INVALID)
 
         # get packages
         installedPackages = dict(getInstalledPackages())
 
         systemPackages = installedPackages['system']['packages']
         userPackages = installedPackages['user']['packages']
-        availablePackages = getRemotePackages()['packages']
+        # availablePackages = getRemotePackages()['packages']
         
         # filter on search
         if searchTerm not in (None, ""):
             self.searchCtrl.ShowCancelButton(True)
             systemPackages = {k: v for k, v in systemPackages.items() if searchTerm in k}
             userPackages = {k: v for k, v in userPackages.items() if searchTerm in k}
-            availablePackages = [v for v in availablePackages if searchTerm in v]
+            #availablePackages = [v for v in availablePackages if searchTerm in v]
         else:
             self.searchCtrl.ShowCancelButton(False)
 
@@ -391,24 +391,24 @@ class PackageListCtrl(wx.Panel):
             self.rootUserPackages,
             _translate("User Packages") + " (%d)" % len(userPackages))
     
-        if len(availablePackages) > 1000:
-            availablePackages = availablePackages[:1000]
-            self.ctrl.SetItemText(
-                self.rootRemotePackages,
-                _translate("Available Packages") + " (1000+)")
-        else:
-            totalSearchMatches = len(availablePackages)
-            self.ctrl.SetItemText(
-                self.rootRemotePackages,
-                _translate("Available Packages") + " (%d)" % totalSearchMatches)
+        # if len(availablePackages) > 1000:
+        #     availablePackages = availablePackages[:1000]
+        #     self.ctrl.SetItemText(
+        #         self.rootRemotePackages,
+        #         _translate("Available Packages") + " (1000+)")
+        # else:
+        #     totalSearchMatches = len(availablePackages)
+        #     self.ctrl.SetItemText(
+        #         self.rootRemotePackages,
+        #         _translate("Available Packages") + " (%d)" % totalSearchMatches)
 
-        for pkg in availablePackages:
-            item = self.ctrl.AppendItem(self.rootRemotePackages, pkg)
-            self.ctrl.SetItemData(item, PACKAGE_STATUS_NOT_INSTALLED)
+        # for pkg in availablePackages:
+        #     item = self.ctrl.AppendItem(self.rootRemotePackages, pkg)
+        #     self.ctrl.SetItemData(item, PACKAGE_STATUS_NOT_INSTALLED)
 
         # Expand all roots
-        if rootRemoteWasExpanded:
-            self.ctrl.Expand(self.rootRemotePackages)
+        # if rootRemoteWasExpanded:
+        #     self.ctrl.Expand(self.rootRemotePackages)
         if rootUserWasExpanded:
             self.ctrl.Expand(self.rootUserPackages)
         if rootSystemWasExpanded:
@@ -560,7 +560,7 @@ class PackageDetailsPanel(wx.Panel):
         installedPackages = dict(getInstalledPackages())
         systemPackages = installedPackages['system']['packages']
         userPackages = installedPackages['user']['packages']
-        availablePackages = getRemotePackages()['packages']
+        # availablePackages = getRemotePackages()['packages']
 
         pkgName = self.package
         state = False
@@ -573,20 +573,20 @@ class PackageDetailsPanel(wx.Panel):
                 self.versionCtrl.GetStringSelection() != userPackages[pkgName]
             )
             state = True
-        elif pkgName in availablePackages:
-            # If available but not installed, can be installed
-            self.uninstallBtn.Disable()
-            self.versionCtrl.Enable()
-            self.installBtn.Enable()
-            self.versionCtrl.SetSelection(self.versionCtrl.GetCount() - 1)  # newest
-            state = True
-        else:
-            # If installed to the system, can't be uninstalled or changed
-            if pkgName in systemPackages:
-                self.versionCtrl.SetStringSelection(systemPackages[pkgName])
-            self.uninstallBtn.Disable()
-            self.versionCtrl.Disable()
-            self.installBtn.Disable()
+        # elif pkgName in availablePackages:
+        #     # If available but not installed, can be installed
+        #     self.uninstallBtn.Disable()
+        #     self.versionCtrl.Enable()
+        #     self.installBtn.Enable()
+        #     self.versionCtrl.SetSelection(self.versionCtrl.GetCount() - 1)  # newest
+        #     state = True
+        # else:
+        #     # If installed to the system, can't be uninstalled or changed
+        #     if pkgName in systemPackages:
+        #         self.versionCtrl.SetStringSelection(systemPackages[pkgName])
+        #     self.uninstallBtn.Disable()
+        #     self.versionCtrl.Disable()
+        #     self.installBtn.Disable()
 
         # Disable all controls if we have None
         self.homeBtn.Enable(state is not None)

--- a/psychopy/scripts/psychopy-pkgutil.py
+++ b/psychopy/scripts/psychopy-pkgutil.py
@@ -33,6 +33,7 @@ _userAppPrefDir = os.environ.get('PSYCHOPYUSERPREFDIR', None)
 if _userAppPrefDir is not None:
     PSYCHOPYUSERPREFDIR = _userAppPrefDir  # user app preferences dir from environment variable
 
+PYPI_FETCH_AVAILABLE_PACKAGES = False  # disable fetching available packages from PyPI by default
 PYPI_SIMPLE_INDEX_URL = "https://pypi.org/simple/"
 PACKAGE_INDEX_FILE = "psychopy_packages.json"
 
@@ -41,6 +42,9 @@ packageCache = None  # initialized later
 
 # time elapsed from the previous update before the index is considered stale
 _indexStaleAfter = 28 * 24 * 3600  # every 4 weeks
+
+# verbosity flag
+_verbose = False
 
 
 # ------------------------------------------------------------------------------
@@ -99,7 +103,8 @@ def setUserBase(userBase):
     
     # set the user base directory
     PYTHONUSERBASE = userBase
-    print('[notice]: User base directory set to:', PYTHONUSERBASE)
+    if _verbose:
+        print('[notice]: User base directory set to:', PYTHONUSERBASE)
 
 
 def getUserBase():
@@ -126,7 +131,8 @@ def setLockFile():
     indexPath = os.path.dirname(os.path.abspath(PACKAGE_INDEX_FILE))
     lockFile = os.path.join(indexPath, 'psychopy_packages.lock')
 
-    print('[notice]: Setting lock file for package index at:', lockFile)
+    if _verbose:
+        print('[notice]: Setting lock file for package index at:', lockFile)
     
     # check if the lock file already exists
     if os.path.exists(lockFile):
@@ -136,8 +142,9 @@ def setLockFile():
     # create the lock file
     with open(lockFile, 'w') as f:
         f.write('Lock file for PsychoPy package index.')
-    
-    print(f'[notice]: Lock file created at: {lockFile}')
+    if _verbose:
+        print(f'[notice]: Lock file created at: {lockFile}')
+
     return True
 
 
@@ -155,7 +162,8 @@ def freeLockFile():
     # check if the lock file exists
     if os.path.exists(lockFile):
         os.remove(lockFile)
-        print(f'[notice]: Lock file removed: {lockFile}')
+        if _verbose:
+            print(f'[notice]: Lock file removed: {lockFile}')
     else:
         print(f"[error]: Lock file '{lockFile}' does not exist.")
         return False
@@ -169,7 +177,8 @@ def setPackageIndexFilePath(indexFile):
     global PACKAGE_INDEX_FILE
     PACKAGE_INDEX_FILE = os.path.abspath(indexFile)
 
-    print(f'[notice]: Package index file set to: {PACKAGE_INDEX_FILE}')
+    if _verbose:
+        print(f'[notice]: Package index file set to: {PACKAGE_INDEX_FILE}')
 
 
 def getPackageIndexFilePath():
@@ -241,18 +250,20 @@ def _fetchPluginIndex(fetch=False):
             return
         
     # download the file
-    print(f'Fetching PsychoPy plugin index from URL: {url}')
+    if _verbose:
+        print(f'Fetching PsychoPy plugin index from URL: {url}')
     downloadStartTime = time.time()
     response = requests.get(url)
     if response.status_code != 200:
         print(f"[error]: Failed to fetch {url}: {response.status_code}")
         return
     
-    print(f'Completed fetching remote PsychoPy plugin index (took '
-          f'{round(time.time() - downloadStartTime, 4)} seconds)')
-
+    if _verbose:
+        print(f'Completed fetching remote PsychoPy plugin index (took '
+              f'{round(time.time() - downloadStartTime, 4)} seconds)')
     # parse the JSON content
-    print('Parsing downloaded PsychoPy plugin index...')
+    if _verbose:
+        print('Parsing downloaded PsychoPy plugin index...')
     parseStartTime = time.time()
     try:
         pluginIndexJSON = json.loads(response.text)
@@ -260,9 +271,10 @@ def _fetchPluginIndex(fetch=False):
         print(f"[error]: Failed to decode JSON from {url}.")
         return False
 
-    print(f'Completed parsing PsychoPy plugin index (took '
-          f'{round(time.time() - parseStartTime, 4)} seconds)')
-    print(f'Found {len(pluginIndexJSON)} packages in the remote plugin index.')
+    if _verbose:
+        print(f'Completed parsing PsychoPy plugin index (took '
+              f'{round(time.time() - parseStartTime, 4)} seconds)')
+        print(f'Found {len(pluginIndexJSON)} packages in the remote plugin index.')
 
     # add fields to the package index
     for pluginInfo in pluginIndexJSON:
@@ -327,12 +339,14 @@ def updatePackageIndex(fetch=True):
     # check if we have a local index file
     localData = None
     if not os.path.exists(PACKAGE_INDEX_FILE):
-        print(f"[notice]: Package index file '{PACKAGE_INDEX_FILE}' not found. "
-              f"Creating a new one...")
+        if _verbose:
+            print(f"[notice]: Package index file '{PACKAGE_INDEX_FILE}' not found. "
+                  f"Creating a new one...")
     else:
         # load the file to get remote repo data
         with open(PACKAGE_INDEX_FILE, 'r') as f:
-            print(f"Reading package index from {PACKAGE_INDEX_FILE}...")
+            if _verbose:
+                print(f"Reading package index from {PACKAGE_INDEX_FILE}...")
             try:
                 localData = json.load(f)
             except json.JSONDecodeError:
@@ -366,8 +380,9 @@ def updatePackageIndex(fetch=True):
     # get all local packages for the index
     for pkgsite in ['system', 'user']:
         pkgList = getInstalledPackages(where=pkgsite)
-        print(f'Found {len(pkgList)} packages in "{pkgsite}" site-packages '
-              f'location.')
+        if _verbose:
+            print(f'Found {len(pkgList)} packages in "{pkgsite}" site-packages '
+                  f'location.')
         localPackages[pkgsite]['packages'] = pkgList
         localPackages[pkgsite]['lastupdated'] = time.time()  # set updated time
 
@@ -385,17 +400,20 @@ def updatePackageIndex(fetch=True):
         # doctype = packageCache['available']['remote'][packageIndex]['doctype']
 
         downloadStartTime = time.time()
-        print(f'Fetching "{packageIndex}" remote package index from URL: {url} ')
+        if _verbose:
+            print(f'Fetching "{packageIndex}" remote package index from URL: {url} ')
         response = requests.get(url)
         if response.status_code != 200:
             print('')
             print(f"[error]: Failed to fetch {url}: {response.status_code}")
             return False
-        print(f'Completed fetching remote package index for "{packageIndex}" '
-              f'(took {round(time.time() - downloadStartTime, 4)} seconds)')
+        if _verbose:
+            print(f'Completed fetching remote package index for "{packageIndex}" '
+                f'(took {round(time.time() - downloadStartTime, 4)} seconds)')
 
         # parse the HTML content
-        print(f'Parsing downloaded "{packageIndex}" remote package index...')
+        if _verbose:
+            print(f'Parsing downloaded "{packageIndex}" remote package index...')
         parseStartTime = time.time()
         soup = BeautifulSoup(response.text, 'html.parser')
         packageCache['available']['remote'][packageIndex]['packages'].clear()
@@ -406,37 +424,43 @@ def updatePackageIndex(fetch=True):
                 packageCache['available']['remote'][packageIndex]['packages'].append(package_name)
 
         packageCache['available']['remote'][packageIndex]['lastupdated'] = time.time()
-
-        print(f'Completed parsing remote package index for "{packageIndex}" '
-              f'(took {round(time.time() - parseStartTime, 4)} seconds)')
+        if _verbose:
+            print(f'Completed parsing remote package index for "{packageIndex}" '
+                f'(took {round(time.time() - parseStartTime, 4)} seconds)')
 
         return True
 
-    for remoteIndex in ['PyPI']:
-        lastUpdated = packageCache['available']['remote'][remoteIndex]['lastupdated'] 
-        isStale = lastUpdated < time.time() - _indexStaleAfter
-        if isStale or fetch:
-            print(f'[notice]: Remote package index "{remoteIndex}" is stale, updating...')
-            _fetch(packageIndex=remoteIndex)
-        else:
-            # index is not stale, use the cached data
-            print(f'[notice]: Remote package index "{remoteIndex}" is not stale, using locally cached data.')
-        
-        totalPackages = len(
-            packageCache['available']['remote'][remoteIndex]['packages'])
-        print(f'Found {totalPackages} available packages in "{remoteIndex}" remote index.')
+    if PYPI_FETCH_AVAILABLE_PACKAGES:
+        for remoteIndex in ['PyPI']:
+            lastUpdated = packageCache['available']['remote'][remoteIndex]['lastupdated'] 
+            isStale = lastUpdated < time.time() - _indexStaleAfter
+            if isStale or fetch:
+                if _verbose:
+                    print(f'[notice]: Remote package index "{remoteIndex}" is stale, updating...')
+                _fetch(packageIndex=remoteIndex)
+            else:
+                # index is not stale, use the cached data
+                if _verbose:
+                    print(f'[notice]: Remote package index "{remoteIndex}" is not stale, using locally cached data.')
+            
+            totalPackages = len(
+                packageCache['available']['remote'][remoteIndex]['packages'])
+            if _verbose:
+                print(f'Found {totalPackages} available packages in "{remoteIndex}" remote index.')
     
     # write out the package index to a file
     with open(PACKAGE_INDEX_FILE, 'w') as f:
-        print(f'Writing package index to {PACKAGE_INDEX_FILE}...')
+        if _verbose:
+            print(f'Writing package index to {PACKAGE_INDEX_FILE}...')
         try:
             json.dump(packageCache, f, indent=4)
         except Exception as e:
             print(f"[error]: Failed to write package index to {PACKAGE_INDEX_FILE}: {e}")
             sys.exit(1)
     
-    print(f'Finished updating local package index cache (took '
-          f'{round(time.time() - updateStartTime, 4)} seconds)')
+    if _verbose:
+        print(f'Finished updating local package index cache (took '
+              f'{round(time.time() - updateStartTime, 4)} seconds)')
     
     freeLockFile()  # free the lock file
         
@@ -697,9 +721,11 @@ def installPackage(packageName, where='user', forceReinstall=False,
         cmd.append('--no-cache-dir')
 
     # use pip to install the package
-    print(f'Installing {packageName} to "{where}" site-packages...')
+    if _verbose:
+        print(f'Installing {packageName} to "{where}" site-packages...')
     _ = _callPIP(cmd, userBase=userBase)
-    print(f'Completed installing {packageName} to "{where}" site-packages.')
+    if _verbose:
+        print(f'Completed installing {packageName} to "{where}" site-packages.')
 
 
 def upgradePackage(packageName, strategy='eager', extraIndexURL=None, userBase=None):
@@ -730,7 +756,8 @@ def upgradePackage(packageName, strategy='eager', extraIndexURL=None, userBase=N
         cmd.append('--upgrade-strategy')
         cmd.append(strategy)
 
-    print('Upgrading package:', packageName)
+    if _verbose:
+        print(f'Upgrading package "{packageName}"...')
 
     _ = _callPIP(cmd, userBase=userBase)
 
@@ -767,7 +794,8 @@ def upgradeAllPackages(where='system', strategy='eager', userBase=None):
         print('No packages to upgrade.')
         return
     
-    print(f'Found {len(outdatedPackages)} packages to upgrade.')
+    if _verbose:
+        print(f'Found {len(outdatedPackages)} packages to upgrade.')
     
     # generate the list of packages to upgrade
     packagesToUpgrade = []
@@ -781,10 +809,12 @@ def upgradeAllPackages(where='system', strategy='eager', userBase=None):
         cmd.append('--upgrade-strategy')
         cmd.append(strategy)
     
-    print(f'Upgrading {len(packagesToUpgrade)} packages in {where} site-packages...')
+    if _verbose:
+        print(f'Upgrading {len(packagesToUpgrade)} packages in {where} site-packages...')
     _ = _callPIP(cmd, userBase=userBase)
 
-    print('Completed upgrading packages.')
+    if _verbose:
+        print('Completed upgrading packages.')
 
 
 def uninstallPackage(packageName, userBase=None):
@@ -847,6 +877,8 @@ def getPackageInfo(packageName):
 def main():
     """Main function to run the package utility.
     """
+    global _verbose
+
     # use argparse 
     desc = f'PsychoPy package managment utility v{__version__} (Copyright 2025 - Open Science Tools Ltd.)'
 
@@ -863,7 +895,7 @@ def main():
         '--app-pref-dir', type=str, default=None, 
         help='PsychoPy app preferences directory.')
     parser.add_argument(
-        '--verbose', action='store_true', help='Enable verbose output.')
+        '--quiet', action='store_true', help='Disable verbose output.')
     
     # subcommands are 'update', 'list', 'install', 'uninstall', and 'upgrade'
     subparsers = parser.add_subparsers(dest='command')
@@ -930,6 +962,9 @@ def main():
             
         if args.index_file:
             setPackageIndexFilePath(args.index_file)
+
+    # set verbosity
+    _verbose = not args.quiet
     
     if args.command == 'update':
         if args.stale_after:


### PR DESCRIPTION
This PR removes package indexing/search of remote repos (i.e. PyPI) since the background task takes too long, and the vast majority of packages are irrelevant to PsychoPy users. At this point only an index of local packages are built and plugin icons are still being cached. I also removed logging messages from the background task as they are irrelevant for regular users and just clog up their output window