### PR TITLE
RF: Allow Parallel Port devices to be managed by Device Manager

### DIFF
--- a/psychopy/experiment/components/parallelOut/__init__.py
+++ b/psychopy/experiment/components/parallelOut/__init__.py
@@ -6,11 +6,11 @@
 # Distributed under the terms of the GNU General Public License (GPL).
 
 from pathlib import Path
-from psychopy.experiment.components import BaseComponent, Param, _translate
-from psychopy import prefs
+from psychopy.experiment.components import BaseDeviceComponent, Param, _translate
+from psychopy.experiment.devices import DeviceBackend
+import sys
 
-
-class ParallelOutComponent(BaseComponent):
+class ParallelOutComponent(BaseDeviceComponent):
     """A class for sending signals from the parallel port"""
 
     categories = ['I/O', 'EEG']
@@ -18,6 +18,11 @@ class ParallelOutComponent(BaseComponent):
     iconFile = Path(__file__).parent / 'parallel.png'
     iconSVG = Path(__file__).parent / 'ParallelOutComponent.svg'
     tooltip = _translate('Parallel out: send signals from the parallel port')
+    legacyParams = [
+        # old device setup params, no longer needed as this is handled by DeviceManager
+        "address",
+        "register",
+    ]
 
     def __init__(self, exp, parentName, name='p_port',
                  startType='time (s)', startVal=0.0,
@@ -33,46 +38,22 @@ class ParallelOutComponent(BaseComponent):
 
         self.type = 'ParallelOut'
         self.url = "https://www.psychopy.org/builder/components/parallelout.html"
-        self.exp.requirePsychopyLibs(['parallel'])
+        self.exp.requirePsychopyLibs([
+            "hardware"
+        ])
 
         # params
         self.order += [
             'startData', 'stopData',  # Data tab
-            'address',  'register',   # Hardware tab
         ]
 
-        # main parameters
-        addressOptions = prefs.hardware['parallelPorts'] + [u'LabJack U3'] + [u'USB2TTL8'] 
-        if not address:
-            address = addressOptions[0]
-
-        msg = _translate("Parallel port to be used (you can change these "
-                         "options in preferences>general)")
-        self.params['address'] = Param(
-            address, valType='str', inputType="choice", allowedVals=addressOptions,
-            categ="Device", hint=msg, label=_translate("Port address"))
-
-        self.depends.append(
-            {"dependsOn": "address",  # must be param name
-             "condition": "=='LabJack U3'",  # val to check for
-             "param": "register",  # param property to alter
-             "true": "show",  # what to do with param if condition is True
-             "false": "hide",  # permitted: hide, show, enable, disable
-             }
-        )
-
-        msg = _translate("U3 Register to write byte to")
-        self.params['register'] = Param(register, valType='str',
-                                        inputType="choice", allowedVals=['EIO', 'FIO'],
-                                        categ="Device", hint=msg, label=_translate("U3 register"))
-
         self.params['startData'] = Param(
-            startData, valType='code', inputType="single", allowedTypes=[], categ='Data',
+            startData, valType='code', inputType="single", allowedTypes=[], categ='Basic',
             hint=_translate("Data to be sent at 'start'"),
             label=_translate("Start data"))
 
         self.params['stopData'] = Param(
-            stopData, valType='code', inputType="single", allowedTypes=[], categ='Data',
+            stopData, valType='code', inputType="single", allowedTypes=[], categ='Basic',
             hint=_translate("Data to be sent at 'end'"),
             label=_translate("Stop data"))
 
@@ -86,94 +67,176 @@ class ParallelOutComponent(BaseComponent):
             label=_translate("Sync to screen"))
 
     def writeInitCode(self, buff):
-        if self.params['address'].val == 'LabJack U3':
-            code = ("from psychopy.hardware import labjacks\n"
-                    "%(name)s = labjacks.U3()\n"
-                    "%(name)s.status = None\n"
-                    % self.params)
-            buff.writeIndentedLines(code)
-        elif self.params['address'].val == 'USB2TTL8':
-            code = ("from psychopy.hardware import labhackers\n"
-                    "%(name)s = labhackers.USB2TTL8()\n"
-                    "%(name)s.status = None\n"
-                    % self.params)
-            buff.writeIndentedLines(code)
-        else:
-            code = ("%(name)s = parallel.ParallelPort(address=%(address)s)\n" %
-                    self.params)
-            buff.writeIndented(code)
+
+        code = (
+            "%(name)s = hardware.parallel.Parallel(\n"
+            "    device=%(deviceLabel)s\n"
+            ")\n"
+        )
+        buff.writeIndented(code % self.params)
 
     def writeFrameCode(self, buff):
         """Write the code that will be called every frame
         """
