### PR TITLE
BF: Fall back to a working keyboard backend when psychtoolbox is missing

### DIFF
--- a/psychopy/hardware/keyboard.py
+++ b/psychopy/hardware/keyboard.py
@@ -333,6 +333,15 @@ class KeyboardDevice(BaseResponseDevice, aliases=["keyboard"]):
             logging.warning("keyboard.Keyboard already using '%s' backend. Can not switch to '%s'" % (self._backend,
                                                                                                       backend))
 
+        # the 'ptb' backend needs psychtoolbox, so if it isn't available clear the
+        # choice and let the fallbacks below pick a backend which is. Leaving it set
+        # would mean the buffers `_backend == 'ptb'` code paths use are never created,
+        # so key presses would be silently discarded.
+        if KeyboardDevice._backend == 'ptb' and not havePTB:
+            logging.warning("keyboard.Keyboard requested the 'ptb' backend, but psychtoolbox is "
+                            "not available. Falling back to another backend.")
+            KeyboardDevice._backend = ''
+
         if clock:
             self.clock = clock
         else:

--- a/psychopy/tests/test_hardware/test_keyboard_backend_fallback.py
+++ b/psychopy/tests/test_hardware/test_keyboard_backend_fallback.py
@@ -1,0 +1,92 @@
+"""Tests that asking for the 'ptb' keyboard backend degrades safely.
+
+`KeyboardDevice._backend` is assigned from the backend the caller asked for,
+but the psychtoolbox buffers are only created under
+``_backend in ['', 'ptb'] and havePTB``, while every later use of them is
+guarded by the weaker ``_backend == 'ptb'``. When psychtoolbox is missing
+those two conditions disagree: `_backend` says 'ptb' but the buffers were
+never made.
+
+That mismatch first showed up as `AttributeError: 'KeyboardDevice' object has
+no attribute '_buffers'` (gh-7493). gh-7494 stopped the crash by defaulting
+`_buffers` to `{}` for every backend, but left `_backend` still reporting
+'ptb', which turned the crash into silent data loss: `dispatchMessages()`
+takes the 'ptb' branch, iterates an empty `_buffers`, and never falls through
+to the backend that would actually collect key presses.
+
+Builder writes the keyboard backend into generated scripts from the user's
+preferences, so `Keyboard(backend='ptb')` on a machine without psychtoolbox
+is a realistic combination rather than a contrived one.
+
+This runs in a subprocess: `psychtoolbox` has to be hidden before `psychopy`
+imports it, and `KeyboardDevice._backend` is a class attribute assigned only
+on the first construction, so a `Keyboard` built earlier in the process would
+stop a later `backend='ptb'` from taking effect.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+
+# Ask for the psychtoolbox backend with psychtoolbox unavailable, then feed in a
+# key press the way pyglet's handler would and check it still comes back out.
+_WITHOUT_PSYCHTOOLBOX = '''
+import sys
+
+class BlockPsychtoolbox:
+    """Meta path finder which makes `import psychtoolbox` fail."""
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "psychtoolbox" or fullname.startswith("psychtoolbox."):
+            raise ModuleNotFoundError("No module named %r (hidden by test)" % fullname)
+        return None
+
+sys.meta_path.insert(0, BlockPsychtoolbox())
+
+from psychopy import core, event
+from psychopy.hardware import keyboard
+
+kb = keyboard.Keyboard(backend="ptb")
+
+assert not keyboard.havePTB, "psychtoolbox was still importable"
+assert keyboard.KeyboardDevice._backend != "ptb", (
+    "backend stayed 'ptb' with no psychtoolbox; key presses would be discarded")
+
+# push a key press into the event backend's buffer, as its pyglet handler does
+event._keyBuffer.append(("a", None, core.getTime()))
+keys = kb.getKeys(waitRelease=False)
+assert keys, "key press was silently discarded"
+
+# on the event backend KeyPress.name carries the (key, time) pair returned by
+# event.getKeys(timeStamped=True) rather than a bare string
+name = keys[0].name
+if not isinstance(name, str):
+    name = name[0]
+assert name == "a", "unexpected key %r" % (keys[0].name,)
+
+print("RESULT|ok|%s" % keyboard.KeyboardDevice._backend)
+'''
+
+
+@pytest.mark.keyboard
+def test_ptb_backend_falls_back_without_psychtoolbox(tmp_path):
+    """Requesting 'ptb' with no psychtoolbox should use a backend that works."""
+    script = tmp_path / "without_psychtoolbox.py"
+    script.write_text(_WITHOUT_PSYCHTOOLBOX, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, "-u", str(script)],
+        capture_output=True,
+        timeout=300,
+    )
+    stdout = proc.stdout.decode("utf-8", errors="replace")
+    stderr = proc.stderr.decode("utf-8", errors="replace")
+
+    if proc.returncode != 0:
+        pytest.fail(
+            "child interpreter exited with %s\n--- stdout ---\n%s\n--- stderr ---\n%s"
+            % (proc.returncode, stdout, stderr)
+        )
+
+    assert any(line.startswith("RESULT|ok|") for line in stdout.splitlines()), stdout


### PR DESCRIPTION
> **Draft — this is a behaviour change in hardware-facing code, and I would rather have your steer on the approach than merge it as-is.** The diagnosis below I am confident about; the remedy is one of several possible, and alternatives are listed at the end.

### The problem

`KeyboardDevice._backend` is assigned from the backend the caller asked for, *before* `havePTB` is consulted:

```python
if self._backend is None and backend in ['iohub', 'ptb', 'event', '']:
    KeyboardDevice._backend = backend
```

The psychtoolbox buffers are then only created under a stronger condition:

```python
if KeyboardDevice._backend in ['', 'ptb'] and havePTB:
    ...
    self._buffers = {}
```

while every later use of them is guarded by the weaker `_backend == 'ptb'`. When psychtoolbox is missing the two disagree — `_backend` reports `'ptb'`, but `_buffers` was never populated.

That mismatch is what produced `AttributeError: 'KeyboardDevice' object has no attribute '_buffers'` in #7493. #7494 stopped the crash by defaulting `_buffers` to `{}` for every backend, which fixed the traceback but left `_backend` still set to `'ptb'`. `dispatchMessages()` therefore takes the `'ptb'` branch, iterates an empty `_buffers`, and never falls through to the branch that would actually collect key presses:

```python
if KeyboardDevice._backend == 'ptb':
    for buffer in self._buffers.values():   # empty -> loop body never runs
        ...
elif KeyboardDevice._backend == 'iohub':
    ...
else:                                        # never reached
    name = event.getKeys(modifiers=False, timeStamped=True)
```

So the crash became silent data loss. Builder writes the keyboard backend into generated scripts from the user's preferences, so `Keyboard(backend='ptb')` on a machine without psychtoolbox is a realistic combination — and such an experiment now runs to completion and records no keyboard responses at all, with nothing in the log to say why.

Present on both `release` and `dev` (same logic, same line numbers).

### Reproduction

Injecting a key press into the event backend's buffer the way its pyglet handler does, with psychtoolbox hidden:

| constructor | resulting backend | injected key press |
| --- | --- | --- |
| `Keyboard()` | `event` | returned by `getKeys()` |
| `Keyboard(backend='ptb')` | `ptb` | **silently discarded** |

### The change, and what it changes

When `_backend` ends up `'ptb'` but `havePTB` is false, the backend choice is cleared and a warning logged, so the existing iohub/event fallbacks select something that works.

**This is a behaviour change, deliberately:** a backend the user explicitly requested is now overridden rather than left in place. Anything reading `KeyboardDevice._backend` will see `'event'` (or `'iohub'`) where it previously saw `'ptb'`. I think that is the right trade — the previous value was not merely different, it described a keyboard that could not report anything — but it is a change, and it is your call.

Confirmed that with psychtoolbox installed, `Keyboard(backend='ptb')` still selects `'ptb'` and populates its buffers, so this does not disable psychtoolbox for anyone who has it.

### Testing

Added `psychopy/tests/test_hardware/test_keyboard_backend_fallback.py`, which hides psychtoolbox in a subprocess, requests the `ptb` backend, and asserts an injected key press is still returned. Fails on `release` without this change:

```
AssertionError: backend stayed 'ptb' with no psychtoolbox; key presses would be discarded
```

and passes with it, stably over repeated runs.

`test_keyboard.py`, `test_keyboard_events.py`, `test_ports.py`, `test_gammasci.py` and the new file together: **39 passed, 14 skipped**.

One test I deliberately did **not** include: a companion check that `'ptb'` is still honoured when psychtoolbox *is* installed. It has to construct a real psychtoolbox keyboard, which starts the `PsychHIDKbQueue` thread, and on a Linux machine without `cap_sys_nice` that thread segfaults the interpreter (I got two SIGSEGVs and a hang in three runs). CI grants that capability in the "Set nice level (linux)" step so it would pass there, but it would be unreliable for contributors locally, and a test that segfaults developer machines seemed worse than none. I verified that property by hand instead.

### Alternatives you may prefer

1. **Raise instead of falling back** — if someone explicitly asks for `ptb` and it is unavailable, arguably that should be an error rather than a silent substitution, at least when the backend was passed explicitly rather than coming from prefs.
2. **Leave `_backend` alone and fix the dispatch** — let `dispatchMessages()` and friends fall through to the event branch when `_buffers` is empty. Smaller conceptual change, but it leaves `_backend` describing something untrue.
3. **Handle it further up**, where the preference is read, so the generated script never asks for a backend that isn't installed.

I went with the fallback because it matches what `Keyboard()` already does when no backend is requested, but I have no strong attachment to it.

---

Co-authored by Claude Opus 5.
