### PR TITLE
BF: Fix AttributeError from removed np.unicode_ in isValidVariableName

### DIFF
--- a/psychopy/data/utils.py
+++ b/psychopy/data/utils.py
@@ -89,15 +89,18 @@ def isValidVariableName(name):
     try:
         name = str(name)  # convert from unicode if possible
     except Exception:
-        if type(name) in [str, np.unicode_]:
+        # str(name) already failed above, so use repr() (never fails for a
+        # str/str subclass) rather than %s (which would call str() again)
+        safeName = repr(name)
+        if type(name) in [str, np.str_]:
             raise exceptions.ConditionsImportError(
-                "name %s (type %s) contains non-ASCII characters (e.g. accents)" % (name, type(name)),
-                translated=_translate("name %s (type %s) contains non-ASCII characters (e.g. accents)") % (name, type(name))
+                "name %s (type %s) contains non-ASCII characters (e.g. accents)" % (safeName, type(name)),
+                translated=_translate("name %s (type %s) contains non-ASCII characters (e.g. accents)") % (safeName, type(name))
             )
         else:
             raise exceptions.ConditionsImportError(
-                "name %s (type %s) could not be converted to a string",
-                translated=_translate("name %s (type %s) could not be converted to a string") % (name, type(name))
+                "name %s (type %s) could not be converted to a string" % (safeName, type(name)),
+                translated=_translate("name %s (type %s) could not be converted to a string") % (safeName, type(name))
             )
 
     if name[0].isdigit():

--- a/psychopy/tests/test_data/test_utils.py
+++ b/psychopy/tests/test_data/test_utils.py
@@ -89,6 +89,20 @@ class Test_utilsClass:
             assert valid == case['valid']
             assert msg == case['msg']
 
+    def test_isValidVariableName_str_conversion_failure(self):
+        # str subclass whose __str__ raises, to exercise the fallback branch
+        # in isValidVariableName where `str(name)` itself fails (regression
+        # test for np.unicode_, removed in NumPy 2.0, being referenced there;
+        # also covers the message formatting, which used to re-trigger the
+        # same str() failure while building the error message)
+        class BadStr(str):
+            def __str__(self):
+                raise UnicodeEncodeError('ascii', 'x', 0, 1, 'bad char')
+
+        with pytest.raises(exceptions.ConditionsImportError) as errMsg:
+            utils.isValidVariableName(BadStr('bad_name'))
+        assert 'could not be converted to a string' in str(errMsg.value)
+
     def test_GetExcelCellName(self):
         assert utils._getExcelCellName(0,0) == 'A1'
         assert utils._getExcelCellName(2, 1) == 'C2'


### PR DESCRIPTION
Backport of #7706 to `release`, as requested by @TEParsons ([comment](https://github.com/psychopy/psychopy/pull/7706#issuecomment-5045339148)), so the fix reaches users in the next release rather than waiting for `dev` to roll forward.

## Summary

`isValidVariableName()` in `psychopy/data/utils.py` referenced `np.unicode_`, which was removed in NumPy 2.0 (`np.str_` is the replacement). The reference lived in the `except` branch meant to handle a variable name whose `str(name)` conversion fails, so instead of raising the intended `ConditionsImportError`, it crashed with an unrelated `AttributeError: np.unicode_ was removed in the NumPy 2.0 release`.

The same branch's message formatting had a related problem: both branches built their message with `"...%s..." % (name, type(name))`, and `%s` calls `str()` on `name` — exactly the call that had just failed — so the path still crashed even after fixing `np.unicode_`. Fixed by formatting with `repr(name)` (via `safeName`), which cannot fail here. Also fixed the untranslated message for the "could not be converted" case, which was missing its `%` formatting entirely and so displayed the raw `%s (type %s)` template unfilled.

This is a clean cherry-pick of 511340f47 (from #7706); it applies to `release` with no conflicts.

## Test plan

- [x] `test_isValidVariableName_str_conversion_failure` in `psychopy/tests/test_data/test_utils.py` uses a `str` subclass whose `__str__` raises, to exercise this except-branch.
- [x] Verified the test fails on the pre-fix `release` code with the reported `AttributeError` and passes after the fix.