### PR TITLE
fix: replace 35 bare except clauses with except Exception

### DIFF
--- a/building/searchCopyrightYear.py
+++ b/building/searchCopyrightYear.py
@@ -60,7 +60,7 @@ targetFiles = 0 # count of files to be updated
 tmpFile = './replaceCopyright'+oldYear+'_'+newYear+'.sh'
 try:
     del files[files.index(tmpFile)]
-except:
+except Exception:
     pass
 tmp = open(tmpFile, 'w')
 tmp.write('#!/bin/sh \necho Updating...\n')

--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -287,7 +287,7 @@ class Color:
             if space not in ("named", "hex"):
                 try:
                     color = ast.literal_eval(color)
-                except:
+                except Exception:
                     pass
         # Handle everything as an array
         if not isinstance(color, np.ndarray):
@@ -1059,7 +1059,7 @@ def isValidColor(color, space='rgb'):
     try:
         buffer = Color(color, space)
         return bool(buffer)
-    except:
+    except Exception:
         return False
 
 

--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -324,7 +324,7 @@ def importConditions(fileName, returnFieldNames=False, selection=""):
                                 raise err
                     # if it's all good, use received array
                     trialsArr = thisAttempt
-                except:
+                except Exception:
                     continue
                 else:
                     # if successful, check the variable names

--- a/psychopy/demos/coder/experiment control/JND_staircase_exp.py
+++ b/psychopy/demos/coder/experiment control/JND_staircase_exp.py
@@ -11,7 +11,7 @@ import time, numpy
 
 try:  # try to get a previous parameters file
     expInfo = fromFile('lastParams.pickle')
-except:  # if not there then use a default set
+except Exception:  # if not there then use a default set
     expInfo = {'observer':'jwp', 'refOrientation':0}
 dateStr = time.strftime("%b_%d_%H%M", time.localtime())  # add the current time
 

--- a/psychopy/demos/coder/timing/millikeyKeyboardTimingTest.py
+++ b/psychopy/demos/coder/timing/millikeyKeyboardTimingTest.py
@@ -84,10 +84,10 @@ def getMilliKeyDevices():
                     mkconf = json.loads(rx_data)
                     mkconf['port'] = p
                     devices.append(mkconf)
-                except:
+                except Exception:
                     raise RuntimeError("ERROR: {}".format(rx_data))
             mkey_sport.close()
-        except:
+        except Exception:
             pass
     return devices
 

--- a/psychopy/demos/coder/understanding psychopy/colors.py
+++ b/psychopy/demos/coder/understanding psychopy/colors.py
@@ -55,7 +55,7 @@ while not endBtn.isClicked:
         # Get color space from radio slider
         space = spaces[int(spaceCtrl.markerPos)]
         col = colors.Color(val, space)
-    except:
+    except Exception:
         col = False
     # Set the color box's fill color, show text "invalid" if color is invalid
     if col:

--- a/psychopy/experiment/components/__init__.py
+++ b/psychopy/experiment/components/__init__.py
@@ -39,7 +39,7 @@ for filename in pycFiles:
     if not os.path.isfile(filename[:-2]):
         try:
             os.remove(filename)
-        except:
+        except Exception:
             pass  # may not have sufficient privs
 
 

--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -142,7 +142,7 @@ class BaseComponent:
         # try to load SVG
         try:
             iconSVG = cls.iconSVG.read_text("utf-8")
