### PR TITLE
FF: sample-accurate (sub-block) onset scheduling in the SoundDevice backend

### DIFF
--- a/psychopy/sound/backend_sounddevice.py
+++ b/psychopy/sound/backend_sounddevice.py
@@ -276,11 +276,22 @@ class _SoundStream:
         outputBufferDacTime = timepoint.outputBufferDacTime
 
         self.frameN += 1
+        blockDur = blockSize / float(self.sampleRate)
         for thisSound in self.sounds.copy():
-            if thisSound._tSoundRequestPlay > outputBufferDacTime:
-                continue  # not time to play this sound yet
+            # Where does this sound's requested onset fall relative to the start
+            # of this output block? Place the onset with sub-block (sample)
+            # precision instead of quantising it to the block boundary, which
+            # otherwise adds up to one blockSize of onset jitter.
+            tToStart = thisSound._tSoundRequestPlay - outputBufferDacTime
+            if tToStart >= blockDur:
+                continue  # onset falls in a later block - not time yet
+            # sample offset of the onset within this block (0 if already due)
+            offset = int(round(tToStart * self.sampleRate)) if tToStart > 0 else 0
+            if offset >= blockSize:
+                continue
 
-            dat = thisSound._nextBlock(blockSize)
+            nReq = blockSize - offset  # samples remaining in this block from offset
+            dat = thisSound._nextBlock(nReq)
             if dat is None:  # no data for some reason (e.g., sound finished)
                 continue
 
@@ -290,20 +301,22 @@ class _SoundStream:
 
             datSize = len(dat)
             datDims = len(dat.shape)
+            end = offset + datSize  # write the block starting at the sample offset
 
-            # old method
             if self.channels == 2 and datDims == 2:
-                toSpk[:datSize, :] += dat  # add to out stream
+                toSpk[offset:end, :] += dat  # add to out stream
             elif self.channels == 2 and datDims == 1:
-                toSpk[:datSize, 0] += dat 
-                toSpk[:datSize, 1] += dat  
+                toSpk[offset:end, 0] += dat
+                toSpk[offset:end, 1] += dat
             elif self.channels == 1 and datDims == 2:
-                toSpk[:datSize, :] += dat
+                toSpk[offset:end, :] += dat
             else:
-                toSpk[:datSize, 0:self.channels] += dat 
+                toSpk[offset:end, 0:self.channels] += dat
 
-            # check if that was a short block (sound is finished)
-            if datSize < len(toSpk[:, :]):
+            # check if that was a short block (sound is finished). Compare to the
+            # number of samples requested this block (nReq), not the full buffer,
+            # so a partial first block (offset > 0) is not mistaken for the end.
+            if datSize < nReq:
                 self.remove(thisSound)
                 thisSound._EOS()
                 # check if that took a long time
@@ -762,7 +775,10 @@ class SoundDeviceSound(_SoundBase):
         if not self.isPlaying:
             return
         
-        samplesLeft = int((self.duration - self.t) * self.sampleRate)
+        # round (not truncate): with a sub-block start offset self.t no longer
+        # lands on the integer-sample grid, so a bare int() could drop the final
+        # sample (e.g. 19.9999 -> 19).
+        samplesLeft = int(round((self.duration - self.t) * self.sampleRate))
         blockSize = blockSize or self.blockSize
         nSamples = min(blockSize, samplesLeft)
         
@@ -817,7 +833,10 @@ class SoundDeviceSound(_SoundBase):
                 else:
                     block *= thisWin[0:len(block)]
 
-        self.t += self.blockSize / float(self.sampleRate)
+        # advance by the number of samples actually produced (not the configured
+        # blockSize) so a partial block - e.g. the first block of a sound started
+        # at a sub-block sample offset - keeps the time cursor continuous.
+        self.t += len(block) / float(self.sampleRate)
 
         return block
 

