### PR TITLE
PKG: don't import (unused) psychopy.projects.sshkeys to reduce dependencies

### DIFF
--- a/psychopy/projects/pavlovia.py
+++ b/psychopy/projects/pavlovia.py
@@ -44,7 +44,6 @@ import gitlab
 import gitlab.v4.objects
 
 # for authentication
-from . import sshkeys
 from uuid import uuid4
 
 from .gitignore import gitIgnoreText


### PR DESCRIPTION

sshkeys depends on the cryptography package which otherwise isn't needed