### PR TITLE
BF: fix removed np.NaN and broken NaN check in iohub eye tracker parser

### DIFF
--- a/psychopy/iohub/devices/eyetracker/filters/parser.py
+++ b/psychopy/iohub/devices/eyetracker/filters/parser.py
@@ -309,7 +309,7 @@ class EyeTrackerEventParser(eventfilters.DeviceEventFilter):
         if self.isValidSample(sample):
             x_velocity_threshold = sample[self.io_event_ix('raw_x')]
             y_velocity_threshold = sample[self.io_event_ix('raw_y')]
-            if x_velocity_threshold == np.NaN:
+            if np.isnan(x_velocity_threshold):
                 return None
             sample_vx = sample[self.io_event_ix('velocity_x')]
             sample_vy = sample[self.io_event_ix('velocity_y')]
@@ -440,7 +440,7 @@ class EyeTrackerEventParser(eventfilters.DeviceEventFilter):
                         pt_list.append(PT)
                     vthresh_values.append(PT)
             if len(vthresh_values) != v + 1:
-                vthresh_values.append(np.NaN)
+                vthresh_values.append(np.nan)
         return vthresh_values
 
     def reset(self):

--- a/psychopy/tests/test_iohub/test_eyetracker_parser.py
+++ b/psychopy/tests/test_iohub/test_eyetracker_parser.py
@@ -1,0 +1,59 @@
+"""Tests for the iohub eye tracker event parser.
+
+Regression tests for the use of the removed ``np.NaN`` alias and the broken
+NaN comparison in ``EyeTrackerEventParser.getSampleEventCategory``.
+
+``np.NaN`` was removed in NumPy 2.0, so simply reaching the line crashed with
+``AttributeError`` for every valid sample. On top of that, ``value == np.NaN``
+is always ``False`` (a NaN never equals anything), so the guard that should
+discard samples with a missing position never fired. The fix replaces both
+uses with ``np.nan`` / ``np.isnan``.
+"""
+
+import numpy as np
+
+from psychopy.iohub.devices.eyetracker.filters.parser import EyeTrackerEventParser
+
+
+# field name -> index into the test sample tuples below
+_IX = {'raw_x': 0, 'raw_y': 1, 'velocity_x': 2, 'velocity_y': 3}
+
+
+def _make_parser(valid=True):
+    """Build a parser without running the heavy ``__init__``.
+
+    ``getSampleEventCategory`` only relies on the ``io_event_ix`` and
+    ``isValidSample`` callables, so we can stub those and exercise the pure
+    categorisation logic without an iohub server or eye tracker hardware.
+    """
+    parser = EyeTrackerEventParser.__new__(EyeTrackerEventParser)
+    parser.io_event_ix = _IX.__getitem__
+    parser.isValidSample = lambda sample: valid
+    return parser
+
+
+def test_nan_position_sample_is_discarded():
+    """A sample with a NaN position must be categorised as ``None``.
+
+    Before the fix this both crashed (``np.NaN`` removed in NumPy 2.0) and,
+    on older NumPy, mis-categorised the sample because ``x == np.NaN`` is
+    always ``False``.
+    """
+    parser = _make_parser()
+    sample = (np.nan, 10.0, 1.0, 1.0)  # raw_x is NaN
+    assert parser.getSampleEventCategory(sample) is None
+
+
+def test_valid_sample_does_not_crash():
+    """Categorising a normal sample must not raise (reaches the former np.NaN line)."""
+    parser = _make_parser()
+    # velocities below the per-axis thresholds (raw_x, raw_y) -> fixation
+    assert parser.getSampleEventCategory((10.0, 10.0, 1.0, 1.0)) == 'FIX'
+    # a velocity at/above its threshold -> saccade
+    assert parser.getSampleEventCategory((10.0, 10.0, 20.0, 1.0)) == 'SAC'
+
+
+def test_invalid_sample_is_missing():
+    """An invalid sample is reported as missing data."""
+    parser = _make_parser(valid=False)
+    assert parser.getSampleEventCategory((10.0, 10.0, 1.0, 1.0)) == 'MIS'


### PR DESCRIPTION
## Summary

`EyeTrackerEventParser.getSampleEventCategory` (and `_calculateAdaptiveVThresholds`) use `np.NaN`, which was **removed in NumPy 2.0**. Since `dev` now officially supports Python 3.12 / NumPy 2 (and the lockfile resolves NumPy ≥ 2.2), reaching the line raises `AttributeError` for **every valid eye sample**, breaking event parsing entirely under NumPy 2:

```
AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.
```

There is also a latent **logic bug** independent of the NumPy version: `x_velocity_threshold == np.NaN` is always `False` (a NaN never compares equal to anything), so the guard meant to discard samples with a missing position never fired.

## Fix

- `parser.py:312` — `if x_velocity_threshold == np.NaN:` → `if np.isnan(x_velocity_threshold):` (fixes both the crash and the never-firing guard)
- `parser.py:443` — `vthresh_values.append(np.NaN)` → `vthresh_values.append(np.nan)` (sentinel, crash only)

## Tests

Adds `psychopy/tests/test_iohub/test_eyetracker_parser.py` — a hardware-free unit test that stubs the parser's `io_event_ix`/`isValidSample` callables and exercises `getSampleEventCategory`:

- a NaN-position sample is now discarded (returns `None`)
- a normal sample is categorised without raising (`FIX`/`SAC`)
- an invalid sample is reported as `MIS`

Verified the first two tests fail on the current code with the `np.NaN` `AttributeError` and pass with the fix.

Part of the ongoing Python 3.12 / NumPy 2.0 migration (see the stalled #6744) — this is one of the residual `np.NaN`/`np.unicode_` removed-alias uses left in the tree.