### PR TITLE
Fix AttributeError: KeyboardDevice missing _buffers attribute wo PTB

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -386,6 +386,12 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
 
         logging.info('keyboard.Keyboard is using %s backend.' % KeyboardDevice._backend)
 
+        # Initialize _buffers and _devs for all backends to prevent AttributeError
+        if not hasattr(self, '_buffers'):
+            self._buffers = {}
+        if not hasattr(self, '_devs'):
+            self._devs = {}
+
         # array in which to store ongoing presses
         self._keysStillDown = deque()
         # set whether or not to mute any keypresses which happen outside of PsychoPy


### PR DESCRIPTION
## Problem 
When trying to play a movie clip (mp4 container) from a local drive, KeyboardDevice crashes with `AttributeError: 'KeyboardDevice' object has no attribute '_buffers'` when using non-PTB backends (iohub or event). I think this is because these attributes are only initialized in the PTB backend branch (but I'm not using that)

## Solution
Just initialize `_buffers` and `_devs` as empty dicts at the end of `__init__`. This ensures the attributes exist even when the PTB backend is not used. I think all actual usages of these attributes have other checks, so empty dicts should be harmless. I think....

## Testing
Tested with movie playback using iohub backend - previously crashed, now works correctly! Also the movie plays very smoothly.