### PR TITLE
CI: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/CodeQL.yaml
+++ b/.github/workflows/CodeQL.yaml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -17,10 +17,10 @@ jobs:
           id-token: write
           contents: write 
         steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v6
 
         - name: Setup Python
-          uses: actions/setup-python@v3
+          uses: actions/setup-python@v6
           with:
             python-version: '3.10'
         

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -20,10 +20,8 @@ jobs:
         python-version: ['3.10']
 
     steps:
-    - uses: actions/checkout@v3
-
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         
@@ -39,7 +37,7 @@ jobs:
   
     - name: cache wxPython for linux
       if: runner.os=='Linux'
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ matrix.os }}-py${{ matrix.python-version }}-${{ steps.month.outputs.month }}


### PR DESCRIPTION
Hi, I would like to add a simple security fix to your CI pipeline. It pin the actions versions, and updates the outdated ones.

- **pypi.yaml**: pin `actions/checkout` from `@master` to `@v6` (security fix — unpinned tags can execute arbitrary upstream code), update `actions/setup-python` from `@v3` to `@v6`
- **pytests.yaml**: update `actions/checkout` `@v3` → `@v6`, `actions/setup-python` `@v4` → `@v6`, `actions/cache` `@v3` → `@v5`, remove duplicate checkout step
- **CodeQL.yaml**: update `actions/checkout` `@v4` → `@v6`

## Motivation

The `actions/checkout@master` tag in `pypi.yaml` is a supply-chain risk: any commit pushed to the `master` branch of `actions/checkout` would run in your release workflow. Pinning to a version tag (`@v6`) ensures only reviewed releases are used.

The other updates bring all workflows to the latest stable action versions and remove a redundant duplicate checkout step in `pytests.yaml`.