### PR TITLE
PKG: reverting the cryptography dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ suggested = [
     "egi-pynetstation>=1.0.0",
     "pyxid2>=1.0.5",
     "Phidget22",
-    "cryptography==48.0.1",  # 49.0 failing to build on macos?
 ]
 legacy = [
     "pyo>=1.0.3",


### PR DESCRIPTION
It didn't fix the build issue and raised new errors (pip falsely claims that cryptography==48.0.1 doesn't exist)