### PR TITLE
RF: Interact with SerialDevice from Builder via a wrapper class

### DIFF
--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -273,12 +273,19 @@ class SerialDeviceBackend(DeviceBackend):
         # define order
         self.order += [
             "timeout",
+            "eol"
         ]
 
         self.params['timeout'] = Param(
             "", valType='code', inputType="single",
             hint=_translate("Time at which to give up listening for a response (leave blank for no limit)"),
             label=_translate("Timeout")
+        )
+
+        self.params['eol'] = Param(
+            "$'\\n'", valType="str", inputType="single", categ="Basic",
+            label=_translate("EOL (end-of-line) character"),
+            hint=_translate("Character automatically added to end of each message - leave blank for no EOL")
         )
 
         # -- Override params ---
@@ -351,6 +358,7 @@ class SerialDeviceBackend(DeviceBackend):
         buff.writeIndentedLines(code)
         # add pause and close
         code = (
+            "    eol=%(eol)s,\n"
             "    pauseDuration=(%(timeout)s or 0.1) / 3,\n"  
             ")\n"
         )

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -168,7 +168,7 @@ class SerialOutComponent(BaseDeviceComponent):
             if params['startDataType'] == "str":
                 params['startData'] = params['startDataStr']
             elif params['startDataType'] == "num":
-                params['startData'] = "bytes(chr(%(startDataNumeric)s), 'utf-8')" % params
+                params['startData'] = params['startDataNumeric']
             elif params['startDataType'] == "binary":
                 params['startData'] = "0b%(startDataBinary)s" % params
             elif params['startDataType'] == "char":
@@ -189,7 +189,7 @@ class SerialOutComponent(BaseDeviceComponent):
             buff.writeIndented(code % params)
             # store code that was sent
             code = (
-                "%(loop)s.addData('%(name)s.stopData', %(startData)s)\n"
+                "%(loop)s.addData('%(name)s.startData', %(startData)s)\n"
             )
             buff.writeIndented(code % params)
             # update status
@@ -213,7 +213,7 @@ class SerialOutComponent(BaseDeviceComponent):
             if params['stopDataType'] == "str":
                 params['stopData'] = params['stopDataStr']
             elif params['stopDataType'] == "num":
-                params['stopData'] = "bytes(bytearray([%(stopDataNumeric)s]))" % params
+                params['stopData'] = params['stopDataNumeric']
             elif params['stopDataType'] == "binary":
                 params['stopData'] = "0b%(stopDataBinary)s" % params
             elif params['stopDataType'] == "char":

--- a/psychopy/experiment/components/serialOut/__init__.py
+++ b/psychopy/experiment/components/serialOut/__init__.py
@@ -148,8 +148,9 @@ class SerialOutComponent(BaseDeviceComponent):
         code = (
             "\n"
             "# point %(name)s to device named %(deviceLabel)s and make sure it's open\n"
-            "%(name)s = deviceManager.getDevice(%(deviceLabel)s)\n"
-            "%(name)s.status = NOT_STARTED\n"
+            "%(name)s = SerialOut(\n"
+            "    device=%(deviceLabel)s\n"
+            ")\n"
             "if not %(name)s.com.is_open:\n"
             "    %(name)s.com.open()\n"
         )
@@ -159,8 +160,6 @@ class SerialOutComponent(BaseDeviceComponent):
         params = copy(self.params)
         # Get containing loop
         params['loop'] = self.currentLoop
-        
-
         # On component start, send start bits
         indented = self.writeStartTestCode(buff)
         if indented:

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -20,6 +20,8 @@ from .exceptions import DeviceNotConnectedError
 from psychopy.tools import systemtools as st
 from psychopy.tools.attributetools import AttributeGetSetMixin
 from .base import BaseDevice
+from psychopy.hardware import DeviceManager
+from psychopy.constants import NOT_STARTED
 
 
 def _findPossiblePorts():
@@ -57,6 +59,71 @@ def _findPossiblePorts():
 
 # map out all ports on this device, to be filled as serial devices are initialised
 ports = {port: None for port in _findPossiblePorts()}
