### PR TITLE
PKG: add uv exception to block libs newer than 7 days old 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,9 @@ requires = [
 ]
 build-backend = "pdm.backend"
 
+[tool.uv]
+exclude-newer = "7 days"
+
 [tool.pdm.build]
 includes = []
 excludes = ["building/"]


### PR DESCRIPTION
This is to prevent the current trend of supply-chain attacks where a lib with many dependencies is hacked and released, affecting all the downstream users