### PR TITLE
BF: Update entry points search to work in Python 3.12

### DIFF
--- a/psychopy/plugins/__init__.py
+++ b/psychopy/plugins/__init__.py
@@ -83,17 +83,20 @@ def getEntryPointGroup(group, subgroups=False):
     """
     # start off with no entry points or sections
     entryPoints = []
-
-    if subgroups:
-        # if searching subgroups, iterate through entry point groups
-        for thisGroup, eps in importlib.metadata.entry_points().items():
-            # get entry points within matching group
-            if thisGroup.startswith(group):
-                # add to list of all entry points
-                entryPoints += eps
+    # handle difference between importlib.metadata 5.0 and previous versions
+    all = importlib.metadata.entry_points()
+    if isinstance(all, dict):
+        groups = list(all)
     else:
-        # otherwise, just get the requested group
-        entryPoints += importlib.metadata.entry_points().get(group, [])
+        groups = all.groups
+    # filter groups
+    if subgroups:
+        groups = [g for g in groups if g.startswith(group)]
+    else:
+        groups = [g for g in groups if g == group]
+    # append entry points
+    for g in groups:
+        entryPoints += importlib.metadata.entry_points(group=g)
 
     return entryPoints
 

--- a/psychopy/plugins/util.py
+++ b/psychopy/plugins/util.py
@@ -19,24 +19,31 @@ def getEntryPoints(module, submodules=True, flatten=True):
         default True.
     """
     # start off with a blank list/dict
-    entryPointsList = []
-    entryPointsDict = {}
-    # iterate through groups
-    for group, points in importlib.metadata.entry_points().items():
-        # does this group correspond to the requested module?
-        if submodules:
-            targeted = group.startswith(module)
-        else:
-            targeted = group == module
-        # if group is targeted, add entry points
-        if targeted:
-            entryPointsList += points
-            entryPointsDict[group] = points
-    # return list or dict according to flatten arg
     if flatten:
-        return entryPointsList
+        output = []
     else:
-        return entryPointsDict
+        output = {}
+    # handle difference between importlib.metadata 5.0 and previous versions
+    all = importlib.metadata.entry_points()
+    if isinstance(all, dict):
+        groups = list(all)
+    else:
+        groups = all.groups
+    # filter groups
+    if submodules:
+        groups = [group for group in groups if group.startswith(module)]
+    else:
+        groups = [group for group in groups if group == module]
+    # get points for each group
+    for group in groups:
+        points = importlib.metadata.entry_points(group=group)
+        # append to output
+        if flatten:
+            output += points
+        else:
+            output[group] = points
+
+    return output
 
 
 class PluginRequiredError(Exception):


### PR DESCRIPTION
In importlib.metadata 5.0 (which comes with Python 3.12) they changed the output of `importlib.metadata.entry_points()` from returning a dict with entry points sorted by group to an EntryPoints (subclass of tuple) object where each point has a `.group` attribute and where the list has a `.groups` attribute.

Handling it by first getting all groups using different methods according to the class of the points object, then calling `importlib.metadata.entry_points(group=...)` with each of the relevant groups. This works because the ouput of `entry_points(group=...)` hasn't changed.

As this is a bigger change than we'd usually pull into release I could change the branch to dev and hold off until 2027.1 as the old method still works in 3.11.