### PR TITLE
RF: replace bare except clauses in iohub and experiment modules

### DIFF
--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -39,7 +39,7 @@ for filename in pycFiles:
     if not os.path.isfile(filename[:-2]):
         try:
             os.remove(filename)
-        except:
+        except OSError:
             pass  # may not have sufficient privs
 
 

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -142,7 +142,7 @@ class BaseComponent:
         # try to load SVG
         try:
             iconSVG = cls.iconSVG.read_text("utf-8")
-        except:
+        except (OSError, AttributeError):
             iconSVG = None
         # include basic info
         profile = {

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -586,7 +586,7 @@ class SettingsComponent:
                 if legKey not in backendValues:
                     backendValues.append(legKey)
                     backendLabels.append(legLbl)
-        except:
+        except Exception:
             # if it doesn't work, just stick with the known backends from plugins
             pass
 
@@ -1351,7 +1351,7 @@ class SettingsComponent:
         if isinstance(colPriority, str):
             try:
                 colPriority = ast.literal_eval(colPriority)
-            except:
+            except (ValueError, SyntaxError):
                 raise ValueError(_translate(
                     "Could not interpret value as dict: {}"
                 ).format(colPriority))

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -86,7 +86,7 @@ def expression2js(expr):
             jsStr = translatePythonToJavaScript(jsStr)
             if jsStr.endswith(';\n'):
                 jsStr = jsStr[:-2]
-        except:
+        except Exception:
             # If translation fails, just use old translation
             pass
     return jsStr

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -104,7 +104,7 @@ class BaseStandaloneRoutine:
         # try to load SVG
         try:
             iconSVG = cls.iconSVG.read_text("utf-8")
-        except:
+        except (OSError, AttributeError):
             iconSVG = None
         # include basic info
         profile = {

--- a/psychopy/iohub/client/__init__.py
+++ b/psychopy/iohub/client/__init__.py
@@ -428,7 +428,7 @@ class ioHubConnection():
                 self._sendToHubServer(('RPC', 'clearEventBuffer', [True, ]))
                 try:
                     self.getDevice('keyboard')._clearLocalEvents()
-                except:
+                except Exception:
                     pass
             else:
                 d = self.devices.getDevice(device_label)
@@ -439,7 +439,7 @@ class ioHubConnection():
             self._sendToHubServer(('RPC', 'clearEventBuffer', [False, ]))
             try:
                 self.getDevice('keyboard')._clearLocalEvents()
-            except:
+            except Exception:
                 pass
         else:
             raise ValueError(

--- a/psychopy/iohub/client/eyetracker/validation/procedure.py
+++ b/psychopy/iohub/client/eyetracker/validation/procedure.py
@@ -123,7 +123,7 @@ class TargetStim:
     def innerRadius(self):
         try:
             return self.stim[1].radius
-        except:
+        except (IndexError, AttributeError):
             return self.stim[0].radius
 
 def create3PointGrid():
@@ -935,7 +935,7 @@ class ValidationTargetRenderer:
             start_radius = self.target.radius
             try:
                 stop_radius = self.target.innerRadius
-            except:
+            except AttributeError:
                 stop_radius = start_radius/2
                 print("Warning: validation target has no .innerRadius property.")
             while fliptime < contractedtime:

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -689,7 +689,7 @@ class Display(Device):
                                     degy, self._psychopy_monitor))
                         return degx, degy
                     self._coord2pix = degcoord2pix
-            except:
+            except Exception:
                 print2err('Error during _calculateCoordMappingFunctions')
                 printExceptionDetailsToStdErr()
 

--- a/psychopy/iohub/errors.py
+++ b/psychopy/iohub/errors.py
@@ -27,7 +27,7 @@ def print2err(*args):
             sys.stderr.write("{0}".format(a))
         sys.stderr.write("\n")
         sys.stderr.flush()
-    except:
+    except Exception:
         for a in args:
             print("{0}".format(a))
         print()
@@ -46,7 +46,7 @@ def printExceptionDetailsToStdErr():
         errStr = "".join(traceback.format_exception(
             exc_type, exc_value, exc_tb))
         print2err(errStr)
-    except:
+    except Exception:
         traceback.print_exc()
 
 

--- a/psychopy/iohub/net.py
+++ b/psychopy/iohub/net.py
@@ -102,7 +102,7 @@ class SocketConnection(): # pylint: disable=too-many-instance-attributes
                     num_packets = num_packets - 1
                 result = self.unpack()
             return result, address
-        except:
+        except Exception:
             pass
 
     def close(self):


### PR DESCRIPTION
Hi, follow-up to #7600 (hardware). This PR replaces 15 bare `except:` clauses across `psychopy/iohub/` (9) and `psychopy/experiment/` (6) with specific exception types. Bare excepts swallow `KeyboardInterrupt` and `SystemExit`, making debugging harder.

Split into two commits for clarity:

- iohub: narrow guards use specific types (`AttributeError`, `(IndexError, AttributeError)`); broad fallbacks use `Exception`
- experiment: `OSError` for filesystem ops, `(ValueError, SyntaxError)` for `ast.literal_eval`, `Exception` for broad fallbacks

The `# noqa: E722` site in `iohub/util/__init__.py` is intentionally left alone.

I grouped two modules together for this PR. I found 16 more bare excepts in other modules. If you prefer to merge everything in one swoop, I can extend this PR to contain all the bare excepts I could find, let me know.