### PR TITLE
BF: ButtonBoxComponent was measuring time from *Routine start*, not *Component start*

### DIFF
--- a/psychopy/experiment/components/buttonBox/__init__.py
+++ b/psychopy/experiment/components/buttonBox/__init__.py
@@ -151,7 +151,7 @@ class ButtonBoxComponent(BaseDeviceComponent):
         code = (
             "# clear %(name)s button presses\n"
             "%(name)s.buttons = []\n"
-            "%(name)s.times = []\n"
+            "%(name)s.rt = []\n"
             "%(name)s.corr = []\n"
             )
         buff.writeIndentedLines(code % self.params)
@@ -202,7 +202,7 @@ class ButtonBoxComponent(BaseDeviceComponent):
                 # if storing all, append
                 code += (
                 "    %(name)s.buttons.append(_thisResp.channel)\n"
-                "    %(name)s.times.append(_thisResp.t)\n"
+                "    %(name)s.rt.append(_thisResp.t)\n"
                 )
                 # include code to get correct
                 if self.params['storeCorrect']:
@@ -216,7 +216,7 @@ class ButtonBoxComponent(BaseDeviceComponent):
                 # if storing last, replace
                 code += (
                 "    %(name)s.buttons = _thisResp.channel\n"
-                "    %(name)s.times = _thisResp.t\n"
+                "    %(name)s.rt = _thisResp.t\n"
                 )
                 # include code to get correct
                 if self.params['storeCorrect']:
@@ -231,7 +231,7 @@ class ButtonBoxComponent(BaseDeviceComponent):
                 code += (
                 "    if not %(name)s.buttons:\n"
                 "        %(name)s.buttons = _thisResp.channel\n"
-                "        %(name)s.times = _thisResp.t\n"
+                "        %(name)s.rt = _thisResp.t\n"
                 )
                 # include code to get correct
                 if self.params['storeCorrect']:
@@ -271,7 +271,7 @@ class ButtonBoxComponent(BaseDeviceComponent):
         code = (
             "# store data from %(name)s\n"
             "thisExp.addData('%(name)s.buttons', %(name)s.buttons)\n"
-            "thisExp.addData('%(name)s.times', %(name)s.times)\n"
+            "thisExp.addData('%(name)s.rt', %(name)s.times)\n"
             "thisExp.addData('%(name)s.corr', %(name)s.corr)\n"
         )
         buff.writeIndentedLines(code % params)

--- a/psychopy/experiment/components/buttonBox/__init__.py
+++ b/psychopy/experiment/components/buttonBox/__init__.py
@@ -147,17 +147,6 @@ class ButtonBoxComponent(BaseDeviceComponent):
         buff.writeIndentedLines(code % inits)
 
     def writeRoutineStartCode(self, buff):
-        # choose a clock to sync to according to component's params
-        if "syncScreenRefresh" in self.params and self.params['syncScreenRefresh']:
-            clockStr = ""
-        else:
-            clockStr = "clock=routineTimer"
-        # sync component start/stop timers with validator clocks
-        code = (
-            f"# synchronise device clock for %(name)s with Routine timer\n"
-            f"%(name)s.resetTimer({clockStr})\n"
-        )
-        buff.writeIndentedLines(code % self.params)
         # clear keys
         code = (
             "# clear %(name)s button presses\n"
@@ -177,6 +166,17 @@ class ButtonBoxComponent(BaseDeviceComponent):
         # writes an if statement to determine whether to draw etc
         indented = self.writeStartTestCode(buff)
         if indented:
+            # sync component start/stop timers with validator clocks
+            if self.params['syncScreenRefresh']:
+                code = (
+                    "win.callOnFlip(%(name)s.resetTimer, core.Clock())"
+                ) % self.params
+            else:
+                code = (
+                    "%(name)s.resetTimer(core.Clock())"
+                )
+            buff.writeIndentedLines(code % self.params)
+
             if self.params['discardPrevious']:
                 # dispatch and clear messages
                 code = (


### PR DESCRIPTION
This can be accounted for in existing data by subtracting `buttonBox.tStart` from `buttonBox.times`, but for consistency with e.g. KeyboardComponent the button press time should be relative to the start of the Component