### PR TITLE
Adding dependabot settings to provide cooldown periods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 180 # very unlikely a security release
+      semver-minor-days: 14  # unlikely a security release
+      semver-patch-days: 5


### PR DESCRIPTION
dependabot provides useful information about updates to packages that we might apply to dev branch (and manually cherry-pick to release branch for critical fixes)

BUT if supply chain has been compromised, with a malicious release of an upstream package, that can sometimes take a few days to be detected and resolved. It's safest to have a cooldown period and only install packages that have remained on PyPI for longer than that cooldown (meaning they were released for several days without being noticed as fake and pulled)