### PR TITLE
BF: Fix three crashes found by static analysis

### DIFF
--- a/psychopy/colors.py
+++ b/psychopy/colors.py
@@ -497,7 +497,7 @@ class Color:
     def __copy__(self):
         return self.__deepcopy__()
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, memo=None):
         dupe = self.__class__(
             self._requested, self._requestedSpace, self.contrast)
         dupe.rgba = self.rgba

--- a/psychopy/layout.py
+++ b/psychopy/layout.py
@@ -291,7 +291,7 @@ class Vector:
     def __copy__(self):
         return self.__deepcopy__()
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, memo=None):
         return self.__class__(self._requested, self._requestedUnits, self.win)
 
     @property

--- a/psychopy/tests/test_colors/test_Color.py
+++ b/psychopy/tests/test_colors/test_Color.py
@@ -1,3 +1,5 @@
+import copy
+
 from psychopy import colors, visual, event, logging
 
 
@@ -39,3 +41,13 @@ def test_readable():
         # while not event.getKeys():
         #     text.draw()
         #     win.flip()
+
+
+def test_deepcopy():
+    """
+    Check that a Color can be deep copied, as well as shallow copied.
+    """
+    col = colors.Color((1, 0, 0), space="rgb")
+    for dupe in (col.copy(), copy.copy(col), copy.deepcopy(col)):
+        assert dupe is not col
+        assert dupe == col

--- a/psychopy/tests/test_misc/test_layout.py
+++ b/psychopy/tests/test_misc/test_layout.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy
 from psychopy import layout, visual
 
@@ -47,3 +49,12 @@ class TestVector:
                     f"Vector of {obj._requested} in {obj._requestedUnits} should return {ans[space]} in {space} units, "
                     f"but instead returned {val}"
                 )
+
+    def test_deepcopy(self):
+        """
+        Check that a Vector can be deep copied, as well as shallow copied.
+        """
+        vec = layout.Vector((1, 1), 'height', self.win)
+        for dupe in (vec.copy(), copy.copy(vec), copy.deepcopy(vec)):
+            assert dupe is not vec
+            assert dupe == vec

--- a/psychopy/tests/test_tools/test_gltools.py
+++ b/psychopy/tests/test_tools/test_gltools.py
@@ -1,0 +1,19 @@
+"""Tests for psychopy.tools.gltools which don't need an OpenGL context."""
+
+from psychopy.tools.gltools import TexImage2DInfo, TexImage2DMultisampleInfo
+
+
+def test_texture_descriptors_store_name():
+    """
+    Check that texture descriptors can be created and keep the handle they were
+    given, as `createTexImage2D` and `createTexImage2DMultisample` require.
+    """
+    cases = [
+        TexImage2DInfo(name=1),
+        TexImage2DMultisampleInfo(name=1),
+    ]
+    for tex in cases:
+        assert int(tex.name.value) == 1, (
+            f"{type(tex).__name__} should store the texture handle it was "
+            f"given, but returned {tex.name}"
+        )

--- a/psychopy/tools/gltools.py
+++ b/psychopy/tools/gltools.py
@@ -3146,6 +3146,16 @@ class TexImage2DMultisampleInfo:
         else:
             raise TypeError('Invalid type for `userData`.')
 
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        if not isinstance(value, GL.GLuint):
+            self._name = GL.GLuint(int(value))
+        else:
+            self._name = value
 
 
 def createTexImage2DMultisample(width, height,


### PR DESCRIPTION
Three crashes found with `ruff --select PLE0302,PLE0237`, following on from #7720. Each has a regression test that fails without the fix.

### `copy.deepcopy()` on `Color` and `Vector` (PLE0302)

`Color.__deepcopy__` and `Vector.__deepcopy__` are declared without the `memo` argument that `copy.deepcopy` passes:

```pycon
>>> copy.deepcopy(Color('red'))
TypeError: Color.__deepcopy__() takes 1 positional argument but 2 were given
```

`.copy()` and `copy.copy()` work, since both call `self.__deepcopy__()` with no arguments — which is presumably why this went unnoticed. `memo` is accepted and ignored: neither class holds a reference back to itself, and the duplicate is rebuilt from the requested value rather than by copying members.

### `TexImage2DMultisampleInfo` cannot be constructed (PLE0237)

`__slots__` lists `_name`, but `__init__` assigns `self.name` and no `name` property exists, so building the descriptor raises `AttributeError` — meaning `createTexImage2DMultisample()` has never returned successfully.

I added the `name` property/setter that the neighbouring `TexImage2DInfo` and `TexCubeMap` already define, rather than renaming the slot, so the handle is coerced to `GLuint` as it is for those classes and `deleteTexture()`'s `texture.name = 0` behaves consistently.

### When these appeared

`__deepcopy__` has been broken since b07093414 (2022.1.0) — that commit moved the body of `copy()` into `__deepcopy__` and added the `__copy__` wrapper, but kept the zero-argument signature, so the change that was meant to make `deepcopy(obj)` work is what broke it.

`TexImage2DMultisampleInfo` is a regression from #7002 (2025.1.0). Before that refactor `createTexImage2DMultisample()` returned a namedtuple and worked; the replacement class adopted the `_name` slot convention from `TexImage2DInfo` without the accompanying property.

### Testing

`pytest psychopy/tests/test_tools/ psychopy/tests/test_colors/ psychopy/tests/test_misc/` — 123 passed. The three new tests each fail on pristine `release`.

### Not included

`TexImage2DMultisampleInfo.__slots__` also omits `_isBound`, which `deleteTexture()` reads, so deleting a multisample texture still raises `AttributeError`. That path needs a GL context to exercise, so I left it for a maintainer to confirm.

---
*Bugs found with [ruff](https://docs.astral.sh/ruff/); patch and description drafted with Claude Opus 5, reviewed by me before posting.*
