### PR TITLE
FF: Remove stray code causing camera settings to be logged when `systemtools` is imported

### DIFF
--- a/psychopy/tools/systemtools.py
+++ b/psychopy/tools/systemtools.py
@@ -664,7 +664,8 @@ def isRegisteredApp():
 # platforms.
 _cameraGetterFuncTbl = {
     'Darwin': _getCameraInfoMacOS,
-    'Windows': _getCameraInfoWindows
+    'Windows': _getCameraInfoWindows,
+    'Linux': _getCameraInfoLinux
 }
 
 

--- a/psychopy/tools/systemtools.py
+++ b/psychopy/tools/systemtools.py
@@ -581,12 +581,6 @@ def _getCameraInfoLinux():
     return videoDevices
 
 
-# print camera information, line by line
-for camInfo in _getCameraInfoLinux():
-    for fmt in camInfo:
-        print(fmt)
-
-
 # array of registered PIDs which PsychoPy considers to be safe
 _pids = [
     os.getpid(),


### PR DESCRIPTION
Small fix to remover some code that was committed while working on camera support for Linux. It caused camera settings to be logged to console on import of that module