### PR TITLE
FF: use string concatenation for default JS (#7588)

### DIFF
--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -143,9 +143,9 @@ class SettingsComponent:
         # if filename is the default value fetch the builder pref for the
         # folder instead
         if filename is None:
-            filename = ("u'xxxx/%s_%s_%s' % (expInfo['participant'], expName,"
-                        " expInfo['date'])")
-        if filename.startswith("u'xxxx"):
+            filename = ("'xxxx/' + expInfo['participant'] + '_' + expName + '_'"
+                        " + expInfo['date']")
+        if filename.startswith("'xxxx"):
             folder = self.exp.prefsBuilder['savedDataFolder'].strip()
             filename = filename.replace("xxxx", folder)
 


### PR DESCRIPTION
Fixes #7588.

## Tested on
- PsychoPy 2026.1.2
- Windows 11
- Python 3.11, pip install (no metapensiero, see note on dependency below)

## Problem
The default Data filename uses Python `%` stringformatting. The transpiler relies on `metapensiero`, an undeclared dependency not installed via `pip` and stored only as a repository on GitLab. Without it, `expression2js` silently emits raw Python as JavaScript, causing `SyntaxError` in the browser. Because metapensiero comes packaged with the standard installation of PsychoPy available on PsychoPy.org, the bug does not come up on that executable, but does come up when packaging the files from the GitHub repository.

## Fix
Change the default from `%` formatting to `+` concatenation (valid in both Python and JS, needs no transpilation).

## Scope
This fixes new experiments only. Existing `.psyexp` files store the old format in XML and would need a migration path or a fix to the silent `except: pass` in `py2js.py:89`.