### PR TITLE
BF: Add expInfo code to survey routine

### DIFF
--- a/psychopy/experiment/routines/pavlovia_survey/__init__.py
+++ b/psychopy/experiment/routines/pavlovia_survey/__init__.py
@@ -129,7 +129,7 @@ class PavloviaSurveyRoutine(BaseStandaloneRoutine):
         code = (
             "});\n"
             "%(name)sClock = new util.Clock();\n"
-            "%(name)s.setVariables(expInfo);\n"
+            "%(name)s.setVariables(expInfo, []);\n"
             "%(name)s.setAutoDraw(true);\n"
             "%(name)s.status = PsychoJS.Status.STARTED;\n"
             "%(name)s.isFinished = false;\n"

--- a/psychopy/experiment/routines/pavlovia_survey/__init__.py
+++ b/psychopy/experiment/routines/pavlovia_survey/__init__.py
@@ -129,6 +129,7 @@ class PavloviaSurveyRoutine(BaseStandaloneRoutine):
         code = (
             "});\n"
             "%(name)sClock = new util.Clock();\n"
+            "%(name)s.setVariables(expInfo);\n"
             "%(name)s.setAutoDraw(true);\n"
             "%(name)s.status = PsychoJS.Status.STARTED;\n"
             "%(name)s.isFinished = false;\n"


### PR DESCRIPTION
I've added "%(name)s.setVariables(expInfo);\n" to the survey routine __initi__.py
Manually editing the code works in 2026.2.2 (different code is needed in 2026.2.1)