### PR TITLE
BF: remove undefined _getSvnVersion/_getHgVersion references in info.py (backport of #7688)

### DIFF
--- a/psychopy/info.py
+++ b/psychopy/info.py
@@ -21,8 +21,6 @@ __all__ = [
     '_getUserNameUID',
     '_getHashGitHead',
     '_getSha1hexDigest',
-    '_getHgVersion',
-    '_getSvnVersion',
     '_thisProcess'
 ]
 
@@ -271,22 +269,6 @@ class RunTimeInfo(dict):
         scriptPath = os.path.abspath(sys.argv[0])
         key = 'experimentScript.digestSHA1'
         self[key] = _getSha1hexDigest(scriptPath, isfile=True)
-        # subversion revision?
-        try:
-            svnrev, last, url = _getSvnVersion(scriptPath)  # svn revision
-            if svnrev:  # or verbose:
-                self['experimentScript.svnRevision'] = svnrev
-                self['experimentScript.svnRevLast'] = last
-                self['experimentScript.svnRevURL'] = url
-        except Exception:
-            pass
-        # mercurical revision?
-        try:
-            hgChangeSet = _getHgVersion(scriptPath)
-            if hgChangeSet:  # or verbose:
-                self['experimentScript.hgChangeSet'] = hgChangeSet
-        except Exception:
-            pass
 
         # when was this run?
         self['experimentRunTime.epoch'] = core.getAbsTime()

--- a/psychopy/tests/test_misc/test_info.py
+++ b/psychopy/tests/test_misc/test_info.py
@@ -6,6 +6,18 @@ import pytest
 # py.test -k info --cov-report term-missing --cov info.py
 
 
+def test_all_names_defined():
+    """Every name exported in ``info.__all__`` must actually be defined.
+
+    Guards against dangling ``__all__`` entries such as the removed
+    ``_getSvnVersion``/``_getHgVersion`` helpers, which lingered in
+    ``__all__`` (and in silently-failing call sites) after their definitions
+    were deleted.
+    """
+    missing = [name for name in info.__all__ if not hasattr(info, name)]
+    assert not missing, f"names in __all__ are undefined: {missing}"
+
+
 @pytest.mark.info
 class TestInfo():
     @classmethod


### PR DESCRIPTION
Backport of #7688, which merged to `dev` on 2026-06-27. The defect is still live on `release`.

Cherry-pick of 1da44cdc4 — applies cleanly, and both files are now byte-identical to their versions on `dev`.

### What was broken

`_getSvnVersion` and `_getHgVersion` were removed in 895f4cbf0 ("PKG: getHgVersion and getSvnVersion no longer useful"), but their entries in `__all__` and their call sites in `RunTimeInfo` were left behind. Two consequences on `release` today:

- `from psychopy.info import *` raises `AttributeError`, because `__all__` names two symbols that do not exist.
- The svn/hg revision capture in `RunTimeInfo` has been dead ever since. The call sites are wrapped in `try/except Exception`, so the `NameError` was silently swallowed — `experimentScript.svnRevision` and `experimentScript.hgChangeSet` have simply never been recorded.

This removes the dangling `__all__` entries and the dead svn/hg blocks, finishing the removal that 895f4cbf0 started.

### Verification

The cherry-pick brings a regression test asserting every name in `info.__all__` resolves. Confirmed it is red before the fix and green after — with the new test in place but `info.py` reverted to its current `release` state:

```
AssertionError: names in __all__ are undefined: ['_getHgVersion', '_getSvnVersion']
1 failed
```

and on this branch:

```
psychopy/tests/test_misc/test_info.py .. 2 passed
```

---

Co-authored by Claude Opus 5.
