### PR TITLE
BF: Fix AttributeError from removed np.unicode_ in isValidVariableName

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -89,15 +89,18 @@ def isValidVariableName(name):
     try:
         name = str(name)  # convert from unicode if possible
     except Exception:
-        if type(name) in [str, np.unicode_]:
+        # str(name) already failed above, so use repr() (never fails for a
+        # str/str subclass) rather than %s (which would call str() again)
+        safeName = repr(name)
+        if type(name) in [str, np.str_]:
             raise exceptions.ConditionsImportError(
-                "name %s (type %s) contains non-ASCII characters (e.g. accents)" % (name, type(name)),
-                translated=_translate("name %s (type %s) contains non-ASCII characters (e.g. accents)") % (name, type(name))
+                "name %s (type %s) contains non-ASCII characters (e.g. accents)" % (safeName, type(name)),
+                translated=_translate("name %s (type %s) contains non-ASCII characters (e.g. accents)") % (safeName, type(name))
             )
         else:
             raise exceptions.ConditionsImportError(
-                "name %s (type %s) could not be converted to a string",
-                translated=_translate("name %s (type %s) could not be converted to a string") % (name, type(name))
+                "name %s (type %s) could not be converted to a string" % (safeName, type(name)),
+                translated=_translate("name %s (type %s) could not be converted to a string") % (safeName, type(name))
             )
 
     if name[0].isdigit():

--- a/psychopy/tests/test_data/test_utils.py
+++ b/psychopy/tests/test_data/test_utils.py
@@ -89,6 +89,20 @@ class Test_utilsClass:
             assert valid == case['valid']
             assert msg == case['msg']
 
+    def test_isValidVariableName_str_conversion_failure(self):
+        # str subclass whose __str__ raises, to exercise the fallback branch
+        # in isValidVariableName where `str(name)` itself fails (regression
+        # test for np.unicode_, removed in NumPy 2.0, being referenced there;
+        # also covers the message formatting, which used to re-trigger the
+        # same str() failure while building the error message)
+        class BadStr(str):
+            def __str__(self):
+                raise UnicodeEncodeError('ascii', 'x', 0, 1, 'bad char')
+
+        with pytest.raises(exceptions.ConditionsImportError) as errMsg:
+            utils.isValidVariableName(BadStr('bad_name'))
+        assert 'could not be converted to a string' in str(errMsg.value)
+
     def test_GetExcelCellName(self):
         assert utils._getExcelCellName(0,0) == 'A1'
         assert utils._getExcelCellName(2, 1) == 'C2'


### PR DESCRIPTION
## Summary

`isValidVariableName()` in `psychopy/data/utils.py` referenced `np.unicode_`, which was removed in NumPy 2.0 (`np.str_` is the replacement). This is one of a handful of leftover NumPy-2-removed-API references from the Python 3.12/NumPy 2 migration (see also #7690 for the `np.NaN` equivalent).

The reference was in the `except` branch that's meant to handle a variable name whose `str(name)` conversion fails, so instead of raising the intended `ConditionsImportError` ("contains non-ASCII characters"), it crashed with an unrelated `AttributeError: `np.unicode_` was removed in the NumPy 2.0 release`.

While writing a regression test for that, I found the branch's own error-message formatting had the same underlying problem: both branches built their message with `"...%s..." % (name, type(name))`, and `%s` formatting calls `str()` on `name` -- exactly the call that had just failed. So even after fixing the `np.unicode_` reference, this path still crashed, just with the original (unwrapped, unhelpful) exception instead of a clean `ConditionsImportError`. Fixed by using `repr(name)` for the message instead, which can't fail here. Also fixed the untranslated message for the "could not be converted" case, which was missing its `%` formatting entirely and so always displayed the raw `%s (type %s)` template unfilled.

## Test plan

- [x] Added `test_isValidVariableName_str_conversion_failure` in `psychopy/tests/test_data/test_utils.py`, using a `str` subclass with a `__str__` that raises, to exercise this except-branch.
- [x] Verified the new test fails on the pre-fix code with the exact reported `AttributeError`, and passes after the fix.
- [x] Full `psychopy/tests/test_data/` suite passes (151 passed, 4 skipped).