### PR TITLE
BF: Skip camera devices with no available formats.

### DIFF
--- a/psychopy/hardware/camera/__init__.py
+++ b/psychopy/hardware/camera/__init__.py
@@ -600,6 +600,9 @@ class CameraDevice(BaseDevice):
         profiles = []
         # iterate through cameras
         for cams in CameraDevice.getCameras().values():
+            # Skip devices with no available formats
+            if not cams:
+                continue
             # if requested, filter for best spec for each device
             if best:
                 allCams = cams.copy()


### PR DESCRIPTION
I have some virtual cameras (e.g. OBS) on my system that have no available formats, and this leads to e.g.:

```python
>>> x = CameraDevice.getAvailableDevices()
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "...\psychopy\hardware\camera\__init__.py", line 614, in getAvailableDevices
    minFrameRate = max(28, min([cam.frameRate for cam in allCams]))
ValueError: min() arg is an empty sequence
```

As far as I can tell, this is the only place where non-emptiness is assumed?

Tested vs. 2026.1.1 on Windows 11. This lets the app device manager successfully list the built-in webcam.