### PR TITLE
BF: Volume couldn't be set each frame due to syntax error

### DIFF
--- a/psychopy/experiment/components/_base.py
+++ b/psychopy/experiment/components/_base.py
@@ -983,9 +983,6 @@ class BaseComponent:
                 valStr = valStr.replace("(", "[", 1)
                 valStr = valStr[::-1].replace(")", "]", 1)[
                          ::-1]  # replace from right
-            # filenames (e.g. for image) need to be loaded from resources
-            if paramName in ["sound"]:
-                valStr = (f"psychoJS.resourceManager.getResource({valStr})")
         else:
             endStr = ''
 
@@ -1001,11 +998,6 @@ class BaseComponent:
             if paramName == 'color':
                 buff.writeIndented(f"{compName}.setColor({params['color']}, colorSpace={params['colorSpace']}")
                 buff.write(f"{loggingStr}){endStr}\n")
-            elif paramName == 'sound':
-                stopVal = params['stopVal'].val
-                if stopVal in ['', None, -1, 'None']:
-                    stopVal = '-1'
-                buff.writeIndented(f"{compName}.setSound({params['sound']}, secs={stopVal}){endStr}\n")
             elif paramName == 'movie' and params['backend'].val in ('moviepy', 'avbin', 'vlc', 'opencv'):
                 # we're going to do this for now ...
                 if params['units'].val == 'from exp settings':

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -139,6 +139,49 @@ class SoundComponent(BaseDeviceComponent):
             )
         )
 
+    def writeParamUpdate(
+        self, 
+        buff, 
+        compName, 
+        paramName, 
+        val, 
+        updateType,
+        params=None, 
+        target="PsychoPy"
+    ):
+        # updating sound param is something of a special case
+        if paramName == "sound":
+            # in Python, needs to have hamming specified
+            if target == "PsychoPy":
+                code = (
+                    "%(name)s.setSound(%(sound)s, hamming=%(hamming)s"
+                )
+                if self.params['stopVal'].val in ['', None, -1, 'None']:
+                    # also specify secs if we have a finite duration
+                    code += ", secs=%(stopVal)s"
+                code += f", logging={updateType != 'set every frame'})"
+                buff.writeIndentedLines(code % self.params)
+            # in JS, the resource needs to be fetched
+            if target == "PsychoJS":
+                code = (
+                    "%(name)s.setSound(%(sound)s);\n"
+                )
+                if self.params['stopVal'].val in ['', None, -1, 'None']:
+                    # also specify secs if we have a finite duration
+                    code += "%(name)s.secs = %(stopVal)s;\n"
+                buff.writeIndentedLines(code % self.params)
+        else:
+            BaseDeviceComponent.writeParamUpdate(
+                self, 
+                buff, 
+                compName, 
+                paramName, 
+                val, 
+                updateType,
+                params, 
+                target
+            )
+
     def writePreCode(self, buff):
         backend = self.exp.settings.params['Audio lib'].val
         # figure out backend
@@ -187,7 +230,7 @@ class SoundComponent(BaseDeviceComponent):
 
     def writeRoutineStartCode(self, buff):
         # do param updates
-        super().writeRoutineStartCode(self, buff)
+        BaseDeviceComponent.writeRoutineStartCode(self, buff)
         # seek back to start
         code = (
             "%(name)s.seek(0)\n"
@@ -219,23 +262,13 @@ class SoundComponent(BaseDeviceComponent):
         buff.writeIndentedLines(code % self.params)
 
     def writeRoutineStartCodeJS(self, buff):
-        stopVal = self.params['stopVal']
-        if stopVal in ['', None, 'None']:
-            stopVal = -1
-        
+        # do param updates
+        BaseDeviceComponent.writeRoutineStartCodeJS(self, buff)        
         # never start a Routine marked as finished
         code = (
             "%(name)s.isFinished = false;"
         )
-        buff.writeIndentedLines(code % self.params)
-
-        if self.params['sound'].updates == 'set every repeat':
-            buff.writeIndented("%(name)s.setValue(%(sound)s);\n" % self.params)
-        if stopVal == -1:
-            buff.writeIndentedLines("%(name)s.setVolume(%(volume)s);\n" % self.params)
-        else:
-            buff.writeIndentedLines("%(name)s.secs=%(stopVal)s;\n"
-                                    "%(name)s.setVolume(%(volume)s);\n" % self.params)
+        buff.writeIndentedLines(code % self.params)  
 
     def writeFrameCode(self, buff):
         """Write the code that will be called every frame
@@ -344,46 +377,6 @@ class SoundComponent(BaseDeviceComponent):
                 "%(name)s.stop();  // ensure sound has stopped at end of Routine\n"
             )
             buff.writeIndentedLines(code % self.params)
-
-    def writeParamUpdate(
-            self,
-            buff,
-            compName,
-            paramName,
-            val,
-            updateType,
-            params=None,
-            target="PsychoPy",
-    ):
-        """
-        Overload BaseComponent.writeParamUpdate to handle special case for SoundComponent
-        """
-        # when writing param updates for Sound.sound, needs to be `setValue` in JS
-        # (this is intended as a temporary patch - please delete when `setSound` in JS can accept
-        # the same range of values as in Py)
-        if target == 'PsychoJS' and paramName == "sound":
-            # get logging string
-            if updateType == 'set every frame' and target == 'PsychoJS':
-                loggingStr = ', false'
-            else:
-                loggingStr = ''
-            # write setValue code
-            code = (
-                f"{compName}.setValue({val}{loggingStr});\n"
-            )
-            buff.writeIndented(code)
-        else:
-            # do normal stuff for every other param
-            BaseDeviceComponent.writeParamUpdate(
-                self,
-                buff,
-                compName,
-                paramName,
-                val,
-                updateType,
-                params=params,
-                target=target,
-            )
 
 
 class SpeakerDeviceBackend(DeviceBackend):

--- a/psychopy/experiment/components/sound/__init__.py
+++ b/psychopy/experiment/components/sound/__init__.py
@@ -186,12 +186,9 @@ class SoundComponent(BaseDeviceComponent):
         buff.writeIndented("%(name)s.setVolume(%(volume)s)\n" % inits)
 
     def writeRoutineStartCode(self, buff):
-        if self.params['stopVal'].val in [None, 'None', '']:
-            buff.writeIndentedLines("%(name)s.setSound(%(sound)s, hamming=%(hamming)s)\n"
-                                    "%(name)s.setVolume(%(volume)s, log=False)\n" % self.params)
-        else:
-            buff.writeIndentedLines("%(name)s.setSound(%(sound)s, secs=%(stopVal)s, hamming=%(hamming)s)\n"
-                                    "%(name)s.setVolume(%(volume)s, log=False)\n" % self.params)
+        # do param updates
+        super().writeRoutineStartCode(self, buff)
+        # seek back to start
         code = (
             "%(name)s.seek(0)\n"
         )


### PR DESCRIPTION
Because we set volume at routine start no matter what, setting it each frame with variables defined each frame (e.g. `t`) created a syntax error as it was also set before the frame loop of the Routine. The code appears to be an unecessary holdover from when we had to set the sound to seek to 0