### PR TITLE
BF: Prioritise getJSON method over native serialization

### DIFF
--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -36,6 +36,18 @@ class LiaisonJSONEncoder(json.JSONEncoder):
 	JSON encoder which calls the `getJSON` method of an object (if it has one) to convert to a
 	string before JSONifying.
 	"""
+
+	def encode(self, o, *args, **kw):
+		# if object has a getJSON method, use it *ahead of* native serialization
+		if hasattr(o, "getJSON"):
+			try:
+				o = o.getJSON(asString=False)
+			except:
+				# continue as normal if getJSON failed
+				pass
+		
+		return super(LiaisonJSONEncoder, self).encode(o, *args, **kw)
+	
 	def default(self, o):
 		try:
 			# if object has a getJSON method, use it


### PR DESCRIPTION
Means that e.g. `Trial` (which is a subclass of dict) can be serialized how we tell it to (i.e. with `thisN`, `thisRepN`, etc. included) rather than being serialized by its dict keys (as is the case when native serialization is prioritised).