### PR TITLE
PKG: updating pyproject to officially support 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [project]
 name = "psychopy"
 dynamic = ["version"]
-requires-python = ">=3.10, <3.12"
+requires-python = ">=3.10, <3.13"
 description = "PsychoPy provides easy, precise, flexible experiments in behavioural sciences"
 readme ={file = "README.md", content-type = "text/markdown"}
 authors = [


### PR DESCRIPTION
Test suite is passing on py3.12
We need to make this change in order to test building the standalone