### PR TITLE
BF: replace mutable default arguments with None

### DIFF
--- a/psychopy/contrib/lazy_import.py
+++ b/psychopy/contrib/lazy_import.py
@@ -148,7 +148,7 @@ class ImportReplacer(ScopeReplacer):
     # the replacement.
     __slots__ = ('_import_replacer_children', '_member', '_module_path')
 
-    def __init__(self, scope, name, module_path, member=None, children={}):
+    def __init__(self, scope, name, module_path, member=None, children=None):
         """Upon request import 'module_path' as the name 'module_name'.
         When imported, prepare children to also be imported.
 
@@ -179,6 +179,8 @@ class ImportReplacer(ScopeReplacer):
             from foo import bar, baz would get translated into 2 import
             requests. On for 'name=bar' and one for 'name=baz'
         """
+        if children is None:
+            children = {}
         if (member is not None) and children:
             raise ValueError('Cannot supply both a member and children')
 

--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -821,7 +821,7 @@ class _KeyBuffer(object):
             key['time'] = evt['Time']
             self._evts.append(key)
 
-    def getKeys(self, keyList=[], ignoreKeys=[], waitRelease=True, clear=True):
+    def getKeys(self, keyList=None, ignoreKeys=None, waitRelease=True, clear=True):
         """Return the KeyPress objects from the software buffer
 
         Parameters

--- a/psychopy/iohub/client/__init__.py
+++ b/psychopy/iohub/client/__init__.py
@@ -492,7 +492,7 @@ class ioHubConnection():
                                              msg_offset=offset,
                                              sec_time=sec_time))
 
-    def sendMessageEvents(self, messageList=[]):
+    def sendMessageEvents(self, messageList=None):
         if messageList:
             self.cacheMessageEvents(messageList)
         if self._message_cache:

--- a/psychopy/iohub/client/eyetracker/validation/procedure.py
+++ b/psychopy/iohub/client/eyetracker/validation/procedure.py
@@ -778,7 +778,7 @@ class ValidationTargetRenderer:
                                         ('eye_y', np.float64),
                                         ('pupil_size', np.float64)]
 
-    def __init__(self, win, target, positions, storeeventsfor=[], triggers=None, msgcategory='',
+    def __init__(self, win, target, positions, storeeventsfor=None, triggers=None, msgcategory='',
                  io=None, terminate_key='escape', gaze_cursor_key='g', gaze_cursor=None,
                  color_space=None, unit_type=None):
         """
@@ -818,7 +818,7 @@ class ValidationTargetRenderer:
         self.win = proxy(win)
         self.target = target
         self.positions = positions
-        self.storeevents = storeeventsfor
+        self.storeevents = storeeventsfor if storeeventsfor is not None else []
         self.msgcategory = msgcategory
 
         if io is None:
@@ -1029,10 +1029,12 @@ class ValidationTargetRenderer:
                 deviceevents[device] = []
         self.targetdata.append(dict(frompos=frompos, topos=topos, events=deviceevents))
 
-    def _addDeviceEvents(self, device_event_dict={}):
+    def _addDeviceEvents(self, device_event_dict=None):
         if self._checkForTerminate():
             return
         self._checkForToggleGaze()
+        if device_event_dict is None:
+            device_event_dict = {}
         dev_event_buffer = self.targetdata[-1]['events']
         for dev, dev_events in dev_event_buffer.items():
             if dev in device_event_dict:

--- a/psychopy/iohub/client/eyetracker/validation/trigger.py
+++ b/psychopy/iohub/client/eyetracker/validation/trigger.py
@@ -13,10 +13,10 @@ getTime = core.getTime
 class Trigger:
     io = None
 
-    def __init__(self, trigger_function=lambda a, b, c: True, user_kwargs={}, repeat_count=0):
+    def __init__(self, trigger_function=lambda a, b, c: True, user_kwargs=None, repeat_count=0):
         Trigger.io = ioHubConnection.getActiveConnection()
         self.trigger_function = trigger_function
-        self.user_kwargs = user_kwargs
+        self.user_kwargs = user_kwargs if user_kwargs is not None else {}
         self._last_triggered_event = None
         self._last_triggered_time = None
         self.repeat_count = repeat_count
@@ -105,7 +105,7 @@ class TimeTrigger(Trigger):
     (that takes no parameters).
     """
 
-    def __init__(self, start_time, delay, repeat_count=0, trigger_function=lambda a, b, c: True, user_kwargs={}):
+    def __init__(self, start_time, delay, repeat_count=0, trigger_function=lambda a, b, c: True, user_kwargs=None):
         Trigger.io = ioHubConnection.getActiveConnection()
         Trigger.__init__(self, trigger_function, user_kwargs, repeat_count)
 
@@ -164,13 +164,13 @@ class DeviceEventTrigger(Trigger):
     """
     _lastEventsByDevice = dict()
 
