### PR TITLE
DOCS: add validator notes to timing page and details on light sensor

### DIFF
--- a/docs/source/builder/components/VisualValidatorRoutine.rst
+++ b/docs/source/builder/components/VisualValidatorRoutine.rst
@@ -7,7 +7,21 @@
 Visual Validator Routine
 -------------------------------
 
-Use a light sensor to confirm that visual stimuli are presented when they should be.
+Use a light sensor to confirm that visual stimuli are presented when they should be. Before using a validator component in your experiment it is important to ensure that you have a photodiode device available for the routine to use. If you do not have a photodiode to hand you can use an "emulator" temporarily until you have access to a real device.
+
+To configure your photodiode with an emulator go to Device Manager > Add device > Screen Buffer Sampler (Debug) > Light Sensor Emulator. Alternatively if you have a photodiode connected you can search for the name of your actual device in the list of available devices.
+
+Once you have selected the Visual Validator component, it is important to add it to your experiment flow. Select Insert Routine > [name of your visual validator component] > add to your flow (usually best at the start of the experiment).
+
+In the "Device" section of the component you can select the name of your photodiode device from the dropdown list. If you have multiple photodiodes connected to your system you may also need to specify a channel number to distinguish between them.
+
+By default "Find best threshold?" and "Find sensor?" " are both set to True. This means that when you run your experiment the visual validator routine will first run a brief routine to find the best threshold for the light sensor, followed by another brief routine to find the size and position of the light sensor on the screen. Once these two brief routines have been run the main visual validator routine will run for the remainder of your experiment. 
+
+Recommended debugging steps for using the visual validator routine in your experiment:
+
+* Use an external piece of software to check that your computer can detect the external hardware. For example, if using Cedrus you can install `Xidon <https://cedrus.com/support/xid/xidon.htm>`_ to check that your computer can detect the device.
+* Set the threshold manually to a value that you know will work with your setup. You can do this by setting "Find best threshold?" to False and then entering a value for "Threshold". Lowering the threshold will make it more sensitive.
+
 
 Categories:
     Validation
@@ -37,7 +51,7 @@ Find best threshold?
 .. _visualvalidatorroutine-threshold:
 
 Threshold (*if :ref:`visualvalidatorroutine-findthreshold` isn't ==True*)
-    Light threshold at which the light sensor should register a positive, units go from 0 (least light) to 255 (most light).
+    Light threshold at which the light sensor should register a positive, units go from 0 (least light) to 1 (most light).
     
 .. _visualvalidatorroutine-findSensor:
 
@@ -80,7 +94,7 @@ Spatial units (*if :ref:`visualvalidatorroutine-finddiode` isn't ==True*)
 Device
 ===============================
 
-Information about the device associated with this Component. Keyboards, speakers, microphones, etc.
+Information about the device associated with this Component (the photodiode or light sensor emulator)
 
 
 .. _visualvalidatorroutine-deviceLabel:

--- a/docs/source/general/timing/index.rst
+++ b/docs/source/general/timing/index.rst
@@ -33,3 +33,19 @@ There are certain steps that we strongly advise you to take before running an ex
 * Use a photodiode or other physical stimulus detector to fully understand the lag, and more importantly the variability of that lag, between any triggers that you send to indicate the start of your stimulus and when the stimulus actually starts.
 
 .. _Black Box Toolkit: https://www.blackboxtoolkit.com/
+
+Validating your timing
+---------------------------------------
+
+The best way to validate the timing of your experiment is to use external hardware such as a photodiode or microphone to measure the actual timing of stimulus presentation. Some options include:
+
+- `Black Box Toolkit <https://www.blackboxtoolkit.com/>`_: A purpose-built device designed specifically for timing validation.
+- `Cedrus RiPONDA <https://cedrus.com/riponda/index.htm>`_: A commercially available device providing precise timing and response measurement.
+- `Cedrus StimTracker <https://cedrus.com/stimtracker/index.htm>`_: Another commercially available device for tracking stimulus presentation and timing.
+
+Each option has different features and trade-offs, so the choice depends on your experimental requirements and budget.
+
+
+When validating your timing, it's important to consider not just the average timing accuracy, but also the variability (jitter) in timing. Even if your average timing is accurate, high variability can still compromise the integrity of your experimental results.
+
+PsychoPy now has inbuilt components to assist with validating timing, see :ref:`visualvalidatorroutine` and :ref:`audiovalidatorroutine` pages for routines that validate visual and auditory stimuli, respectively.


### PR DESCRIPTION
Added details about validator components to the general > timing page and also added details on using light sensors. 