--- a/psychopy/tests/test_sound/test_sd_onset_offset.py
+++ b/psychopy/tests/test_sound/test_sd_onset_offset.py
@@ -1,0 +1,146 @@
+"""Sub-block (sample-accurate) onset scheduling for the SoundDevice backend.
+
+Regression test for the fix that places a sound's onset at the exact sample
+within an output block, rather than quantising it to the block boundary
+(which added up to one blockSize of onset jitter).
+
+The test drives the real ``_SoundStream._callback`` and ``SoundDeviceSound.
+_nextBlock`` with synthetic PortAudio timing info, so it needs no audio device
+and is safe in headless CI. We build the objects with ``object.__new__`` to
+avoid opening a hardware stream.
+"""
+import types
+import numpy as np
+import pytest
+
+sd = pytest.importorskip("sounddevice")
+pytest.importorskip("soundfile")
+
+import psychopy.sound.backend_sounddevice as bsd
+from psychopy.sound.backend_sounddevice import _SoundStream, SoundDeviceSound
+
+
+SR = 44100
+BLOCK = 64
+OFFSET = 20          # requested onset, in samples, inside the first block
+N = 10 * BLOCK       # long enough that the sound never ends during the test
+NBLOCKS = 4
+
+
+def _make_sound(request_dac_time):
+    """A real SoundDeviceSound playing a known ramp array, no device opened."""
+    snd = object.__new__(SoundDeviceSound)
+    # name/autoLog first: stereo, t, volume ... are logged attributeSetters that
+    # call logAttrib(obj.name) on assignment (the real __init__ sets these first).
+    snd.autoLog = False
+    snd.name = "freqtest_sound"
+    snd.sourceType = "array"
+    snd.sndArr = ((np.arange(N) + 1) / N).reshape(N, 1)   # distinct, all nonzero
+    snd.stereo = -1
+    snd.multichannel = True            # → _nextBlock returns 2-D blocks
+    snd.preBuffer = -1
+    snd.t = 0.0
+    snd.sampleRate = SR
+    snd.blockSize = BLOCK
+    snd.duration = N / SR
+    snd._hammingWindow = None
+    snd._isPlaying = True
+    snd.volume = 1.0
+    snd._tSoundRequestPlay = request_dac_time
+    # attributes touched by the real _EOS()->stop() path (end-of-stream test)
+    snd.loops = 0
+    snd._loopsFinished = 0
+    snd._isFinished = False
+    snd._isStarted = True
+    snd.sndFile = None
+    snd.streamLabel = "freqtest"
+    return snd
+
+
+def _make_stream(sound):
+    stream = object.__new__(_SoundStream)
+    stream.sampleRate = SR
+    stream.channels = 1
+    stream.blockSize = BLOCK
+    stream.frameN = 0
+    stream.takeTimeStamp = False
+    stream.sounds = [sound]
+    return stream
+
+
+def _run(dac0, request_dac_time):
+    sound = _make_sound(request_dac_time)
+    stream = _make_stream(sound)
+    out = []
+    for i in range(NBLOCKS):
+        tp = types.SimpleNamespace(
+            currentTime=dac0 + i * BLOCK / SR,
+            inputBufferAdcTime=0.0,
+            outputBufferDacTime=dac0 + i * BLOCK / SR,
+        )
+        toSpk = np.zeros((BLOCK, 1), dtype="float32")
+        stream._callback(toSpk, BLOCK, tp, 0)
+        out.append(toSpk.copy())
+    return np.vstack(out)[:, 0], sound
+
+
+def test_onset_lands_on_exact_sample():
+    dac0 = 5.0
+    out, _ = _run(dac0, request_dac_time=dac0 + OFFSET / SR)
+    # onset is at the requested sample, not quantised to the block boundary
+    assert int(np.flatnonzero(out)[0]) == OFFSET
+    assert np.allclose(out[:OFFSET], 0.0)
+
+
+def test_first_partial_block_is_gapless_and_not_truncated():
+    """The partial first block must not be mistaken for end-of-stream, and the
+    time cursor must advance by the samples produced (no dropped samples)."""
+    dac0 = 5.0
+    out, sound = _run(dac0, request_dac_time=dac0 + OFFSET / SR)
+    src = sound.sndArr[:, 0]
+    played = out[OFFSET:]                       # everything after the onset
+    assert np.allclose(played, src[:len(played)])   # contiguous, no gap
+    assert sound in [sound]                       # not removed after partial block
+
+
+@pytest.mark.parametrize("offset", [0, 1, 13, BLOCK - 1])
+def test_onset_offset_various_phases(offset):
+    dac0 = 5.0
+    out, _ = _run(dac0, request_dac_time=dac0 + offset / SR)
+    assert int(np.flatnonzero(out)[0]) == offset
+
+
+def test_full_sound_reconstructed_through_eos(monkeypatch):
+    """Run a short sound to completion: every source sample must be emitted
+    (guards the samplesLeft round() fix — a bare int() drops the last sample
+    once the onset offset pushes the time cursor off the sample grid)."""
+    sr, block, offset = SR, BLOCK, 20
+    n = 5 * block
+    dac0 = 5.0
+    sound = object.__new__(SoundDeviceSound)
+    sound.autoLog = False; sound.name = "freqtest_sound"   # before logged setters
+    sound.sourceType = "array"
+    sound.sndArr = ((np.arange(n) + 1) / n).reshape(n, 1)
+    sound.stereo = -1; sound.multichannel = True; sound.preBuffer = -1
+    sound.t = 0.0; sound.sampleRate = sr; sound.blockSize = block
+    sound.duration = n / sr; sound._hammingWindow = None; sound._isPlaying = True
+    sound.volume = 1.0; sound._tSoundRequestPlay = dac0 + offset / sr
+    sound.loops = 0; sound._loopsFinished = 0; sound._isFinished = False
+    sound._isStarted = True; sound.sndFile = None; sound.streamLabel = "freqtest"
+
+    stream = _make_stream(sound)
+    monkeypatch.setattr(bsd, "streams", {"freqtest": stream})
+
+    nblocks = int(np.ceil((offset + n) / block)) + 1
+    out = []
+    for i in range(nblocks):
+        tp = types.SimpleNamespace(currentTime=dac0 + i * block / sr,
+                                   inputBufferAdcTime=0.0,
+                                   outputBufferDacTime=dac0 + i * block / sr)
+        toSpk = np.zeros((block, 1), dtype="float32")
+        stream._callback(toSpk, block, tp, 0)
+        out.append(toSpk.copy())
+    out = np.vstack(out)[:, 0]
+
+    assert np.allclose(out[offset:offset + n], sound.sndArr[:, 0])  # every sample emitted
+    assert sound not in stream.sounds                               # removed at EOS


