### PR TITLE
BF: Fixed issue with plugins window not opening

### DIFF
--- a/psychopy/scripts/psychopy-pkgutil.py
+++ b/psychopy/scripts/psychopy-pkgutil.py
@@ -169,6 +169,8 @@ def setPackageIndexFilePath(indexFile):
     global PACKAGE_INDEX_FILE
     PACKAGE_INDEX_FILE = os.path.abspath(indexFile)
 
+    if not os.path.exists(os.path.dirname(PACKAGE_INDEX_FILE)):
+        os.makedirs(os.path.dirname(PACKAGE_INDEX_FILE), exist_ok=True)
     print(f'[notice]: Package index file set to: {PACKAGE_INDEX_FILE}')
 
 


### PR DESCRIPTION
Fixes #7362

The issue is that PsychoPy was failing to create an index of packages due to a missing cache folder

The following call is run as a subprocess to update the package index:
```
 'C:\Program Files\PsychoPy\python.exe' 'C:\Program Files\PsychoPy\lib\site-packages\psychopy\scripts\psychopy-pkgutil.py'  --app-pref-dir C:\Users\<username>\AppData\Roaming\psychopy3 update
 ```
but it was failing with
```
Traceback (most recent call last):
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\scripts\psychopy-pkgutil.py", line 969, in <module>
    main()
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\scripts\psychopy-pkgutil.py", line 937, in main
    updatePackageIndex(fetch=args.fetch)
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\scripts\psychopy-pkgutil.py", line 299, in updatePackageIndex
    setLockFile()  # set the lock file to prevent multiple processes from updating
  File "C:\Program Files\PsychoPy\lib\site-packages\psychopy\scripts\psychopy-pkgutil.py", line 137, in setLockFile
    with open(lockFile, 'w') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\<username>\\AppData\\Roaming\\psychopy3\\cache\\appCache\\psychopy_packages.lock'
```