-        except:
+        except Exception:
             iconSVG = None
         # include basic info
         profile = {

--- a/psychopy/experiment/components/settings/__init__.py
+++ b/psychopy/experiment/components/settings/__init__.py
@@ -553,7 +553,7 @@ class SettingsComponent:
                 if legKey not in backendValues:
                     backendValues.append(legKey)
                     backendLabels.append(legLbl)
-        except:
+        except Exception:
             # if it doesn't work, just stick with the known backends from plugins
             pass
 
@@ -1163,7 +1163,7 @@ class SettingsComponent:
         if isinstance(colPriority, str):
             try:
                 colPriority = ast.literal_eval(colPriority)
-            except:
+            except Exception:
                 raise ValueError(_translate(
                     "Could not interpret value as dict: {}"
                 ).format(colPriority))

--- a/psychopy/experiment/py2js.py
+++ b/psychopy/experiment/py2js.py
@@ -86,7 +86,7 @@ def expression2js(expr):
             jsStr = translatePythonToJavaScript(jsStr)
             if jsStr.endswith(';\n'):
                 jsStr = jsStr[:-2]
-        except:
+        except Exception:
             # If translation fails, just use old translation
             pass
     return jsStr

--- a/psychopy/experiment/routines/_base.py
+++ b/psychopy/experiment/routines/_base.py
@@ -104,7 +104,7 @@ class BaseStandaloneRoutine:
         # try to load SVG
         try:
             iconSVG = cls.iconSVG.read_text("utf-8")
-        except:
+        except Exception:
             iconSVG = None
         # include basic info
         profile = {

--- a/psychopy/iohub/client/__init__.py
+++ b/psychopy/iohub/client/__init__.py
@@ -428,7 +428,7 @@ class ioHubConnection():
                 self._sendToHubServer(('RPC', 'clearEventBuffer', [True, ]))
                 try:
                     self.getDevice('keyboard')._clearLocalEvents()
-                except:
+                except Exception:
                     pass
             else:
                 d = self.devices.getDevice(device_label)
@@ -439,7 +439,7 @@ class ioHubConnection():
             self._sendToHubServer(('RPC', 'clearEventBuffer', [False, ]))
             try:
                 self.getDevice('keyboard')._clearLocalEvents()
-            except:
+            except Exception:
                 pass
         else:
             raise ValueError(

--- a/psychopy/iohub/client/eyetracker/validation/procedure.py
+++ b/psychopy/iohub/client/eyetracker/validation/procedure.py
@@ -123,7 +123,7 @@ class TargetStim:
     def innerRadius(self):
         try:
             return self.stim[1].radius
-        except:
+        except Exception:
             return self.stim[0].radius
 
 def create3PointGrid():
@@ -935,7 +935,7 @@ class ValidationTargetRenderer:
             start_radius = self.target.radius
             try:
                 stop_radius = self.target.innerRadius
-            except:
+            except Exception:
                 stop_radius = start_radius/2
                 print("Warning: validation target has no .innerRadius property.")
             while fliptime < contractedtime:

--- a/psychopy/iohub/devices/display/__init__.py
+++ b/psychopy/iohub/devices/display/__init__.py
@@ -711,7 +711,7 @@ class Display(Device):
                                     degy, self._psychopy_monitor))
                         return degx, degy
                     self._coord2pix = degcoord2pix
-            except:
+            except Exception:
                 print2err('Error during _calculateCoordMappingFunctions')
                 printExceptionDetailsToStdErr()
 

--- a/psychopy/iohub/errors.py
+++ b/psychopy/iohub/errors.py
@@ -27,7 +27,7 @@ def print2err(*args):
             sys.stderr.write("{0}".format(a))
         sys.stderr.write("\n")
         sys.stderr.flush()
-    except:
+    except Exception:
         for a in args:
             print("{0}".format(a))
         print()
@@ -46,7 +46,7 @@ def printExceptionDetailsToStdErr():
         errStr = "".join(traceback.format_exception(
             exc_type, exc_value, exc_tb))
         print2err(errStr)
-    except:
+    except Exception:
         traceback.print_exc()
 
 

--- a/psychopy/iohub/net.py
+++ b/psychopy/iohub/net.py
@@ -102,7 +102,7 @@ class SocketConnection(): # pylint: disable=too-many-instance-attributes
                     num_packets = num_packets - 1
                 result = self.unpack()
             return result, address
-        except:
+        except Exception:
             pass
 
     def close(self):

--- a/psychopy/iohub/util/__init__.py
+++ b/psychopy/iohub/util/__init__.py
@@ -273,7 +273,7 @@ def getDevicePaths(device_name=""):
             # load the target the entry point points to, it could be a class or a module
             try:
                 ep_target = ep.load()
-            except:  # noqa: E722
+            except Exception:  # noqa: E722
                 logging.error(f"Failed to load entry point: {ep}")
                 continue
 

--- a/psychopy/liaison.py
+++ b/psychopy/liaison.py
@@ -41,7 +41,7 @@ class LiaisonJSONEncoder(json.JSONEncoder):
 			# if object has a getJSON method, use it
 			if hasattr(o, "getJSON"):
 				return o.getJSON(asString=False)
-		except:
+		except Exception:
 			# if there's an error in the getJSON method, continue so we can try regular encoding
 			pass
 		# if object is an error, transform in standardised form

--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -752,7 +752,7 @@ def loadPlugin(plugin):
                     logging.error(
                         "Plugin `{}` entry point requires module `{}`, but it "
                         "cannot be imported.".format(plugin, module_name))
-                except:
+                except Exception:
                     importSuccess = False
                     logging.error(
                         "Plugin `{}` entry point requires module `{}`, but an "

--- a/psychopy/preferences/preferences.py
+++ b/psychopy/preferences/preferences.py
@@ -16,7 +16,7 @@ import shutil
 
 try:
     import psychopy_app
-except:
+except Exception:
     psychopy_app = None
 
 try:
@@ -387,7 +387,7 @@ class Preferences:
                     try:
                         # attempt to un-stringify
                         section[key] = json.loads(val)
-                    except:
+                    except Exception:
                         # use as-is if this fails
                         section[key] = val
     

--- a/psychopy/tests/test_validators/test_voicekeyValidator.py
+++ b/psychopy/tests/test_validators/test_voicekeyValidator.py
@@ -30,7 +30,7 @@ class TestAudioValidator:
             for speaker in foundSpeakers:
                 try:
                     sound.Sound("A", speaker=speaker)
-                except:
+                except Exception:
                     continue
                 else:
                     # if successful, we have a matching pair!

--- a/psychopy/tools/fontmanager.py
+++ b/psychopy/tools/fontmanager.py
@@ -666,7 +666,7 @@ def findFontFiles(folders=(), recursive=True, currentDir=Path(".")):
             try:
                 from matplotlib import font_manager
                 searchPaths.append(font_manager.findSystemFonts)
-            except:
+            except Exception:
                 pass
         elif sys.platform == 'darwin':
             # on mac matplotlib doesn't include 'ttc' files (which are fine)
@@ -1068,7 +1068,7 @@ class FontFinder:
         # try expanding ~ (but don't worry if it failed)
         try:
             thisFolder = thisFolder.expanduser()
-        except:
+        except Exception:
             pass
         # try each extension
         for ext in cls.supportedExtensions:

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -408,7 +408,7 @@ def getOpenGLInfo():
 # OpenGL limits for this system
 try:
     MAX_TEXTURE_UNITS = getOpenGLInfo().maxTextureUnits
-except:
+except Exception:
     MAX_TEXTURE_UNITS = 32
 
 

--- a/psychopy/tools/pkgtools.py
+++ b/psychopy/tools/pkgtools.py
@@ -230,7 +230,7 @@ def installPackage(
     # handle install from file
     try:
         packagePath = Path(package)
-    except:
+    except Exception:
         pass
     else:
         if packagePath.is_file():

--- a/psychopy/tools/stimulustools.py
+++ b/psychopy/tools/stimulustools.py
@@ -79,7 +79,7 @@ def serialize(obj, includeClass=True):
     # convert possible file paths into Path
     try:
         pathVal = Path(obj)
-    except:
+    except Exception:
         pass
     else:
         if pathVal.is_file() or pathVal.is_dir():
@@ -97,7 +97,7 @@ def serialize(obj, includeClass=True):
         json.dumps(obj)
     except TypeError:
         pass
-    except:
+    except Exception:
         # if we got something other than a TypeError, substitute None
         return None
     else:

--- a/psychopy/visual/backends/pygletbackend.py
+++ b/psychopy/visual/backends/pygletbackend.py
@@ -474,7 +474,7 @@ class PygletBackend(BaseBackend):
         for dispatcher in self.win._eventDispatchers:
             try:
                 dispatcher.dispatch_events()
-            except:
+            except Exception:
                 dispatcher._dispatch_events()
 
         # this might need to be done even more often than once per frame?


### PR DESCRIPTION
## Summary

Replaces **35** bare `except:` with `except Exception:` across **26 files**.

Key areas: preferences, tools, experiment components, iohub client, visual backends, demos.

## Why

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`.