### PR TITLE
BF: Made Mouse Component "new clicks only" specific to each Component

### DIFF
--- a/psychopy/event.py
+++ b/psychopy/event.py
@@ -602,6 +602,8 @@ class Mouse:
             self.setVisible(visible)
         if newPos is not None:
             self.setPos(newPos)
+        # this is set by Builder code
+        self.prevButtonState = [0, 0, 0]
 
     @property
     def units(self):

--- a/psychopy/experiment/components/mouse/__init__.py
+++ b/psychopy/experiment/components/mouse/__init__.py
@@ -344,12 +344,14 @@ class MouseComponent(BaseComponent):
 
             if self.params['newClicksOnly']:
                 code += (
-                    "prevButtonState = %(name)s.getPressed()"
-                    "  # if button is down already this ISN'T a new click\n")
+                    "# if button is down already this ISN'T a new click\n"
+                    "%(name)s.prevButtonState = %(name)s.getPressed()\n"
+                )
             else:
                 code += (
-                    "prevButtonState = [0, 0, 0]"
-                    "  # if now button is down we will treat as 'new' click\n")
+                    "# if now button is down we will treat as 'new' click\n"
+                    "%(name)s.prevButtonState = [0, 0, 0]\n"
+                )
             buff.writeIndentedLines(code % self.params)
 
         # to get out of the if statement
@@ -377,16 +379,17 @@ class MouseComponent(BaseComponent):
 
         def _buttonPressCode(buff, dedent):
             """Code compiler for mouse button events"""
-            code = ("buttons = %(name)s.getPressed()\n"
-                    "if buttons != prevButtonState:  # button state changed?")
+            code = (
+                "buttons = %(name)s.getPressed()\n"
+                "# button state changed?\n"
+                "if buttons != %(name)s.prevButtonState:\n"
+                "    %(name)s.prevButtonState = buttons\n"
+                "    # state changed to a new click\n"
+                "    if sum(buttons) > 0:\n"
+            )
             buff.writeIndentedLines(code % self.params)
-            buff.setIndentLevel(1, relative=True)
-            dedent += 1
-            buff.writeIndented("prevButtonState = buttons\n")
-            code = ("if sum(buttons) > 0:  # state changed to a new click\n")
-            buff.writeIndentedLines(code % self.params)
-            buff.setIndentLevel(1, relative=True)
-            dedent += 1
+            buff.setIndentLevel(2, relative=True)
+            dedent += 2
             # keep track of whether something's been written
             hasContent = False
             # write code to check clickable stim, if there are any


### PR DESCRIPTION
Because we were just using the variable `prevButtonState` for *all* Mouse Components, if you have 2 Mouse Components in your experiment, the second will use the same `prevButtonState` as the first so new clicks are discarded as not new.