### PR TITLE
DOCS: fix codecov hyperlink

### DIFF
--- a/docs/source/developers/testsuitecontributing.rst
+++ b/docs/source/developers/testsuitecontributing.rst
@@ -268,7 +268,7 @@ Add a `teardown_class` method to your TestRect class.
 CodeCov
 ------------------------------------------
 
-CodeCov is a handy tool which runs the full test suite and keeps track of which lines of code are executed - giving each file in the PsychoPy repo a percentage score for "coverage". If more lines of code in that file are executed when the test suite runs, then it has a higher coverage score. You can view the full coverage report for the repo [here](https://app.codecov.io/gh/psychopy/psychopy/).
+CodeCov is a handy tool which runs the full test suite and keeps track of which lines of code are executed - giving each file in the PsychoPy repo a percentage score for "coverage". If more lines of code in that file are executed when the test suite runs, then it has a higher coverage score. You can view the full coverage report for the repo `here <https://app.codecov.io/gh/psychopy/psychopy/>`_.
 
 Some areas of the code are more important than others, so it's important not to make decisions purely based on what most increases coverage, but coverage can act as a good indicator for what areas the test suite is lacking in. If you want to make a test but aren't sure what to do, finding a file or folder with a poor coverage score is a great place to start!
 


### PR DESCRIPTION
### What 
- Use the the correct formatting for `.rst` hyperlinks for text on the `/developers/testsuitecontributing.html` 

### Why
- It seems like `.md` hyperlink format is being used and the "here" is not actually a hyperlink.

This is actually currently visible on the page: 

<img width="673" height="168" alt="image" src="https://github.com/user-attachments/assets/88eb6f18-c377-4393-9166-a91f3cfd46f8" />

