### PR TITLE
FF: Handle when system locale isn't detectable

### DIFF
--- a/psychopy/localization/translation.py
+++ b/psychopy/localization/translation.py
@@ -1,3 +1,4 @@
+import logging
 from i18next import config, trans
 from pathlib import Path
 import locale
@@ -31,6 +32,12 @@ def setLocale(value):
     # if requested system, get system locale
     if value in (None, "system locale", "system"):
         value = locale.getdefaultlocale()[0]
+    # use English as a fallback if locale is undetectable
+    if value is None:
+        logging.warning(
+            "Could not detect system locale, using en-US"
+        )
+        value = "en-US"
     # sanitize
     value = value.replace("_", "-")
     # set


### PR DESCRIPTION
Mostly `locale.getdefaultlocale` should always give something meaningful, but on some computers (@RebeccaHirst 's macbook for some reason) it returns `None`. In these cases, it's not really possible to detect the system locale, so we shouldlog a warning and fallback to US English rather than failing altogether