### PR TITLE
BF: Light sensor find function was slightly offset

### DIFF
--- a/psychopy/hardware/lightsensor.py
+++ b/psychopy/hardware/lightsensor.py
@@ -229,6 +229,12 @@ class BaseLightSensorGroup(base.BaseResponseDevice):
             fillColor="white",
             autoDraw=False
         )
+        # store last good size/pos
+        lastGood = {
+            'units': rect.units,
+            'size': list(rect.size),
+            'pos': list(rect.pos)
+        }
 
         # if not given a channel, use first one which is responsive to the win
         if channel is None:
@@ -296,6 +302,10 @@ class BaseLightSensorGroup(base.BaseResponseDevice):
                 if self.getState(channel):
                     # mark that we've got a response
                     responsive = True
+                    # update last good size/pos
+                    lastGood['units'] = rect.units
+                    lastGood['size'] = list(rect.size)
+                    lastGood['pos'] = list(rect.pos)
                     # if it detected this rectangle, recur
                     return scanQuadrants(responsive=responsive)
             # if none of these have returned, rect is too small to cover the whole light sensor, so return
@@ -420,13 +430,13 @@ class BaseLightSensorGroup(base.BaseResponseDevice):
         win.flip()
 
         # set size/pos/units
-        self.units = "norm"
-        self.size = rect.size * 2
-        self.pos = rect.pos
+        self.units = lastGood['units']
+        self.size = lastGood['size']
+        self.pos = lastGood['pos']
 
         return (
-            layout.Position(self.pos, units="norm", win=win),
-            layout.Position(self.size, units="norm", win=win),
+            layout.Position(lastGood['pos'], units="norm", win=win),
+            layout.Position(lastGood['size'], units="norm", win=win),
         )
 
     def findThreshold(self, win, channel=None):


### PR DESCRIPTION
findSensor  runs until the patch is too small to be detected, then takes the final position of the patch & returns its position and its size doubled. This works most of the time, but the actual positions look like this:

<img width="784" height="517" alt="image" src="https://github.com/user-attachments/assets/476271b8-a4fd-4152-8546-6be01419d724" />

...where the green box is the last patch which the photodiode detected, the red box is the last position the patch was at, and the blue box is what the patch ultimately gets set as. If you're unfortunate enough to be in the top left edge of the green area, the test will pass but then the patch won't be detected in your experiment.

The way to fix this is to not rely on the final position of the patch, but instead to store the position of the patch when it is detected and use the last detected position. In other words, store the size/pos of the green box, rather than trying to figure it out from the size/pos of the red box.