+
+
+class SerialOut(AttributeGetSetMixin):
+    """
+    Wrapper around SerialDevice which handles Builder specific stuff (e.g. started/active/stopped 
+    status) on a per-Component basis
+    """
+
+    def __init__(self, device, autolog=True):
+        if isinstance(device, SerialDevice):
+            # if given a serial device
+            self.device = device
+        # if given a string, get via DeviceManager
+        if isinstance(device, str):
+            if device in DeviceManager.devices:
+                self.device = DeviceManager.getDevice(device)
+            else:
+                # don't use formatted string literals in _translate()
+                raise ValueError(_translate(
+                    "Could not find device named '{device}', make sure it has been set up "
+                    "in DeviceManager."
+                ).format(device))
+        # set an initial status
+        self.status = NOT_STARTED
+        # set autolog
+        self.autolog = autolog
+    
+    @property
+    def com(self):
+        return self.device.com
+    
+    @property
+    def portString(self):
+        return self.device.portString
+
+    def pause(self):
+        """Pause for a default period for this device
+        """
+        self.device.pause()
+    
+    def sendMessage(self, message, autoLog=True):
+        return self.device.sendMessage(
+            message, 
+            autoLog=autoLog
+        )
+    
+    def getResponse(self, length=1, timeout=0.1, autoLog=True):
+        return self.device.getResponse(
+            length=length, 
+            timeout=timeout, 
+            autoLog=autoLog
+        )
+
+    def awaitResponse(self, multiline=False, timeout=None):
+        return self.device.awaitResponse(
+            self,
+            multiline=multiline,
+            timeout=timeout
+        )
+
+    def isAwake(self):
+        return self.device.isAwake()
+    
+    def isOpen(self):
+        return self.device.isOpen()
 
 
 class SerialDevice(BaseDevice, AttributeGetSetMixin):

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -216,8 +216,15 @@ class SerialDevice(BaseDevice, AttributeGetSetMixin):
             inStr = self.com.read(self.com.inWaiting())
             msg = "Sending '%s' to %s but found '%s' on the input buffer"
             logging.warning(msg % (message, self.name, inStr))
-        if type(message) is not bytes:
+        # transform string input into bytes
+        if isinstance(message, str):
             message = bytes(message, 'utf-8')
+        # transform integers into bytes via bytearray
+        if isinstance(message, int):
+            message = bytes(bytearray([message]))
+        # transform arrays into bytearray
+        if isinstance(message, (list, tuple)):
+            message = bytearray(message)
         if not message.endswith(self.eol):
             message += self.eol  # append a newline if necess
         self.com.write(message)

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -113,10 +113,7 @@ class SerialDevice(BaseDevice, AttributeGetSetMixin):
         self.com = None
         self.OK = False
         self.maxAttempts = maxAttempts
-        if type(eol) is bytes:
-            self.eol = eol
-        else:
-            self.eol = bytes(eol, 'utf-8')
+        self.eol = eol
         self.type = self.name  # for backwards compatibility
 
         # try to open the port
@@ -187,6 +184,18 @@ class SerialDevice(BaseDevice, AttributeGetSetMixin):
             )
         # we aren't in a time-critical period so flush messages
         logging.flush()
+    
+    @property
+    def eol(self):
+        return self._eol
+
+    @eol.setter
+    def eol(self, value):
+        # coerce to bytes
+        if type(value) is not bytes:
+            value = bytes(value, "utf-8")
+        # set
+        self._eol = value
 
     def isAwake(self):
         """This should be overridden by the device class

--- a/psychopy/hardware/serialdevice.py
+++ b/psychopy/hardware/serialdevice.py
@@ -86,6 +86,22 @@ class SerialOut(AttributeGetSetMixin):
         # set autolog
         self.autolog = autolog
     
+    def __getattr__(self, name):
+        try:
+            # try as normal first
+            return getattr(self, name)
+        except AttributeError as err:
+            if hasattr(self.device, name):
+                # if this instance doesn't have the attribute but the device does, warn and use that
+                logging.warn(
+                    f"SerialOut has no attribute {name}, but SerialDevice does, so using "
+                    f"SerialDevice.{name}. To silence this message, use `.device.{name}` instead."
+                )
+                return getattr(self.device, name)
+            else:
+                # if it just doesn't have the attribute, fail as normal
+                raise err
+    
     @property
     def com(self):
         return self.device.com


### PR DESCRIPTION
This means that Builder can manager per-Component stuff (i.e. `.status`) *separately from the device*, as otherwise if you have multiple Serial Out Components in a Routine they interfere with one another (because once one is set to STARTED, they all are, because the device object itself has the attribute).

This is a breaking change, as if you were interacting with the Component via code and expecting to get the device object directly, you would now need to do `<component name>.device` instead to get the device. 