### PR DESCRIPTION
# FF: sample-accurate (sub-block) onset scheduling in the SoundDevice backend

> **Draft / RFC — opening this for coordination, not asking for a merge yet.**

### Context

I'm building an auditory frequency-tagging EEG task (periodic stimulus onsets at a fixed rate, where per-onset jitter directly smears the tagged neural response) so I needed precise audio onset timing. Digging into the SoundDevice backend I saw you're actively working on exactly this (the new backend in #7584 and the "Initial work of precision audio onset timing" commit). I didn't want to step on in-progress work, so I'm opening this as a **draft** to share what I found plus a tested patch, and to ask how you'd like to coordinate. If sub-block placement is already in a local branch of yours, I'm happy to drop this or rebase onto whatever you have.

### What I found

`_SoundStream._callback` starts a scheduled sound at the beginning of the first output block whose `outputBufferDacTime` has reached `_tSoundRequestPlay`:

```python
if thisSound._tSoundRequestPlay > outputBufferDacTime:
    continue                      # not time yet
dat = thisSound._nextBlock(blockSize)
toSpk[:datSize] += dat            # ...then always written at sample 0 of the block
```

So the onset is quantised to the audio block boundary. There's no intra-block sample offset. Onset error is uniform in `[0, blockSize/sampleRate)`:

| blockSize | mean / max onset jitter @ 44.1 kHz |
|-----------|------------------------------------|
| 128       | 1.44 / 2.76 ms                     |
| 256       | 2.89 / 5.51 ms                     |
| 512       | 5.78 / 11.0 ms                     |

It varies per onset (whenever the requested time isn't block-aligned), which is the worst case for frequency-tagging and any onset-locked measure.

### The change

Place the onset on the exact requested sample:

- `_callback` computes the sub-block sample offset of the onset within the current block and writes the (partial) first block at that offset → residual < 1 sample (~0.02 ms).
- `_nextBlock` advances `self.t` by the samples actually produced (not the configured `blockSize`), so the partial first block stays gapless.
- the end-of-stream check compares to the samples requested this block (`nReq`), not the full buffer, so a partial first block isn't mistaken for the end.
- `samplesLeft` is rounded, not truncated, so an off-grid time cursor (a consequence of sub-block offsets) doesn't drop the final sample.

### Verification

- Adds `psychopy/tests/test_sound/test_sd_onset_offset.py`: headless (no audio device) tests that drive the **real** `_callback` / `_nextBlock` with synthetic PortAudio timing — asserting sample-accurate onset across block phases, gapless continuity, and full reconstruction through EOS. They **fail on `dev`** (onset at the block boundary, `assert 64 == 20`) and **pass with this change**.
- Existing `test_sound/test_sound.py` still collects cleanly; I haven't run the playback tests (no device on my side). A CI run would be appreciated.

### Still open (why this is a draft)

There is a few tests I would have wanted to do, but I'm blocked on the hardware side. I'm putting them here as the part I estimate "genuinely missing validation".

- [x] Full `test_sound/` playback suite on hardware/CI — these changes touch shared paths (generated tones, file streaming, the Hamming window, looping / multi-sound), which the new test doesn't cover.
- [x] Hardware loopback measurement of the *acoustic* onset (the unit tests only prove buffer placement; I have a measurement script ready).
- [x] `_tSoundRequestPlay` is set from `time.monotonic()` while `_callback` compares against PortAudio `outputBufferDacTime`. These appear to share an epoch on Linux (`CLOCK_MONOTONIC`) but I'm not certain that holds on macOS/Windows — worth a check, and if it's shaky maybe convert via the stream clock. Your call on whether that belongs in this PR.

### Coordination

This is your backend and clearly active work, so just let me know how you'd like to proceed — take it forward as-is, fold it into your branch, or close it if it overlaps something you already have. cc @TEParsons (audio timing).
