### PR TITLE
BF: Fix Auto->JS isinstance(list) to Array

### DIFF
--- a/psychopy/experiment/py2js_transpiler.py
+++ b/psychopy/experiment/py2js_transpiler.py
@@ -232,6 +232,12 @@ class pythonTransformer(ast.NodeTransformer):
         # transform the node func:
         node.func = pythonTransformer().visit(node.func)
 
+        # isinstance(x, list) -> x instanceof Array
+        if isinstance(node.func, ast.Name) and node.func.id == 'isinstance':
+            if len(node.args) == 2 and isinstance(node.args[1], ast.Name) and node.args[1].id == 'list':
+                node.args[1] = ast.Name(id='Array', ctx=ast.Load())
+                return node
+
         # substitutable transformation, e.g. Vector.append(5) --> Vector.push(5):
         if isinstance(node.func, ast.Attribute):  # and isinstance(node.func.value, ast.Name):
             substitutedNode = self.substitutionTransform(node.func, node.args, node.keywords)

--- a/psychopy/tests/test_experiment/test_py2js.py
+++ b/psychopy/tests/test_experiment/test_py2js.py
@@ -85,6 +85,11 @@ class TestTranspiler:
         for case in cases:
             self.runTranspile(case['py'], case['js'])
 
+    def test_isinstance_list(self):
+        js = translatePythonToJavaScript("a = isinstance(keys, list)")
+        assert "instanceof Array" in js
+        assert "instanceof list" not in js
+
 
     def test_var_defs(self):
         cases = [


### PR DESCRIPTION
Fixes #7526

- Translate isinstance(x, list) to instanceof Array in py2js transpiler
- Add test to prevent regression

Test: python -m pytest psychopy/tests/test_experiment/test_py2js.py -k isinstance