-        routineClockName = self.exp.flow._currentRoutine._clockName
-
-        buff.writeIndented("# *%s* updates\n" % (self.params['name']))
         # writes an if statement to determine whether to draw etc
         indented = self.writeStartTestCode(buff)
         if indented:
-            buff.writeIndented("%(name)s.status = STARTED\n" % self.params)
-
-            if self.params['address'].val == 'LabJack U3':
-                if not self.params['syncScreen'].val:
-                    code = "%(name)s.setData(int(%(startData)s), address=%(register)s)\n" % self.params
-                else:
-                    code = ("win.callOnFlip(%(name)s.setData, int(%(startData)s), address=%(register)s)\n" %
-                            self.params)
+            # set start data
+            code = (
+                "# set %(name)s start data\n"
+            )
+            if not self.params['syncScreen'].val:
+                code += (
+                    "%(name)s.setData(\n"
+                    "    int(%(startData)s)\n"
+                    ")\n"
+                )
             else:
-                if not self.params['syncScreen'].val:
-                    code = "%(name)s.setData(int(%(startData)s))\n" % self.params
-                else:
-                    code = ("win.callOnFlip(%(name)s.setData, int(%(startData)s))\n" %
-                            self.params)
-
-            buff.writeIndented(code)
-
+                code += (
+                    "win.callOnFlip(\n"
+                    "    %(name)s.setData, \n"
+                    "    int(%(startData)s)\n"
+                    ")\n"
+                )
+            buff.writeIndentedLines(code % self.params)
         # to get out of the if statement
         buff.setIndentLevel(-indented, relative=True)
 
         # test for stop (only if there was some setting for duration or stop)
         indented = self.writeStopTestCode(buff)
         if indented:
-            if self.params['address'].val == 'LabJack U3':
-                if not self.params['syncScreen'].val:
-                    code = "%(name)s.setData(int(%(stopData)s), address=%(register)s)\n" % self.params
-                else:
-                    code = ("win.callOnFlip(%(name)s.setData, int(%(stopData)s), address=%(register)s)\n" %
-                            self.params)
+            # set stop data
+            code = (
+                "# set %(name)s stop data\n"
+            )
+            if not self.params['syncScreen'].val:
+                code += (
+                    "%(name)s.setData(\n"
+                    "    int(%(stopData)s)\n"
+                    ")\n"
+                )
             else:
-                if not self.params['syncScreen'].val:
-                    code = "%(name)s.setData(int(%(stopData)s))\n" % self.params
-                else:
-                    code = ("win.callOnFlip(%(name)s.setData, int(%(stopData)s))\n" %
-                            self.params)
-
-            buff.writeIndented(code)
-
+                code += (
+                    "win.callOnFlip(\n"
+                    "    %(name)s.setData, \n"
+                    "    int(%(stopData)s)\n"
+                    ")\n"
+                )
+            buff.writeIndentedLines(code % self.params)
         # to get out of the if statement
         buff.setIndentLevel(-indented, relative=True)
 
-        # dedent
-# buff.setIndentLevel(-dedentAtEnd, relative=True)#'if' statement of the
-# time test and button check
-
     def writeRoutineEndCode(self, buff):
-        # make sure that we do switch to stopData if the routine has been
-        # aborted before our 'end'
-        buff.writeIndented("if %(name)s.status == STARTED:\n" % self.params)
-        if self.params['address'].val == 'LabJack U3':
-            if not self.params['syncScreen'].val:
-                code = "    %(name)s.setData(int(%(stopData)s), address=%(register)s)\n" % self.params
-            else:
-                code = ("    win.callOnFlip(%(name)s.setData, int(%(stopData)s), address=%(register)s)\n" %
-                        self.params)
+        # set stop data at end of Routine (in case Routine ended before Component)
+        code = (
+            "# set %(name)s stop data\n"
+        )
+        if not self.params['syncScreen'].val:
+            code += (
+                "%(name)s.setData(\n"
+                "    int(%(stopData)s)\n"
+                ")\n"
+            )
         else:
