### PR TITLE
BF: Allow ioHub to see separate X screens on linux. 

### DIFF
--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -485,7 +485,29 @@ class Display(Device):
             dx, dy = default_screen.x, default_screen.y
             dw, dh = default_screen.width, default_screen.height
             dbounds = (dx, dy, dx + dw, dy + dh)
-            pyglet_screens = pyglet.canvas.get_display().get_screens()
+            is_zaphod = False
+            if sys.platform.startswith('linux'):
+                pyglet_screens = []
+                from pyglet.canvas.xlib import NoSuchDisplayException
+                try:
+                    # test whether it's a Zaphodhead setup
+                    display = pyglet.canvas.Display(x_screen=1)
+                    is_zaphod = True
+                except NoSuchDisplayException:
+                    pass
+
+            if sys.platform.startswith('linux') and is_zaphod:
+                screen_count = 0
+                # make an assumption that no nested Xinerama-within-Zaphodhead
+                while True:
+                    try:
+                        display = pyglet.canvas.Display(x_screen=screen_count)
+                        pyglet_screens.append(display.get_default_screen())
+                        screen_count += 1
+                    except NoSuchDisplayException:
+                        break
+            else:
+                pyglet_screens = pyglet.canvas.get_display().get_screens()
             display_count = len(pyglet_screens)
             for i in range(display_count):
                 d = pyglet_screens[i]

--- a/psychopy/visual/image.py
+++ b/psychopy/visual/image.py
@@ -135,7 +135,7 @@ class ImageStim(BaseVisualStim, DraggingMixin, ContainerMixin, ColorMixin,
             #if hasattr(self, '_listID'):
                 # GL.glDeleteLists(self._listID, 1)
             self.clearTextures()
-        except (ImportError, ModuleNotFoundError, TypeError):
+        except (ImportError, ModuleNotFoundError, TypeError, GL.lib.GLException):
             pass  # has probably been garbage-collected already
 
     def _updateListShaders(self):


### PR DESCRIPTION
Similar to c0394a5b9d6377bf73af2a9920c483839bd9ea1c. ioHub couldn't discover separate screens under a ZaphodHeads setup, which led to e.g. eye tracking calibration windows being drawn only on the primary display. Works for me with ZaphodHeads and with Xinerama.

PS: is MouseGaze working? The "simple" coder demo gives me e.g.

```
## Running: C:\Program Files\PsychoPy\lib\site-packages\psychopy\demos\coder\iohub\eyetracking\simple.py ##
RPC_DEVICE_RUNTIME_ERROR
Traceback (most recent call last):
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\iohub\server.py", line 300, in handleExperimentDeviceRequest
    result = method()
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\iohub\devices\eyetracker\hw\mouse\eyetracker.py", line 407, in runSetupProcedure
    calibration = MouseGazeCalibrationProcedure(self, calibration_args)
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\iohub\devices\eyetracker\hw\mouse\calibration.py", line 10, in __init__
    BaseCalibrationProcedure.__init__(self, eyetrackerInterface, calibration_args, allow_escape_in_progress=True)
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\iohub\devices\eyetracker\calibration\procedure.py", line 53, in __init__
    self._device_config['calibration']['target_attributes'] = calibration_args['target_attributes']
KeyError: 'target_attributes'
Calibration returned:  PC_DEVICE_RUNTIME_ERROR
```