### PR TITLE
TESTS: enable uv cache across test runs

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -31,12 +31,14 @@ jobs:
       uses: astral-sh/setup-uv@v7
       with:
         activate-environment: true
+        enable-cache: true
 
     - name: get_month
       if: runner.os=='Linux'
       id: month
       run: echo "month=$(date +'%Y-%m')" >> "$GITHUB_OUTPUT"
   
+    # NB no effect if we use uv to do the installation, only affects pip installs
     - name: cache wxPython for linux
       if: runner.os=='Linux'
       uses: actions/cache@v5


### PR DESCRIPTION
We were enabling pip cache using actions/cache but uv doesn't use ~/.cache/pip

setup-uv has its own cache system in setup-uv action

Actually note, according to uv docs the uv default setting is auto, so this *should* be getting used anyway. Maybe the issue is that the cache doesn't get used because we install from 
`https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-24.04`