-    def __init__(self, device, event_type, event_attribute_conditions={}, repeat_count=-1,
-                 trigger_function=lambda a, b, c: True, user_kwargs={}):
+    def __init__(self, device, event_type, event_attribute_conditions=None, repeat_count=-1,
+                 trigger_function=lambda a, b, c: True, user_kwargs=None):
         Trigger.io = ioHubConnection.getActiveConnection()
         Trigger.__init__(self, trigger_function, user_kwargs, repeat_count)
         self.device = device
         self.event_type = event_type
-        self.event_attribute_conditions = event_attribute_conditions
+        self.event_attribute_conditions = event_attribute_conditions if event_attribute_conditions is not None else {}
 
     def triggered(self, **kwargs):
         if Trigger.triggered(self) is False:

--- a/psychopy/iohub/datastore/util.py
+++ b/psychopy/iohub/datastore/util.py
@@ -99,8 +99,8 @@ def getEyeSampleTypesInFile(hdf5FilePath):
     return result
 
 
-def saveEventReport(hdf5FilePath=None, eventType=None, eventFields=[], useConditionsTable=False,
-                    usePsychopyDataFile=None, columnNames=[],
+def saveEventReport(hdf5FilePath=None, eventType=None, eventFields=None, useConditionsTable=False,
+                    usePsychopyDataFile=None, columnNames=None,
                     trialStart=None, trialStop=None, timeMargins=(0.0, 0.0)
                     ):
     """
@@ -393,7 +393,7 @@ class ExperimentDataAccessUtility:
 
     """
 
-    def __init__(self, hdfFilePath, hdfFileName, experimentCode=None, sessionCodes=[], mode='r'):
+    def __init__(self, hdfFilePath, hdfFileName, experimentCode=None, sessionCodes=None, mode='r'):
         """An instance of the ExperimentDataAccessUtility class is created by
         providing the location and name of the file to read, as well as any
         session code filtering you want applied to the retrieved datasets.
@@ -491,7 +491,7 @@ class ExperimentDataAccessUtility:
             if sessions is None:
                 sessions = []
 
-            sessionCodes = self._sessionCodes
+            sessionCodes = self._sessionCodes if self._sessionCodes is not None else []
             sesscols = self.hdfFile.root.data_collection.session_meta_data.colnames
             SessionMetaDataInstance = namedtuple('SessionMetaDataInstance', sesscols)
             for r in self.hdfFile.root.data_collection.session_meta_data:

--- a/psychopy/iohub/devices/eyetracker/__init__.py
+++ b/psychopy/iohub/devices/eyetracker/__init__.py
@@ -233,7 +233,7 @@ class EyeTrackerDevice(Device):
 
         return EyeTrackerConstants.FUNCTIONALITY_NOT_SUPPORTED
 
-    def runSetupProcedure(self, calibration_args={}):
+    def runSetupProcedure(self, calibration_args=None):
         """
         The runSetupProcedure method starts the eye tracker calibration
         routine. If calibration_args are provided, they should be used to

--- a/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
+++ b/psychopy/iohub/devices/eyetracker/hw/mouse/eyetracker.py
@@ -400,10 +400,12 @@ class EyeTracker(EyeTrackerDevice):
         """
         return self._recording
 
-    def runSetupProcedure(self, calibration_args={}):
+    def runSetupProcedure(self, calibration_args=None):
         """
         runSetupProcedure displays a mock calibration procedure. No calibration is actually done.
         """
+        if calibration_args is None:
+            calibration_args = {}
         calibration = MouseGazeCalibrationProcedure(self, calibration_args)
         cal_run = calibration.runCalibration()
         calibration.window.close()

--- a/psychopy/iohub/lazy_import.py
+++ b/psychopy/iohub/lazy_import.py
@@ -308,7 +308,7 @@ class ImportReplacer(ScopeReplacer):
     # the replacement.
     __slots__ = ('_import_replacer_children', '_member', '_module_path')
 
-    def __init__(self, scope, name, module_path, member=None, children={}):
+    def __init__(self, scope, name, module_path, member=None, children=None):
         """Upon request import 'module_path' as the name 'module_name'. When
         imported, prepare children to also be imported.
 
@@ -340,6 +340,8 @@ class ImportReplacer(ScopeReplacer):
             requests. On for 'name=bar' and one for 'name=baz'
 
         """
+        if children is None:
+            children = {}
         if (member is not None) and children:
             raise ValueError('Cannot supply both a member and children')
 


### PR DESCRIPTION
Replaces mutable default arguments (`[]`/`{}`) with `None`, initialising in the body where the value is mutated or indexed.

One behavioural note: `mouse.EyeTracker.runSetupProcedure` forwards the arg into `BaseCalibrationProcedure`, which calls `.update()` on it, so it gets an explicit `None` guard.