-            if not self.params['syncScreen'].val:
-                code = "    %(name)s.setData(int(%(stopData)s))\n" % self.params
-            else:
-                code = ("    win.callOnFlip(%(name)s.setData, int(%(stopData)s))\n" % self.params)
-
-        buff.writeIndented(code)
+            code += (
+                "win.callOnFlip(\n"
+                "    %(name)s.setData, \n"
+                "    int(%(stopData)s)\n"
+                ")\n"
+            )
+        buff.writeIndentedLines(code % self.params)
 
         # get parent to write code too (e.g. store onset/offset times)
         super().writeRoutineEndCode(buff)
+
+
+class ParallelDeviceBackend(DeviceBackend):
+    backendLabel = "Parallel Port"
+    deviceClass = "psychopy.hardware.parallel.ParallelDevice"
+    icon = "light/parallel.png"
+
+    def __init__(self, profile):
+        # init parent class
+        DeviceBackend.__init__(self, profile)
+
+        # different default address options for Windows vs Linux...
+        addressOptions = [
+            "USB2TTL8",
+            "custom"
+        ]
+        if sys.platform == "win32":
+            addressOptions = [
+                "0x0378", 
+                "0x03BC"
+            ] + addressOptions
+        if sys.platform == "linux":
+            addressOptions = [
+                "/dev/parport0", 
+                "/dev/parport1"
+            ] + addressOptions
+
+        self.params['address'] = Param(
+            addressOptions[0],
+            valType="str",
+            inputType="choice",
+            allowedVals=addressOptions,
+            label=_translate("Port address"),
+            hint=_translate(
+                "Parallel port to be used (choose 'custom' to specify any address)"
+            )
+        )
+        self.params['customAddress'] = Param(
+            "",
+            valType="str",
+            inputType="single",
+            label=_translate("Custom port address"),
+            hint=_translate(
+                "Specify any address for the port"
+            )
+        )
+        self.depends.append({
+            "dependsOn": "address",  # if...
+            "condition": "== 'custom'",  # meets...
+            "param": "customAddress",  # then...
+            "true": "show",  # should...
+            "false": "hide",  # otherwise...
+        })
+        
+
+    def writeDeviceCode(self, buff):
+        # handle special case (USB2TTL)
+        if self.params['address'] == 'USB2TTL8':
+            code = (
+                "# initialize %(name)s\n"
+                "from psychopy.hardware import labhackers\n"
+                "deviceManager.devices[%(name)s] = labhackers.USB2TTL8()\n"
+            )
+            buff.writeIndentedLines(code % self.params)
+            return
+
+        # open init call
+        code = (
+            "# initialize %(name)s\n"
+            "deviceManager.addDevice(\n"
+            "    deviceName=%(name)s,\n"
+            "    deviceClass='psychopy.hardware.parallel.ParallelDevice',\n"
+        )
+        
+        # add address (handle custom)
+        if self.params['address'] == "custom":
+            code += (
+            "    address=%(customAddress)s\n"
+            )
+        else:
+            code += (
+            "    address=%(address)s\n"
+            )
+        # close init call and write
+        code += (
+            ")\n"
+        )
+        buff.writeIndentedLines(code % self.params)
+
+
+# register backend with Component
+ParallelOutComponent.registerBackend(ParallelDeviceBackend)

--- a/psychopy/experiment/devices.py
+++ b/psychopy/experiment/devices.py
@@ -99,6 +99,7 @@ class DeviceBackend:
         # initialise params and order arrays
         self.params = {}
         self.order = []
