### PR TITLE
BF: Find user-level installed fonts on Linux

### DIFF
--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -35,6 +35,7 @@ _X11FontDirectories = [
     "/usr/X11/lib/X11/fonts",
     # here is the new standard location for fonts
     "/usr/share/fonts",
+    "~/.local/share/fonts",
     # documented as a good place to install new fonts
     "/usr/local/share/fonts",
     # common application, not really useful
@@ -1064,6 +1065,11 @@ class FontFinder:
             return output
         # pathify folder
         thisFolder = Path(folder)
+        # try expanding ~ (but don't worry if it failed)
+        try:
+            thisFolder = thisFolder.expanduser()
+        except:
+            pass
         # try each extension
         for ext in cls.supportedExtensions:
             try:


### PR DESCRIPTION
`/usr/share/fonts` is the standard install location for fonts installed system-wide, but there's a different standard location for user-level fonts, and user-level install is the default (on GNOME at least) if you install by just double clicking a .ttf file and pressing "Install".

This path is common to GNOME and KDE from what I can tell from the docs, so should cover the majority of distros (at least as much so as the existing search paths).