### PR TITLE
BF: remove undefined _getSvnVersion/_getHgVersion references in info.py

### DIFF
--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -21,8 +21,6 @@ __all__ = [
     '_getUserNameUID',
     '_getHashGitHead',
     '_getSha1hexDigest',
-    '_getHgVersion',
-    '_getSvnVersion',
     '_thisProcess'
 ]
 
@@ -271,22 +269,6 @@ class RunTimeInfo(dict):
         scriptPath = os.path.abspath(sys.argv[0])
         key = 'experimentScript.digestSHA1'
         self[key] = _getSha1hexDigest(scriptPath, isfile=True)
-        # subversion revision?
-        try:
-            svnrev, last, url = _getSvnVersion(scriptPath)  # svn revision
-            if svnrev:  # or verbose:
-                self['experimentScript.svnRevision'] = svnrev
-                self['experimentScript.svnRevLast'] = last
-                self['experimentScript.svnRevURL'] = url
-        except Exception:
-            pass
-        # mercurical revision?
-        try:
-            hgChangeSet = _getHgVersion(scriptPath)
-            if hgChangeSet:  # or verbose:
-                self['experimentScript.hgChangeSet'] = hgChangeSet
-        except Exception:
-            pass
 
         # when was this run?
         self['experimentRunTime.epoch'] = core.getAbsTime()

--- a/psychopy/tests/test_misc/test_info.py
+++ b/psychopy/tests/test_misc/test_info.py
@@ -6,6 +6,18 @@ import pytest
 # py.test -k info --cov-report term-missing --cov info.py
 
 
+def test_all_names_defined():
+    """Every name exported in ``info.__all__`` must actually be defined.
+
+    Guards against dangling ``__all__`` entries such as the removed
+    ``_getSvnVersion``/``_getHgVersion`` helpers, which lingered in
+    ``__all__`` (and in silently-failing call sites) after their definitions
+    were deleted.
+    """
+    missing = [name for name in info.__all__ if not hasattr(info, name)]
+    assert not missing, f"names in __all__ are undefined: {missing}"
+
+
 @pytest.mark.info
 class TestInfo():
     @classmethod


### PR DESCRIPTION
## Summary

`_getSvnVersion` and `_getHgVersion` were removed in 895f4cbf0 ("PKG: getHgVersion and getSvnVersion no longer useful"), but two loose ends were left behind in `psychopy/info.py`:

- their entries in `__all__`, and
- their call sites in `RunTimeInfo._setExperimentInfo`.

Because the call sites are wrapped in `try/except Exception`, the `NameError` raised by the missing functions has been **silently swallowed** ever since — so the SVN/Mercurial revision capture (`experimentScript.svnRevision`, `experimentScript.hgChangeSet`, …) has been dead code with no observable effect.

`pyflakes psychopy/info.py` reports these as undefined names:

```
psychopy/info.py:13:1: undefined name '_getHgVersion' in __all__
psychopy/info.py:13:1: undefined name '_getSvnVersion' in __all__
psychopy/info.py:276:33: undefined name '_getSvnVersion'
psychopy/info.py:285:27: undefined name '_getHgVersion'
```

## Changes

- Remove the dangling `__all__` entries and the dead SVN/Mercurial blocks, completing the removal started in 895f4cbf0. The other private names in `__all__` (`_getUserNameUID`, `_getHashGitHead`, `_getSha1hexDigest`, `_thisProcess`) remain defined and are kept.
- Add a regression test (`test_all_names_defined`) asserting every name in `info.__all__` resolves, so a future dangling export is caught.

No behaviour change: the removed code never executed successfully.

## Testing

```
python -m pytest psychopy/tests/test_misc/test_info.py -q   # 2 passed
python -m pyflakes psychopy/info.py                         # no undefined-name warnings
```

Found via static analysis; not linked to an existing issue.