### PR TITLE
BF: Clear validator messages before starting validation

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -493,6 +493,7 @@ class BaseComponent:
             # queue validation
             code = (
                 "# tell attached validator (%(name)s) to start looking for a start flag\n"
+                "%(name)s.sensor.clearResponses()\n"
                 "%(name)s.status = STARTED\n"
             )
             buff.writeIndentedLines(code % validator.params)


### PR DESCRIPTION
This doesn't matter so much if your stimulus is constant (as with visual validators, or audio validators checking e.g. a tone), but if your stimulus has quiet parts then you'll get multiple start/stop messages besides the ones used (and cleared) for validation. This means on the second repeat of a trial, the validator might report the last start message it got from the previous stimulus as the start of this stimulus, leading to some very odd data (stimuli validated as starting several seconds early).