### PR TITLE
BF: Error when playing movies: AttributeError: 'MovieFileReader' object has no attribute '_cleanUpAudioTrack'

### DIFF
--- a/psychopy/visual/movies/__init__.py
+++ b/psychopy/visual/movies/__init__.py
@@ -843,8 +843,6 @@ class MovieFileReader:
             self._player.set_pause(True)  # pause the player
             self._player.close_player()
 
-        self._cleanUpAudioTrack()  # clean up the audio track
-
         self._player = None
 
     def _cleanUpFrameStore(self, keepAfterPTS=None):
@@ -1665,7 +1663,7 @@ class MovieStim(BaseVisualStim, DraggingMixin, ColorMixin, ContainerMixin):
             Path to movie file. Must be a format that FFMPEG supports.
 
         """
-        self.setMovie(filename=filename)
+        self.setMovie(filename)
 
     def unload(self, log=True):
         """Stop and unload the movie.


### PR DESCRIPTION
Fixes an attribute error that is raised when the movie is unloaded.