### PR TITLE
BF: Using $ and \n in a textbox together wasn't translating to JS correctly

### DIFF
--- a/psychopy/experiment/params.py
+++ b/psychopy/experiment/params.py
@@ -267,7 +267,10 @@ class Param():
                 if self.codeWanted and valid:
                     # If code is wanted, return code (translated to JS if needed)
                     if utils.scriptTarget == 'PsychoJS':
-                        valJS = py2js.expression2js(val)
+                        if self.valType == "extendedStr" or self.inputType == 'multi':
+                            valJS = py2js.snippet2js(val)
+                        else:
+                            valJS = py2js.expression2js(val)
                         if self.val != valJS:
                             logging.debug("Rewriting with py2js: {} -> {}".format(self.val, valJS))
                         return valJS


### PR DESCRIPTION
Using a newline character in a text param is fine:
```
this is a line
this is another
```
As is using \n in a code param:
```
"this is a line\nthis is another"
```
But using a newline in a text param *with a $ to indicate that it's code* isn't:
```
$"this is a line\nthis is another"
```

This is because multiline code is handled in `Param.__str__`, but only if `valType == "code"`, not if `valType == "str" and "$" in val`. This fixes it by adding in a similar if statement to that part of the stringifying code.