+        self.depends = []
         # add a param for the device label to all backends
         self.params['name'] = Param(
             "", valType="str", inputType="name", categ=None,

--- a/psychopy/hardware/parallel.py
+++ b/psychopy/hardware/parallel.py
@@ -1,5 +1,6 @@
 import sys
 from psychopy import logging, clock
+from psychopy.hardware import DeviceManager
 from psychopy.hardware.base import BaseResponseDevice, BaseResponse
 
 
@@ -97,7 +98,7 @@ class ParallelDevice(BaseResponseDevice):
         # parallel ports aren't detectable, so just return one
         return [
             {
-                'deviceLabel': "Parallel Port",
+                'deviceName': "Parallel Port",
                 'deviceClass': "psychopy.hardware.parallel.ParallelDevice"
             }
         ]
@@ -145,6 +146,36 @@ class ParallelDevice(BaseResponseDevice):
             data = data & (255 ^ 2 ** (pinNumber - 2))
         # set in backend
         self.setData(data)
+
+
+class Parallel:
+    """
+    Builder-friendly wrapper around the ParallelDevice class.
+    """
+    def __init__(self, device):
+        if isinstance(device, ParallelDevice):
+            # store device object if given one
+            self.device = device
+        elif isinstance(device, str) and DeviceManager.getDevice(device):
+            # try getting it from device manager if it looks like a name
+            self.device = DeviceManager.getDevice(device)
+        else:
+            # assume an address if not an object or name
+            self.device = ParallelDevice(device)
+        # start off with no status
+        self.status = None
+
+    def getData(self):
+        return self.device.getData()
+    
+    def setData(self, data):
+        return self.device.setData(data=data)
+
+    def getPin(self, pinNumber):
+        return self.device.getPin(pinNumber=pinNumber)
+
+    def setPin(self, pinNumber, state):
+        return self.device.setPin(pinNumber=pinNumber, state=state)
 
 
 class _BaseParallelBackend:

--- a/psychopy/hardware/parallel.py
+++ b/psychopy/hardware/parallel.py
@@ -41,6 +41,7 @@ class ParallelDevice(BaseResponseDevice):
     responseClass = ParallelResponse
 
     def __init__(self, address):
+        BaseResponseDevice.__init__(self)
         # store address
         if isinstance(address, str) and address.startswith('0x'):
             # convert u"0x0378" into 0x0378
@@ -49,7 +50,7 @@ class ParallelDevice(BaseResponseDevice):
             self.address = address
         # pick appropriate backend according to OS
         if sys.platform.startswith('linux'):
-            self.backend = _LinuxParallelBackend()
+            self.backend = _LinuxParallelBackend(self.address)
         elif sys.platform == "win32":
             from ctypes import windll
 
@@ -67,7 +68,7 @@ class ParallelDevice(BaseResponseDevice):
                 except FileNotFoundError:
                     continue
                 # if we do, use the corresponding backend
-                self.backend = cls()
+                self.backend = cls(self.address)
             # if no drivers, error
             if self.backend is None:
                 raise SystemError(
@@ -103,7 +104,7 @@ class ParallelDevice(BaseResponseDevice):
 
     def dispatchMessages(self):
         # get data
-        data = self.backend.getData()
+        data = self.backend.readData()
         # do nothing if data hasn't changed
         if len(self.responses) and data == self.responses[-1].value:
             return
@@ -157,8 +158,8 @@ class _BaseParallelBackend:
         address : int
             Address of the parallel port
         """
-        raise NotImplementedError()
-
+        # store address
+        self.address = address
 
     def setData(self, address, data):
         """
@@ -195,10 +196,9 @@ class _DLPortIOParallelBackend(_BaseParallelBackend):
     def __init__(self, address):
         from ctypes import windll
 
+        _BaseParallelBackend.__init__(self, address=address)
         # get functions
         self.functions = windll.dlportio
-        # store address
-        self.address = address
 
     def setData(self, data):
         self.functions.DlPortWritePortUchar(self.address, data)
@@ -213,13 +213,12 @@ class _InpOutParallelBackend(_BaseParallelBackend):
         from ctypes import windll
         import platform
 
+        _BaseParallelBackend.__init__(self, address=address)
         # get functions
         if platform.architecture()[0] == '32bit':
             self.functions = getattr(windll, 'inpout32')
         elif platform.architecture()[0] == '64bit':
             self.functions = getattr(windll, 'inpoutx64')
-        # store address
-        self.address = address
         # put into byte mode
         _inp = self.functions.Inp32(
             self.address + 0x402 
@@ -235,7 +234,6 @@ class _InpOutParallelBackend(_BaseParallelBackend):
             int(_inp & ~uint8(1 << 5))
         )
 
-
     def setData(self, data):
         self.functions.DlPortWritePortUchar(self.address, data)
 
@@ -247,6 +245,7 @@ class _LinuxParallelBackend(_BaseParallelBackend):
     def __init__(self, address):
         import parallel as pyp
 
+        _BaseParallelBackend.__init__(self, address=address)
         # create Parallel object for functions
         self.functions = pyp.Parallel(address)
 

--- a/psychopy/hardware/parallel.py
+++ b/psychopy/hardware/parallel.py
@@ -1,0 +1,257 @@
+import sys
+from psychopy import logging, clock
+from psychopy.hardware.base import BaseResponseDevice, BaseResponse
+
+
+class ParallelResponse(BaseResponse):
+    def getPin(self, pinNumber):
+        """
+        Get the value of a specific pin in this response.
+
+        Parameters
+        ----------
+        pinNumber : int
+            Number of the pin to get the value of
+        """
+        if pinNumber == 10:
+            # 10 = ACK
+            return (self.value >> 6) & 1
+        elif pinNumber == 11:
+            # 11 = BUSY
+            return (self.value >> 7) & 1
+        elif pinNumber == 12:
+            # 12 = PAPER-OUT
+            return (self.value >> 5) & 1
+        elif pinNumber == 13:
+            # 13 = SELECT
+            return (self.value >> 4) & 1
+        elif pinNumber == 15:
+            # 15 = ERROR
+            return (self.value >> 3) & 1
+        elif 2 <= pinNumber <= 9:
+            return (self.value >> (pinNumber - 2)) & 1
+        else:
+            logging.error(
+                f"Could not read pin {pinNumber} on parallel response."
+            )
+            return
+
+
+class ParallelDevice(BaseResponseDevice):
+    responseClass = ParallelResponse
+
+    def __init__(self, address):
+        # store address
+        if isinstance(address, str) and address.startswith('0x'):
+            # convert u"0x0378" into 0x0378
+            self.address = int(address, 16)
+        else:
+            self.address = address
+        # pick appropriate backend according to OS
+        if sys.platform.startswith('linux'):
+            self.backend = _LinuxParallelBackend()
+        elif sys.platform == "win32":
+            from ctypes import windll
+
+            # start off with no backend
+            self.backend = None
+            # check which drivers we have
+            for key, cls in [
+                ('inpout32', _InpOutParallelBackend),
+                ('inpoutx64', _InpOutParallelBackend),
+                ('dlportio', _DLPortIOParallelBackend)
+            ]:
+                # if we don't have the driver, try the next
+                try:
+                    getattr(windll, key)
+                except FileNotFoundError:
+                    continue
+                # if we do, use the corresponding backend
+                self.backend = cls()
+            # if no drivers, error
+            if self.backend is None:
+                raise SystemError(
+                    "No parallel port drivers found. Please install either inpout32, inpoutx64 or "
+                    "dlportio"
+                )
+        else:
+            raise OSError(
+                "Parallel Port not supported on Mac OS"
+            )
+        # start timer
+        self.timer = clock.Clock()
+        # get initial state
+        self.dispatchMessages()
+
+    def isSameDevice(self, other):
+        if isinstance(other, ParallelDevice):
+            return self.address == other.address
+        elif isinstance(other, type(self.address)):
+            return self.address == other
+        else:
+            return False
+
+    @staticmethod
+    def getAvailableDevices():
+        # parallel ports aren't detectable, so just return one
+        return [
+            {
+                'deviceLabel': "Parallel Port",
+                'deviceClass': "psychopy.hardware.parallel.ParallelDevice"
+            }
+        ]
+
+    def dispatchMessages(self):
+        # get data
+        data = self.backend.getData()
+        # do nothing if data hasn't changed
+        if len(self.responses) and data == self.responses[-1].value:
+            return
+        # parse data to a ParallelResponse
+        msg = self.parseMessage(data)
+        # receive it
+        self.receiveMessage(msg)
+
+    def parseMessage(self, message):
+        return ParallelResponse(
+            t=self.timer.getTime(), 
+            value=message, 
+            device=self
+        )
+
+    def getData(self):
+        # dispatch messages to detect any change
+        self.dispatchMessages()
+        # return data from last response
+        return self.responses[-1].value
+    
+    def setData(self, data):
+        self.backend.setData(data)
+
+    def getPin(self, pinNumber):
+        # dispatch messages to detect any change
+        self.dispatchMessages()
+        # return data from last response
+        return self.responses[-1].getPin(pinNumber)
+
+    def setPin(self, pinNumber, state):
+        # get current state
+        data = self.getData()
+        # change just this pin
+        if state:
+            data = data | 2 ** (pinNumber - 2)
+        else:
+            data = data & (255 ^ 2 ** (pinNumber - 2))
+        # set in backend
+        self.setData(data)
+
+
+class _BaseParallelBackend:
+    def __init__(self, address):
+        """
+        Base class for a ParallelBackend; extremely minimal implementation with just get and set 
+        data functions.
+
+        Parameters
+        ----------
+        address : int
+            Address of the parallel port
+        """
+        raise NotImplementedError()
+
+
+    def setData(self, address, data):
+        """
+        Set data on the given port
+
+        Parameters
+        ----------
+        address : int
+            Port to set data on
+        data : bytes
+            Data to set
+        """
+        raise NotImplementedError()
+
+    def readData(self, address):
+        """
+        Read data from the given port
+
+        Parameters
+        ----------
+        address : int
+            Port to read data from
+        
+        Returns
+        -------
+        bytes
+            Data from the port
+        """
+        raise NotImplementedError()
+
+
+
+class _DLPortIOParallelBackend(_BaseParallelBackend):
+    def __init__(self, address):
+        from ctypes import windll
+
+        # get functions
+        self.functions = windll.dlportio
+        # store address
+        self.address = address
+
+    def setData(self, data):
+        self.functions.DlPortWritePortUchar(self.address, data)
+
+    def readData(self):
+        return self.functions.DlPortReadPortUchar(self.address)
+
+
+class _InpOutParallelBackend(_BaseParallelBackend):
+    def __init__(self, address):
+        from numpy import uint8
+        from ctypes import windll
+        import platform
+
+        # get functions
+        if platform.architecture()[0] == '32bit':
+            self.functions = getattr(windll, 'inpout32')
+        elif platform.architecture()[0] == '64bit':
+            self.functions = getattr(windll, 'inpoutx64')
+        # store address
+        self.address = address
+        # put into byte mode
+        _inp = self.functions.Inp32(
+            self.address + 0x402 
+        )
+        self.functions.Out32(
+            self.address + 0x402,
+            int((_inp & ~uint8(1 << 5 | 1 << 6 | 1 << 7)) | (1 << 5))
+        )
+        # make sure bit 5 of control register is not set (to make sure the port is in output mode)
+        _inp = self.functions.Inp32(self.address + 2)
+        self.functions.Out32(
+            self.address + 2,
+            int(_inp & ~uint8(1 << 5))
+        )
+
+
+    def setData(self, data):
+        self.functions.DlPortWritePortUchar(self.address, data)
+
+    def readData(self):
+        return self.functions.DlPortReadPortUchar(self.address)
+
+
+class _LinuxParallelBackend(_BaseParallelBackend):
+    def __init__(self, address):
+        import parallel as pyp
+
+        # create Parallel object for functions
+        self.functions = pyp.Parallel(address)
+
+    def setData(self, data):
+        self.functions.setData(data)
+
+    def getData(self, data):
+        return self.functions.PPRDATA()

--- a/psychopy/tests/test_hardware/test_parallel.py
+++ b/psychopy/tests/test_hardware/test_parallel.py
@@ -1,0 +1,34 @@
+from psychopy.hardware import parallel
+
+
+class _TestParallelBackend(parallel._BaseParallelBackend):
+    def __init__(self, address):
+        parallel._BaseParallelBackend.__init__(self, address=address)
+        # use an arbitrary attribute to simulate the pin values
+        self.data = int("0000000000000", 2)
+
+    def setData(self, data):
+        self.data = data
+
+    def readData(self):
+        return self.data
+
+
+class TestParallelDevice:
+    def setup_class(cls):
+        # replace all parallel backends with a dummy class for testing
+        parallel._LinuxParallelBackend = _TestParallelBackend
+        parallel._DLPortIOParallelBackend = _TestParallelBackend
+        parallel._InpOutParallelBackend = _TestParallelBackend
+
+    def test_getset_pins(self):
+        # make a parallel device
+        obj = parallel.ParallelDevice("test")
+        # for each pin...
+        for i in range(2, 9):
+            # try setting to True or False
+            for value in (True, False):
+                # set value
+                obj.setPin(i, value)
+                # check value
+                assert obj.getPin(i) == value


### PR DESCRIPTION
Breaking change as people using the Parallel Out Component now need to define a device in order to specify an address, also LabJack had to be moved to its own Component (https://github.com/psychopy/psychopy-labjack/pull/1).