### PR TITLE
RF: replace bare except clauses in hardware module

### DIFF
--- a/psychopy/hardware/base.py
+++ b/psychopy/hardware/base.py
@@ -36,13 +36,13 @@ class BaseResponse:
         for key in self.fields:
             try:
                 attrs.append(f"{key}={getattr(self, key)}")
-            except:
+            except AttributeError:
                 continue
         attrs = ", ".join(attrs)
         # construct
         try:
             return f"<{type(self).__name__} from {self.getDeviceName()}: {attrs}>"
-        except:
+        except Exception:
             return f"<{type(self).__name__}: {attrs}>"
     
     def getDeviceName(self):
@@ -382,7 +382,7 @@ class BaseResponseDevice(BaseDevice):
         # try to dispatch messages
         try:
             self.dispatchMessages()
-        except:
+        except Exception:
             pass
         # clear resp list
         self.responses = []

--- a/psychopy/hardware/button.py
+++ b/psychopy/hardware/button.py
@@ -34,7 +34,7 @@ class ButtonResponse(base.BaseResponse):
         if isinstance(other, dict):
             try:
                 return ButtonResponse(**other) == self
-            except:
+            except (TypeError, KeyError):
                 # if it can't instantiate a ButtonResponse, it's not the same as this
                 return False
         

--- a/psychopy/hardware/manager.py
+++ b/psychopy/hardware/manager.py
@@ -166,7 +166,7 @@ class DeviceManager:
         # import package
         try:
             pkg = importlib.import_module(pkgName)
-        except:
+        except (ImportError, ModuleNotFoundError):
             raise ModuleNotFoundError(
                 f"Could not find module: {pkgName}"
             )
@@ -823,7 +823,7 @@ class DeviceManager:
                         # import it so we can detect it
                         try:
                             DeviceManager._resolveClassString(cls.deviceClass)
-                        except:
+                        except Exception:
                             logging.warn(
                                 f"Failed to load class {cls.deviceClass} from specification in "
                                 f"{cls.__name__} ({emt.__name__})"

--- a/psychopy/hardware/microphone.py
+++ b/psychopy/hardware/microphone.py
@@ -1317,7 +1317,7 @@ class MicrophoneDevice(BaseDevice, aliases=["mic", "microphone"]):
             # generate a sound for this speaker
             try:
                 snd = sound.Sound("A", stereo=True, speaker=speaker)
-            except:
+            except Exception:
                 # silently skip on error
                 continue
             # get a baseline volume

--- a/psychopy/hardware/speaker.py
+++ b/psychopy/hardware/speaker.py
@@ -240,7 +240,7 @@ class SpeakerDevice(BaseDevice):
                         logging.error(line[11:])
                     elif line.strip():
                         print(line)
-            except:
+            except Exception:
                 pass
         # if everything failed, raise an error
         if self.stream is None:


### PR DESCRIPTION
This PR replaces 8 bare `except:` clauses with specific exception types across `psychopy/hardware/`.

`AttributeError` for `getattr` lookups, `ImportError`/`ModuleNotFoundError` for module imports, `TypeError`/`KeyError` for dict unpacking, `Exception` where the failure mode is broad. 

Bare excepts silently swallow `KeyboardInterrupt` and `SystemExit`, making debugging harder
