### PR TITLE
FF: Improvements to logging iohub events and errors

### DIFF
--- a/psychopy/iohub/__init__.py
+++ b/psychopy/iohub/__init__.py
@@ -13,7 +13,6 @@ if sys.platform == 'darwin':
     import objc  # pylint: disable=import-error
 
 EXP_SCRIPT_DIRECTORY = ''
-IOHUB_LOG_FILE_PATH = ''
 
 
 def _localFunc():

--- a/psychopy/iohub/errors.py
+++ b/psychopy/iohub/errors.py
@@ -2,7 +2,6 @@
 # Part of the PsychoPy library
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
-import os
 import sys
 import traceback
 
@@ -33,14 +32,6 @@ def print2err(*args):
             print("{0}".format(a))
         print()
 
-    # write to log file 
-    import psychopy.iohub  # only on error import
-    with open(psychopy.iohub.IOHUB_LOG_FILE_PATH, "a", encoding="utf-8") as log_file:
-        for a in args:
-            log_file.write("{0}".format(a))
-        log_file.write("\n")
-        log_file.flush()
-        	
             
 def printExceptionDetailsToStdErr():
     """

--- a/psychopy/iohub/start_iohub_process.py
+++ b/psychopy/iohub/start_iohub_process.py
@@ -105,7 +105,6 @@ def run(rootScriptPathDir, configFilePath):
         logging.debug("Starting device monitors...")
         for m in s.deviceMonitors:
             m.start()
-            logging.debug("Started `{0}` device monitor".format(m.name))
             glets.append(m)
 
         tlet = gevent.spawn(s.processEventsTasklet, 0.01)
@@ -158,7 +157,7 @@ def run(rootScriptPathDir, configFilePath):
             
         if s:
             s.shutdown()
-            
+
         return False
 
 if __name__ == '__main__':

--- a/psychopy/iohub/start_iohub_process.py
+++ b/psychopy/iohub/start_iohub_process.py
@@ -2,10 +2,12 @@
 # Part of the PsychoPy library
 # Copyright (C) 2012-2020 iSolver Software Solutions (C) 2021 Open Science Tools Ltd.
 # Distributed under the terms of the GNU General Public License (GPL).
+
 import json
 import os
 import sys
 import tempfile
+import traceback
 import gevent
 try:
     if os.name == 'nt':
@@ -25,22 +27,48 @@ import psychopy.clock as clock
 from psychopy.iohub import IOHUB_DIRECTORY
 from psychopy.iohub.devices import Computer
 Computer.is_iohub_process = True
-from psychopy.iohub.errors import printExceptionDetailsToStdErr
+from psychopy.iohub.errors import printExceptionDetailsToStdErr, print2err
 from psychopy.iohub.server import ioServer
 from psychopy.iohub.util import updateDict, yload, yLoader
+import psychopy.logging as logging
+from psychopy.preferences import prefs
+import atexit
 
 
 def run(rootScriptPathDir, configFilePath):
     s = None
     try:
         psychopy.iohub.EXP_SCRIPT_DIRECTORY = rootScriptPathDir
-        psychopy.iohub.IOHUB_LOG_FILE_PATH = os.path.join(
-            psychopy.prefs.paths['userPrefsDir'],  
-            "iohub_last_session.log")
 
-        # create/clear log file path for this session
-        open(psychopy.iohub.IOHUB_LOG_FILE_PATH, 'w').close()
+        # setup logging for the iohub subprocess
+        logFilePath = os.path.join(
+            prefs.paths['userPrefsDir'], 'iohub_last_session.log')
+        iohubLogFile = logging.LogFile(
+            logFilePath, 
+            level=logging.DEBUG, 
+            filemode='w')
+        
+        # swap out the default for the iohub logger
+        logging.console = iohubLogFile
+        logging.flush()
 
+        # set the exception hook to ensure any uncaught exceptions are logged
+        def exception_hook(exctype, value, traceback):
+            logging.flush()
+            print2err(exctype, value, traceback)
+            sys.stderr.flush()
+            sys.__excepthook__(exctype, value, traceback)
+
+        sys.excepthook = exception_hook
+
+        # flushing logging and stderr at exit ensures that any messages
+        # buffered aren't lost if the process exits abnormally
+        atexit.register(logging.flush)
+        # handle stderr flushing at exit for messages printed via print2err,
+        # these will appear in the psychopy process stderr
+        atexit.register(sys.stderr.flush)
+
+        # get ioHub config
         tdir = tempfile.gettempdir()
         cdir, _ = os.path.split(configFilePath)
         if tdir == cdir:
@@ -58,26 +86,39 @@ def run(rootScriptPathDir, configFilePath):
 
         s = ioServer(rootScriptPathDir, ioHubConfig)
         udp_port = s.config.get('udp_port', 9000)
-        s.log("Receiving diagram's on: {}".format(udp_port))
+        logging.debug("ioHub Server UDP port: {}".format(udp_port))
+
+        # s.log("Receiving diagram's on: {}".format(udp_port))
+        logging.debug("Receiving diagram's on: {}".format(udp_port))
         s.udpService.start()
         s.setStatus("INITIALIZING")
         msgpump_interval = s.config.get('msgpump_interval', 0.001)
+        logging.debug("Set `msgpump_interval` to: {}".format(msgpump_interval))
+
+        # start tasklets
+        logging.debug("Starting iohub server tasklets...")
+
         glets = []
 
         tlet = gevent.spawn(s.pumpMsgTasklet, msgpump_interval)
         glets.append(tlet)
+        logging.debug("Starting device monitors...")
         for m in s.deviceMonitors:
             m.start()
+            logging.debug("Started `{0}` device monitor".format(m.name))
             glets.append(m)
 
         tlet = gevent.spawn(s.processEventsTasklet, 0.01)
         glets.append(tlet)
+        logging.debug("Started `processEventsTasklet` tasklet")
 
         if Computer.psychopy_process:
             tlet = gevent.spawn(s.checkForPsychopyProcess, 0.5)
             glets.append(tlet)
+            logging.debug("Started `checkForPsychopyProcess` tasklet")
 
         s.setStatus("RUNNING")
+        logging.info("ioHub Server is RUNNING")
 
         if hasattr(gevent, 'run'):
             gevent.run()
@@ -86,16 +127,38 @@ def run(rootScriptPathDir, configFilePath):
             gevent.joinall(glets)
 
         # Wait for the server to be ready to shutdown
+        logging.debug(
+            "ioHub Server is SHUTTING DOWN, waiting for tasklets to finish ...")
         gevent.wait()
 
         lrtime = Computer.global_clock.getLastResetTime()
-        s.log('Server END Time Offset: {0}'.format(lrtime), 'DEBUG')
+        # s.log('Server END Time Offset: {0}'.format(lrtime), 'DEBUG')
+        logging.debug('Server END Time Offset: {0}'.format(lrtime))
+        logging.info("ioHub Server has SHUTDOWN")
+
         return True
 
     except Exception: # pylint: disable=broad-except
+        logging.fatal(
+            "ioHub Server has encountered an unrecoverable error, "
+            "check traceback below for details.")
+        logging.flush()
+        # write stderr to log file
+        with open(logFilePath, "a", encoding="utf-8") as log_file:
+            exc_type, exc_value, exc_tb = sys.exc_info()
+            errStr = "".join(traceback.format_exception(
+                exc_type, exc_value, exc_tb))
+            log_file.write(errStr)
+            log_file.write("\n")
+            log_file.flush()
+        
+        # print last exception details to psychopy process stderr
+        # so the user can see it in the console
         printExceptionDetailsToStdErr()
+            
         if s:
             s.shutdown()
+            
         return False
 
 if __name__ == '__main__':
@@ -125,3 +188,7 @@ if __name__ == '__main__':
     Computer.global_clock = clock.MonotonicClock(initial_offset)
 
     run(rootScriptPathDir=scriptPathDir, configFilePath=configFileName)
+
+
+if __name__ == "__main__":
+    pass


### PR DESCRIPTION
This PR fixes issues around getting messages displayed or logged somewhere in the event of an internal error occurring in the iohub subprocess. This is done by adding exception hooks to the subprocess Python interpreter which flush stderr buffers automatically on error. We also bound `atexit` handlers to perform a final flush to ensure the subprocess doesn't just swallow whatever those buffers contain when shutting down.

Log messages for the last iohub session are now written to a file named `iohub_last_session.log` in the user pref directory. The last traceback is appended to the end to the file if an unhandled error were to occur during the session. The error will also appear in the Runner console.