### PR TITLE
DOC: clarify StairHandler nReversals minimum (#3174)

### DIFF
--- a/psychopy/data/staircase.py
+++ b/psychopy/data/staircase.py
@@ -82,13 +82,15 @@ class StairHandler(_BaseTrialHandler):
                 The initial value for the staircase.
 
             nReversals:
-                The minimum number of reversals permitted.
-                If `stepSizes` is a list, but the minimum number of
-                reversals to perform, `nReversals`, is less than the
-                length of this list, PsychoPy will automatically increase
-                the minimum number of reversals and emit a warning.
-                This minimum number of reversals is always set to be
-                greater than 0.
+                The minimum number of reversals required before the
+                staircase can finish (together with `nTrials`). If `None`,
+                this defaults to the number of step sizes.
+                If `nReversals` is less than the number of step sizes, it is
+                automatically raised to that number and a warning is emitted.
+                Note that a single (scalar) `stepSizes` value is treated as a
+                list of length 1, so the number of step sizes -- and therefore
+                `nReversals` -- is always at least 1 (i.e. `nReversals=0` is
+                not honored).
 
             stepSizes:
                 The size of steps as a single value or a list (or array).

--- a/psychopy/tests/test_data/test_StairHandlers.py
+++ b/psychopy/tests/test_data/test_StairHandlers.py
@@ -16,6 +16,34 @@ DEBUG = False
 np.random.seed(1000)
 
 
+def test_nReversals_clamped_to_nStepSizes():
+    """`nReversals` is raised to the number of step sizes when lower.
+
+    Regression test for GH-3174: a scalar `stepSizes` is treated as a single
+    step size, so the number of step sizes -- and therefore `nReversals` --
+    is always at least 1, and `nReversals=0` cannot be honored.
+    """
+    # scalar step size counts as one step size -> minimum of 1 reversal
+    stairs = data.StairHandler(startVal=0.5, nReversals=0, stepSizes=0.1,
+                               nTrials=5)
+    assert stairs.nReversals == 1
+
+    # nReversals below the number of step sizes is raised to that number
+    stairs = data.StairHandler(startVal=0.5, nReversals=1,
+                               stepSizes=[0.4, 0.2, 0.1], nTrials=5)
+    assert stairs.nReversals == 3
+
+    # nReversals above the number of step sizes is left untouched
+    stairs = data.StairHandler(startVal=0.5, nReversals=5,
+                               stepSizes=[0.4, 0.2, 0.1], nTrials=5)
+    assert stairs.nReversals == 5
+
+    # nReversals=None defaults to the number of step sizes
+    stairs = data.StairHandler(startVal=0.5, nReversals=None,
+                               stepSizes=[0.4, 0.2], nTrials=5)
+    assert stairs.nReversals == 2
+
+
 class _BaseTestStairHandler():
     def setup_method(self):
         self.tmp_dir = mkdtemp(prefix='psychopy-tests-%s' %


### PR DESCRIPTION
## Summary

Resolves #3174 by fixing the documentation, which is the approach @peircej favoured in the issue discussion (*"My instinct here is to fix the docs"*).

The `nReversals` docstring described behaviour that no longer matches the code. It implied the minimum-reversals bump only applies *"if `stepSizes` is a list"*, but `stepSizes` is **always** coerced to a list — a scalar becomes a length-1 list:

```python
try:
    self.stepSizes = list(stepSizes)
except TypeError:           # scalar
    self.stepSizes = [stepSizes]
```

So `nReversals` is always raised to at least the number of step sizes (minimum 1), and `nReversals=0` is never honored. Reproduction on current `dev`:

```python
>>> StairHandler(startVal=0.5, nReversals=0, stepSizes=0.1, nTrials=5).nReversals
1          # not 0 — bumped to len(stepSizes), with a warning
>>> StairHandler(startVal=0.5, nReversals=1, stepSizes=[0.4,0.2,0.1], nTrials=5).nReversals
3          # raised to len(stepSizes)
```

## Changes

- Rewrite the `nReversals` docstring to describe the actual behaviour: it is raised to the number of step sizes when lower (with a warning), defaults to that number when `None`, and — because a scalar step size counts as a single step size — is always at least 1, so `nReversals=0` is not honored.
- Add a regression test (`test_nReversals_clamped_to_nStepSizes`) covering the scalar, list-shorter, list-longer, and `None` cases.

No behaviour change — this documents and pins existing behaviour.

## On the code-change alternative

The issue also raised the option of *allowing* `nReversals=0`. Per @peircej's note about possible knock-on effects (a staircase terminating without ever entering the threshold region), this PR intentionally does **not** change behaviour; it only aligns the docs with the code. Happy to open a separate discussion/PR if enabling `nReversals=0` is wanted.

## Testing

```
python -m pytest psychopy/tests/test_data/test_StairHandlers.py -q   # 55 passed
```