### PR TITLE
BF: psychopy.app has moved to its own package psychopy_app

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -22,7 +22,7 @@ from packaging.version import Version
 
 from psychopy import logging, prefs, exceptions
 from psychopy.tools.filetools import DictStorage, KnownProjects
-from psychopy import app
+import psychopy_app as app
 from psychopy.localization import _translate
 import wx
 


### PR DESCRIPTION
...but should this code be moved to that app package too? If calling psychopy.projects.pavlovia requires the app then lets put it in the app?