### PR TITLE
BF: fix undefined names in triggerbox parallel port module

### DIFF
--- a/psychopy/hardware/triggerbox/parallel.py
+++ b/psychopy/hardware/triggerbox/parallel.py
@@ -17,6 +17,9 @@ __all__ = [
     'closeAllParallelPorts'
 ]
 
+import sys
+
+from psychopy import logging
 from .base import BaseTriggerBox
 
 # used to keep track of open parallel ports to avoid multiple objects accessing
@@ -196,8 +199,8 @@ class ParallelPortTrigger(BaseTriggerBox):
                 "Cannot change the port address while the port is open.")
 
         # convert u"0x0378" into 0x0378
-        if isinstance(address, str) and address.startswith('0x'):
-            address = int(address, 16)
+        if isinstance(portAddress, str) and portAddress.startswith('0x'):
+            portAddress = int(portAddress, 16)
 
         self._portAddress = portAddress
 


### PR DESCRIPTION
`psychopy/hardware/triggerbox/parallel.py` uses `sys` and `logging` without importing them, so any code path reaching them raises `NameError`:
- `_setupPort()` branches on `sys.platform` (Linux / win32 / Mac)
- the "no driver found" and "imported on a Mac" warnings call `logging.warning`

Separately, `setPortAddress()` referenced an undefined local `address` when converting a hex-string address (e.g. `"0x0378"`) and then stored the *unconverted* `portAddress` argument — so hex-string addresses were never converted and the conversion branch itself raised `NameError`. Now uses the `portAddress` parameter consistently.

Imports follow the convention in `psychopy.parallel` (`import sys` + `from psychopy import logging`). Found via `pyflakes`.