### PR TITLE
BF: Allow iohub errors in clients to be logged

### DIFF
--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -13,6 +13,7 @@ if sys.platform == 'darwin':
     import objc  # pylint: disable=import-error
 
 EXP_SCRIPT_DIRECTORY = ''
+IOHUB_LOG_FILE_PATH = ''
 
 
 def _localFunc():

--- a/psychopy/iohub/errors.py
+++ b/psychopy/iohub/errors.py
@@ -32,16 +32,23 @@ def print2err(*args):
             print("{0}".format(a))
         print()
         	
+            
 def printExceptionDetailsToStdErr():
     """
     Print the last raised exception in the iohub (well, calling) process
     to the psychopy process stderr.
     """
     try:
-        traceback.print_exc(file=sys.stderr)
-        sys.stderr.flush()
+        # older method, kept for reference
+        # traceback.print_exc(file=sys.stderr)
+        # sys.stderr.flush()
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        errStr = "".join(traceback.format_exception(
+            exc_type, exc_value, exc_tb))
+        print2err(errStr)
     except:
         traceback.print_exc()
+
 
 class ioHubError(Exception):
     #TODO: Fix the way exceptions raised in the iohub process are handled

--- a/psychopy/iohub/errors.py
+++ b/psychopy/iohub/errors.py
@@ -2,6 +2,7 @@
 # Part of the PsychoPy library
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
+import os
 import sys
 import traceback
 
@@ -31,6 +32,14 @@ def print2err(*args):
         for a in args:
             print("{0}".format(a))
         print()
+
+    # write to log file 
+    import psychopy.iohub  # only on error import
+    with open(psychopy.iohub.IOHUB_LOG_FILE_PATH, "a", encoding="utf-8") as log_file:
+        for a in args:
+            log_file.write("{0}".format(a))
+        log_file.write("\n")
+        log_file.flush()
         	
             
 def printExceptionDetailsToStdErr():

--- a/psychopy/iohub/start_iohub_process.py
+++ b/psychopy/iohub/start_iohub_process.py
@@ -34,6 +34,12 @@ def run(rootScriptPathDir, configFilePath):
     s = None
     try:
         psychopy.iohub.EXP_SCRIPT_DIRECTORY = rootScriptPathDir
+        psychopy.iohub.IOHUB_LOG_FILE_PATH = os.path.join(
+            psychopy.prefs.paths['userPrefsDir'],  
+            "iohub_last_session.log")
+
+        # create/clear log file path for this session
+        open(psychopy.iohub.IOHUB_LOG_FILE_PATH, 'w').close()
 
         tdir = tempfile.gettempdir()
         cdir, _ = os.path.split(configFilePath)


### PR DESCRIPTION
Fixes issue where tracebacks arising from unhanded exceptions in ioHub subprocesses were not being properly logged 