### PR TITLE
ENH!: If Keyboard is set to "register on release", .rt should reflect key release rather than key press

### DIFF
--- a/psychopy/experiment/components/keyboard/__init__.py
+++ b/psychopy/experiment/components/keyboard/__init__.py
@@ -294,6 +294,13 @@ class KeyboardComponent(BaseComponent):
                     "{name}.rt = [key.rt for key in _{name}_allKeys]\n"
                     "{name}.duration = [key.duration for key in _{name}_allKeys]\n")
             buff.writeIndentedLines(code.format(name=self.params['name']))
+        # adjust .rt to describe release rather than press, if that's what we're listening for
+        if self.params['registerOn'] == "release":
+            code = (
+                "# adjust rt to reflect key release rather than key press\n"
+                "%(name)s.rt += %(name)s.duration\n"
+            )
+            buff.writeIndentedLines(code % self.params)
 
         if storeCorr:
             code = ("# was this correct?\n"


### PR DESCRIPTION
As the .rt attribute predates the notion of "register on...", .rt always reflects the time of key press regardless of what "register on..." is set to. This is unintuitive, and easily remedied by adding .duration to .rt if "register on release" is chosen, however I'm doing this as a draft as it's a change which could break user's analysis pipelines if they're relying on the previous behaviour.